### PR TITLE
Fix project-sync owner configuration in tiangong-lca-next

### DIFF
--- a/.github/scripts/project-sync.mjs
+++ b/.github/scripts/project-sync.mjs
@@ -3,7 +3,7 @@
 import { readFile } from 'node:fs/promises';
 
 const GRAPHQL_URL = 'https://api.github.com/graphql';
-const PROJECT_OWNER = process.env.PROJECT_OWNER || 'Neo9281';
+const PROJECT_OWNER = process.env.PROJECT_OWNER || 'tiangong-lca';
 const PROJECT_NUMBER = Number(process.env.PROJECT_NUMBER || '1');
 const DEFAULT_REPO_TAG = process.env.DEFAULT_REPO_TAG;
 const DEFAULT_WORKSPACE_INTEGRATION = process.env.DEFAULT_WORKSPACE_INTEGRATION;
@@ -230,6 +230,24 @@ async function loadProject() {
   const data = await graphql(
     `
       query ($owner: String!, $number: Int!) {
+        organization(login: $owner) {
+          projectV2(number: $number) {
+            id
+            fields(first: 50) {
+              nodes {
+                __typename
+                ... on ProjectV2SingleSelectField {
+                  id
+                  name
+                  options {
+                    id
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
         user(login: $owner) {
           projectV2(number: $number) {
             id
@@ -256,7 +274,7 @@ async function loadProject() {
     },
   );
 
-  const project = data.user?.projectV2;
+  const project = data.organization?.projectV2 || data.user?.projectV2;
   if (!project) {
     throw new Error(`Unable to load ${PROJECT_OWNER} / Project #${PROJECT_NUMBER}.`);
   }

--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Sync GitHub Project item
         env:
           PROJECT_AUTOMATION_TOKEN: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
-          PROJECT_OWNER: Neo9281
+          PROJECT_OWNER: tiangong-lca
           PROJECT_NUMBER: "1"
           DEFAULT_REPO_TAG: next
           DEFAULT_WORKSPACE_INTEGRATION: Pending


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#273

## Summary
- Switch the next repo project-sync workflow and script defaults from Neo9281 to tiangong-lca.
- Make the sync script support organization-owned GitHub Projects while preserving user fallback behavior.

## Key Decisions
- Updated both the workflow env and the GraphQL project loader so organization-owned projects resolve correctly.

## Validation
- Ran node --check .github/scripts/project-sync.mjs.
- Push validation passed the repo pre-push gate: lint, TypeScript check, Jest coverage, and full-coverage assertion.

## Follow-ups
- No additional workspace integration is needed for this repo-local workflow change.