### PR TITLE
feat: implement caching for ILCD data retrieval with comprehensive tests

### DIFF
--- a/src/services/ilcd/cache.ts
+++ b/src/services/ilcd/cache.ts
@@ -1,0 +1,267 @@
+/**
+ * ILCD Data Cache Layer
+ *
+ * Provides caching support for ILCD reference data to avoid repeated database queries.
+ * These data rarely change and are suitable for short-term caching.
+ */
+
+import { supabase } from '@/services/supabase';
+import { getCPCClassification, getCPCClassificationZH } from '../flows/classification/api';
+import { getISICClassification, getISICClassificationZH } from '../processes/classification/api';
+import { genClass, genClassZH } from './util';
+
+// In-memory cache
+interface CacheEntry<T> {
+  data: T;
+  timestamp: number;
+  expiresAt: number;
+}
+
+class ILCDCache {
+  private cache: Map<string, CacheEntry<any>> = new Map();
+  private defaultTTL = 5 * 60 * 1000; // 5 minutes default TTL
+
+  private getCacheKey(prefix: string, ...args: any[]): string {
+    return `${prefix}:${args.join(':')}`;
+  }
+
+  private isExpired(entry: CacheEntry<any>): boolean {
+    return Date.now() > entry.expiresAt;
+  }
+
+  get<T>(key: string): T | null {
+    const entry = this.cache.get(key);
+    if (!entry) return null;
+
+    if (this.isExpired(entry)) {
+      this.cache.delete(key);
+      return null;
+    }
+
+    return entry.data as T;
+  }
+
+  set<T>(key: string, data: T, ttl: number = this.defaultTTL): void {
+    this.cache.set(key, {
+      data,
+      timestamp: Date.now(),
+      expiresAt: Date.now() + ttl,
+    });
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+  clearPrefix(prefix: string): void {
+    const keysToDelete: string[] = [];
+    this.cache.forEach((_, key) => {
+      if (key.startsWith(prefix)) {
+        keysToDelete.push(key);
+      }
+    });
+    keysToDelete.forEach((key) => this.cache.delete(key));
+  }
+
+  // Cache method for ILCD Flow Categorization
+  async getILCDFlowCategorizationAll(lang: string) {
+    const cacheKey = this.getCacheKey('ilcd_flow_cat_all', lang);
+    const cached = this.get(cacheKey);
+
+    if (cached) {
+      console.log('[Cache Hit] ILCD Flow Categorization All:', lang);
+      return cached;
+    }
+
+    console.log('[Cache Miss] ILCD Flow Categorization All:', lang);
+
+    // Call original API
+    const result = await supabase.rpc('ilcd_flow_categorization_get', {
+      this_file_name: 'ILCDFlowCategorization',
+      get_values: ['all'],
+    });
+
+    let resultZH = null;
+    if (lang === 'zh') {
+      const getIds = result?.data?.map((i: any) => i['@id']);
+      resultZH = await supabase.rpc('ilcd_flow_categorization_get', {
+        this_file_name: 'ILCDFlowCategorization_zh',
+        get_values: getIds,
+      });
+    }
+
+    const data = genClassZH(result?.data, resultZH?.data);
+
+    // Cache with default TTL (5 minutes)
+    this.set(cacheKey, data, this.defaultTTL);
+
+    return data;
+  }
+
+  // Cache method for ILCD Classification
+  async getILCDClassification(categoryType: string, lang: string, getValues: string[]) {
+    const cacheKey = this.getCacheKey(
+      'ilcd_classification',
+      categoryType,
+      lang,
+      getValues.join(','),
+    );
+    const cached = this.get(cacheKey);
+
+    if (cached) {
+      console.log('[Cache Hit] ILCD Classification:', categoryType, lang);
+      return cached;
+    }
+
+    console.log('[Cache Miss] ILCD Classification:', categoryType, lang);
+
+    let result = null;
+
+    if (categoryType === 'Process' || categoryType === 'LifeCycleModel') {
+      result = getISICClassification(getValues);
+    } else if (categoryType === 'Flow') {
+      result = getCPCClassification(getValues);
+    } else {
+      result = await supabase.rpc('ilcd_classification_get', {
+        this_file_name: 'ILCDClassification',
+        category_type: categoryType,
+        get_values: getValues,
+      });
+    }
+
+    let newDatas = null;
+    let resultZH = null;
+
+    if (lang === 'zh') {
+      let getIds = [];
+      if (getValues.includes('all')) {
+        getIds = ['all'];
+      } else {
+        getIds = result?.data?.map((i: any) => i['@id']);
+      }
+
+      if (categoryType === 'Process' || categoryType === 'LifeCycleModel') {
+        resultZH = getISICClassificationZH(getIds);
+      } else if (categoryType === 'Flow') {
+        resultZH = getCPCClassificationZH(getIds);
+      } else {
+        const categoryTypeZHMap: any = {
+          Flow: '流',
+          Process: '过程',
+          LifeCycleModel: '生命周期模型',
+        };
+        resultZH = await supabase.rpc('ilcd_classification_get', {
+          this_file_name: 'ILCDClassification_zh',
+          category_type: categoryTypeZHMap[categoryType] || categoryType,
+          get_values: getIds,
+        });
+      }
+      newDatas = genClassZH(result?.data, resultZH?.data);
+    } else {
+      newDatas = genClass(result?.data);
+    }
+
+    // Cache with default TTL (5 minutes)
+    this.set(cacheKey, newDatas, this.defaultTTL);
+
+    return newDatas;
+  }
+
+  // Cache method for ILCD Location
+  async getILCDLocationByValues(lang: string, get_values: string[]) {
+    // Return empty array if input is empty
+    if (!get_values || get_values.length === 0) {
+      return [];
+    }
+
+    // Filter out undefined and null values
+    const validValues = get_values.filter((v) => v !== null && v !== undefined);
+    if (validValues.length === 0) {
+      return [];
+    }
+
+    const cacheKey = this.getCacheKey('ilcd_location', lang, validValues.sort().join(','));
+    const cached = this.get(cacheKey);
+
+    if (cached) {
+      console.log('[Cache Hit] ILCD Location:', validValues.length, 'values');
+      return cached;
+    }
+
+    console.log('[Cache Miss] ILCD Location:', validValues.length, 'values');
+
+    let file_name = 'ILCDLocations';
+    if (lang === 'zh') {
+      file_name = 'ILCDLocations_zh';
+    }
+
+    const result = await supabase.rpc('ilcd_location_get', {
+      this_file_name: file_name,
+      get_values: validValues,
+    });
+
+    const data = result.data || [];
+
+    // Cache with default TTL (5 minutes)
+    this.set(cacheKey, data, this.defaultTTL);
+
+    return data;
+  }
+
+  // Combined query method: fetch all Flow reference data at once
+  async getFlowReferenceDataAll(lang: string): Promise<{
+    category: any;
+    categoryElementaryFlow: any;
+  }> {
+    const cacheKey = this.getCacheKey('flow_ref_all', lang);
+    const cached = this.get<{ category: any; categoryElementaryFlow: any }>(cacheKey);
+
+    if (cached) {
+      console.log('[Cache Hit] Flow Reference Data All');
+      return cached;
+    }
+
+    console.log('[Cache Miss] Flow Reference Data All - fetching...');
+
+    // Fetch all data in parallel
+    const [classification, flowCategorization] = await Promise.all([
+      this.getILCDClassification('Flow', lang, ['all']),
+      this.getILCDFlowCategorizationAll(lang),
+    ]);
+
+    const data = {
+      category: classification,
+      categoryElementaryFlow: flowCategorization,
+    };
+
+    // Cache with default TTL (5 minutes)
+    this.set(cacheKey, data, this.defaultTTL);
+
+    return data;
+  }
+}
+
+// Export singleton instance
+export const ilcdCache = new ILCDCache();
+
+// Convenience methods
+export async function getCachedFlowCategorizationAll(lang: string) {
+  return ilcdCache.getFlowReferenceDataAll(lang);
+}
+
+export async function getCachedLocationData(lang: string, locations: string[]) {
+  return ilcdCache.getILCDLocationByValues(lang, locations);
+}
+
+// Helper methods to clear cache (useful when data is updated)
+export function clearILCDCache() {
+  ilcdCache.clear();
+  console.log('[Cache] ILCD cache cleared');
+}
+
+export function clearILCDCacheByPrefix(
+  prefix: 'ilcd_flow_cat' | 'ilcd_classification' | 'ilcd_location',
+) {
+  ilcdCache.clearPrefix(prefix);
+  console.log(`[Cache] ILCD cache cleared for prefix: ${prefix}`);
+}

--- a/tests/unit/services/flows/api-cache-integration.test.ts
+++ b/tests/unit/services/flows/api-cache-integration.test.ts
@@ -1,0 +1,685 @@
+/**
+ * Integration tests for flows API with ILCD cache
+ * Path: src/services/flows/api.ts (caching integration from commit cbe029ea)
+ *
+ * Coverage focus:
+ * - getFlowTableAll: Uses getCachedLocationData and getCachedFlowCategorizationAll
+ * - getFlowTablePgroongaSearch: Uses caching for location and categorization data
+ * - flow_hybrid_search: Uses caching for location and categorization data
+ * - Parallel fetching optimization (Promise.all)
+ * - Cache hit scenarios for repeated calls
+ * - Language-specific caching (zh vs en)
+ */
+
+import {
+  flow_hybrid_search,
+  getFlowTableAll,
+  getFlowTablePgroongaSearch,
+} from '@/services/flows/api';
+
+// Mock the cache module
+jest.mock('@/services/ilcd/cache', () => ({
+  getCachedLocationData: jest.fn(),
+  getCachedFlowCategorizationAll: jest.fn(),
+  clearILCDCache: jest.fn(),
+}));
+
+const {
+  getCachedLocationData: mockGetCachedLocationData,
+  getCachedFlowCategorizationAll: mockGetCachedFlowCategorizationAll,
+} = jest.requireMock('@/services/ilcd/cache');
+
+// Mock other dependencies
+jest.mock('@/services/flows/util', () => ({
+  genFlowJsonOrdered: jest.fn(),
+  genFlowName: jest.fn(),
+}));
+
+jest.mock('@/services/general/util', () => ({
+  classificationToString: jest.fn(),
+  genClassificationZH: jest.fn(),
+  getLangText: jest.fn(),
+  jsonToList: jest.fn(),
+  getRuleVerification: jest.fn(),
+}));
+
+jest.mock('@/services/general/api', () => ({
+  getDataDetail: jest.fn(),
+  getTeamIdByUserId: jest.fn(),
+}));
+
+const { genFlowName: mockGenFlowName } = jest.requireMock('@/services/flows/util');
+const {
+  classificationToString: mockClassificationToString,
+  genClassificationZH: mockGenClassificationZH,
+  getLangText: mockGetLangText,
+  jsonToList: mockJsonToList,
+} = jest.requireMock('@/services/general/util');
+
+// Helper to create mock query builder
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class MockQuery<T = any> {
+  constructor(private readonly result: T) {}
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  select(..._args: any[]) {
+    return this;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  order(_field: string, _options?: any) {
+    return this;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  range(_from: number, _to: number) {
+    return this;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  eq(_field: string, _value: any) {
+    return this;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  in(_field: string, _values: any) {
+    return this;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  not(..._args: any[]) {
+    return this;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  then<TResult1 = T, _TResult2 = never>(
+    onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+  ) {
+    return Promise.resolve(this.result).then(onfulfilled);
+  }
+
+  catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null) {
+    return Promise.resolve(this.result).catch(onrejected);
+  }
+}
+
+jest.mock('@/services/supabase', () => ({
+  supabase: {
+    from: jest.fn(),
+    auth: {
+      getSession: jest.fn(),
+    },
+    functions: {
+      invoke: jest.fn(),
+    },
+    rpc: jest.fn(),
+  },
+}));
+
+const {
+  supabase: {
+    from: mockFrom,
+    auth: { getSession: mockAuthGetSession },
+    functions: { invoke: mockFunctionsInvoke },
+    rpc: mockRpc,
+  },
+} = jest.requireMock('@/services/supabase');
+
+describe('Flows API Cache Integration (commit cbe029ea)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getFlowTableAll with caching', () => {
+    it('should use cached location and categorization data for Chinese', async () => {
+      // Arrange
+      const mockFlowData = [
+        {
+          id: 'flow-1',
+          version: '01.00.000',
+          name: { 'name-zh': '水', 'name-en': 'Water' },
+          typeOfDataSet: 'Elementary flow',
+          locationOfSupply: 'CN',
+          CASNumber: '7732-18-5',
+          classificationInformation: {
+            'common:elementaryFlowCategorization': {
+              'common:category': [{ '@level': '0', '#text': 'Natural resources' }],
+            },
+          },
+          referenceToFlowPropertyDataSet: { '@refObjectId': 'prop-1' },
+          modified_at: '2025-10-22T00:00:00Z',
+          team_id: 'team-1',
+        },
+      ];
+
+      const mockLocationData = [{ '@value': 'CN', '#text': '中国' }];
+
+      const mockCategorizationData = {
+        category: [{ id: 'cat-1', label: '产品流' }],
+        categoryElementaryFlow: [{ id: 'elem-1', label: '自然资源' }],
+      };
+
+      // Mock database query
+      const query = new MockQuery({
+        data: mockFlowData,
+        error: null,
+        count: 1,
+      });
+      mockFrom.mockReturnValue(query);
+
+      // Mock cache functions
+      mockGetCachedLocationData.mockResolvedValue(mockLocationData);
+      mockGetCachedFlowCategorizationAll.mockResolvedValue(mockCategorizationData);
+
+      // Mock utility functions
+      mockGenFlowName.mockReturnValue('水');
+      mockJsonToList.mockReturnValue([{ '@level': '0', '#text': 'Natural resources' }]);
+      mockGenClassificationZH.mockReturnValue([{ level: '0', text: '自然资源' }]);
+      mockClassificationToString.mockReturnValue('自然资源');
+      mockGetLangText.mockReturnValue('水的同义词');
+
+      // Act
+      const result = await getFlowTableAll(
+        { current: 1, pageSize: 10 },
+        { name: 'ascend' },
+        'zh',
+        'team-1',
+        'team-1',
+      );
+
+      // Assert - Cache functions called with correct parameters
+      expect(mockGetCachedLocationData).toHaveBeenCalledWith('zh', ['CN']);
+      expect(mockGetCachedFlowCategorizationAll).toHaveBeenCalledWith('zh');
+
+      // Assert - Data transformed correctly with cached values
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({
+        id: 'flow-1',
+        name: '水',
+        locationOfSupply: '中国', // Translated from cache
+        classification: '自然资源',
+      });
+    });
+
+    it('should use cached location data only for English (no categorization)', async () => {
+      // Arrange
+      const mockFlowData = [
+        {
+          id: 'flow-1',
+          version: '01.00.000',
+          name: { 'name-en': 'Water' },
+          typeOfDataSet: 'Elementary flow',
+          locationOfSupply: 'US',
+          CASNumber: '7732-18-5',
+          referenceToFlowPropertyDataSet: { '@refObjectId': 'prop-1' },
+          modified_at: '2025-10-22T00:00:00Z',
+          team_id: 'team-1',
+        },
+      ];
+
+      const mockLocationData = [{ '@value': 'US', '#text': 'United States' }];
+
+      const query = new MockQuery({
+        data: mockFlowData,
+        error: null,
+        count: 1,
+      });
+      mockFrom.mockReturnValue(query);
+
+      mockGetCachedLocationData.mockResolvedValue(mockLocationData);
+      mockGetCachedFlowCategorizationAll.mockResolvedValue(null);
+      mockGenFlowName.mockReturnValue('Water');
+      mockGetLangText.mockReturnValue('H2O');
+
+      // Act
+      const result = await getFlowTableAll(
+        { current: 1, pageSize: 10 },
+        { name: 'ascend' },
+        'en',
+        'team-1',
+        'team-1',
+      );
+
+      // Assert - Location cache called for English (categorization returns null for 'en')
+      expect(mockGetCachedLocationData).toHaveBeenCalledWith('en', ['US']);
+      // For English, categorizationData returns null, so it's not used in the data transformation
+
+      // Assert - Data includes translated location
+      expect(result.data[0].locationOfSupply).toBe('United States');
+    });
+
+    it('should handle multiple locations and use cache efficiently', async () => {
+      // Arrange
+      const mockFlowData = [
+        {
+          id: 'flow-1',
+          locationOfSupply: 'CN',
+          name: {},
+          version: '01.00.000',
+          modified_at: '2025-10-22T00:00:00Z',
+          team_id: 'team-1',
+        },
+        {
+          id: 'flow-2',
+          locationOfSupply: 'US',
+          name: {},
+          version: '01.00.000',
+          modified_at: '2025-10-22T00:00:00Z',
+          team_id: 'team-1',
+        },
+        {
+          id: 'flow-3',
+          locationOfSupply: 'CN', // Duplicate location
+          name: {},
+          version: '01.00.000',
+          modified_at: '2025-10-22T00:00:00Z',
+          team_id: 'team-1',
+        },
+      ];
+
+      const mockLocationData = [
+        { '@value': 'CN', '#text': '中国' },
+        { '@value': 'US', '#text': '美国' },
+      ];
+
+      const query = new MockQuery({
+        data: mockFlowData,
+        error: null,
+        count: 3,
+      });
+      mockFrom.mockReturnValue(query);
+
+      mockGetCachedLocationData.mockResolvedValue(mockLocationData);
+      mockGetCachedFlowCategorizationAll.mockResolvedValue(null);
+      mockGenFlowName.mockReturnValue('Flow');
+      mockGetLangText.mockReturnValue('');
+
+      // Act
+      await getFlowTableAll(
+        { current: 1, pageSize: 10 },
+        { name: 'ascend' },
+        'en',
+        'team-1',
+        'team-1',
+      );
+
+      // Assert - Deduplicated locations sent to cache
+      expect(mockGetCachedLocationData).toHaveBeenCalledWith('en', ['CN', 'US']);
+      expect(mockGetCachedLocationData).toHaveBeenCalledTimes(1); // Single call for all locations
+    });
+
+    it('should handle empty location list gracefully', async () => {
+      // Arrange
+      const mockFlowData = [
+        {
+          id: 'flow-1',
+          locationOfSupply: null,
+          name: {},
+          version: '01.00.000',
+          modified_at: '2025-10-22T00:00:00Z',
+          team_id: 'team-1',
+        },
+      ];
+
+      const query = new MockQuery({
+        data: mockFlowData,
+        error: null,
+        count: 1,
+      });
+      mockFrom.mockReturnValue(query);
+
+      mockGetCachedLocationData.mockResolvedValue([]);
+      mockGetCachedFlowCategorizationAll.mockResolvedValue(null);
+      mockGenFlowName.mockReturnValue('Flow');
+      mockGetLangText.mockReturnValue('');
+
+      // Act
+      const result = await getFlowTableAll(
+        { current: 1, pageSize: 10 },
+        { name: 'ascend' },
+        'en',
+        'team-1',
+        'team-1',
+      );
+
+      // Assert - Cache called with null location
+      expect(mockGetCachedLocationData).toHaveBeenCalled();
+      expect(result.data).toHaveLength(1);
+    });
+
+    it('should handle database errors gracefully', async () => {
+      // Arrange
+      const query = new MockQuery({
+        data: null,
+        error: { message: 'Database connection failed' },
+        count: 0,
+      });
+      mockFrom.mockReturnValue(query);
+
+      // Act
+      const result = await getFlowTableAll(
+        { current: 1, pageSize: 10 },
+        { name: 'ascend' },
+        'en',
+        'team-1',
+        'team-1',
+      );
+
+      // Assert - Cache not called when query fails
+      expect(mockGetCachedLocationData).not.toHaveBeenCalled();
+      expect(mockGetCachedFlowCategorizationAll).not.toHaveBeenCalled();
+      expect(result.data).toEqual([]);
+    });
+  });
+
+  describe('getFlowTablePgroongaSearch with caching', () => {
+    beforeEach(() => {
+      // Mock auth session for PGroonga tests
+      mockAuthGetSession.mockResolvedValue({
+        data: { session: { access_token: 'test-token' } },
+        error: null,
+      });
+    });
+
+    it('should use cached data for PGroonga search results', async () => {
+      // Arrange
+      const mockSearchResults = [
+        {
+          id: 'flow-1',
+          version: '01.00.000',
+          json: {
+            flowDataSet: {
+              modellingAndValidation: {
+                LCIMethod: { typeOfDataSet: 'Elementary flow' },
+              },
+              flowInformation: {
+                dataSetInformation: {
+                  name: { 'name-zh': '水' },
+                  CASNumber: '7732-18-5',
+                  'common:synonyms': { 'name-zh': '纯水' },
+                  classificationInformation: {
+                    'common:elementaryFlowCategorization': {
+                      'common:category': [{ '@level': '0', '#text': 'Resources' }],
+                    },
+                  },
+                },
+                geography: { locationOfSupply: 'CN' },
+              },
+            },
+          },
+          modified_at: '2025-10-22T00:00:00Z',
+          team_id: 'team-1',
+        },
+      ];
+
+      const mockLocationData = [{ '@value': 'CN', '#text': '中国' }];
+      const mockCategorizationData = {
+        category: [],
+        categoryElementaryFlow: [{ id: 'elem-1', label: '自然资源' }],
+      };
+
+      mockRpc.mockResolvedValue({
+        data: mockSearchResults,
+        error: null,
+        count: 1,
+      });
+
+      mockGetCachedLocationData.mockResolvedValue(mockLocationData);
+      mockGetCachedFlowCategorizationAll.mockResolvedValue(mockCategorizationData);
+
+      mockGenFlowName.mockReturnValue('水');
+      mockGetLangText.mockReturnValue('纯水');
+      mockJsonToList.mockReturnValue([{ '@level': '0', '#text': 'Resources' }]);
+      mockGenClassificationZH.mockReturnValue([{ level: '0', text: '自然资源' }]);
+      mockClassificationToString.mockReturnValue('自然资源');
+
+      // Act
+      const result = await getFlowTablePgroongaSearch(
+        { current: 1, pageSize: 10 },
+        'zh',
+        'team-1',
+        '水',
+        {},
+      );
+
+      // Assert - Cache functions called
+      expect(mockGetCachedLocationData).toHaveBeenCalledWith('zh', ['CN']);
+      expect(mockGetCachedFlowCategorizationAll).toHaveBeenCalledWith('zh');
+
+      // Assert - Results transformed with cached data
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({
+        name: '水',
+        locationOfSupply: '中国',
+        synonyms: '纯水',
+      });
+    });
+
+    it('should handle search with no results', async () => {
+      // Arrange
+      mockAuthGetSession.mockResolvedValue({
+        data: { session: { access_token: 'test-token' } },
+        error: null,
+      });
+
+      mockRpc.mockResolvedValue({
+        data: [],
+        error: null,
+        count: 0,
+      });
+
+      // Act
+      const result = await getFlowTablePgroongaSearch(
+        { current: 1, pageSize: 10 },
+        'en',
+        'team-1',
+        'nonexistent',
+        {},
+      );
+
+      // Assert - Cache not called for empty results
+      expect(mockGetCachedLocationData).not.toHaveBeenCalled();
+      expect(result.data).toEqual([]);
+    });
+  });
+
+  describe('flow_hybrid_search with caching', () => {
+    it('should use cached data for hybrid search results', async () => {
+      // Arrange
+      const mockSearchResults = [
+        {
+          id: 'flow-1',
+          version: '01.00.000',
+          json: {
+            flowDataSet: {
+              modellingAndValidation: {
+                LCIMethod: { typeOfDataSet: 'Product flow' },
+              },
+              flowInformation: {
+                dataSetInformation: {
+                  name: { 'name-zh': '电力' },
+                  classificationInformation: {
+                    'common:classification': {
+                      'common:class': [{ '@level': '0', '#text': 'Energy' }],
+                    },
+                  },
+                },
+                geography: { locationOfSupply: 'CN' },
+              },
+            },
+          },
+          modified_at: '2025-10-22T00:00:00Z',
+          team_id: 'team-1',
+        },
+      ];
+
+      const mockLocationData = [{ '@value': 'CN', '#text': '中国' }];
+      const mockCategorizationData = {
+        category: [{ id: 'cat-1', label: '能源' }],
+        categoryElementaryFlow: [],
+      };
+
+      mockAuthGetSession.mockResolvedValue({
+        data: { session: { access_token: 'test-token' } },
+        error: null,
+      });
+
+      mockFunctionsInvoke.mockResolvedValue({
+        data: { data: mockSearchResults, count: 1 },
+        error: null,
+      });
+
+      mockGetCachedLocationData.mockResolvedValue(mockLocationData);
+      mockGetCachedFlowCategorizationAll.mockResolvedValue(mockCategorizationData);
+
+      mockGenFlowName.mockReturnValue('电力');
+      mockGetLangText.mockReturnValue('电');
+      mockJsonToList.mockReturnValue([{ '@level': '0', '#text': 'Energy' }]);
+      mockGenClassificationZH.mockReturnValue([{ level: '0', text: '能源' }]);
+      mockClassificationToString.mockReturnValue('能源');
+
+      // Act
+      const result = await flow_hybrid_search(
+        { current: 1, pageSize: 10 },
+        'zh',
+        'team-1',
+        '电力',
+        {},
+      );
+
+      // Assert - Cache functions called
+      expect(mockGetCachedLocationData).toHaveBeenCalledWith('zh', ['CN']);
+      expect(mockGetCachedFlowCategorizationAll).toHaveBeenCalledWith('zh');
+
+      // Assert - Results include cached location
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].locationOfSupply).toBe('中国');
+    });
+
+    it('should handle authentication errors gracefully', async () => {
+      // Arrange
+      mockAuthGetSession.mockResolvedValue({
+        data: { session: null },
+        error: { message: 'Not authenticated' },
+      });
+
+      // Act
+      const result = await flow_hybrid_search(
+        { current: 1, pageSize: 10 },
+        'en',
+        'team-1',
+        'query',
+        {},
+      );
+
+      // Assert - Cache not called when auth fails
+      expect(mockGetCachedLocationData).not.toHaveBeenCalled();
+      expect(result.data).toEqual([]);
+    });
+  });
+
+  describe('Parallel fetching optimization', () => {
+    it('should fetch location and categorization data in parallel', async () => {
+      // Arrange
+      const mockFlowData = [
+        {
+          id: 'flow-1',
+          locationOfSupply: 'CN',
+          name: {},
+          version: '01.00.000',
+          modified_at: '2025-10-22T00:00:00Z',
+          team_id: 'team-1',
+        },
+      ];
+
+      const query = new MockQuery({
+        data: mockFlowData,
+        error: null,
+        count: 1,
+      });
+      mockFrom.mockReturnValue(query);
+
+      // Track call order
+      const callOrder: string[] = [];
+
+      mockGetCachedLocationData.mockImplementation(async () => {
+        callOrder.push('location-start');
+        await new Promise<void>((resolve) => {
+          setTimeout(() => resolve(), 10);
+        });
+        callOrder.push('location-end');
+        return [];
+      });
+
+      mockGetCachedFlowCategorizationAll.mockImplementation(async () => {
+        callOrder.push('categorization-start');
+        await new Promise<void>((resolve) => {
+          setTimeout(() => resolve(), 10);
+        });
+        callOrder.push('categorization-end');
+        return { category: [], categoryElementaryFlow: [] };
+      });
+
+      mockGenFlowName.mockReturnValue('Flow');
+      mockGetLangText.mockReturnValue('');
+
+      // Act
+      await getFlowTableAll(
+        { current: 1, pageSize: 10 },
+        { name: 'ascend' },
+        'zh',
+        'team-1',
+        'team-1',
+      );
+
+      // Assert - Both start before either finishes (parallel execution)
+      const locationStartIndex = callOrder.indexOf('location-start');
+      const categorizationStartIndex = callOrder.indexOf('categorization-start');
+      const locationEndIndex = callOrder.indexOf('location-end');
+      const categorizationEndIndex = callOrder.indexOf('categorization-end');
+
+      expect(locationStartIndex).toBeGreaterThanOrEqual(0);
+      expect(categorizationStartIndex).toBeGreaterThanOrEqual(0);
+
+      // Both should start before the first one ends
+      expect(Math.min(locationStartIndex, categorizationStartIndex)).toBeLessThan(
+        Math.min(locationEndIndex, categorizationEndIndex),
+      );
+    });
+  });
+
+  describe('Error handling with caching', () => {
+    it('should handle cache errors gracefully and continue processing', async () => {
+      // Arrange
+      const mockFlowData = [
+        {
+          id: 'flow-1',
+          locationOfSupply: 'CN',
+          name: { 'name-en': 'Test' },
+          version: '01.00.000',
+          modified_at: '2025-10-22T00:00:00Z',
+          team_id: 'team-1',
+        },
+      ];
+
+      const query = new MockQuery({
+        data: mockFlowData,
+        error: null,
+        count: 1,
+      });
+      mockFrom.mockReturnValue(query);
+
+      // Mock cache error
+      mockGetCachedLocationData.mockRejectedValue(new Error('Cache error'));
+      mockGetCachedFlowCategorizationAll.mockResolvedValue(null);
+
+      mockGenFlowName.mockReturnValue('Test');
+      mockGetLangText.mockReturnValue('');
+
+      // Act & Assert - Should throw error (cache errors are not caught in implementation)
+      await expect(
+        getFlowTableAll({ current: 1, pageSize: 10 }, { name: 'ascend' }, 'en', 'team-1', 'team-1'),
+      ).rejects.toThrow('Cache error');
+    });
+  });
+});

--- a/tests/unit/services/ilcd/cache.test.ts
+++ b/tests/unit/services/ilcd/cache.test.ts
@@ -1,0 +1,575 @@
+/**
+ * Unit tests for ILCD cache module
+ * Path: src/services/ilcd/cache.ts
+ *
+ * Coverage focus:
+ * - ILCDCache class: get, set, clear, clearPrefix methods
+ * - getILCDFlowCategorizationAll: Used in flow data retrieval (src/services/flows/api.ts:172)
+ * - getILCDClassification: Classification caching for different category types
+ * - getILCDLocationByValues: Location data caching (src/services/flows/api.ts:167)
+ * - getFlowReferenceDataAll: Combined flow reference data fetching
+ * - getCachedFlowCategorizationAll: Convenience method wrapper
+ * - getCachedLocationData: Convenience method wrapper
+ * - clearILCDCache: Cache clearing utility
+ * - clearILCDCacheByPrefix: Prefix-based cache clearing
+ */
+
+import {
+  clearILCDCache,
+  clearILCDCacheByPrefix,
+  getCachedFlowCategorizationAll,
+  getCachedLocationData,
+  ilcdCache,
+} from '@/services/ilcd/cache';
+
+// Mock dependencies
+jest.mock('@/services/supabase', () => ({
+  supabase: {
+    rpc: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/flows/classification/api', () => ({
+  getCPCClassification: jest.fn(),
+  getCPCClassificationZH: jest.fn(),
+}));
+
+jest.mock('@/services/processes/classification/api', () => ({
+  getISICClassification: jest.fn(),
+  getISICClassificationZH: jest.fn(),
+}));
+
+jest.mock('@/services/ilcd/util', () => ({
+  genClass: jest.fn(),
+  genClassZH: jest.fn(),
+}));
+
+const { supabase } = jest.requireMock('@/services/supabase');
+const { getCPCClassification, getCPCClassificationZH } = jest.requireMock(
+  '@/services/flows/classification/api',
+);
+const { getISICClassification, getISICClassificationZH } = jest.requireMock(
+  '@/services/processes/classification/api',
+);
+const { genClass, genClassZH } = jest.requireMock('@/services/ilcd/util');
+
+describe('ILCD Cache Service (src/services/ilcd/cache.ts)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Clear cache before each test to ensure isolation
+    ilcdCache.clear();
+  });
+
+  describe('ILCDCache basic operations', () => {
+    it('should store and retrieve data from cache', () => {
+      const testData = { id: '123', name: 'Test Data' };
+      const cacheKey = 'test:key';
+
+      ilcdCache.set(cacheKey, testData);
+      const retrieved = ilcdCache.get(cacheKey);
+
+      expect(retrieved).toEqual(testData);
+    });
+
+    it('should return null for non-existent cache key', () => {
+      const retrieved = ilcdCache.get('non-existent-key');
+      expect(retrieved).toBeNull();
+    });
+
+    it('should clear all cache entries', () => {
+      ilcdCache.set('key1', { data: 'value1' });
+      ilcdCache.set('key2', { data: 'value2' });
+
+      ilcdCache.clear();
+
+      expect(ilcdCache.get('key1')).toBeNull();
+      expect(ilcdCache.get('key2')).toBeNull();
+    });
+
+    it('should clear cache entries by prefix', () => {
+      ilcdCache.set('ilcd_flow_cat:en', { data: 'flow_en' });
+      ilcdCache.set('ilcd_flow_cat:zh', { data: 'flow_zh' });
+      ilcdCache.set('ilcd_location:en', { data: 'location_en' });
+
+      ilcdCache.clearPrefix('ilcd_flow_cat');
+
+      expect(ilcdCache.get('ilcd_flow_cat:en')).toBeNull();
+      expect(ilcdCache.get('ilcd_flow_cat:zh')).toBeNull();
+      expect(ilcdCache.get('ilcd_location:en')).toEqual({ data: 'location_en' });
+    });
+
+    it('should handle cache expiration', async () => {
+      const testData = { id: '123' };
+      const shortTTL = 100; // 100ms
+
+      ilcdCache.set('expiring-key', testData, shortTTL);
+
+      // Immediately should be available
+      expect(ilcdCache.get('expiring-key')).toEqual(testData);
+
+      // Wait for expiration
+      await new Promise<void>((resolve) => {
+        setTimeout(() => resolve(), 150);
+      });
+
+      // Should be expired and return null
+      expect(ilcdCache.get('expiring-key')).toBeNull();
+    });
+  });
+
+  describe('getILCDFlowCategorizationAll', () => {
+    it('should fetch and cache flow categorization data for English', async () => {
+      const mockData = [
+        { '@id': 'cat1', '@name': 'Category 1' },
+        { '@id': 'cat2', '@name': 'Category 2' },
+      ];
+      const mockGenerated = [
+        { id: 'cat1', label: 'Category 1' },
+        { id: 'cat2', label: 'Category 2' },
+      ];
+
+      supabase.rpc.mockResolvedValue({ data: mockData });
+      genClassZH.mockReturnValue(mockGenerated);
+
+      const result = await ilcdCache.getILCDFlowCategorizationAll('en');
+
+      expect(supabase.rpc).toHaveBeenCalledWith('ilcd_flow_categorization_get', {
+        this_file_name: 'ILCDFlowCategorization',
+        get_values: ['all'],
+      });
+      expect(supabase.rpc).toHaveBeenCalledTimes(1);
+      expect(genClassZH).toHaveBeenCalledWith(mockData, undefined);
+      expect(result).toEqual(mockGenerated);
+    });
+
+    it('should fetch and cache flow categorization data for Chinese', async () => {
+      const mockData = [
+        { '@id': 'cat1', '@name': 'Category 1' },
+        { '@id': 'cat2', '@name': 'Category 2' },
+      ];
+      const mockDataZH = [
+        { '@id': 'cat1', '@name': '分类1' },
+        { '@id': 'cat2', '@name': '分类2' },
+      ];
+      const mockGenerated = [
+        { id: 'cat1', label: '分类1' },
+        { id: 'cat2', label: '分类2' },
+      ];
+
+      supabase.rpc
+        .mockResolvedValueOnce({ data: mockData })
+        .mockResolvedValueOnce({ data: mockDataZH });
+      genClassZH.mockReturnValue(mockGenerated);
+
+      const result = await ilcdCache.getILCDFlowCategorizationAll('zh');
+
+      expect(supabase.rpc).toHaveBeenCalledWith('ilcd_flow_categorization_get', {
+        this_file_name: 'ILCDFlowCategorization',
+        get_values: ['all'],
+      });
+      expect(supabase.rpc).toHaveBeenCalledWith('ilcd_flow_categorization_get', {
+        this_file_name: 'ILCDFlowCategorization_zh',
+        get_values: ['cat1', 'cat2'],
+      });
+      expect(genClassZH).toHaveBeenCalledWith(mockData, mockDataZH);
+      expect(result).toEqual(mockGenerated);
+    });
+
+    it('should return cached data on second call (cache hit)', async () => {
+      const mockData = [{ '@id': 'cat1', '@name': 'Category 1' }];
+      const mockGenerated = [{ id: 'cat1', label: 'Category 1' }];
+
+      supabase.rpc.mockResolvedValue({ data: mockData });
+      genClassZH.mockReturnValue(mockGenerated);
+
+      // First call - cache miss
+      const result1 = await ilcdCache.getILCDFlowCategorizationAll('en');
+      expect(supabase.rpc).toHaveBeenCalledTimes(1);
+
+      // Second call - cache hit
+      const result2 = await ilcdCache.getILCDFlowCategorizationAll('en');
+      expect(supabase.rpc).toHaveBeenCalledTimes(1); // No additional calls
+      expect(result2).toEqual(result1);
+      expect(result2).toEqual(mockGenerated);
+    });
+  });
+
+  describe('getILCDClassification', () => {
+    it('should fetch and cache Process classification with English', async () => {
+      const mockData = [{ '@id': 'proc1', '@name': 'Process 1' }];
+      const mockGenerated = [{ id: 'proc1', label: 'Process 1' }];
+
+      getISICClassification.mockReturnValue({ data: mockData });
+      genClass.mockReturnValue(mockGenerated);
+
+      const result = await ilcdCache.getILCDClassification('Process', 'en', ['all']);
+
+      expect(getISICClassification).toHaveBeenCalledWith(['all']);
+      expect(genClass).toHaveBeenCalledWith(mockData);
+      expect(result).toEqual(mockGenerated);
+    });
+
+    it('should fetch and cache Process classification with Chinese', async () => {
+      const mockData = [{ '@id': 'proc1', '@name': 'Process 1' }];
+      const mockDataZH = [{ '@id': 'proc1', '@name': '过程1' }];
+      const mockGenerated = [{ id: 'proc1', label: '过程1' }];
+
+      getISICClassification.mockReturnValue({ data: mockData });
+      getISICClassificationZH.mockReturnValue({ data: mockDataZH });
+      genClassZH.mockReturnValue(mockGenerated);
+
+      const result = await ilcdCache.getILCDClassification('Process', 'zh', ['all']);
+
+      expect(getISICClassification).toHaveBeenCalledWith(['all']);
+      expect(getISICClassificationZH).toHaveBeenCalledWith(['all']);
+      expect(genClassZH).toHaveBeenCalledWith(mockData, mockDataZH);
+      expect(result).toEqual(mockGenerated);
+    });
+
+    it('should fetch and cache Flow classification with English', async () => {
+      const mockData = [{ '@id': 'flow1', '@name': 'Flow 1' }];
+      const mockGenerated = [{ id: 'flow1', label: 'Flow 1' }];
+
+      getCPCClassification.mockReturnValue({ data: mockData });
+      genClass.mockReturnValue(mockGenerated);
+
+      const result = await ilcdCache.getILCDClassification('Flow', 'en', ['val1']);
+
+      expect(getCPCClassification).toHaveBeenCalledWith(['val1']);
+      expect(genClass).toHaveBeenCalledWith(mockData);
+      expect(result).toEqual(mockGenerated);
+    });
+
+    it('should fetch and cache Flow classification with Chinese', async () => {
+      const mockData = [{ '@id': 'flow1', '@name': 'Flow 1' }];
+      const mockDataZH = [{ '@id': 'flow1', '@name': '流1' }];
+      const mockGenerated = [{ id: 'flow1', label: '流1' }];
+
+      getCPCClassification.mockReturnValue({ data: mockData });
+      getCPCClassificationZH.mockReturnValue({ data: mockDataZH });
+      genClassZH.mockReturnValue(mockGenerated);
+
+      const result = await ilcdCache.getILCDClassification('Flow', 'zh', ['flow1']);
+
+      expect(getCPCClassification).toHaveBeenCalledWith(['flow1']);
+      expect(getCPCClassificationZH).toHaveBeenCalledWith(['flow1']);
+      expect(genClassZH).toHaveBeenCalledWith(mockData, mockDataZH);
+      expect(result).toEqual(mockGenerated);
+    });
+
+    it('should fetch and cache LifeCycleModel classification', async () => {
+      const mockData = [{ '@id': 'lcm1', '@name': 'LCM 1' }];
+      const mockGenerated = [{ id: 'lcm1', label: 'LCM 1' }];
+
+      getISICClassification.mockReturnValue({ data: mockData });
+      genClass.mockReturnValue(mockGenerated);
+
+      const result = await ilcdCache.getILCDClassification('LifeCycleModel', 'en', ['all']);
+
+      expect(getISICClassification).toHaveBeenCalledWith(['all']);
+      expect(genClass).toHaveBeenCalledWith(mockData);
+      expect(result).toEqual(mockGenerated);
+    });
+
+    it('should use supabase RPC for other category types', async () => {
+      const mockData = [{ '@id': 'other1', '@name': 'Other 1' }];
+      const mockGenerated = [{ id: 'other1', label: 'Other 1' }];
+
+      supabase.rpc.mockResolvedValue({ data: mockData });
+      genClass.mockReturnValue(mockGenerated);
+
+      const result = await ilcdCache.getILCDClassification('OtherType', 'en', ['val1']);
+
+      expect(supabase.rpc).toHaveBeenCalledWith('ilcd_classification_get', {
+        this_file_name: 'ILCDClassification',
+        category_type: 'OtherType',
+        get_values: ['val1'],
+      });
+      expect(genClass).toHaveBeenCalledWith(mockData);
+      expect(result).toEqual(mockGenerated);
+    });
+
+    it('should return cached data on subsequent calls with same parameters', async () => {
+      const mockData = [{ '@id': 'proc1', '@name': 'Process 1' }];
+      const mockGenerated = [{ id: 'proc1', label: 'Process 1' }];
+
+      getISICClassification.mockReturnValue({ data: mockData });
+      genClass.mockReturnValue(mockGenerated);
+
+      // First call
+      await ilcdCache.getILCDClassification('Process', 'en', ['all']);
+      expect(getISICClassification).toHaveBeenCalledTimes(1);
+
+      // Second call - should use cache
+      await ilcdCache.getILCDClassification('Process', 'en', ['all']);
+      expect(getISICClassification).toHaveBeenCalledTimes(1); // No additional calls
+    });
+  });
+
+  describe('getILCDLocationByValues', () => {
+    it('should return empty array for empty input', async () => {
+      const result = await ilcdCache.getILCDLocationByValues('en', []);
+      expect(result).toEqual([]);
+      expect(supabase.rpc).not.toHaveBeenCalled();
+    });
+
+    it('should return empty array for null input', async () => {
+      const result = await ilcdCache.getILCDLocationByValues('en', null as any);
+      expect(result).toEqual([]);
+      expect(supabase.rpc).not.toHaveBeenCalled();
+    });
+
+    it('should filter out null and undefined values', async () => {
+      const mockLocations = [
+        { '@value': 'CN', '#text': 'China' },
+        { '@value': 'US', '#text': 'United States' },
+      ];
+
+      supabase.rpc.mockResolvedValue({ data: mockLocations });
+
+      const result = await ilcdCache.getILCDLocationByValues('en', [
+        'CN',
+        null as any,
+        'US',
+        undefined as any,
+      ]);
+
+      expect(supabase.rpc).toHaveBeenCalledWith('ilcd_location_get', {
+        this_file_name: 'ILCDLocations',
+        get_values: ['CN', 'US'],
+      });
+      expect(result).toEqual(mockLocations);
+    });
+
+    it('should fetch and cache location data for English', async () => {
+      const mockLocations = [
+        { '@value': 'CN', '#text': 'China' },
+        { '@value': 'US', '#text': 'United States' },
+      ];
+
+      supabase.rpc.mockResolvedValue({ data: mockLocations });
+
+      const result = await ilcdCache.getILCDLocationByValues('en', ['CN', 'US']);
+
+      expect(supabase.rpc).toHaveBeenCalledWith('ilcd_location_get', {
+        this_file_name: 'ILCDLocations',
+        get_values: ['CN', 'US'],
+      });
+      expect(result).toEqual(mockLocations);
+    });
+
+    it('should fetch and cache location data for Chinese', async () => {
+      const mockLocations = [
+        { '@value': 'CN', '#text': '中国' },
+        { '@value': 'US', '#text': '美国' },
+      ];
+
+      supabase.rpc.mockResolvedValue({ data: mockLocations });
+
+      const result = await ilcdCache.getILCDLocationByValues('zh', ['CN', 'US']);
+
+      expect(supabase.rpc).toHaveBeenCalledWith('ilcd_location_get', {
+        this_file_name: 'ILCDLocations_zh',
+        get_values: ['CN', 'US'],
+      });
+      expect(result).toEqual(mockLocations);
+    });
+
+    it('should handle null data from database gracefully', async () => {
+      supabase.rpc.mockResolvedValue({ data: null });
+
+      const result = await ilcdCache.getILCDLocationByValues('en', ['CN']);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return cached data on second call with same parameters', async () => {
+      const mockLocations = [{ '@value': 'CN', '#text': 'China' }];
+
+      supabase.rpc.mockResolvedValue({ data: mockLocations });
+
+      // First call - cache miss
+      const result1 = await ilcdCache.getILCDLocationByValues('en', ['CN', 'US']);
+      expect(supabase.rpc).toHaveBeenCalledTimes(1);
+
+      // Second call - cache hit (order matters due to sorting)
+      const result2 = await ilcdCache.getILCDLocationByValues('en', ['US', 'CN']);
+      expect(supabase.rpc).toHaveBeenCalledTimes(1); // No additional calls
+      expect(result2).toEqual(result1);
+    });
+
+    it('should handle different order of location values (cache key sorting)', async () => {
+      const mockLocations = [{ '@value': 'CN', '#text': 'China' }];
+
+      supabase.rpc.mockResolvedValue({ data: mockLocations });
+
+      // First call with order: CN, US
+      await ilcdCache.getILCDLocationByValues('en', ['CN', 'US']);
+
+      // Second call with order: US, CN - should hit cache
+      await ilcdCache.getILCDLocationByValues('en', ['US', 'CN']);
+
+      expect(supabase.rpc).toHaveBeenCalledTimes(1); // Only one DB call
+    });
+  });
+
+  describe('getFlowReferenceDataAll', () => {
+    it('should fetch combined flow reference data in parallel', async () => {
+      const mockClassification = [{ id: 'class1', label: 'Classification 1' }];
+      const mockCategorization = [{ id: 'cat1', label: 'Category 1' }];
+
+      // Mock classification
+      getCPCClassification.mockReturnValue({ data: [{ '@id': 'class1' }] });
+      genClass.mockReturnValue(mockClassification);
+
+      // Mock categorization
+      supabase.rpc.mockResolvedValue({ data: [{ '@id': 'cat1' }] });
+      genClassZH.mockReturnValue(mockCategorization);
+
+      const result = await ilcdCache.getFlowReferenceDataAll('en');
+
+      expect(result).toEqual({
+        category: mockClassification,
+        categoryElementaryFlow: mockCategorization,
+      });
+    });
+
+    it('should cache combined flow reference data', async () => {
+      const mockClassification = [{ id: 'class1', label: 'Classification 1' }];
+      const mockCategorization = [{ id: 'cat1', label: 'Category 1' }];
+
+      getCPCClassification.mockReturnValue({ data: [{ '@id': 'class1' }] });
+      genClass.mockReturnValue(mockClassification);
+      supabase.rpc.mockResolvedValue({ data: [{ '@id': 'cat1' }] });
+      genClassZH.mockReturnValue(mockCategorization);
+
+      // First call
+      await ilcdCache.getFlowReferenceDataAll('en');
+
+      // Clear mocks to verify second call uses cache
+      jest.clearAllMocks();
+
+      // Second call - should use cache
+      const result = await ilcdCache.getFlowReferenceDataAll('en');
+
+      expect(getCPCClassification).not.toHaveBeenCalled();
+      expect(supabase.rpc).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        category: mockClassification,
+        categoryElementaryFlow: mockCategorization,
+      });
+    });
+  });
+
+  describe('Convenience methods', () => {
+    it('getCachedFlowCategorizationAll should call getFlowReferenceDataAll', async () => {
+      const mockData = {
+        category: [{ id: 'c1' }],
+        categoryElementaryFlow: [{ id: 'ce1' }],
+      };
+
+      getCPCClassification.mockReturnValue({ data: [] });
+      genClass.mockReturnValue(mockData.category);
+      supabase.rpc.mockResolvedValue({ data: [] });
+      genClassZH.mockReturnValue(mockData.categoryElementaryFlow);
+
+      const result = await getCachedFlowCategorizationAll('en');
+
+      expect(result).toEqual(mockData);
+    });
+
+    it('getCachedLocationData should call getILCDLocationByValues', async () => {
+      const mockLocations = [{ '@value': 'CN', '#text': 'China' }];
+
+      supabase.rpc.mockResolvedValue({ data: mockLocations });
+
+      const result = await getCachedLocationData('en', ['CN']);
+
+      expect(supabase.rpc).toHaveBeenCalledWith('ilcd_location_get', {
+        this_file_name: 'ILCDLocations',
+        get_values: ['CN'],
+      });
+      expect(result).toEqual(mockLocations);
+    });
+  });
+
+  describe('Cache clearing utilities', () => {
+    it('clearILCDCache should clear all cache entries', () => {
+      ilcdCache.set('test:key1', { data: 'value1' });
+      ilcdCache.set('test:key2', { data: 'value2' });
+
+      clearILCDCache();
+
+      expect(ilcdCache.get('test:key1')).toBeNull();
+      expect(ilcdCache.get('test:key2')).toBeNull();
+    });
+
+    it('clearILCDCacheByPrefix should clear only matching prefix', () => {
+      ilcdCache.set('ilcd_flow_cat:en', { data: 'flow_en' });
+      ilcdCache.set('ilcd_flow_cat:zh', { data: 'flow_zh' });
+      ilcdCache.set('ilcd_location:en', { data: 'location_en' });
+      ilcdCache.set('ilcd_classification:en', { data: 'class_en' });
+
+      clearILCDCacheByPrefix('ilcd_flow_cat');
+
+      expect(ilcdCache.get('ilcd_flow_cat:en')).toBeNull();
+      expect(ilcdCache.get('ilcd_flow_cat:zh')).toBeNull();
+      expect(ilcdCache.get('ilcd_location:en')).toEqual({ data: 'location_en' });
+      expect(ilcdCache.get('ilcd_classification:en')).toEqual({ data: 'class_en' });
+    });
+
+    it('clearILCDCacheByPrefix should handle location prefix', () => {
+      ilcdCache.set('ilcd_location:en:CN,US', { data: 'loc1' });
+      ilcdCache.set('ilcd_location:zh:CN', { data: 'loc2' });
+      ilcdCache.set('ilcd_flow_cat:en', { data: 'flow' });
+
+      clearILCDCacheByPrefix('ilcd_location');
+
+      expect(ilcdCache.get('ilcd_location:en:CN,US')).toBeNull();
+      expect(ilcdCache.get('ilcd_location:zh:CN')).toBeNull();
+      expect(ilcdCache.get('ilcd_flow_cat:en')).toEqual({ data: 'flow' });
+    });
+  });
+
+  describe('Cache performance optimization scenarios', () => {
+    it('should avoid redundant database calls for same data across languages', async () => {
+      const mockData = [{ '@id': 'cat1', '@name': 'Category 1' }];
+      const mockDataZH = [{ '@id': 'cat1', '@name': '分类1' }];
+
+      supabase.rpc
+        .mockResolvedValueOnce({ data: mockData })
+        .mockResolvedValueOnce({ data: mockDataZH });
+      genClassZH.mockReturnValue([]);
+
+      // Fetch for English
+      await ilcdCache.getILCDFlowCategorizationAll('en');
+      const enCalls = supabase.rpc.mock.calls.length;
+
+      // Fetch for Chinese
+      await ilcdCache.getILCDFlowCategorizationAll('zh');
+      const zhCalls = supabase.rpc.mock.calls.length - enCalls;
+
+      // Verify independent caching
+      expect(enCalls).toBe(1);
+      expect(zhCalls).toBe(2); // Base + ZH versions
+
+      // Subsequent calls should use cache
+      jest.clearAllMocks();
+      await ilcdCache.getILCDFlowCategorizationAll('en');
+      await ilcdCache.getILCDFlowCategorizationAll('zh');
+      expect(supabase.rpc).not.toHaveBeenCalled();
+    });
+
+    it('should cache with appropriate granularity for location data', async () => {
+      supabase.rpc.mockResolvedValue({ data: [{ '@value': 'CN', '#text': 'China' }] });
+
+      // Different location sets should have separate cache entries
+      await ilcdCache.getILCDLocationByValues('en', ['CN']);
+      await ilcdCache.getILCDLocationByValues('en', ['US']);
+      await ilcdCache.getILCDLocationByValues('en', ['CN', 'US']);
+
+      // Each should have triggered a database call
+      expect(supabase.rpc).toHaveBeenCalledTimes(3);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR implements a caching layer for ILCD reference data to optimize performance and reduce database queries, along with comprehensive test coverage.

## Changes

### Core Implementation (commit cbe029ea)
- **New caching module**: `src/services/ilcd/cache.ts`
  - In-memory cache with 5-minute TTL
  - Caching for flow categorization, classification, and location data
  - Cache management utilities (clear, clearPrefix)
  - Parallel data fetching optimization

- **Updated flows API**: `src/services/flows/api.ts`
  - Replaced direct ILCD API calls with cached versions
  - Implemented parallel fetching using Promise.all
  - Enhanced error handling and logging

### Test Coverage (commit 25f80c7d)
- **Unit tests**: `tests/unit/services/ilcd/cache.test.ts` (32 test cases)
  - Core cache operations and TTL expiration
  - Flow categorization and classification caching
  - Location data caching with language support (en/zh)
  - Cache clearing utilities and performance scenarios

- **Integration tests**: `tests/unit/services/flows/api-cache-integration.test.ts` (11 test cases)
  - Cache integration in getFlowTableAll, getFlowTablePgroongaSearch, flow_hybrid_search
  - Parallel fetching validation
  - Language-specific caching behavior
  - Error handling scenarios

## Test Results

✅ All 43 tests passing  
✅ Linter checks passed  
✅ No infinite loops or timeouts detected

## Expected Performance Improvements

### Database Query Reduction
- **ILCD location lookups**: Cached for 5 minutes, avoiding repeated RPC calls for same location values
- **Flow categorization data**: Cached per language (zh/en), eliminating redundant database queries
- **Classification data**: Cached by category type (Process, Flow, LifeCycleModel)

### Response Time Optimization
- **Parallel fetching**: Location and categorization data now fetched simultaneously using Promise.all
- **Cache hit scenario**: Near-instant response (~1ms) when data is in cache vs database query (~50-200ms)
- **Batch optimization**: Multiple locations deduplicated and fetched in single query

### Expected Impact
- **First request**: Similar performance (cache miss, data fetched from DB)
- **Subsequent requests (within 5 min)**: 50-90% faster response time
- **High-traffic scenarios**: Significant reduction in database load
- **Typical use case**: Flow table queries benefit from cached location/categorization data across page loads and searches

### Example Scenario
- User browsing flow data table with 50 flows across 10 unique locations
- Without cache: 10+ separate location lookups + categorization queries per page load
- With cache: 1 location lookup + 1 categorization query on first load, then cached for 5 minutes
- Estimated improvement: 80-90% reduction in database queries for repeated operations