### PR TITLE
fix: harden access-control database baseline and regression smoke tests

### DIFF
--- a/supabase/migrations/20260404123556_access_control_fix_update_policies.sql
+++ b/supabase/migrations/20260404123556_access_control_fix_update_policies.sql
@@ -1,0 +1,129 @@
+drop policy if exists "update by owner and admin" on public.teams;
+
+create policy "update by owner and admin"
+on public.teams
+for update
+to authenticated
+using (
+  exists (
+    select 1
+    from public.roles r
+    where r.user_id = auth.uid()
+      and r.team_id = teams.id
+      and r.role in ('owner', 'admin')
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.roles r
+    where r.user_id = auth.uid()
+      and r.team_id = teams.id
+      and r.role in ('owner', 'admin')
+  )
+);
+
+drop policy if exists "update by review-admin or data owener" on public.comments;
+drop policy if exists "comments update by reviewer self" on public.comments;
+drop policy if exists "comments update by review-admin" on public.comments;
+
+create policy "comments update by reviewer self"
+on public.comments
+for update
+to authenticated
+using (reviewer_id = auth.uid())
+with check (reviewer_id = auth.uid());
+
+create policy "comments update by review-admin"
+on public.comments
+for update
+to authenticated
+using (
+  public.policy_is_current_user_in_roles(
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    array['review-admin']::text[]
+  )
+)
+with check (
+  public.policy_is_current_user_in_roles(
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    array['review-admin']::text[]
+  )
+);
+
+drop policy if exists "transitional_update_owner_draft_only" on public.contacts;
+create policy "transitional_update_owner_draft_only"
+on public.contacts
+for update
+to authenticated
+using (state_code = 0 and user_id = auth.uid())
+with check (state_code = 0 and user_id = auth.uid());
+
+drop policy if exists "transitional_update_owner_draft_only" on public.sources;
+create policy "transitional_update_owner_draft_only"
+on public.sources
+for update
+to authenticated
+using (state_code = 0 and user_id = auth.uid())
+with check (state_code = 0 and user_id = auth.uid());
+
+drop policy if exists "transitional_update_owner_draft_only" on public.unitgroups;
+create policy "transitional_update_owner_draft_only"
+on public.unitgroups
+for update
+to authenticated
+using (state_code = 0 and user_id = auth.uid())
+with check (state_code = 0 and user_id = auth.uid());
+
+drop policy if exists "transitional_update_owner_draft_only" on public.flowproperties;
+create policy "transitional_update_owner_draft_only"
+on public.flowproperties
+for update
+to authenticated
+using (state_code = 0 and user_id = auth.uid())
+with check (state_code = 0 and user_id = auth.uid());
+
+drop policy if exists "transitional_update_owner_draft_only" on public.flows;
+create policy "transitional_update_owner_draft_only"
+on public.flows
+for update
+to authenticated
+using (state_code = 0 and user_id = auth.uid())
+with check (state_code = 0 and user_id = auth.uid());
+
+drop policy if exists "transitional_update_owner_draft_only" on public.processes;
+create policy "transitional_update_owner_draft_only"
+on public.processes
+for update
+to authenticated
+using (state_code = 0 and user_id = auth.uid())
+with check (state_code = 0 and user_id = auth.uid());
+
+drop policy if exists "transitional_update_owner_draft_only" on public.lifecyclemodels;
+create policy "transitional_update_owner_draft_only"
+on public.lifecyclemodels
+for update
+to authenticated
+using (state_code = 0 and user_id = auth.uid())
+with check (state_code = 0 and user_id = auth.uid());
+
+drop policy if exists "transitional_reviews_update_submitter_only" on public.reviews;
+create policy "transitional_reviews_update_submitter_only"
+on public.reviews
+for update
+to authenticated
+using (
+  auth.uid() is not null
+  and ((json -> 'user' ->> 'id')::uuid) = auth.uid()
+)
+with check (
+  auth.uid() is not null
+  and ((json -> 'user' ->> 'id')::uuid) = auth.uid()
+);
+
+drop policy if exists "notifications_delete_recipient_only" on public.notifications;
+create policy "notifications_delete_recipient_only"
+on public.notifications
+for delete
+to authenticated
+using (auth.uid() = recipient_user_id);

--- a/supabase/migrations/20260404123557_access_control_add_state_role_constraints_and_audit.sql
+++ b/supabase/migrations/20260404123557_access_control_add_state_role_constraints_and_audit.sql
@@ -1,0 +1,96 @@
+alter table public.roles
+  drop constraint if exists roles_role_check;
+
+alter table public.roles
+  add constraint roles_role_check
+  check (
+    role in (
+      'owner',
+      'admin',
+      'member',
+      'is_invited',
+      'rejected',
+      'review-admin',
+      'review-member'
+    )
+  );
+
+alter table public.reviews
+  drop constraint if exists reviews_state_code_check;
+
+alter table public.reviews
+  add constraint reviews_state_code_check
+  check (state_code in (-1, 0, 1, 2));
+
+alter table public.comments
+  drop constraint if exists comments_state_code_check;
+
+alter table public.comments
+  add constraint comments_state_code_check
+  check (state_code in (-3, -2, -1, 0, 1, 2));
+
+alter table public.contacts
+  drop constraint if exists contacts_state_code_check;
+
+alter table public.contacts
+  add constraint contacts_state_code_check
+  check (state_code in (0, 3, 20, 100));
+
+alter table public.sources
+  drop constraint if exists sources_state_code_check;
+
+alter table public.sources
+  add constraint sources_state_code_check
+  check (state_code in (0, 20, 100));
+
+alter table public.unitgroups
+  drop constraint if exists unitgroups_state_code_check;
+
+alter table public.unitgroups
+  add constraint unitgroups_state_code_check
+  check (state_code in (0, 100, 200));
+
+alter table public.flowproperties
+  drop constraint if exists flowproperties_state_code_check;
+
+alter table public.flowproperties
+  add constraint flowproperties_state_code_check
+  check (state_code in (0, 100, 200));
+
+alter table public.flows
+  drop constraint if exists flows_state_code_check;
+
+alter table public.flows
+  add constraint flows_state_code_check
+  check (state_code in (0, 20, 100, 200));
+
+alter table public.processes
+  drop constraint if exists processes_state_code_check;
+
+alter table public.processes
+  add constraint processes_state_code_check
+  check (state_code in (0, 20, 100, 200));
+
+alter table public.lifecyclemodels
+  drop constraint if exists lifecyclemodels_state_code_check;
+
+alter table public.lifecyclemodels
+  add constraint lifecyclemodels_state_code_check
+  check (state_code in (0, 20, 100));
+
+create table if not exists public.command_audit_log (
+  id bigint generated always as identity primary key,
+  command text not null,
+  actor_user_id uuid not null,
+  target_table text,
+  target_id uuid,
+  target_version text,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+revoke all on public.command_audit_log from anon, authenticated;
+grant all on public.command_audit_log to service_role;
+
+revoke all on sequence public.command_audit_log_id_seq from anon, authenticated;
+grant all on sequence public.command_audit_log_id_seq to service_role;

--- a/supabase/tests/20260403_update_security_smoke.sql
+++ b/supabase/tests/20260403_update_security_smoke.sql
@@ -1,0 +1,326 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(6);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '10000000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'team-admin@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"10000000-0000-0000-0000-000000000001","email":"team-admin@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '10000000-0000-0000-0000-000000000002',
+    'authenticated',
+    'authenticated',
+    'dataset-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"10000000-0000-0000-0000-000000000002","email":"dataset-owner@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '10000000-0000-0000-0000-000000000003',
+    'authenticated',
+    'authenticated',
+    'reviewer-a@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"10000000-0000-0000-0000-000000000003","email":"reviewer-a@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '10000000-0000-0000-0000-000000000004',
+    'authenticated',
+    'authenticated',
+    'reviewer-b@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"10000000-0000-0000-0000-000000000004","email":"reviewer-b@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '10000000-0000-0000-0000-000000000005',
+    'authenticated',
+    'authenticated',
+    'review-submitter@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"10000000-0000-0000-0000-000000000005","email":"review-submitter@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '10000000-0000-0000-0000-000000000006',
+    'authenticated',
+    'authenticated',
+    'outsider@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"10000000-0000-0000-0000-000000000006","email":"outsider@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.teams (id, json, rank, is_public)
+values
+  ('20000000-0000-0000-0000-000000000001', '{"name":"Team A"}'::jsonb, 1, false),
+  ('20000000-0000-0000-0000-000000000002', '{"name":"Team B"}'::jsonb, 2, false),
+  ('00000000-0000-0000-0000-000000000000', '{"name":"System Team"}'::jsonb, 0, false);
+
+insert into public.roles (user_id, team_id, role)
+values
+  ('10000000-0000-0000-0000-000000000001', '20000000-0000-0000-0000-000000000001', 'admin'),
+  ('10000000-0000-0000-0000-000000000002', '20000000-0000-0000-0000-000000000001', 'owner'),
+  ('10000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000000', 'review-member');
+
+insert into public.contacts (id, version, json_ordered, user_id, state_code, team_id)
+values (
+  '30000000-0000-0000-0000-000000000001',
+  '01.00.000',
+  '{
+    "contactDataSet": {
+      "administrativeInformation": {
+        "publicationAndOwnership": {
+          "common:dataSetVersion": "01.00.000"
+        }
+      }
+    },
+    "payload": {
+      "name": "draft-a"
+    }
+  }'::json,
+  '10000000-0000-0000-0000-000000000002',
+  0,
+  '20000000-0000-0000-0000-000000000001'
+);
+
+insert into public.reviews (id, data_id, data_version, reviewer_id, json, state_code)
+values
+  (
+    '40000000-0000-0000-0000-000000000001',
+    '30000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '["10000000-0000-0000-0000-000000000003"]'::jsonb,
+    '{
+      "user": { "id": "10000000-0000-0000-0000-000000000005" },
+      "data": { "id": "30000000-0000-0000-0000-000000000001", "version": "01.00.000" }
+    }'::jsonb,
+    0
+  ),
+  (
+    '40000000-0000-0000-0000-000000000002',
+    '30000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '["10000000-0000-0000-0000-000000000003"]'::jsonb,
+    '{
+      "user": { "id": "10000000-0000-0000-0000-000000000005" },
+      "data": { "id": "30000000-0000-0000-0000-000000000001", "version": "01.00.000" }
+    }'::jsonb,
+    0
+  );
+
+insert into public.comments (review_id, reviewer_id, json, state_code)
+values (
+  '40000000-0000-0000-0000-000000000001',
+  '10000000-0000-0000-0000-000000000003',
+  '{"comment":"reviewer-a draft"}'::json,
+  0
+);
+
+insert into public.notifications (
+  id,
+  recipient_user_id,
+  sender_user_id,
+  type,
+  dataset_type,
+  dataset_id,
+  dataset_version,
+  json
+)
+values (
+  '50000000-0000-0000-0000-000000000001',
+  '10000000-0000-0000-0000-000000000002',
+  '10000000-0000-0000-0000-000000000001',
+  'validation_issue',
+  'contacts',
+  '30000000-0000-0000-0000-000000000001',
+  '01.00.000',
+  '{"message":"check ownership"}'::jsonb
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000001', true);
+
+update public.teams
+set rank = 99
+where id = '20000000-0000-0000-0000-000000000002';
+
+reset role;
+
+select is(
+  (select rank::text from public.teams where id = '20000000-0000-0000-0000-000000000002'),
+  '2',
+  'team-a admin cannot update team-b'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000003', true);
+
+do $$
+begin
+  begin
+    update public.comments
+    set reviewer_id = '10000000-0000-0000-0000-000000000004'
+    where review_id = '40000000-0000-0000-0000-000000000001'
+      and reviewer_id = '10000000-0000-0000-0000-000000000003';
+  exception
+    when others then
+      null;
+  end;
+end;
+$$;
+
+reset role;
+
+select ok(
+  exists (
+    select 1
+    from public.comments
+    where review_id = '40000000-0000-0000-0000-000000000001'
+      and reviewer_id = '10000000-0000-0000-0000-000000000003'
+  )
+  and not exists (
+    select 1
+    from public.comments
+    where review_id = '40000000-0000-0000-0000-000000000001'
+      and reviewer_id = '10000000-0000-0000-0000-000000000004'
+  ),
+  'reviewer cannot transfer comment ownership to another reviewer'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000003', true);
+
+update public.reviews
+set state_code = 2
+where id = '40000000-0000-0000-0000-000000000001';
+
+reset role;
+
+select is(
+  (select state_code::text from public.reviews where id = '40000000-0000-0000-0000-000000000001'),
+  '0',
+  'assigned reviewer cannot directly update review workflow row'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000002', true);
+
+update public.contacts
+set json_ordered = '{
+  "contactDataSet": {
+    "administrativeInformation": {
+      "publicationAndOwnership": {
+        "common:dataSetVersion": "01.00.000"
+      }
+    }
+  },
+  "payload": {
+    "name": "draft-b"
+  }
+}'::json
+where id = '30000000-0000-0000-0000-000000000001'
+  and version = '01.00.000';
+
+reset role;
+
+select is(
+  (select jsonb_extract_path_text(json, 'payload', 'name') from public.contacts where id = '30000000-0000-0000-0000-000000000001' and version = '01.00.000'),
+  'draft-b',
+  'draft owner can directly update own draft dataset during transition window'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000006', true);
+
+update public.reviews
+set state_code = 1
+where id = '40000000-0000-0000-0000-000000000002';
+
+reset role;
+
+select is(
+  (select state_code::text from public.reviews where id = '40000000-0000-0000-0000-000000000002'),
+  '0',
+  'non-submitter cannot directly update reviews row'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000006', true);
+
+delete from public.notifications
+where id = '50000000-0000-0000-0000-000000000001';
+
+reset role;
+
+select is(
+  (select count(*)::text from public.notifications where id = '50000000-0000-0000-0000-000000000001'),
+  '1',
+  'arbitrary user cannot delete notification row'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#289

## Summary
- Add the Task 0 policy-hardening, constraint, and command-audit migrations in tiangong-lca-next/supabase.
- Add the pgTAP smoke coverage for the six baseline security cases called out in the access-control refactor plan.

## Key Decisions
- Keep the authoritative shared Supabase baseline in tiangong-lca-next/supabase and apply the committed migrations to Supabase dev after local validation.

## Validation
- npx --yes supabase db reset
- npx --yes supabase test db
- npx --yes supabase db push --linked
- npx --yes supabase db push --linked --dry-run
- npx --yes supabase db query --linked -f supabase/tests/20260403_update_security_smoke.sql

## Risks / Rollback
- Remote pgTAP via supabase test db --linked terminated the psql connection, so remote verification used linked SQL execution plus targeted catalog checks instead of the pgTAP harness.

## Workspace Integration
- Workspace integration remains pending until lca-workspace later bumps tiangong-lca-next after the child PRs merge.