### PR TITLE
docs: codify Ant Design first UI rules for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,24 @@ Read only what matches the current task:
 - `docker/volumes/functions/**`: synced self-hosted edge-functions mirror. Do not edit these files in `tiangong-lca-next`.
 - `docker/pull-edge-functions.sh`: the only supported way to refresh `docker/volumes/functions/**` in this repo.
 
+## UI Consistency / Ant Design First
+
+For `tiangong-lca-next`, UI consistency is a hard product requirement.
+
+When implementing or modifying frontend UI in this repository, follow these rules:
+
+1. Reuse existing shared components and established project patterns first.
+2. If no suitable shared abstraction exists, prefer Ant Design native components, documented props, built-in variants, and standard interaction patterns.
+3. For visual decisions that affect product consistency, prefer Ant Design theme tokens, component tokens, or established project token abstractions over ad-hoc hard-coded values.
+4. Avoid unnecessary custom visual styling. Custom CSS, inline styles, and local CSS modules are not the default path when Ant Design or existing shared abstractions can already satisfy the requirement.
+5. Custom styling is allowed only when Ant Design props, tokens, or existing shared abstractions cannot reasonably satisfy the requirement. In such cases, keep the override minimal, preserve the established visual language, and explain the reason in the PR description or code comments when it is not obvious.
+6. If a custom visual pattern starts repeating, extract it into a shared component or reusable abstraction instead of duplicating it locally.
+
+Clarification:
+
+- This rule targets product-facing visual styling and interaction consistency, not a total ban on layout code.
+- Local layout styling is acceptable when appropriate, but prefer existing project patterns and Ant Design layout primitives for simple composition before introducing one-off visual treatments.
+
 ## Delivery Contract
 
 - Investigate first (`rg`, nearest feature, existing tests).

--- a/AGENTS_CN.md
+++ b/AGENTS_CN.md
@@ -71,6 +71,24 @@ npm run build
 - `docker/volumes/functions/**`：自托管 edge-functions 的同步镜像，禁止在 `tiangong-lca-next` 中直接编辑。
 - `docker/pull-edge-functions.sh`：本仓库刷新 `docker/volumes/functions/**` 的唯一正确方式。
 
+## UI 一致性 / Ant Design 优先
+
+对 `tiangong-lca-next` 而言，UI 风格一致性是硬性的产品要求。
+
+在本仓库中实现或修改前端 UI 时，必须遵循以下规则：
+
+1. 优先复用现有共享组件和已经建立的项目模式。
+2. 如果没有合适的共享抽象，优先使用 Ant Design 原生组件、文档化 props、内置变体以及标准交互模式。
+3. 只要是会影响产品视觉一致性的设计决策，优先使用 Ant Design theme tokens、component tokens 或项目既有的 token 抽象，而不是临时写死的颜色值、尺寸值等硬编码。
+4. 避免不必要的自定义视觉样式。当 Ant Design 或既有共享抽象已经能满足需求时，自定义 CSS、内联样式和局部 CSS modules 都不应成为默认实现路径。
+5. 只有在 Ant Design props、tokens 或既有共享抽象无法合理满足需求时，才允许使用自定义样式。此时必须保持 override 尽可能小，继续遵守既有产品视觉语言，并在理由不明显时于 PR 描述或代码注释中说明原因。
+6. 如果某种自定义视觉模式开始重复出现，应将其提炼为共享组件或可复用抽象，而不是在局部重复复制。
+
+说明：
+
+- 本规则约束的是面向产品的视觉样式和交互一致性，并不是彻底禁止编写布局代码。
+- 在合适场景下可以编写局部布局样式；但在只是做简单组合时，应优先使用既有项目模式和 Ant Design 的布局原语，而不是额外引入一次性视觉处理。
+
 ## 交付约束
 
 - 先调研（`rg`、最近似功能、现有测试）。


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#275

## Summary
- Add a dedicated UI consistency section to the next repo AGENTS entrypoint so agents default to shared abstractions, Ant Design native components, and token-first visual decisions.
- Mirror the same rule set into AGENTS_CN.md to keep the bilingual entrypoints aligned.

## Key Decisions
- Keep the rule in the repo entrypoint instead of burying it in feature-level docs so agents see it before frontend implementation work.

## Validation
- Not run (documentation-only AGENTS update).

## Risks / Rollback
- Low risk: documentation-only change with no runtime code impact.

## Workspace Integration
- Requires a later lca-workspace submodule bump after merge.