### PR TITLE
fix: improve lifecycle model selection contrast

### DIFF
--- a/src/components/X6Graph/index.tsx
+++ b/src/components/X6Graph/index.tsx
@@ -8,7 +8,14 @@ interface X6GraphProps {
   zoomable?: boolean;
   pannable?: boolean;
   minScale?: number;
-  selectOptions?: any;
+  selectOptions?: {
+    enabled?: boolean;
+    multiple?: boolean;
+    movable?: boolean;
+    showNodeSelectionBox?: boolean;
+    showEdgeSelectionBox?: boolean;
+    pointerEvents?: 'none' | 'auto';
+  };
   connectionOptions?: {
     snap?: boolean;
     allowBlank?: boolean;
@@ -68,6 +75,7 @@ const X6GraphComponent = ({
   const setGraph = useGraphStore((state) => state.setGraph);
   const { token } = theme.useToken();
   const defaultGridColor = token.colorTextTertiary;
+  const hasTransformHandles = !!(transformOptions?.resizing || transformOptions?.rotating);
 
   useEffect(() => {
     const graph = new Graph({
@@ -182,11 +190,12 @@ const X6GraphComponent = ({
       graph.use(
         new Selection({
           enabled: true,
-          multiple: true,
+          multiple: selectOptions?.multiple ?? true,
           rubberband: false,
-          movable: true,
-          showNodeSelectionBox: false,
-          showEdgeSelectionBox: false,
+          movable: selectOptions?.movable ?? true,
+          showNodeSelectionBox: selectOptions?.showNodeSelectionBox ?? !hasTransformHandles,
+          showEdgeSelectionBox: selectOptions?.showEdgeSelectionBox ?? false,
+          pointerEvents: selectOptions?.pointerEvents ?? (hasTransformHandles ? 'auto' : 'none'),
         }),
       );
     }

--- a/src/pages/LifeCycleModels/Components/toolbar/styles/index.less
+++ b/src/pages/LifeCycleModels/Components/toolbar/styles/index.less
@@ -10,6 +10,18 @@
   stroke-width: 1.5px;
 }
 
+.x6-widget-selection-box {
+  margin-top: -6px;
+  margin-left: -6px;
+  padding-right: 8px;
+  padding-bottom: 8px;
+  border: 2px solid var(--ant-color-primary) !important;
+  border-radius: 10px;
+  outline: 1px solid var(--ant-color-text);
+  outline-offset: 1px;
+  box-shadow: 0 0 10px 0 var(--ant-color-primary-hover);
+}
+
 .x6-edge-selected {
   path:nth-child(2) {
     stroke: var(--ant-color-primary);

--- a/src/pages/Review/Components/reviewLifeCycleModels/Components/toolbar/styles/index.less
+++ b/src/pages/Review/Components/reviewLifeCycleModels/Components/toolbar/styles/index.less
@@ -7,12 +7,25 @@
 // selection
 .x6-node-selected rect {
   stroke: var(--ant-color-primary);
+  stroke-width: 1.5px;
+}
+
+.x6-widget-selection-box {
+  margin-top: -6px;
+  margin-left: -6px;
+  padding-right: 8px;
+  padding-bottom: 8px;
+  border: 2px solid var(--ant-color-primary) !important;
+  border-radius: 10px;
+  outline: 1px solid var(--ant-color-text);
+  outline-offset: 1px;
+  box-shadow: 0 0 10px 0 var(--ant-color-primary-hover);
 }
 
 .x6-edge-selected {
   path:nth-child(2) {
     stroke: var(--ant-color-primary);
-    stroke-width: 1.5px;
+    stroke-width: 2px;
   }
 }
 
@@ -24,18 +37,26 @@
 
 // transform
 .x6-widget-transform {
-  margin: -1px 0 0 -1px;
+  margin: -2px 0 0 -2px;
   padding: 0px;
-  border: 1px solid var(--ant-color-primary);
+  border: 2px solid var(--ant-color-primary);
+  outline: 1px solid var(--ant-color-text);
+  outline-offset: 1px;
+  box-shadow: 0 0 8px 0 var(--ant-color-primary-hover);
 }
 .x6-widget-transform > div {
-  border: 1px solid var(--ant-color-primary);
+  border: 1px solid var(--ant-color-text);
+  background-color: var(--ant-color-bg-container);
+  box-shadow: 0 0 0 1px var(--ant-color-primary);
 }
 .x6-widget-transform > div:hover {
   background-color: var(--ant-color-primary-hover);
 }
 .x6-widget-transform-active-handle {
-  background-color: var(--ant-color-primary-hover);
+  background-color: var(--ant-color-primary);
+  box-shadow:
+    0 0 0 1px var(--ant-color-text),
+    0 0 0 2px var(--ant-color-bg-container);
 }
 .x6-widget-transform-resize {
   border-radius: 0;

--- a/tests/unit/components/X6Graph.test.tsx
+++ b/tests/unit/components/X6Graph.test.tsx
@@ -123,6 +123,16 @@ describe('X6Graph component (src/components/X6Graph/index.tsx)', () => {
     expect(instance.use).toHaveBeenCalledTimes(2);
     expect(instance.use).toHaveBeenCalledWith(expect.any(Snapline));
     expect(instance.use).toHaveBeenCalledWith(expect.any(Selection));
+    const selectionPlugin = instance.use.mock.calls.find(
+      ([plugin]: [unknown]) => plugin instanceof Selection,
+    )?.[0];
+    expect(selectionPlugin.options).toMatchObject({
+      multiple: true,
+      movable: true,
+      showNodeSelectionBox: true,
+      showEdgeSelectionBox: false,
+      pointerEvents: 'none',
+    });
     expect(mockSetGraph).toHaveBeenCalledWith(instance);
   });
 
@@ -316,5 +326,21 @@ describe('X6Graph component (src/components/X6Graph/index.tsx)', () => {
     )?.[0];
 
     expect(transformPlugin.options).toEqual({ resizing: true, rotating: false });
+  });
+
+  it('hides the node selection box when transform handles are enabled', () => {
+    const { Selection, __graphInstances } = jest.requireMock('@antv/x6');
+
+    render(<X6GraphComponent transformOptions={{ resizing: true }} />);
+
+    const instance = __graphInstances[0];
+    const selectionPlugin = instance.use.mock.calls.find(
+      ([plugin]: [unknown]) => plugin instanceof Selection,
+    )?.[0];
+
+    expect(selectionPlugin.options).toMatchObject({
+      showNodeSelectionBox: false,
+      pointerEvents: 'auto',
+    });
   });
 });


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#264

## Summary
- Show a visible X6 single-node selection box on lifecycle model canvases when transform handles are not enabled, so view and review flows have a clear selected state.
- Keep edit/create flows on the transform outline and handles by suppressing the extra selection box when transform handles are enabled.
- Strengthen the shared selection/transform styling used by lifecycle model canvases in both LifeCycleModels and review pages.
- Add `X6Graph` coverage for both no-transform and transform-enabled selection defaults.

## Key Decisions
- The reported missing border was not only a contrast problem: view mode had X6 `Selection` enabled, but no visible node selection box, and those canvases do not mount `Transform`.
- Default `X6Graph` to `showNodeSelectionBox: true` and `pointerEvents: 'none'` when no transform handles are configured.
- Keep `showNodeSelectionBox: false` and `pointerEvents: 'auto'` when transform handles are enabled so edit/create continue to use the transform box and handles.

## Validation
- `npm run lint`
- `npm run test:ci -- tests/unit/components/X6Graph.test.tsx tests/unit/pages/LifeCycleModels/Components/view.test.tsx tests/unit/pages/LifeCycleModels/Components/edit.test.tsx tests/unit/pages/LifeCycleModels/Components/create.test.tsx --runInBand --testTimeout=20000 --no-coverage`
- `npm run test:ci -- tests/unit/components/X6Graph.test.tsx tests/unit/pages/Review/Components/reviewLifeCycleModels.test.tsx tests/unit/pages/Review/Components/reviewLifeCycleModels/Components/toolbar/viewIndex.test.tsx --runInBand --testTimeout=20000 --no-coverage`
- `git push origin fix/issue-264` (runs `prepush:gate` = lint + full coverage + coverage assertion)

## Risks / Rollback
- Low risk: `X6Graph` is only used by lifecycle model canvases in this repo, and the selection-default split now follows whether transform handles are enabled.

## Workspace Integration
- Requires later `lca-workspace` submodule integration after merge.
