### PR TITLE
fix: normalize single-file json imports

### DIFF
--- a/src/components/ImportData/index.tsx
+++ b/src/components/ImportData/index.tsx
@@ -6,7 +6,7 @@ import type { FC } from 'react';
 import { useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 interface ImportDataProps {
-  onJsonData: (data: any) => void;
+  onJsonData: (data: any[]) => void;
   disabled?: boolean;
 }
 
@@ -43,8 +43,9 @@ const ImportData: FC<ImportDataProps> = ({ onJsonData, disabled = false }) => {
         try {
           const content = e.target?.result as string;
           const jsonData = JSON.parse(content);
+          const normalizedJsonData = Array.isArray(jsonData) ? jsonData : [jsonData];
 
-          onJsonData(jsonData);
+          onJsonData(normalizedJsonData);
 
           handleCancel();
         } catch (error) {

--- a/tests/unit/components/ImportData.test.tsx
+++ b/tests/unit/components/ImportData.test.tsx
@@ -7,7 +7,7 @@ import ImportData from '@/components/ImportData';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 type ImportDataProps = {
-  onJsonData: (data: unknown) => void;
+  onJsonData: (data: unknown[]) => void;
   disabled?: boolean;
 };
 
@@ -199,14 +199,18 @@ describe('ImportData Component', () => {
     expect(message.warning).toHaveBeenCalledWith('Please select a file to import');
   });
 
-  it('accepts a valid JSON file and forwards parsed data', async () => {
-    mockFileReader({ content: JSON.stringify({ flows: [] }) });
+  it('wraps a single imported dataset object into an array before forwarding it', async () => {
+    mockFileReader({ content: JSON.stringify({ contactDataSet: { contactInformation: {} } }) });
     setup();
     openModal();
 
-    const file = new File([JSON.stringify({ flows: [] })], 'flows.json', {
-      type: 'application/json',
-    });
+    const file = new File(
+      [JSON.stringify({ contactDataSet: { contactInformation: {} } })],
+      'contact.json',
+      {
+        type: 'application/json',
+      },
+    );
 
     await act(async () => {
       latestDraggerProps?.beforeUpload?.(file as any);
@@ -219,7 +223,7 @@ describe('ImportData Component', () => {
     fireEvent.click(screen.getByTestId('modal-ok'));
 
     await waitFor(() => {
-      expect(onJsonDataMock).toHaveBeenCalledWith({ flows: [] });
+      expect(onJsonDataMock).toHaveBeenCalledWith([{ contactDataSet: { contactInformation: {} } }]);
     });
 
     await waitFor(() => {
@@ -227,6 +231,30 @@ describe('ImportData Component', () => {
     });
 
     expect(message.error).not.toHaveBeenCalled();
+  });
+
+  it('preserves imported arrays without adding another wrapper layer', async () => {
+    mockFileReader({ content: JSON.stringify([{ flowDataSet: { flowInformation: {} } }]) });
+    setup();
+    openModal();
+
+    const file = new File(
+      [JSON.stringify([{ flowDataSet: { flowInformation: {} } }])],
+      'flows.json',
+      {
+        type: 'application/json',
+      },
+    );
+
+    await act(async () => {
+      latestDraggerProps?.beforeUpload?.(file as any);
+    });
+
+    fireEvent.click(screen.getByTestId('modal-ok'));
+
+    await waitFor(() => {
+      expect(onJsonDataMock).toHaveBeenCalledWith([{ flowDataSet: { flowInformation: {} } }]);
+    });
   });
 
   it('clears the selected file when the user removes it', async () => {


### PR DESCRIPTION
## Summary\n- normalize imported JSON payloads so single dataset objects are wrapped into an array before page-level consumers read them\n- fix contact JSON imports that previously appeared to do nothing because pages expect importData[0]\n- preserve existing array-based imports and add regression coverage for both payload shapes\n\n## Testing\n- npm run test:ci -- tests/unit/components/ImportData.test.tsx tests/unit/pages/Contacts/ContactCreate.test.tsx --runInBand --testTimeout=10000 --no-coverage\n- npm run lint\n- npm run prepush:gate