### PR TITLE
Refactor language files for process exchange pages and add new translations

### DIFF
--- a/src/locales/en-US/pages_process.ts
+++ b/src/locales/en-US/pages_process.ts
@@ -156,4 +156,11 @@ export default {
   'pages.process.view.administrativeInformation.licenseType.freeOfChargeForMembersOnly': 'Free of charge for members only',
   'pages.process.view.administrativeInformation.licenseType.licenseFee': 'License fee',
   'pages.process.view.administrativeInformation.licenseType.other': 'Other',
+
+  'pages.process.view.exchanges.uncertaintyDistributionType.measured': 'Measured',
+  'pages.process.view.exchanges.uncertaintyDistributionType.calculated': 'Calculated',
+  'pages.process.view.exchanges.uncertaintyDistributionType.estimated': 'Estimated',
+  'pages.process.view.exchanges.uncertaintyDistributionType.unknownDerivation': 'Unknown derivation',
+  'pages.process.view.exchanges.uncertaintyDistributionType.missingImportant': 'Missing important',
+  'pages.process.view.exchanges.uncertaintyDistributionType.missingUnimportant': 'Missing unimportant',
 };

--- a/src/locales/zh-CN/pages_process.ts
+++ b/src/locales/zh-CN/pages_process.ts
@@ -152,4 +152,11 @@ export default {
   'pages.process.view.administrativeInformation.licenseType.freeOfChargeForMembersOnly': '仅对会员免费',
   'pages.process.view.administrativeInformation.licenseType.licenseFee': '许可费',
   'pages.process.view.administrativeInformation.licenseType.other': '其他',
+
+  'pages.process.view.exchanges.uncertaintyDistributionType.measured': '测量',
+  'pages.process.view.exchanges.uncertaintyDistributionType.calculated': '计算',
+  'pages.process.view.exchanges.uncertaintyDistributionType.estimated': '估算',
+  'pages.process.view.exchanges.uncertaintyDistributionType.unknownDerivation': '推导方式未知',
+  'pages.process.view.exchanges.uncertaintyDistributionType.missingImportant': '缺失重要数据',
+  'pages.process.view.exchanges.uncertaintyDistributionType.missingUnimportant': '缺失不重要数据',  
 };

--- a/src/pages/Account/index.tsx
+++ b/src/pages/Account/index.tsx
@@ -81,7 +81,7 @@ const Profile: FC = () => {
         <Form.Item
           label={<FormattedMessage id="pages.account.profile.name" defaultMessage="Name" />}
           name={'name'}
-          tooltip="The name you prefer to be called"
+          tooltip={<FormattedMessage id="pages.account.profile.name.tooltip" defaultMessage="The name you prefer to be called" />}
         >
           <Input prefix={<UserOutlined />} />
         </Form.Item>

--- a/src/pages/Processes/Components/Exchange/create.tsx
+++ b/src/pages/Processes/Components/Exchange/create.tsx
@@ -21,6 +21,9 @@ import {
 import type { FC } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage } from 'umi';
+import {
+  DataDerivationTypeStatusOptions,
+} from '../optiondata';
 
 type Props = {
   lang: string;
@@ -166,7 +169,7 @@ const ProcessExchangeCreate: FC<Props> = ({ lang, onData }) => {
               }
               name={'dataDerivationTypeStatus'}
             >
-              <Input />
+              <Select options={DataDerivationTypeStatusOptions} />
             </Form.Item>
             <Divider orientationMargin="0" orientation="left" plain>
               <FormattedMessage
@@ -174,7 +177,10 @@ const ProcessExchangeCreate: FC<Props> = ({ lang, onData }) => {
                 defaultMessage="Comment"
               />
             </Divider>
-            <LangTextItemForm name="generalComment" label="General Comment" />
+            <LangTextItemForm
+              name="generalComment"
+              label={<FormattedMessage id="pages.process.view.exchange.generalComment" defaultMessage="Comment" />}
+            />
 
             <Card
               size="small"
@@ -204,7 +210,10 @@ const ProcessExchangeCreate: FC<Props> = ({ lang, onData }) => {
                       defaultMessage="Functional unit, Production period, or Other parameter"
                     />
                   </Divider>
-                  <LangTextItemForm name="functionalUnitOrOther" label="Functional Unit Or Other" />
+                  <LangTextItemForm
+                    name="functionalUnitOrOther" 
+                    label={<FormattedMessage id="pages.process.view.exchange.functionalUnitOrOther" defaultMessage="Functional unit, Production period, or Other parameter" />}
+                    />
                 </>
               ) : (
                 <></>

--- a/src/pages/Processes/Components/Exchange/edit.tsx
+++ b/src/pages/Processes/Components/Exchange/edit.tsx
@@ -21,6 +21,9 @@ import {
 import type { FC } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { FormattedMessage } from 'umi';
+import {
+  DataDerivationTypeStatusOptions,
+} from '../optiondata';
 
 type Props = {
   id: string;
@@ -209,7 +212,7 @@ const ProcessExchangeEdit: FC<Props> = ({
               }
               name={'dataDerivationTypeStatus'}
             >
-              <Input />
+              <Select options={DataDerivationTypeStatusOptions} />
             </Form.Item>
             <Divider orientationMargin="0" orientation="left" plain>
               <FormattedMessage
@@ -217,7 +220,10 @@ const ProcessExchangeEdit: FC<Props> = ({
                 defaultMessage="Comment"
               />
             </Divider>
-            <LangTextItemForm name="generalComment" label="General Comment" />
+            <LangTextItemForm
+              name="generalComment"
+              label={<FormattedMessage id="pages.process.view.exchange.generalComment" defaultMessage="Comment" />}
+            />
 
             <Card
               size="small"
@@ -247,7 +253,10 @@ const ProcessExchangeEdit: FC<Props> = ({
                       defaultMessage="Functional unit, Production period, or Other parameter"
                     />
                   </Divider>
-                  <LangTextItemForm name="functionalUnitOrOther" label="Functional Unit Or Other" />
+                  <LangTextItemForm
+                    name="functionalUnitOrOther" 
+                    label={<FormattedMessage id="pages.process.view.exchange.functionalUnitOrOther" defaultMessage="Functional unit, Production period, or Other parameter" />}
+                    />
                 </>
               ) : (
                 <></>

--- a/src/pages/Processes/Components/Exchange/view.tsx
+++ b/src/pages/Processes/Components/Exchange/view.tsx
@@ -11,6 +11,9 @@ import { Button, Card, Descriptions, Divider, Drawer, Space, Tooltip } from 'ant
 import type { FC } from 'react';
 import { useState } from 'react';
 import { FormattedMessage } from 'umi';
+import {
+  DataDerivationTypeStatusOptions,
+} from '../optiondata';
 
 type Props = {
   id: string;
@@ -20,6 +23,12 @@ type Props = {
   buttonType: string;
   // actionRef: React.MutableRefObject<ActionType | undefined>;
 };
+
+const getDataDerivationTypeStatusOptions = (value: string) => {
+  const option = DataDerivationTypeStatusOptions.find((opt) => opt.value === value);
+  return option ? option.label : '-';
+};
+
 const ProcessExchangeView: FC<Props> = ({ id, data, lang, dataSource, buttonType }) => {
   const [drawerVisible, setDrawerVisible] = useState(false);
   const [footerButtons, setFooterButtons] = useState<JSX.Element>();
@@ -159,7 +168,7 @@ const ProcessExchangeView: FC<Props> = ({ id, data, lang, dataSource, buttonType
             }
             labelStyle={{ width: '220px' }}
           >
-            {viewData.dataDerivationTypeStatus ?? '-'}
+            {getDataDerivationTypeStatusOptions(viewData.dataDerivationTypeStatus)}
           </Descriptions.Item>
         </Descriptions>
 

--- a/src/pages/Processes/Components/optiondata.tsx
+++ b/src/pages/Processes/Components/optiondata.tsx
@@ -431,3 +431,60 @@ export const licenseTypeOptions = [
     ),
   },
 ];
+
+export const DataDerivationTypeStatusOptions = [
+  {
+    value: 'Measured',
+    label: (
+      <FormattedMessage
+        id="pages.process.view.exchanges.uncertaintyDistributionType.measured"
+        defaultMessage="Measured"
+      />
+    ),
+  },
+  {
+    value: 'Calculated',
+    label: (
+      <FormattedMessage
+        id="pages.process.view.exchanges.uncertaintyDistributionType.calculated"
+        defaultMessage="Calculated"
+      />
+    ),
+  },
+  {
+    value: 'Estimated',
+    label: (
+      <FormattedMessage
+        id="pages.process.view.exchanges.uncertaintyDistributionType.estimated"
+        defaultMessage="Estimated"
+      />
+    ),
+  },
+  {
+    value: 'Unknown derivation',
+    label: (
+      <FormattedMessage
+        id="pages.process.view.exchanges.uncertaintyDistributionType.unknownDerivation"
+        defaultMessage="Unknown derivation"
+      />
+    ),
+  },
+  {
+    value: 'Missing important',
+    label: (
+      <FormattedMessage
+        id="pages.process.view.exchanges.uncertaintyDistributionType.missingImportant"
+        defaultMessage="Missing important"
+      />
+    ),
+  },
+  {
+    value: 'Missing unimportant',
+    label: (
+      <FormattedMessage
+        id="pages.process.view.exchanges.uncertaintyDistributionType.missingUnimportant"
+        defaultMessage="Missing unimportant"
+      />
+    ),
+  },
+];


### PR DESCRIPTION
@linancn 
This pull request introduces several enhancements to the localization and form handling in the `src/pages/Processes/Components/Exchange` module. The changes primarily focus on adding new localization strings, updating form components to use `FormattedMessage` for internationalization, and integrating a new set of options for data derivation types.

### Localization Enhancements:
* [`src/locales/en-US/pages_process.ts`]: Added new localization strings for uncertainty distribution types.
* [`src/locales/zh-CN/pages_process.ts`]: Added corresponding Chinese localization strings for uncertainty distribution types.

### Form Component Updates:
* [`src/pages/Account/index.tsx`]: Updated the tooltip for the name field to use `FormattedMessage` for internationalization.
* `src/pages/Processes/Components/Exchange/create.tsx`: 
  * Imported `DataDerivationTypeStatusOptions` for use in the form.
  * Replaced `Input` with `Select` for the `dataDerivationTypeStatus` field and updated labels to use `FormattedMessage`. 
* `src/pages/Processes/Components/Exchange/edit.tsx`: 
  * Imported `DataDerivationTypeStatusOptions` for use in the form.
  * Replaced `Input` with `Select` for the `dataDerivationTypeStatus` field and updated labels to use `FormattedMessage`.

### Data Derivation Type Options Integration:
* `src/pages/Processes/Components/Exchange/view.tsx`: 
  * Imported `DataDerivationTypeStatusOptions` and added a helper function to get the label for a given value. 
  * Updated the view to display the label for `dataDerivationTypeStatus` using the new helper function.
* [`src/pages/Processes/Components/optiondata.tsx`]: Added `DataDerivationTypeStatusOptions` array with localized labels for data derivation types.