### PR TITLE
fix: align location cache path with public assets

### DIFF
--- a/src/services/locations/util.ts
+++ b/src/services/locations/util.ts
@@ -55,7 +55,7 @@ export const getCachedLocationFileData = async <T>(filename: string): Promise<T 
 
 export const cacheAndDecompressLocationFile = async (filename: string): Promise<boolean> => {
   try {
-    const response = await fetch(`/location/${filename}`);
+    const response = await fetch(`/locations/${filename}`);
     if (!response.ok) {
       console.warn(`Location source file not found: ${filename}`);
       return false;

--- a/tests/unit/services/locations/util.test.ts
+++ b/tests/unit/services/locations/util.test.ts
@@ -97,7 +97,7 @@ describe('Locations Util (src/services/locations/util.ts)', () => {
     mockInitIndexedDbStore.mockResolvedValue('db');
 
     await expect(cacheAndDecompressLocationFile('file.json.gz')).resolves.toBe(true);
-    expect(global.fetch).toHaveBeenCalledWith('/location/file.json.gz');
+    expect(global.fetch).toHaveBeenCalledWith('/locations/file.json.gz');
     expect(mockPutCachedJsonEntry).toHaveBeenCalledWith('db', 'location_files', 'file.json.gz', {
       ok: true,
     });


### PR DESCRIPTION
Closes #268

## Summary
- Update the location cache fetch path from /location/* to /locations/* so it matches the published frontend assets.
- Restore the startup cache warmup triggered by LocationCacheMonitor and prevent the 404 from surfacing on pages that mount the shared layout.

## Key Decisions
- Keep the fix in the shared location utility so every caller uses the same public asset path without page-specific workarounds.

## Validation
- npm test -- --runInBand tests/unit/services/locations/util.test.ts tests/unit/components/LocationCacheMonitor.test.tsx
- The repository pre-push gate passed: lint, TypeScript, full unit suite, and 100% coverage check.

## Risks / Rollback
- Low risk: the change only updates the static asset URL used when warming the location cache.

## Workspace Integration
- Requires a later lca-workspace submodule bump after the PR merges because Workspace Integration is still Pending.