### PR TITLE
refactor: cut next dataset services over to app_dataset_* commands

### DIFF
--- a/src/pages/Contacts/Components/edit.tsx
+++ b/src/pages/Contacts/Components/edit.tsx
@@ -24,7 +24,7 @@ import {
   FormContact,
 } from '@/services/contacts/data';
 import { genContactFromData, genContactJsonOrdered } from '@/services/contacts/util';
-import { getRefData, updateStateCodeApi } from '@/services/general/api';
+import { getRefData, publishDatasetApi } from '@/services/general/api';
 import { getReviewUserRoleApi, getUserTeamId } from '@/services/roles/api';
 import type { SupabaseMutationResult } from '@/services/supabase/data';
 import styles from '@/style/custom.less';
@@ -223,7 +223,11 @@ const ContactEdit: FC<Props> = ({
     if (autoClose) setSpinning(true);
     await updateReferenceDescription();
     const formFieldsValue = formRefEdit.current?.getFieldsValue();
-    const updateResult: UpdateContactResult = await updateContact(id, version, formFieldsValue);
+    const updateResult: UpdateContactResult | undefined = await updateContact(
+      id,
+      version,
+      formFieldsValue,
+    );
     if (updateResult?.data) {
       const isRuleVerified = isRuleVerificationPassed(updateResult?.data?.[0]?.rule_verification);
       if (typeof updateResult?.data?.[0]?.state_code === 'number') {
@@ -540,19 +544,40 @@ const ContactEdit: FC<Props> = ({
       return;
     }
 
-    const result = await updateStateCodeApi(currentId, currentVersion, 'contacts', 100);
-    if (!result) {
-      message.error(
-        intl.formatMessage({
-          id: 'pages.action.error',
-          defaultMessage: 'Action failed',
-        }),
-      );
+    const result = await publishDatasetApi<{ state_code?: number }>(
+      'contacts',
+      currentId,
+      currentVersion,
+    );
+    if (!result || result.error || !result.data?.[0]) {
+      if (result?.error?.state_code === 100) {
+        message.error(
+          intl.formatMessage({
+            id: 'pages.review.openData',
+            defaultMessage: 'This data is open data, save failed',
+          }),
+        );
+      } else if (result?.error?.state_code === 20) {
+        message.error(
+          intl.formatMessage({
+            id: 'pages.review.underReview',
+            defaultMessage: 'Data is under review, save failed',
+          }),
+        );
+      } else {
+        message.error(
+          result?.error?.message ??
+            intl.formatMessage({
+              id: 'pages.action.error',
+              defaultMessage: 'Action failed',
+            }),
+        );
+      }
       setSpinning(false);
       return;
     }
 
-    setCurrentStateCode(100);
+    setCurrentStateCode(result.data[0]?.state_code ?? 100);
     actionRef?.current?.reload();
     message.success(
       intl.formatMessage({

--- a/src/pages/Contacts/index.tsx
+++ b/src/pages/Contacts/index.tsx
@@ -227,9 +227,13 @@ const TableList: FC = () => {
                     name: (
                       <ContributeData
                         onOk={async () => {
-                          const { error } = await contributeSource('contacts', row.id, row.version);
-                          if (error) {
-                            console.log(error);
+                          const contributeResult = await contributeSource(
+                            'contacts',
+                            row.id,
+                            row.version,
+                          );
+                          if (contributeResult?.error) {
+                            console.log(contributeResult.error);
                           } else {
                             message.success(
                               intl.formatMessage({

--- a/src/pages/Flowproperties/index.tsx
+++ b/src/pages/Flowproperties/index.tsx
@@ -278,13 +278,13 @@ const TableList: FC = () => {
                     name: (
                       <ContributeData
                         onOk={async () => {
-                          const { error } = await contributeSource(
+                          const contributeResult = await contributeSource(
                             'flowproperties',
                             row.id,
                             row.version,
                           );
-                          if (error) {
-                            console.log(error);
+                          if (contributeResult?.error) {
+                            console.log(contributeResult.error);
                           } else {
                             message.success(
                               intl.formatMessage({

--- a/src/pages/Flows/index.tsx
+++ b/src/pages/Flows/index.tsx
@@ -289,9 +289,13 @@ const TableList: FC = () => {
                     name: (
                       <ContributeData
                         onOk={async () => {
-                          const { error } = await contributeSource('flows', row.id, row.version);
-                          if (error) {
-                            console.log(error);
+                          const contributeResult = await contributeSource(
+                            'flows',
+                            row.id,
+                            row.version,
+                          );
+                          if (contributeResult?.error) {
+                            console.log(contributeResult.error);
                           } else {
                             message.success(
                               intl.formatMessage({

--- a/src/pages/Processes/Components/edit.tsx
+++ b/src/pages/Processes/Components/edit.tsx
@@ -39,6 +39,7 @@ import {
 import { genProcessFromData, genProcessJsonOrdered } from '@/services/processes/util';
 import { getUserTeamId } from '@/services/roles/api';
 import styles from '@/style/custom.less';
+import { isRuleVerificationPassed } from '@/utils/ruleVerification';
 import { CloseOutlined, FormOutlined, ProductOutlined } from '@ant-design/icons';
 import { ActionType, ProForm, ProFormInstance } from '@ant-design/pro-components';
 import { Button, Drawer, Form, Input, Space, Spin, Tooltip, message } from 'antd';
@@ -60,6 +61,7 @@ type ProcessCheckTarget = FormProcessWithDatas & {
   stateCode: number;
   ruleVerification: boolean;
 };
+type HandleSubmitResult = Awaited<ReturnType<typeof updateProcess>>;
 type RefProblemNode = ProblemNode & {
   versionUnderReview?: boolean;
   underReviewVersion?: string;
@@ -396,7 +398,10 @@ const ProcessEdit: FC<Props> = ({
     return nextData;
   };
 
-  const handleSubmit = async (closeDrawer: boolean, options?: { silent?: boolean }) => {
+  const handleSubmit = async (
+    closeDrawer: boolean,
+    options?: { silent?: boolean },
+  ): Promise<HandleSubmitResult> => {
     const silent = options?.silent ?? false;
     if (closeDrawer) setSpinning(true);
     const currentData = getCurrentProcessData();
@@ -505,7 +510,7 @@ const ProcessEdit: FC<Props> = ({
     if (!closeDrawer) {
       return updateResult;
     }
-    return true;
+    return undefined;
   };
 
   const handleCheckData = async (
@@ -713,14 +718,23 @@ const ProcessEdit: FC<Props> = ({
       setSpinning(false);
       return { checkResult: false, unReview: [] as refDataType[] };
     }
+    const updatedProcess = updateResult.data?.[0];
+    if (
+      !updatedProcess?.id ||
+      !updatedProcess?.version ||
+      typeof updatedProcess.state_code !== 'number'
+    ) {
+      setSpinning(false);
+      return { checkResult: false, unReview: [] as refDataType[] };
+    }
     return handleCheckData(
       'checkData',
       {
-        id: updateResult.data[0]?.id,
-        version: updateResult.data[0]?.version,
-        ...genProcessFromData(updateResult.data[0]?.json?.processDataSet),
-        ruleVerification: updateResult.data[0]?.rule_verification,
-        stateCode: updateResult.data[0]?.state_code,
+        id: updatedProcess.id,
+        version: updatedProcess.version,
+        ...genProcessFromData(updatedProcess.json?.processDataSet),
+        ruleVerification: isRuleVerificationPassed(updatedProcess.rule_verification),
+        stateCode: updatedProcess.state_code,
       },
       { silent },
     );
@@ -740,16 +754,25 @@ const ProcessEdit: FC<Props> = ({
       setSpinning(false);
       return;
     }
-    if (!updateResult.data) {
+    if (!updateResult?.data) {
+      setSpinning(false);
+      return;
+    }
+    const updatedProcess = updateResult.data?.[0];
+    if (
+      !updatedProcess?.id ||
+      !updatedProcess?.version ||
+      typeof updatedProcess.state_code !== 'number'
+    ) {
       setSpinning(false);
       return;
     }
     const { checkResult, unReview } = await handleCheckData('review', {
-      id: updateResult.data[0]?.id,
-      version: updateResult.data[0]?.version,
-      ...genProcessFromData(updateResult.data[0]?.json?.processDataSet),
-      ruleVerification: updateResult.data[0]?.rule_verification,
-      stateCode: updateResult.data[0]?.state_code,
+      id: updatedProcess.id,
+      version: updatedProcess.version,
+      ...genProcessFromData(updatedProcess.json?.processDataSet),
+      ruleVerification: isRuleVerificationPassed(updatedProcess.rule_verification),
+      stateCode: updatedProcess.state_code,
     });
 
     if (checkResult) {
@@ -1033,7 +1056,10 @@ const ProcessEdit: FC<Props> = ({
                   return [];
                 },
               }}
-              onFinish={() => handleSubmit(true)}
+              onFinish={async () => {
+                await handleSubmit(true);
+                return true;
+              }}
             >
               <ProcessForm
                 lang={lang}

--- a/src/pages/Sources/Components/edit.tsx
+++ b/src/pages/Sources/Components/edit.tsx
@@ -221,7 +221,7 @@ const SourceEdit: FC<Props> = ({
       });
     }
     const fieldsValue = formRefEdit.current?.getFieldsValue();
-    const result: UpdateSourceResult = await updateSource(id, version, {
+    const result: UpdateSourceResult | undefined = await updateSource(id, version, {
       ...fieldsValue,
       sourceInformation: {
         ...fromData?.sourceInformation,

--- a/src/pages/Sources/index.tsx
+++ b/src/pages/Sources/index.tsx
@@ -232,9 +232,13 @@ const TableList: FC = () => {
                     name: (
                       <ContributeData
                         onOk={async () => {
-                          const { error } = await contributeSource('sources', row.id, row.version);
-                          if (error) {
-                            console.log(error);
+                          const contributeResult = await contributeSource(
+                            'sources',
+                            row.id,
+                            row.version,
+                          );
+                          if (contributeResult?.error) {
+                            console.log(contributeResult.error);
                           } else {
                             message.success(
                               intl.formatMessage({

--- a/src/pages/Unitgroups/index.tsx
+++ b/src/pages/Unitgroups/index.tsx
@@ -252,13 +252,13 @@ const TableList: FC = () => {
                     name: (
                       <ContributeData
                         onOk={async () => {
-                          const { error } = await contributeSource(
+                          const contributeResult = await contributeSource(
                             'unitgroups',
                             row.id,
                             row.version,
                           );
-                          if (error) {
-                            console.log(error);
+                          if (contributeResult?.error) {
+                            console.log(contributeResult.error);
                           } else {
                             message.success(
                               intl.formatMessage({

--- a/src/services/contacts/api.ts
+++ b/src/services/contacts/api.ts
@@ -13,8 +13,8 @@ import { getCachedClassificationData } from '../classifications/cache';
 import {
   getDataDetail,
   getTeamIdByUserId,
+  invokeDatasetCommand,
   normalizeLangPayloadForSave,
-  resolveFunctionInvokeError,
 } from '../general/api';
 import { genContactJsonOrdered } from './util';
 
@@ -77,24 +77,18 @@ export async function updateContact(id: string, version: string, data: any) {
     newData,
     userTeamId,
   );
-  let result: any = {};
-  const session = await supabase.auth.getSession();
-  if (session.data.session) {
-    result = await supabase.functions.invoke('update_data', {
-      headers: {
-        Authorization: `Bearer ${session.data.session?.access_token ?? ''}`,
-      },
-      body: { id, version, table: 'contacts', data: { json_ordered: newData, rule_verification } },
-      region: FunctionRegion.UsEast1,
-    });
-  }
-  if (result.error) {
-    console.log('error', result.error);
-    return {
-      error: await resolveFunctionInvokeError(result.error),
-    };
-  }
-  return result?.data;
+  return invokeDatasetCommand(
+    'app_dataset_save_draft',
+    {
+      id,
+      version,
+      table: 'contacts',
+      jsonOrdered: newData,
+    },
+    {
+      ruleVerification: rule_verification,
+    },
+  );
 }
 
 export async function deleteContact(id: string, version: string) {

--- a/src/services/flowproperties/api.ts
+++ b/src/services/flowproperties/api.ts
@@ -13,8 +13,8 @@ import { getCachedClassificationData } from '../classifications/cache';
 import {
   getDataDetail,
   getTeamIdByUserId,
+  invokeDatasetCommand,
   normalizeLangPayloadForSave,
-  resolveFunctionInvokeError,
 } from '../general/api';
 import { genFlowpropertyJsonOrdered } from './util';
 
@@ -78,29 +78,18 @@ export async function updateFlowproperties(id: string, version: string, data: an
     userTeamId,
   );
 
-  let result: any = {};
-  const session = await supabase.auth.getSession();
-  if (session.data.session) {
-    result = await supabase.functions.invoke('update_data', {
-      headers: {
-        Authorization: `Bearer ${session.data.session?.access_token ?? ''}`,
-      },
-      body: {
-        id,
-        version,
-        table: 'flowproperties',
-        data: { json_ordered: newData, rule_verification },
-      },
-      region: FunctionRegion.UsEast1,
-    });
-  }
-  if (result.error) {
-    console.log('error', result.error);
-    return {
-      error: await resolveFunctionInvokeError(result.error),
-    };
-  }
-  return result?.data;
+  return invokeDatasetCommand(
+    'app_dataset_save_draft',
+    {
+      id,
+      version,
+      table: 'flowproperties',
+      jsonOrdered: newData,
+    },
+    {
+      ruleVerification: rule_verification,
+    },
+  );
 }
 
 export async function deleteFlowproperties(id: string, version: string) {

--- a/src/services/flows/api.ts
+++ b/src/services/flows/api.ts
@@ -13,8 +13,8 @@ import { getCachedFlowCategorizationAll } from '../classifications/cache';
 import {
   getDataDetail,
   getTeamIdByUserId,
+  invokeDatasetCommand,
   normalizeLangPayloadForSave,
-  resolveFunctionInvokeError,
 } from '../general/api';
 import { getILCDLocationByValues } from '../locations/api';
 import { getCachedLocationData } from '../locations/cache';
@@ -134,24 +134,18 @@ export async function updateFlows(id: string, version: string, data: any) {
     newData,
     userTeamId,
   );
-  let result: any = {};
-  const session = await supabase.auth.getSession();
-  if (session.data.session) {
-    result = await supabase.functions.invoke('update_data', {
-      headers: {
-        Authorization: `Bearer ${session.data.session?.access_token ?? ''}`,
-      },
-      body: { id, version, table: 'flows', data: { json_ordered: newData, rule_verification } },
-      region: FunctionRegion.UsEast1,
-    });
-  }
-  if (result.error) {
-    console.log('error', result.error);
-    return {
-      error: await resolveFunctionInvokeError(result.error),
-    };
-  }
-  return result?.data;
+  return invokeDatasetCommand(
+    'app_dataset_save_draft',
+    {
+      id,
+      version,
+      table: 'flows',
+      jsonOrdered: newData,
+    },
+    {
+      ruleVerification: rule_verification,
+    },
+  );
 }
 
 export async function deleteFlows(id: string, version: string) {

--- a/src/services/general/api.ts
+++ b/src/services/general/api.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/services/supabase';
+import type { SupabaseError, SupabaseMutationResult } from '@/services/supabase/data';
 import { normalizeTidasPackageExportErrorMessage } from '@/services/tidasPackage/exportErrors';
 import { FunctionRegion } from '@supabase/supabase-js';
 import { message } from 'antd';
@@ -22,7 +23,20 @@ type InvokeErrorBody = {
   detail?: string;
   error?: string;
   message?: string;
+  details?: unknown;
   state_code?: number;
+  review_state_code?: number;
+};
+
+type ResolvedFunctionInvokeError = {
+  code?: string;
+  detail?: string;
+  details?: unknown;
+  error?: string;
+  message: string;
+  review_state_code?: number;
+  state_code?: number;
+  status?: number;
 };
 
 type GetRefDataOptions = {
@@ -124,6 +138,21 @@ export type TidasPackageRoot = {
   id: string;
   version: string;
 };
+
+type DatasetCommandFunctionName =
+  | 'app_dataset_save_draft'
+  | 'app_dataset_assign_team'
+  | 'app_dataset_publish';
+
+const DATASET_COMMAND_TABLES: readonly TidasPackageRootTable[] = [
+  'contacts',
+  'sources',
+  'unitgroups',
+  'flowproperties',
+  'flows',
+  'processes',
+  'lifecyclemodels',
+] as const;
 
 export type TidasPackageSummary = {
   total_entries: number;
@@ -681,7 +710,102 @@ export async function importTidasPackageApi(file: File) {
 
 const VERSION_PATTERN = /^\d{2}\.\d{2}\.\d{3}$/;
 
-export async function resolveFunctionInvokeError(error: { message?: string; context?: Response }) {
+function isDatasetCommandTable(value: string): value is TidasPackageRootTable {
+  return DATASET_COMMAND_TABLES.includes(value as TidasPackageRootTable);
+}
+
+function extractStateCode(details: unknown): number | undefined {
+  if (!details || typeof details !== 'object') {
+    return undefined;
+  }
+
+  const candidate = details as { state_code?: unknown; review_state_code?: unknown };
+  if (typeof candidate.state_code === 'number') {
+    return candidate.state_code;
+  }
+  if (typeof candidate.review_state_code === 'number') {
+    return candidate.review_state_code;
+  }
+
+  return undefined;
+}
+
+function extractReviewStateCode(details: unknown): number | undefined {
+  if (!details || typeof details !== 'object') {
+    return undefined;
+  }
+
+  const candidate = details as { review_state_code?: unknown };
+  return typeof candidate.review_state_code === 'number' ? candidate.review_state_code : undefined;
+}
+
+function normalizeFunctionInvokeErrorShape(error: {
+  code?: string;
+  details?: unknown;
+  message: string;
+  review_state_code?: number;
+  state_code?: number;
+}): SupabaseError {
+  const normalized = {
+    message: error.message,
+    code: typeof error.code === 'string' ? error.code : 'FUNCTION_ERROR',
+    details: error.details ?? '',
+    hint: '',
+  } as SupabaseError;
+
+  const stateCode =
+    typeof error.state_code === 'number' ? error.state_code : extractStateCode(error.details);
+  if (typeof stateCode === 'number') {
+    normalized.state_code = stateCode;
+  }
+
+  const reviewStateCode =
+    typeof error.review_state_code === 'number'
+      ? error.review_state_code
+      : extractReviewStateCode(error.details);
+  if (typeof reviewStateCode === 'number') {
+    normalized.review_state_code = reviewStateCode;
+  }
+
+  return normalized;
+}
+
+function normalizeDatasetCommandRows<Row extends Record<string, unknown>>(
+  data: unknown,
+  ruleVerification?: boolean | null,
+): Row[] {
+  let payload = data;
+  if (payload && typeof payload === 'object' && !Array.isArray(payload) && 'data' in payload) {
+    payload = (payload as Record<string, unknown>).data;
+  }
+
+  const rows = Array.isArray(payload)
+    ? payload
+    : payload === null || payload === undefined
+      ? []
+      : [payload];
+
+  return rows.map((row) => {
+    if (
+      typeof ruleVerification !== 'boolean' ||
+      !row ||
+      typeof row !== 'object' ||
+      Array.isArray(row)
+    ) {
+      return row as Row;
+    }
+
+    return {
+      ...(row as Record<string, unknown>),
+      rule_verification: ruleVerification,
+    } as unknown as Row;
+  });
+}
+
+export async function resolveFunctionInvokeError(error: {
+  message?: string;
+  context?: Response;
+}): Promise<ResolvedFunctionInvokeError> {
   const fallbackMessage = error?.message || 'Request failed';
   const context = error?.context;
 
@@ -719,6 +843,64 @@ export async function resolveFunctionInvokeError(error: { message?: string; cont
       status: context.status,
     };
   }
+}
+
+export async function invokeDatasetCommand<Row extends Record<string, unknown>>(
+  functionName: DatasetCommandFunctionName,
+  body: Record<string, unknown>,
+  options: { ruleVerification?: boolean | null } = {},
+): Promise<SupabaseMutationResult<Row>> {
+  const session = await supabase.auth.getSession();
+  if (!session.data.session) {
+    return {
+      data: null,
+      error: {
+        message: 'Authentication required',
+        code: 'AUTH_REQUIRED',
+        details: '',
+        hint: '',
+      } as SupabaseError,
+      count: null,
+      status: 401,
+      statusText: 'AUTH_REQUIRED',
+    };
+  }
+
+  const result = await supabase.functions.invoke(functionName, {
+    headers: {
+      Authorization: `Bearer ${session.data.session?.access_token ?? ''}`,
+    },
+    body,
+    region: FunctionRegion.UsEast1,
+  });
+
+  if (result.error) {
+    console.log('error', result.error);
+    const resolved = await resolveFunctionInvokeError(result.error);
+    const normalizedError = normalizeFunctionInvokeErrorShape({
+      message: resolved.message,
+      code: resolved.code,
+      details: resolved.details,
+      review_state_code: resolved.review_state_code,
+      state_code: resolved.state_code,
+    });
+
+    return {
+      data: null,
+      error: normalizedError,
+      count: null,
+      status: resolved.status ?? result.error.context?.status ?? 500,
+      statusText: normalizedError.code,
+    };
+  }
+
+  return {
+    data: normalizeDatasetCommandRows<Row>(result.data, options.ruleVerification),
+    error: null,
+    count: null,
+    status: 200,
+    statusText: 'OK',
+  };
 }
 
 export async function getDataDetail(id: string, version: string, table: string) {
@@ -931,7 +1113,7 @@ export async function getTeamIdByUserId() {
 }
 
 export async function contributeSource(tableName: string, id: string, version: string) {
-  if (!tableName) {
+  if (!tableName || !isDatasetCommandTable(tableName)) {
     return {
       error: true,
       message: 'Contribute failed',
@@ -939,24 +1121,12 @@ export async function contributeSource(tableName: string, id: string, version: s
   }
   const teamId = await getTeamIdByUserId();
   if (teamId) {
-    let result: any = {};
-    const session = await supabase.auth.getSession();
-    if (session.data.session) {
-      result = await supabase.functions.invoke('update_data', {
-        headers: {
-          Authorization: `Bearer ${session.data.session?.access_token ?? ''}`,
-        },
-        body: { id, version, table: tableName, data: { team_id: teamId } },
-        region: FunctionRegion.UsEast1,
-      });
-    }
-    if (result.error) {
-      console.log('error', result.error);
-      return {
-        error: await resolveFunctionInvokeError(result.error),
-      };
-    }
-    return result?.data;
+    return invokeDatasetCommand('app_dataset_assign_team', {
+      id,
+      version,
+      table: tableName,
+      teamId,
+    });
   } else {
     message.error(
       getLocale() === 'zh-CN' ? '您不是任何团队的成员' : 'You are not a member of any team',
@@ -966,6 +1136,16 @@ export async function contributeSource(tableName: string, id: string, version: s
     error: true,
     message: 'Contribute failed',
   };
+}
+
+export async function publishDatasetApi<
+  Row extends Record<string, unknown> = Record<string, unknown>,
+>(tableName: TidasPackageRootTable, id: string, version: string) {
+  return invokeDatasetCommand<Row>('app_dataset_publish', {
+    id,
+    version,
+    table: tableName,
+  });
 }
 
 export async function getAllVersions(

--- a/src/services/processes/api.ts
+++ b/src/services/processes/api.ts
@@ -7,11 +7,13 @@ import { getCurrentUser } from '@/services/auth';
 import {
   contributeSource,
   getRefData,
+  invokeDatasetCommand,
   normalizeLangPayloadForSave,
   resolveFunctionInvokeError,
 } from '@/services/general/api';
 import { getLifeCyclesByIdAndVersion } from '@/services/lifeCycleModels/api';
 import { supabase } from '@/services/supabase';
+import type { SupabaseMutationResult } from '@/services/supabase/data';
 import { FunctionRegion } from '@supabase/supabase-js';
 import { SortOrder } from 'antd/es/table/interface';
 import { getCachedClassificationData } from '../classifications/cache';
@@ -39,7 +41,17 @@ const selectStr4Table = `
     team_id,
     user_id,
     model_id
-  `;
+`;
+
+type ProcessCommandRow = {
+  id?: string;
+  version?: string;
+  json?: { processDataSet?: any };
+  state_code?: number;
+  rule_verification?: boolean;
+};
+
+export type UpdateProcessResult = SupabaseMutationResult<ProcessCommandRow>;
 
 export type LcaMyProcessOption = {
   id: string;
@@ -186,7 +198,12 @@ export async function createProcess(id: string, data: any, modelId?: string) {
   return result;
 }
 
-export async function updateProcess(id: string, version: string, data: any, modelId?: string) {
+export async function updateProcess(
+  id: string,
+  version: string,
+  data: any,
+  modelId?: string,
+): Promise<UpdateProcessResult | undefined> {
   const rawData = genProcessJsonOrdered(id, data);
   const normalizedResult = await normalizeLangPayloadForSave(rawData);
   const newData = normalizedResult?.payload ?? rawData;
@@ -212,27 +229,19 @@ export async function updateProcess(id: string, version: string, data: any, mode
     newData,
     userTeamId,
   );
-  const session = await supabase.auth.getSession();
-  if (!session.data.session) {
-    return undefined;
-  }
-  const result = await supabase.functions.invoke('update_data', {
-    headers: {
-      Authorization: `Bearer ${session.data.session?.access_token ?? ''}`,
-    },
-    body: {
+  return invokeDatasetCommand<ProcessCommandRow>(
+    'app_dataset_save_draft',
+    {
       id,
       version,
       table: 'processes',
-      data: { json_ordered: newData, model_id: modelId, rule_verification },
+      jsonOrdered: newData,
+      modelId,
     },
-    region: FunctionRegion.UsEast1,
-  });
-  if (result.error) {
-    console.error('updateProcess error', result.error);
-    return { error: await resolveFunctionInvokeError(result.error) };
-  }
-  return result?.data;
+    {
+      ruleVerification: rule_verification,
+    },
+  );
 }
 
 export async function updateProcessApi(id: string, version: string, data: any) {

--- a/src/services/sources/api.ts
+++ b/src/services/sources/api.ts
@@ -13,8 +13,8 @@ import { getCachedClassificationData } from '../classifications/cache';
 import {
   getDataDetail,
   getTeamIdByUserId,
+  invokeDatasetCommand,
   normalizeLangPayloadForSave,
-  resolveFunctionInvokeError,
 } from '../general/api';
 import { genSourceJsonOrdered } from './util';
 
@@ -77,24 +77,18 @@ export async function updateSource(id: string, version: string, data: any) {
     newData,
     userTeamId,
   );
-  let result: any = {};
-  const session = await supabase.auth.getSession();
-  if (session.data.session) {
-    result = await supabase.functions.invoke('update_data', {
-      headers: {
-        Authorization: `Bearer ${session.data.session?.access_token ?? ''}`,
-      },
-      body: { id, version, table: 'sources', data: { json_ordered: newData, rule_verification } },
-      region: FunctionRegion.UsEast1,
-    });
-  }
-  if (result.error) {
-    console.log('error', result.error);
-    return {
-      error: await resolveFunctionInvokeError(result.error),
-    };
-  }
-  return result?.data;
+  return invokeDatasetCommand(
+    'app_dataset_save_draft',
+    {
+      id,
+      version,
+      table: 'sources',
+      jsonOrdered: newData,
+    },
+    {
+      ruleVerification: rule_verification,
+    },
+  );
 }
 
 export async function deleteSource(id: string, version: string) {

--- a/src/services/supabase/data.ts
+++ b/src/services/supabase/data.ts
@@ -4,7 +4,10 @@ import type {
   PostgrestSingleResponse,
 } from '@supabase/supabase-js';
 
-export type SupabaseError = PostgrestError & { state_code?: number };
+export type SupabaseError = PostgrestError & {
+  state_code?: number;
+  review_state_code?: number;
+};
 
 export type SupabaseQueryResult<T> = Omit<PostgrestResponse<T>, 'error'> & {
   error: SupabaseError | null;

--- a/src/services/unitgroups/api.ts
+++ b/src/services/unitgroups/api.ts
@@ -13,8 +13,8 @@ import { getCachedClassificationData } from '../classifications/cache';
 import {
   getDataDetail,
   getTeamIdByUserId,
+  invokeDatasetCommand,
   normalizeLangPayloadForSave,
-  resolveFunctionInvokeError,
 } from '../general/api';
 import { genUnitGroupJsonOrdered } from './util';
 
@@ -78,29 +78,18 @@ export async function updateUnitGroup(id: string, version: string, data: any) {
     userTeamId,
   );
 
-  let result: any = {};
-  const session = await supabase.auth.getSession();
-  if (session.data.session) {
-    result = await supabase.functions.invoke('update_data', {
-      headers: {
-        Authorization: `Bearer ${session.data.session?.access_token ?? ''}`,
-      },
-      body: {
-        id,
-        version,
-        table: 'unitgroups',
-        data: { json_ordered: newData, rule_verification },
-      },
-      region: FunctionRegion.UsEast1,
-    });
-  }
-  if (result.error) {
-    console.log('error', result.error);
-    return {
-      error: await resolveFunctionInvokeError(result.error),
-    };
-  }
-  return result?.data;
+  return invokeDatasetCommand(
+    'app_dataset_save_draft',
+    {
+      id,
+      version,
+      table: 'unitgroups',
+      jsonOrdered: newData,
+    },
+    {
+      ruleVerification: rule_verification,
+    },
+  );
 }
 
 export async function deleteUnitGroup(id: string, version: string) {

--- a/tests/unit/pages/Contacts/ContactEdit.test.tsx
+++ b/tests/unit/pages/Contacts/ContactEdit.test.tsx
@@ -383,8 +383,8 @@ jest.mock('@/services/general/api', () => ({
   __esModule: true,
   getDataDetail: jest.fn(() => Promise.resolve({ data: {} })),
   getDataDetailById: jest.fn(() => Promise.resolve({ data: [] })),
+  publishDatasetApi: jest.fn(() => Promise.resolve({ data: [{ state_code: 100 }], error: null })),
   getRefData: jest.fn(() => Promise.resolve({ success: true, data: {} })),
-  updateStateCodeApi: jest.fn(() => Promise.resolve({ updated: true })),
 }));
 
 jest.mock('@/services/general/util', () => ({
@@ -414,7 +414,7 @@ jest.mock('@tiangong-lca/tidas-sdk', () => ({
 
 const { getContactDetail: mockGetContactDetail, updateContact: mockUpdateContact } =
   jest.requireMock('@/services/contacts/api');
-const { getRefData: mockGetRefData, updateStateCodeApi: mockUpdateStateCodeApi } =
+const { getRefData: mockGetRefData, publishDatasetApi: mockPublishDatasetApi } =
   jest.requireMock('@/services/general/api');
 const { showValidationIssueModal: mockShowValidationIssueModal } = jest.requireMock(
   '@/components/ValidationIssueModal',
@@ -486,7 +486,7 @@ describe('ContactEdit component', () => {
         ruleVerification: true,
       },
     });
-    mockUpdateStateCodeApi.mockResolvedValue({ updated: true });
+    mockPublishDatasetApi.mockResolvedValue({ data: [{ state_code: 100 }], error: null });
     Object.values(getMockAntdMessage()).forEach((fn) => fn.mockClear());
   });
 
@@ -699,12 +699,7 @@ describe('ContactEdit component', () => {
     await user.click(syncButton);
 
     await waitFor(() =>
-      expect(mockUpdateStateCodeApi).toHaveBeenCalledWith(
-        'contact-123',
-        '01.00.000',
-        'contacts',
-        100,
-      ),
+      expect(mockPublishDatasetApi).toHaveBeenCalledWith('contacts', 'contact-123', '01.00.000'),
     );
     expect(mockGetRefData).toHaveBeenCalledWith('source-123', '01.00.000', 'sources', 'team-1');
     expect(actionRef.current.reload).toHaveBeenCalled();
@@ -749,12 +744,7 @@ describe('ContactEdit component', () => {
     await waitFor(() =>
       expect(mockGetRefData).toHaveBeenCalledWith('source-1', '1.0.0', 'sources', ''),
     );
-    expect(mockUpdateStateCodeApi).toHaveBeenCalledWith(
-      'contact-123',
-      '01.00.000',
-      'contacts',
-      100,
-    );
+    expect(mockPublishDatasetApi).toHaveBeenCalledWith('contacts', 'contact-123', '01.00.000');
     expect(actionRef.current.reload).toHaveBeenCalledTimes(1);
   });
 
@@ -796,7 +786,7 @@ describe('ContactEdit component', () => {
         'Referenced data {id}({version}) must be open data.',
       );
     });
-    expect(mockUpdateStateCodeApi).not.toHaveBeenCalled();
+    expect(mockPublishDatasetApi).not.toHaveBeenCalled();
   });
 
   it('shows an under-review error when saving is rejected with state_code 20', async () => {
@@ -1259,7 +1249,7 @@ describe('ContactEdit component', () => {
     await user.click(syncButton);
 
     await waitFor(() => expect(getMockAntdMessage().error).toHaveBeenCalledWith('sync blocked'));
-    expect(mockUpdateStateCodeApi).not.toHaveBeenCalled();
+    expect(mockPublishDatasetApi).not.toHaveBeenCalled();
 
     mockUpdateContact.mockResolvedValueOnce({
       data: null,
@@ -1315,7 +1305,7 @@ describe('ContactEdit component', () => {
         'Current contact data is incomplete. Please fill all required fields before syncing.',
       ),
     );
-    expect(mockUpdateStateCodeApi).not.toHaveBeenCalled();
+    expect(mockPublishDatasetApi).not.toHaveBeenCalled();
   });
 
   it('treats a null rule verification as passed when syncing to open data', async () => {
@@ -1374,12 +1364,7 @@ describe('ContactEdit component', () => {
     await user.click(syncButton);
 
     await waitFor(() =>
-      expect(mockUpdateStateCodeApi).toHaveBeenCalledWith(
-        'contact-123',
-        '01.00.000',
-        'contacts',
-        100,
-      ),
+      expect(mockPublishDatasetApi).toHaveBeenCalledWith('contacts', 'contact-123', '01.00.000'),
     );
     expect(getMockAntdMessage().error).not.toHaveBeenCalledWith(
       'Current contact data is incomplete. Please fill all required fields before syncing.',
@@ -1414,12 +1399,7 @@ describe('ContactEdit component', () => {
     await user.click(syncButton);
 
     await waitFor(() =>
-      expect(mockUpdateStateCodeApi).toHaveBeenCalledWith(
-        'contact-123',
-        '01.00.000',
-        'contacts',
-        100,
-      ),
+      expect(mockPublishDatasetApi).toHaveBeenCalledWith('contacts', 'contact-123', '01.00.000'),
     );
     expect(mockGetRefData).not.toHaveBeenCalled();
     expect(mockGetRefTableName).toHaveBeenCalledWith('unknown data set');
@@ -1550,14 +1530,14 @@ describe('ContactEdit component', () => {
         'Contact reference {id}({version}) must match the current contact ID and version.',
       ),
     );
-    expect(mockUpdateStateCodeApi).not.toHaveBeenCalled();
+    expect(mockPublishDatasetApi).not.toHaveBeenCalled();
   });
 
   it('shows an action error when state-code update fails during sync', async () => {
     const user = userEvent.setup();
     mockGetReviewUserRoleApi.mockResolvedValue({ user_id: 'review-admin-1', role: 'review-admin' });
     mockGetAllRefObj.mockReturnValue([]);
-    mockUpdateStateCodeApi.mockResolvedValueOnce(null);
+    mockPublishDatasetApi.mockResolvedValueOnce(null);
 
     renderWithProviders(
       <ContactEdit

--- a/tests/unit/services/contacts/api.test.ts
+++ b/tests/unit/services/contacts/api.test.ts
@@ -20,12 +20,8 @@ jest.mock('@/services/contacts/util');
 
 describe('Contacts API Service', () => {
   const { supabase } = jest.requireMock('@/services/supabase');
-  const {
-    getTeamIdByUserId,
-    getDataDetail,
-    normalizeLangPayloadForSave,
-    resolveFunctionInvokeError,
-  } = jest.requireMock('@/services/general/api');
+  const { getTeamIdByUserId, getDataDetail, invokeDatasetCommand, normalizeLangPayloadForSave } =
+    jest.requireMock('@/services/general/api');
   const { getCachedClassificationData } = jest.requireMock('@/services/classifications/cache');
   const { getLangText, jsonToList, genClassificationZH, classificationToString } =
     jest.requireMock('@/services/general/util');
@@ -67,8 +63,6 @@ describe('Contacts API Service', () => {
       payload: value,
       validationError: undefined,
     }));
-    resolveFunctionInvokeError.mockImplementation(async (error: any) => error);
-
     getLangText.mockImplementation((value: any) => value?.[0]?.['#text'] || '');
     jsonToList.mockImplementation((value: any) => (Array.isArray(value) ? value : [value]));
     genClassificationZH.mockReturnValue([{ '@level': '0', '#text': 'Test Classification' }]);
@@ -161,19 +155,12 @@ describe('Contacts API Service', () => {
   describe('updateContact', () => {
     it('should update contact via edge function with session', async () => {
       const { updateContact } = require('@/services/contacts/api');
-
-      mockAuth.mockResolvedValue({
-        data: {
-          session: {
-            access_token: 'test-token',
-            user: { id: 'user-123' },
-          },
-        },
-      });
-
-      mockFunctions.mockResolvedValue({
-        data: { success: true, id: 'contact-123' },
+      invokeDatasetCommand.mockResolvedValue({
+        data: [{ id: 'contact-123', rule_verification: true }],
         error: null,
+        count: null,
+        status: 200,
+        statusText: 'OK',
       });
 
       const testData = {
@@ -186,62 +173,56 @@ describe('Contacts API Service', () => {
 
       const result = await updateContact('contact-123', 'v1.0', testData);
 
-      expect(mockAuth).toHaveBeenCalled();
-      expect(mockFunctions).toHaveBeenCalledWith('update_data', {
-        headers: {
-          Authorization: 'Bearer test-token',
-        },
-        body: {
+      expect(invokeDatasetCommand).toHaveBeenCalledWith(
+        'app_dataset_save_draft',
+        {
           id: 'contact-123',
           version: 'v1.0',
           table: 'contacts',
-          data: {
-            json_ordered: expect.any(Object),
-            rule_verification: true,
-          },
+          jsonOrdered: expect.any(Object),
         },
-        region: expect.any(String),
+        {
+          ruleVerification: true,
+        },
+      );
+      expect(result).toEqual({
+        data: [{ id: 'contact-123', rule_verification: true }],
+        error: null,
+        count: null,
+        status: 200,
+        statusText: 'OK',
       });
-      expect(result.success).toBe(true);
     });
 
     it('should not update contact when no session', async () => {
       const { updateContact } = require('@/services/contacts/api');
-
-      mockAuth.mockResolvedValue({
-        data: { session: null },
-      });
+      invokeDatasetCommand.mockResolvedValue(undefined);
 
       const result = await updateContact('contact-123', 'v1.0', {});
 
-      expect(mockFunctions).not.toHaveBeenCalled();
+      expect(invokeDatasetCommand).toHaveBeenCalled();
       expect(result).toBeUndefined();
     });
 
     it('should handle edge function error', async () => {
       const { updateContact } = require('@/services/contacts/api');
-
-      mockAuth.mockResolvedValue({
-        data: {
-          session: {
-            access_token: 'test-token',
-          },
-        },
-      });
-
-      mockFunctions.mockResolvedValue({
+      invokeDatasetCommand.mockResolvedValue({
         data: null,
-        error: { message: 'Update failed' },
+        error: { message: 'Update failed', code: 'FUNCTION_ERROR', details: '', hint: '' },
+        count: null,
+        status: 500,
+        statusText: 'FUNCTION_ERROR',
       });
-
-      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
 
       const result = await updateContact('contact-123', 'v1.0', {});
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('error', { message: 'Update failed' });
-      expect(result).toEqual({ error: { message: 'Update failed' } });
-
-      consoleLogSpy.mockRestore();
+      expect(result).toEqual({
+        data: null,
+        error: { message: 'Update failed', code: 'FUNCTION_ERROR', details: '', hint: '' },
+        count: null,
+        status: 500,
+        statusText: 'FUNCTION_ERROR',
+      });
     });
 
     it('should return a validation error when language normalization fails during update', async () => {
@@ -254,7 +235,7 @@ describe('Contacts API Service', () => {
 
       const result = await updateContact('contact-123', 'v1.0', {});
 
-      expect(mockFunctions).not.toHaveBeenCalled();
+      expect(invokeDatasetCommand).not.toHaveBeenCalled();
       expect(result).toMatchObject({
         data: null,
         status: 400,
@@ -273,16 +254,12 @@ describe('Contacts API Service', () => {
         payload: undefined,
         validationError: undefined,
       });
-      mockAuth.mockResolvedValue({
-        data: {
-          session: {
-            user: { id: 'user-123' },
-          },
-        },
-      });
-      mockFunctions.mockResolvedValue({
-        data: { success: true },
+      invokeDatasetCommand.mockResolvedValue({
+        data: [{ success: true, rule_verification: true }],
         error: null,
+        count: null,
+        status: 200,
+        statusText: 'OK',
       });
 
       const result = await updateContact('contact-123', 'v1.0', {
@@ -293,24 +270,27 @@ describe('Contacts API Service', () => {
         },
       });
 
-      expect(mockFunctions).toHaveBeenCalledWith('update_data', {
-        headers: {
-          Authorization: 'Bearer ',
-        },
-        body: {
+      expect(invokeDatasetCommand).toHaveBeenCalledWith(
+        'app_dataset_save_draft',
+        {
           id: 'contact-123',
           version: 'v1.0',
           table: 'contacts',
-          data: {
-            json_ordered: expect.objectContaining({
-              contactDataSet: expect.any(Object),
-            }),
-            rule_verification: true,
-          },
+          jsonOrdered: expect.objectContaining({
+            contactDataSet: expect.any(Object),
+          }),
         },
-        region: expect.any(String),
+        {
+          ruleVerification: true,
+        },
+      );
+      expect(result).toEqual({
+        data: [{ success: true, rule_verification: true }],
+        error: null,
+        count: null,
+        status: 200,
+        statusText: 'OK',
       });
-      expect(result).toEqual({ success: true });
     });
   });
 

--- a/tests/unit/services/flowproperties/api.test.ts
+++ b/tests/unit/services/flowproperties/api.test.ts
@@ -26,7 +26,6 @@ import {
   getReferenceUnitGroups,
   updateFlowproperties,
 } from '@/services/flowproperties/api';
-import { FunctionRegion } from '@supabase/supabase-js';
 import { createMockSession, createQueryBuilder } from '../../../helpers/mockBuilders';
 import { mockILCDClassificationResponse, mockMultilingualText } from '../../../helpers/testData';
 
@@ -67,8 +66,8 @@ jest.mock('@/services/classifications/cache', () => ({
 jest.mock('@/services/general/api', () => ({
   getDataDetail: jest.fn(),
   getTeamIdByUserId: jest.fn(),
+  invokeDatasetCommand: jest.fn(),
   normalizeLangPayloadForSave: jest.fn(),
-  resolveFunctionInvokeError: jest.fn(),
 }));
 
 const { supabase } = jest.requireMock('@/services/supabase');
@@ -76,12 +75,8 @@ const { genFlowpropertyJsonOrdered } = jest.requireMock('@/services/flowproperti
 const { getLangText, classificationToString, jsonToList, genClassificationZH } =
   jest.requireMock('@/services/general/util');
 const { getCachedClassificationData } = jest.requireMock('@/services/classifications/cache');
-const {
-  getDataDetail,
-  getTeamIdByUserId,
-  normalizeLangPayloadForSave,
-  resolveFunctionInvokeError,
-} = jest.requireMock('@/services/general/api');
+const { getDataDetail, getTeamIdByUserId, invokeDatasetCommand, normalizeLangPayloadForSave } =
+  jest.requireMock('@/services/general/api');
 const { createFlowProperty: mockCreateFlowProperty } = jest.requireMock('@tiangong-lca/tidas-sdk');
 
 describe('FlowProperties API Service (src/services/flowproperties/api.ts)', () => {
@@ -90,11 +85,17 @@ describe('FlowProperties API Service (src/services/flowproperties/api.ts)', () =
   beforeEach(() => {
     jest.clearAllMocks();
     supabase.auth.getSession.mockResolvedValue(mockSession);
+    invokeDatasetCommand.mockResolvedValue({
+      data: [],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: 'OK',
+    });
     normalizeLangPayloadForSave.mockImplementation(async (payload: any) => ({
       payload,
       validationError: undefined,
     }));
-    resolveFunctionInvokeError.mockImplementation(async (error: any) => error);
     // Setup default SDK mock behavior
     mockCreateFlowProperty.mockReturnValue({
       validateEnhanced: jest.fn().mockReturnValue({ success: true }),
@@ -221,63 +222,74 @@ describe('FlowProperties API Service (src/services/flowproperties/api.ts)', () =
       const mockVersion = '1.0.0';
       const mockData = { flowPropertiesInformation: {} };
       const mockOrderedData = { ordered: true };
-      const mockFunctionResult = { data: { success: true }, error: null };
+      const mockFunctionResult = {
+        data: [{ id: mockId, rule_verification: true }],
+        error: null,
+        count: null,
+        status: 200,
+        statusText: 'OK',
+      };
       const mockValidateEnhanced = jest.fn().mockReturnValue({ success: true });
 
       genFlowpropertyJsonOrdered.mockReturnValue(mockOrderedData);
       mockCreateFlowProperty.mockReturnValue({
         validateEnhanced: mockValidateEnhanced,
       });
-      supabase.functions.invoke.mockResolvedValue(mockFunctionResult);
+      invokeDatasetCommand.mockResolvedValue(mockFunctionResult);
 
       const result = await updateFlowproperties(mockId, mockVersion, mockData);
 
-      expect(supabase.auth.getSession).toHaveBeenCalled();
-      expect(supabase.functions.invoke).toHaveBeenCalledWith('update_data', {
-        headers: {
-          Authorization: 'Bearer test-token',
-        },
-        body: {
+      expect(invokeDatasetCommand).toHaveBeenCalledWith(
+        'app_dataset_save_draft',
+        {
           id: mockId,
           version: mockVersion,
           table: 'flowproperties',
-          data: {
-            json_ordered: mockOrderedData,
-            rule_verification: true,
-          },
+          jsonOrdered: mockOrderedData,
         },
-        region: FunctionRegion.UsEast1,
-      });
-      expect(result).toEqual({ success: true });
+        {
+          ruleVerification: true,
+        },
+      );
+      expect(result).toEqual(mockFunctionResult);
     });
 
     it('should handle edge function error', async () => {
-      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
       genFlowpropertyJsonOrdered.mockReturnValue({});
       mockCreateFlowProperty.mockReturnValue({
         validateEnhanced: jest.fn().mockReturnValue({ success: true }),
       });
 
-      const mockError = { message: 'Update failed' };
-      supabase.functions.invoke.mockResolvedValue({ data: null, error: mockError });
+      const mockError = { message: 'Update failed', code: 'FUNCTION_ERROR', details: '', hint: '' };
+      invokeDatasetCommand.mockResolvedValue({
+        data: null,
+        error: mockError,
+        count: null,
+        status: 500,
+        statusText: 'FUNCTION_ERROR',
+      });
 
       const result = await updateFlowproperties('id', 'version', {});
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('error', mockError);
-      expect(result).toEqual({ error: mockError });
-      consoleLogSpy.mockRestore();
+      expect(result).toEqual({
+        data: null,
+        error: mockError,
+        count: null,
+        status: 500,
+        statusText: 'FUNCTION_ERROR',
+      });
     });
 
     it('should return undefined when no session is available', async () => {
-      supabase.auth.getSession.mockResolvedValueOnce({ data: { session: null } });
       genFlowpropertyJsonOrdered.mockReturnValue({});
       mockCreateFlowProperty.mockReturnValue({
         validateEnhanced: jest.fn().mockReturnValue({ success: true }),
       });
+      invokeDatasetCommand.mockResolvedValue(undefined);
 
       const result = await updateFlowproperties('id', 'version', {});
 
-      expect(supabase.functions.invoke).not.toHaveBeenCalled();
+      expect(invokeDatasetCommand).toHaveBeenCalled();
       expect(result).toBeUndefined();
     });
 
@@ -300,31 +312,30 @@ describe('FlowProperties API Service (src/services/flowproperties/api.ts)', () =
         statusText: 'LANG_VALIDATION_ERROR',
         count: null,
       });
-      expect(supabase.functions.invoke).not.toHaveBeenCalled();
+      expect(invokeDatasetCommand).not.toHaveBeenCalled();
     });
 
     it('should invoke update_data with an empty bearer token when the session token is missing', async () => {
-      supabase.auth.getSession.mockResolvedValueOnce({
-        data: {
-          session: {
-            access_token: undefined,
-            user: {
-              id: 'user-123',
-            },
-          },
-        },
-      });
       genFlowpropertyJsonOrdered.mockReturnValue({});
-      supabase.functions.invoke.mockResolvedValue({ data: { success: true }, error: null });
+      invokeDatasetCommand.mockResolvedValue({
+        data: [{ success: true, rule_verification: true }],
+        error: null,
+        count: null,
+        status: 200,
+        statusText: 'OK',
+      });
 
       await updateFlowproperties('id', '01.00.000', {});
 
-      expect(supabase.functions.invoke).toHaveBeenCalledWith(
-        'update_data',
+      expect(invokeDatasetCommand).toHaveBeenCalledWith(
+        'app_dataset_save_draft',
         expect.objectContaining({
-          headers: {
-            Authorization: 'Bearer ',
-          },
+          id: 'id',
+          version: '01.00.000',
+          table: 'flowproperties',
+        }),
+        expect.objectContaining({
+          ruleVerification: true,
         }),
       );
     });
@@ -335,7 +346,13 @@ describe('FlowProperties API Service (src/services/flowproperties/api.ts)', () =
         payload: undefined,
         validationError: undefined,
       });
-      supabase.functions.invoke.mockResolvedValue({ data: { success: true }, error: null });
+      invokeDatasetCommand.mockResolvedValue({
+        data: [{ success: true, rule_verification: true }],
+        error: null,
+        count: null,
+        status: 200,
+        statusText: 'OK',
+      });
 
       await updateFlowproperties('id', '01.00.000', {});
 
@@ -343,14 +360,13 @@ describe('FlowProperties API Service (src/services/flowproperties/api.ts)', () =
         ordered: true,
         fallback: 'raw-update',
       });
-      expect(supabase.functions.invoke).toHaveBeenCalledWith(
-        'update_data',
+      expect(invokeDatasetCommand).toHaveBeenCalledWith(
+        'app_dataset_save_draft',
         expect.objectContaining({
-          body: expect.objectContaining({
-            data: expect.objectContaining({
-              json_ordered: { ordered: true, fallback: 'raw-update' },
-            }),
-          }),
+          jsonOrdered: { ordered: true, fallback: 'raw-update' },
+        }),
+        expect.objectContaining({
+          ruleVerification: true,
         }),
       );
     });

--- a/tests/unit/services/flows/api.test.ts
+++ b/tests/unit/services/flows/api.test.ts
@@ -72,15 +72,15 @@ const { getCachedFlowCategorizationAll: mockGetCachedFlowCategorizationAll } = j
 jest.mock('@/services/general/api', () => ({
   getDataDetail: jest.fn(),
   getTeamIdByUserId: jest.fn(),
+  invokeDatasetCommand: jest.fn(),
   normalizeLangPayloadForSave: jest.fn(),
-  resolveFunctionInvokeError: jest.fn(async (error: any) => error),
 }));
 
 const {
   getDataDetail: mockGetDataDetail,
   getTeamIdByUserId: mockGetTeamIdByUserId,
+  invokeDatasetCommand: mockInvokeDatasetCommand,
   normalizeLangPayloadForSave: mockNormalizeLangPayloadForSave,
-  resolveFunctionInvokeError: mockResolveFunctionInvokeError,
 } = jest.requireMock('@/services/general/api');
 
 class MockQuery<T = any> {
@@ -235,11 +235,17 @@ beforeEach(() => {
 
   mockGetDataDetail.mockResolvedValue({ data: null });
   mockGetTeamIdByUserId.mockResolvedValue(null);
+  mockInvokeDatasetCommand.mockResolvedValue({
+    data: [],
+    error: null,
+    count: null,
+    status: 200,
+    statusText: 'OK',
+  });
   mockNormalizeLangPayloadForSave.mockImplementation(async (payload: any) => ({
     payload,
     validationError: undefined,
   }));
-  mockResolveFunctionInvokeError.mockImplementation(async (error: any) => error);
 
   mockAuthGetSession.mockResolvedValue({
     data: {
@@ -299,49 +305,61 @@ describe('createFlows', () => {
 
 describe('updateFlows', () => {
   it('invokes supabase edge function with ordered data', async () => {
-    const updateResult = { data: [{ id: 'flow-id', rule_verification: true }] };
-    mockFunctionsInvoke.mockResolvedValue(updateResult);
+    const updateResult = {
+      data: [{ id: 'flow-id', rule_verification: true }],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: 'OK',
+    };
+    mockInvokeDatasetCommand.mockResolvedValue(updateResult);
 
     const response = await updateFlows('flow-id', '01.00.000', { name: 'Updated flow' });
 
     expect(mockGenFlowJsonOrdered).toHaveBeenCalledWith('flow-id', { name: 'Updated flow' });
-    expect(mockFunctionsInvoke).toHaveBeenCalledWith('update_data', {
-      headers: {
-        Authorization: 'Bearer token',
-      },
-      body: {
+    expect(mockInvokeDatasetCommand).toHaveBeenCalledWith(
+      'app_dataset_save_draft',
+      {
         id: 'flow-id',
         version: '01.00.000',
         table: 'flows',
-        data: expect.objectContaining({
-          json_ordered: expect.objectContaining({ id: 'flow-id' }),
-          rule_verification: true,
-        }),
+        jsonOrdered: expect.objectContaining({ id: 'flow-id' }),
       },
-      region: FunctionRegion.UsEast1,
-    });
-    expect(response).toBe(updateResult.data);
+      {
+        ruleVerification: true,
+      },
+    );
+    expect(response).toBe(updateResult);
   });
 
   it('returns undefined when no active session is found', async () => {
-    mockAuthGetSession.mockResolvedValue({ data: { session: null } });
+    mockInvokeDatasetCommand.mockResolvedValue(undefined);
 
     const response = await updateFlows('flow-id', '01.00.000', { name: 'Updated flow' });
 
-    expect(mockFunctionsInvoke).not.toHaveBeenCalled();
+    expect(mockInvokeDatasetCommand).toHaveBeenCalled();
     expect(response).toBeUndefined();
   });
 
   it('logs edge-function errors and returns the resolved error payload', async () => {
-    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
-    const mockError = { message: 'update failed' };
-    mockFunctionsInvoke.mockResolvedValue({ data: null, error: mockError });
+    const mockError = { message: 'update failed', code: 'FUNCTION_ERROR', details: '', hint: '' };
+    mockInvokeDatasetCommand.mockResolvedValue({
+      data: null,
+      error: mockError,
+      count: null,
+      status: 500,
+      statusText: 'FUNCTION_ERROR',
+    });
 
     const response = await updateFlows('flow-id', '01.00.000', { name: 'Updated flow' });
 
-    expect(consoleLogSpy).toHaveBeenCalledWith('error', mockError);
-    expect(response).toEqual({ error: mockError });
-    consoleLogSpy.mockRestore();
+    expect(response).toEqual({
+      data: null,
+      error: mockError,
+      count: null,
+      status: 500,
+      statusText: 'FUNCTION_ERROR',
+    });
   });
 
   it('returns a language validation error before invoking the update edge function', async () => {
@@ -352,7 +370,7 @@ describe('updateFlows', () => {
 
     const response = await updateFlows('flow-id', '01.00.000', { name: 'Updated flow' });
 
-    expect(mockFunctionsInvoke).not.toHaveBeenCalled();
+    expect(mockInvokeDatasetCommand).not.toHaveBeenCalled();
     expect(response).toEqual(
       expect.objectContaining({
         data: null,
@@ -367,21 +385,25 @@ describe('updateFlows', () => {
   });
 
   it('uses an empty bearer token when the session lacks an access token', async () => {
-    mockAuthGetSession.mockResolvedValueOnce({
-      data: {
-        session: {
-          user: { id: 'user-id' },
-        },
-      },
+    mockInvokeDatasetCommand.mockResolvedValue({
+      data: [{ id: 'flow-id', rule_verification: true }],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: 'OK',
     });
-    mockFunctionsInvoke.mockResolvedValue({ data: [{ id: 'flow-id' }] });
 
     await updateFlows('flow-id', '01.00.000', { name: 'Updated flow' });
 
-    expect(mockFunctionsInvoke).toHaveBeenCalledWith(
-      'update_data',
+    expect(mockInvokeDatasetCommand).toHaveBeenCalledWith(
+      'app_dataset_save_draft',
       expect.objectContaining({
-        headers: { Authorization: 'Bearer ' },
+        id: 'flow-id',
+        version: '01.00.000',
+        table: 'flows',
+      }),
+      expect.objectContaining({
+        ruleVerification: true,
       }),
     );
   });

--- a/tests/unit/services/general/api.test.ts
+++ b/tests/unit/services/general/api.test.ts
@@ -137,6 +137,11 @@ afterEach(() => {
 const sampleId = '12345678-1234-1234-1234-123456789012';
 const sampleVersion = '01.00.000';
 
+const createErrorContext = (body: Record<string, unknown>, status: number) => ({
+  status,
+  text: jest.fn().mockResolvedValue(JSON.stringify(body)),
+});
+
 describe('exportDataApi', () => {
   it('should select lifecycle model fields when table is lifecyclemodels', async () => {
     const resultPayload = { data: [{ json_ordered: { foo: 'bar' }, json_tg: {} }] };
@@ -531,6 +536,100 @@ describe('updateStateCodeApi', () => {
   });
 });
 
+describe('invokeDatasetCommand', () => {
+  it('normalizes command envelopes into legacy mutation results', async () => {
+    mockAuthGetSession.mockResolvedValue({ data: { session: { access_token: 'token-cmd' } } });
+    mockFunctionsInvoke.mockResolvedValue({
+      data: {
+        ok: true,
+        command: 'dataset_save_draft',
+        data: {
+          id: sampleId,
+          version: sampleVersion,
+        },
+      },
+      error: null,
+    });
+
+    const result = await generalApi.invokeDatasetCommand(
+      'app_dataset_save_draft',
+      {
+        id: sampleId,
+        version: sampleVersion,
+        table: 'flows',
+        jsonOrdered: { ordered: true },
+      },
+      {
+        ruleVerification: false,
+      },
+    );
+
+    expect(mockFunctionsInvoke).toHaveBeenCalledWith('app_dataset_save_draft', {
+      headers: { Authorization: 'Bearer token-cmd' },
+      body: {
+        id: sampleId,
+        version: sampleVersion,
+        table: 'flows',
+        jsonOrdered: { ordered: true },
+      },
+      region: expect.anything(),
+    });
+    expect(result).toEqual({
+      data: [
+        {
+          id: sampleId,
+          version: sampleVersion,
+          rule_verification: false,
+        },
+      ],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: 'OK',
+    });
+  });
+
+  it('flattens command error details back into the legacy error shape', async () => {
+    mockAuthGetSession.mockResolvedValue({ data: { session: { access_token: 'token-cmd' } } });
+    mockFunctionsInvoke.mockResolvedValue({
+      data: null,
+      error: {
+        message: 'Forbidden',
+        context: createErrorContext(
+          {
+            code: 'DATA_UNDER_REVIEW',
+            message: 'Data is under review and cannot be modified',
+            details: {
+              state_code: 20,
+              review_state_code: 20,
+            },
+          },
+          403,
+        ),
+      },
+    });
+
+    const result = await generalApi.invokeDatasetCommand('app_dataset_save_draft', {
+      id: sampleId,
+      version: sampleVersion,
+      table: 'flows',
+      jsonOrdered: { ordered: true },
+    });
+
+    expect(result).toEqual({
+      data: null,
+      error: expect.objectContaining({
+        message: 'Data is under review and cannot be modified',
+        code: 'DATA_UNDER_REVIEW',
+        state_code: 20,
+      }),
+      count: null,
+      status: 403,
+      statusText: 'DATA_UNDER_REVIEW',
+    });
+  });
+});
+
 describe('getReviewsOfData', () => {
   it('should return reviews array when present', async () => {
     const payload = { data: [{ reviews: ['review-1'] }] };
@@ -654,21 +753,34 @@ describe('contributeSource', () => {
       ],
     });
     mockFrom.mockReturnValueOnce(rolesBuilder);
-    mockFunctionsInvoke.mockResolvedValue({ data: { contributed: true } });
+    mockFunctionsInvoke.mockResolvedValue({
+      data: {
+        ok: true,
+        command: 'dataset_assign_team',
+        data: { id: sampleId, team_id: 'team-123' },
+      },
+      error: null,
+    });
 
     const result = await generalApi.contributeSource('flows', sampleId, sampleVersion);
 
-    expect(mockFunctionsInvoke).toHaveBeenCalledWith('update_data', {
+    expect(mockFunctionsInvoke).toHaveBeenCalledWith('app_dataset_assign_team', {
       headers: { Authorization: 'Bearer token-3' },
       body: {
         id: sampleId,
         version: sampleVersion,
         table: 'flows',
-        data: { team_id: 'team-123' },
+        teamId: 'team-123',
       },
       region: expect.anything(),
     });
-    expect(result).toEqual({ contributed: true });
+    expect(result).toEqual({
+      data: [{ id: sampleId, team_id: 'team-123' }],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: 'OK',
+    });
   });
 
   it('should show error when user is not in a team', async () => {
@@ -705,19 +817,59 @@ describe('contributeSource', () => {
       data: [{ user_id: 'user-1', team_id: 'team-empty-token', role: 'member' }],
     });
     mockFrom.mockReturnValueOnce(rolesBuilder);
-    mockFunctionsInvoke.mockResolvedValue({ data: { contributed: true } });
+    mockFunctionsInvoke.mockResolvedValue({
+      data: {
+        ok: true,
+        command: 'dataset_assign_team',
+        data: { id: sampleId, team_id: 'team-empty-token' },
+      },
+      error: null,
+    });
 
     await generalApi.contributeSource('sources', sampleId, sampleVersion);
 
-    expect(mockFunctionsInvoke).toHaveBeenCalledWith('update_data', {
+    expect(mockFunctionsInvoke).toHaveBeenCalledWith('app_dataset_assign_team', {
       headers: { Authorization: 'Bearer ' },
       body: {
         id: sampleId,
         version: sampleVersion,
         table: 'sources',
-        data: { team_id: 'team-empty-token' },
+        teamId: 'team-empty-token',
       },
       region: expect.anything(),
+    });
+  });
+});
+
+describe('publishDatasetApi', () => {
+  it('publishes a dataset through the dedicated command boundary', async () => {
+    mockAuthGetSession.mockResolvedValue({ data: { session: { access_token: 'token-publish' } } });
+    mockFunctionsInvoke.mockResolvedValue({
+      data: {
+        ok: true,
+        command: 'dataset_publish',
+        data: { id: sampleId, state_code: 100 },
+      },
+      error: null,
+    });
+
+    const result = await generalApi.publishDatasetApi('contacts', sampleId, sampleVersion);
+
+    expect(mockFunctionsInvoke).toHaveBeenCalledWith('app_dataset_publish', {
+      headers: { Authorization: 'Bearer token-publish' },
+      body: {
+        id: sampleId,
+        version: sampleVersion,
+        table: 'contacts',
+      },
+      region: expect.anything(),
+    });
+    expect(result).toEqual({
+      data: [{ id: sampleId, state_code: 100 }],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: 'OK',
     });
   });
 });
@@ -1499,12 +1651,40 @@ describe('Edge Cases and Error Handling', () => {
         data: [{ user_id: 'user-1', team_id: 'team-123', role: 'member' }],
       });
       mockFrom.mockReturnValueOnce(rolesBuilder);
-      mockFunctionsInvoke.mockResolvedValue({ error: { message: 'Network error' } });
+      mockFunctionsInvoke.mockResolvedValue({
+        data: null,
+        error: {
+          message: 'Forbidden',
+          context: createErrorContext(
+            {
+              code: 'TEAM_MEMBERSHIP_REQUIRED',
+              message: 'You must belong to the target team before assigning dataset ownership',
+              details: {
+                state_code: 403,
+              },
+            },
+            403,
+          ),
+        },
+      });
       const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
 
-      await generalApi.contributeSource('flows', sampleId, sampleVersion);
+      const result = await generalApi.contributeSource('flows', sampleId, sampleVersion);
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('error', { message: 'Network error' });
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ message: 'Forbidden' }),
+      );
+      expect(result).toEqual({
+        data: null,
+        error: expect.objectContaining({
+          code: 'TEAM_MEMBERSHIP_REQUIRED',
+          state_code: 403,
+        }),
+        count: null,
+        status: 403,
+        statusText: 'TEAM_MEMBERSHIP_REQUIRED',
+      });
 
       consoleLogSpy.mockRestore();
     });

--- a/tests/unit/services/processes/api.test.ts
+++ b/tests/unit/services/processes/api.test.ts
@@ -36,6 +36,7 @@ jest.mock('@/services/supabase', () => ({
 const mockGetTeamIdByUserId = jest.fn();
 const mockGetRefData = jest.fn();
 const mockContributeSource = jest.fn();
+const mockInvokeDatasetCommand = jest.fn();
 const mockNormalizeLangPayloadForSave = jest.fn();
 const mockResolveFunctionInvokeError = jest.fn();
 
@@ -44,6 +45,7 @@ jest.mock('@/services/general/api', () => ({
   getTeamIdByUserId: (...args: any[]) => mockGetTeamIdByUserId.apply(null, args),
   getRefData: (...args: any[]) => mockGetRefData.apply(null, args),
   contributeSource: (...args: any[]) => mockContributeSource.apply(null, args),
+  invokeDatasetCommand: (...args: any[]) => mockInvokeDatasetCommand.apply(null, args),
   normalizeLangPayloadForSave: (...args: any[]) =>
     mockNormalizeLangPayloadForSave.apply(null, args),
   resolveFunctionInvokeError: (...args: any[]) => mockResolveFunctionInvokeError.apply(null, args),
@@ -138,6 +140,7 @@ beforeEach(() => {
   mockFunctionsInvoke.mockReset();
   mockRpc.mockReset();
   mockGetTeamIdByUserId.mockReset();
+  mockInvokeDatasetCommand.mockReset();
   mockNormalizeLangPayloadForSave.mockReset();
   mockResolveFunctionInvokeError.mockReset();
   mockGetCachedLocationData.mockReset();
@@ -164,6 +167,13 @@ beforeEach(() => {
   mockGetCachedLocationData.mockResolvedValue([]);
   mockGetCachedClassificationData.mockResolvedValue({});
   mockGetLifeCyclesByIdAndVersion.mockResolvedValue({ data: [] });
+  mockInvokeDatasetCommand.mockResolvedValue({
+    data: [],
+    error: null,
+    count: null,
+    status: 200,
+    statusText: 'OK',
+  });
   mockNormalizeLangPayloadForSave.mockResolvedValue(undefined);
   mockResolveFunctionInvokeError.mockImplementation(async (error: any) => error);
   mockValidateDatasetRuleVerification.mockResolvedValue({ ruleVerification: true });
@@ -376,88 +386,83 @@ describe('createProcess', () => {
 
 describe('updateProcess', () => {
   it('invokes update function with ordered payload when session exists', async () => {
-    mockAuthGetSession.mockResolvedValueOnce({
-      data: {
-        session: {
-          access_token: 'access-token',
-        },
-      },
-    });
-    const invokeResult = { data: { data: [{ id: sampleId }] }, error: null };
-    mockFunctionsInvoke.mockResolvedValueOnce(invokeResult);
+    const invokeResult = {
+      data: [{ id: sampleId, rule_verification: true }],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: 'OK',
+    };
+    mockInvokeDatasetCommand.mockResolvedValueOnce(invokeResult);
 
     const result = await processesApi.updateProcess(sampleId, sampleVersion, { some: 'data' });
 
     expect(mockGenProcessJsonOrdered).toHaveBeenCalledWith(sampleId, { some: 'data' });
-    expect(mockFunctionsInvoke).toHaveBeenCalledWith('update_data', {
-      headers: { Authorization: 'Bearer access-token' },
-      body: {
+    expect(mockInvokeDatasetCommand).toHaveBeenCalledWith(
+      'app_dataset_save_draft',
+      {
         id: sampleId,
         version: sampleVersion,
         table: 'processes',
-        data: {
-          json_ordered: { ordered: true },
-          model_id: undefined,
-          rule_verification: true,
-        },
+        jsonOrdered: { ordered: true },
+        modelId: undefined,
       },
-      region: FunctionRegion.UsEast1,
-    });
-    expect(result).toEqual(invokeResult.data);
+      {
+        ruleVerification: true,
+      },
+    );
+    expect(result).toEqual(invokeResult);
   });
 
   it('returns undefined when no active session is available', async () => {
-    mockAuthGetSession.mockResolvedValueOnce({ data: { session: null } });
+    mockInvokeDatasetCommand.mockResolvedValueOnce(undefined);
 
     const result = await processesApi.updateProcess(sampleId, sampleVersion, { some: 'data' });
 
-    expect(mockFunctionsInvoke).not.toHaveBeenCalled();
+    expect(mockInvokeDatasetCommand).toHaveBeenCalled();
     expect(result).toBeUndefined();
   });
 
   it('returns structured error when invocation fails', async () => {
-    mockAuthGetSession.mockResolvedValueOnce({
-      data: {
-        session: {
-          access_token: 'access-token',
-        },
-      },
-    });
-    const failure = { error: { message: 'update failed' }, data: null };
-    mockFunctionsInvoke.mockResolvedValueOnce(failure);
+    const failure = {
+      data: null,
+      error: { message: 'update failed', code: 'FUNCTION_ERROR', details: '', hint: '' },
+      count: null,
+      status: 500,
+      statusText: 'FUNCTION_ERROR',
+    };
+    mockInvokeDatasetCommand.mockResolvedValueOnce(failure);
 
     const result = await processesApi.updateProcess(sampleId, sampleVersion, { some: 'data' });
 
-    expect(result).toEqual({ error: failure.error });
+    expect(result).toEqual(failure);
   });
 
   it('uses fallback bearer token and keeps rule verification false when validation fails', async () => {
     mockValidateDatasetRuleVerification.mockResolvedValueOnce({ ruleVerification: false });
-    mockAuthGetSession.mockResolvedValueOnce({
-      data: {
-        session: {
-          access_token: undefined,
-        },
-      },
+    mockInvokeDatasetCommand.mockResolvedValueOnce({
+      data: [{ ok: true, rule_verification: false }],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: 'OK',
     });
-    mockFunctionsInvoke.mockResolvedValueOnce({ data: { ok: true }, error: null });
 
     await processesApi.updateProcess(sampleId, sampleVersion, { some: 'data' }, 'model-x');
 
-    expect(mockFunctionsInvoke).toHaveBeenCalledWith('update_data', {
-      headers: { Authorization: 'Bearer ' },
-      body: {
+    expect(mockInvokeDatasetCommand).toHaveBeenCalledWith(
+      'app_dataset_save_draft',
+      {
         id: sampleId,
         version: sampleVersion,
         table: 'processes',
-        data: {
-          json_ordered: { ordered: true },
-          model_id: 'model-x',
-          rule_verification: false,
-        },
+        jsonOrdered: { ordered: true },
+        modelId: 'model-x',
       },
-      region: FunctionRegion.UsEast1,
-    });
+      {
+        ruleVerification: false,
+      },
+    );
   });
 
   it('returns a structured validation error when language normalization fails', async () => {
@@ -481,7 +486,7 @@ describe('updateProcess', () => {
       statusText: 'LANG_VALIDATION_ERROR',
       count: null,
     });
-    expect(mockFunctionsInvoke).not.toHaveBeenCalled();
+    expect(mockInvokeDatasetCommand).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/services/sources/api.test.ts
+++ b/tests/unit/services/sources/api.test.ts
@@ -77,7 +77,7 @@ jest.mock('@/services/classifications/cache', () => ({
 jest.mock('@/services/general/api', () => ({
   getDataDetail: jest.fn(),
   getTeamIdByUserId: jest.fn(),
-  resolveFunctionInvokeError: jest.fn(async (error: any) => error),
+  invokeDatasetCommand: jest.fn(),
   normalizeLangPayloadForSave: jest.fn(),
 }));
 
@@ -89,7 +89,7 @@ const { supabase } = jest.requireMock('@/services/supabase');
 const { classificationToString, genClassificationZH, getLangText, jsonToList } =
   jest.requireMock('@/services/general/util');
 const { getCachedClassificationData } = jest.requireMock('@/services/classifications/cache');
-const { getDataDetail, getTeamIdByUserId, normalizeLangPayloadForSave } =
+const { getDataDetail, getTeamIdByUserId, invokeDatasetCommand, normalizeLangPayloadForSave } =
   jest.requireMock('@/services/general/api');
 const { genSourceJsonOrdered } = jest.requireMock('@/services/sources/util');
 const { createSource: mockCreateSource } = jest.requireMock('@tiangong-lca/tidas-sdk');
@@ -100,6 +100,13 @@ describe('Sources API Service (src/services/sources/api.ts)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     supabase.auth.getSession.mockResolvedValue(mockSession);
+    invokeDatasetCommand.mockResolvedValue({
+      data: [],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: 'OK',
+    });
     normalizeLangPayloadForSave.mockImplementation(async (payload: any) => ({
       payload,
       validationError: undefined,
@@ -234,32 +241,37 @@ describe('Sources API Service (src/services/sources/api.ts)', () => {
       const mockVersion = '01.00.000';
       const mockData = { sourceDataSet: {} };
       const mockOrderedData = { ordered: true };
-      const mockFunctionResult = createMockEdgeFunctionResponse({ success: true });
       const mockValidateEnhanced = jest.fn().mockReturnValue({ success: true });
+      const mockFunctionResult = {
+        data: [{ id: mockId, rule_verification: true }],
+        error: null,
+        count: null,
+        status: 200,
+        statusText: 'OK',
+      };
 
       genSourceJsonOrdered.mockReturnValue(mockOrderedData);
       mockCreateSource.mockReturnValue({
         validateEnhanced: mockValidateEnhanced,
       });
-      supabase.functions.invoke.mockResolvedValue(mockFunctionResult);
+      invokeDatasetCommand.mockResolvedValue(mockFunctionResult);
 
       const result = await updateSource(mockId, mockVersion, mockData);
 
       expect(normalizeLangPayloadForSave).toHaveBeenCalledWith(mockOrderedData);
-      expect(supabase.auth.getSession).toHaveBeenCalled();
-      expect(supabase.functions.invoke).toHaveBeenCalledWith('update_data', {
-        headers: {
-          Authorization: 'Bearer test-token',
-        },
-        body: {
+      expect(invokeDatasetCommand).toHaveBeenCalledWith(
+        'app_dataset_save_draft',
+        {
           id: mockId,
           version: mockVersion,
           table: 'sources',
-          data: { json_ordered: mockOrderedData, rule_verification: true },
+          jsonOrdered: mockOrderedData,
         },
-        region: FunctionRegion.UsEast1,
-      });
-      expect(result).toEqual({ success: true });
+        {
+          ruleVerification: true,
+        },
+      );
+      expect(result).toEqual(mockFunctionResult);
     });
 
     it('should return a language validation error instead of invoking the update edge function', async () => {
@@ -275,7 +287,7 @@ describe('Sources API Service (src/services/sources/api.ts)', () => {
 
       const result = await updateSource(mockId, mockVersion, { sourceDataSet: {} });
 
-      expect(supabase.functions.invoke).not.toHaveBeenCalled();
+      expect(invokeDatasetCommand).not.toHaveBeenCalled();
       expect(result).toMatchObject({
         data: null,
         error: {
@@ -291,15 +303,15 @@ describe('Sources API Service (src/services/sources/api.ts)', () => {
       const mockVersion = '01.00.000';
       const mockData = { sourceDataSet: {} };
 
-      supabase.auth.getSession.mockResolvedValue({ data: { session: null } });
       genSourceJsonOrdered.mockReturnValue({});
       mockCreateSource.mockReturnValue({
         validateEnhanced: jest.fn().mockReturnValue({ success: true }),
       });
+      invokeDatasetCommand.mockResolvedValue(undefined);
 
       const result = await updateSource(mockId, mockVersion, mockData);
 
-      expect(supabase.functions.invoke).not.toHaveBeenCalled();
+      expect(invokeDatasetCommand).toHaveBeenCalled();
       expect(result).toBeUndefined();
     });
 
@@ -307,22 +319,29 @@ describe('Sources API Service (src/services/sources/api.ts)', () => {
       const mockId = 'source-123';
       const mockVersion = '01.00.000';
       const mockData = { sourceDataSet: {} };
-      const mockError = { message: 'Update failed' };
+      const mockError = { message: 'Update failed', code: 'FUNCTION_ERROR', details: '', hint: '' };
 
       genSourceJsonOrdered.mockReturnValue({});
       mockCreateSource.mockReturnValue({
         validateEnhanced: jest.fn().mockReturnValue({ success: true }),
       });
-      supabase.functions.invoke.mockResolvedValue({ data: null, error: mockError });
-
-      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+      invokeDatasetCommand.mockResolvedValue({
+        data: null,
+        error: mockError,
+        count: null,
+        status: 500,
+        statusText: 'FUNCTION_ERROR',
+      });
 
       const result = await updateSource(mockId, mockVersion, mockData);
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('error', mockError);
-      expect(result).toEqual({ error: mockError });
-
-      consoleLogSpy.mockRestore();
+      expect(result).toEqual({
+        data: null,
+        error: mockError,
+        count: null,
+        status: 500,
+        statusText: 'FUNCTION_ERROR',
+      });
     });
 
     it('should fall back to raw ordered data and an empty bearer token when normalization omits the payload', async () => {
@@ -330,37 +349,34 @@ describe('Sources API Service (src/services/sources/api.ts)', () => {
       const mockVersion = '01.00.000';
       const rawOrderedData = { ordered: 'raw-update' };
 
-      supabase.auth.getSession.mockResolvedValue({
-        data: {
-          session: {
-            user: { id: 'user-123' },
-          },
-        },
-      });
       genSourceJsonOrdered.mockReturnValue(rawOrderedData);
       normalizeLangPayloadForSave.mockResolvedValue({
         payload: undefined,
         validationError: undefined,
       });
-      supabase.functions.invoke.mockResolvedValue(
-        createMockEdgeFunctionResponse({ success: true }),
-      );
+      invokeDatasetCommand.mockResolvedValue({
+        data: [{ success: true, rule_verification: true }],
+        error: null,
+        count: null,
+        status: 200,
+        statusText: 'OK',
+      });
 
       await updateSource(mockId, mockVersion, { sourceDataSet: {} });
 
       expect(mockCreateSource).toHaveBeenCalledWith(rawOrderedData);
-      expect(supabase.functions.invoke).toHaveBeenCalledWith('update_data', {
-        headers: {
-          Authorization: 'Bearer ',
-        },
-        body: {
+      expect(invokeDatasetCommand).toHaveBeenCalledWith(
+        'app_dataset_save_draft',
+        {
           id: mockId,
           version: mockVersion,
           table: 'sources',
-          data: { json_ordered: rawOrderedData, rule_verification: true },
+          jsonOrdered: rawOrderedData,
         },
-        region: FunctionRegion.UsEast1,
-      });
+        {
+          ruleVerification: true,
+        },
+      );
     });
   });
 

--- a/tests/unit/services/unitgroups/api.test.ts
+++ b/tests/unit/services/unitgroups/api.test.ts
@@ -61,13 +61,14 @@ const { getCachedClassificationData: mockGetCachedClassificationData } = jest.re
 jest.mock('@/services/general/api', () => ({
   getDataDetail: jest.fn(),
   getTeamIdByUserId: jest.fn(),
-  resolveFunctionInvokeError: jest.fn(async (error: any) => error),
+  invokeDatasetCommand: jest.fn(),
   normalizeLangPayloadForSave: jest.fn(),
 }));
 
 const {
   getDataDetail: mockGetDataDetail,
   getTeamIdByUserId: mockGetTeamIdByUserId,
+  invokeDatasetCommand: mockInvokeDatasetCommand,
   normalizeLangPayloadForSave: mockNormalizeLangPayloadForSave,
 } = jest.requireMock('@/services/general/api');
 
@@ -205,6 +206,13 @@ beforeEach(() => {
   mockGetCachedClassificationData.mockResolvedValue([]);
   mockGetTeamIdByUserId.mockResolvedValue(null);
   mockGetDataDetail.mockResolvedValue({ data: null });
+  mockInvokeDatasetCommand.mockResolvedValue({
+    data: [],
+    error: null,
+    count: null,
+    status: 200,
+    statusText: 'OK',
+  });
   mockNormalizeLangPayloadForSave.mockImplementation(async (payload: any) => ({
     payload,
     validationError: undefined,
@@ -270,69 +278,72 @@ describe('createUnitGroup', () => {
 
 describe('updateUnitGroup', () => {
   it('invokes edge function with ordered payload', async () => {
-    const updateResult = { data: { success: true } };
-    mockFunctionsInvoke.mockResolvedValueOnce(updateResult as any);
+    const updateResult = {
+      data: [{ id: 'ug-1', rule_verification: true }],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: 'OK',
+    };
+    mockInvokeDatasetCommand.mockResolvedValueOnce(updateResult as any);
     mockGenUnitGroupJsonOrdered.mockReturnValueOnce({ updated: true });
 
     const result = await updateUnitGroup('ug-1', '01.00.000', { name: 'Updated' });
 
-    expect(mockFunctionsInvoke).toHaveBeenCalledWith('update_data', {
-      headers: { Authorization: 'Bearer token' },
-      body: {
+    expect(mockInvokeDatasetCommand).toHaveBeenCalledWith(
+      'app_dataset_save_draft',
+      {
         id: 'ug-1',
         version: '01.00.000',
         table: 'unitgroups',
-        data: {
-          json_ordered: { updated: true },
-          rule_verification: true,
-        },
+        jsonOrdered: { updated: true },
       },
-      region: FunctionRegion.UsEast1,
-    });
-    expect(result).toEqual(updateResult.data);
+      {
+        ruleVerification: true,
+      },
+    );
+    expect(result).toEqual(updateResult);
   });
 
   it('returns undefined when no active session exists', async () => {
-    mockAuthGetSession.mockResolvedValueOnce({ data: { session: null } });
+    mockInvokeDatasetCommand.mockResolvedValueOnce(undefined);
 
     const result = await updateUnitGroup('ug-1', '01.00.000', { name: 'Updated' });
 
-    expect(mockFunctionsInvoke).not.toHaveBeenCalled();
+    expect(mockInvokeDatasetCommand).toHaveBeenCalled();
     expect(result).toBeUndefined();
   });
 
   it('uses empty bearer token fallback and logs invocation error', async () => {
-    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
-    mockAuthGetSession.mockResolvedValueOnce({
-      data: {
-        session: {
-          access_token: undefined,
-        },
-      },
-    });
-    mockFunctionsInvoke.mockResolvedValueOnce({
-      data: undefined,
-      error: { message: 'invoke failed' },
+    mockInvokeDatasetCommand.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'invoke failed', code: 'FUNCTION_ERROR', details: '', hint: '' },
+      count: null,
+      status: 500,
+      statusText: 'FUNCTION_ERROR',
     });
 
     const result = await updateUnitGroup('ug-1', '01.00.000', { name: 'Updated' });
 
-    expect(mockFunctionsInvoke).toHaveBeenCalledWith('update_data', {
-      headers: { Authorization: 'Bearer ' },
-      body: {
+    expect(mockInvokeDatasetCommand).toHaveBeenCalledWith(
+      'app_dataset_save_draft',
+      {
         id: 'ug-1',
         version: '01.00.000',
         table: 'unitgroups',
-        data: {
-          json_ordered: expect.any(Object),
-          rule_verification: true,
-        },
+        jsonOrdered: expect.any(Object),
       },
-      region: FunctionRegion.UsEast1,
+      {
+        ruleVerification: true,
+      },
+    );
+    expect(result).toEqual({
+      data: null,
+      error: { message: 'invoke failed', code: 'FUNCTION_ERROR', details: '', hint: '' },
+      count: null,
+      status: 500,
+      statusText: 'FUNCTION_ERROR',
     });
-    expect(logSpy).toHaveBeenCalledWith('error', { message: 'invoke failed' });
-    expect(result).toEqual({ error: { message: 'invoke failed' } });
-    logSpy.mockRestore();
   });
 
   it('returns a language validation error before invoking the update edge function', async () => {
@@ -343,7 +354,7 @@ describe('updateUnitGroup', () => {
 
     const result = await updateUnitGroup('ug-1', '01.00.000', { name: 'Updated' });
 
-    expect(mockFunctionsInvoke).not.toHaveBeenCalled();
+    expect(mockInvokeDatasetCommand).not.toHaveBeenCalled();
     expect(result).toEqual(
       expect.objectContaining({
         data: null,


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#291

## Summary
- Add a shared dataset-command service adapter in src/services/general/api.ts that preserves the legacy mutation result shape.
- Cut owner-facing dataset save, team-assignment, and publish flows over to app_dataset_* wrappers without changing current page contracts.

## Key Decisions
- Flatten command error envelopes back into the legacy error shape so existing pages keep their current UX branches during the refactor.

## Validation
- npx jest --runInBand --testTimeout=20000 tests/unit/services/general/api.test.ts tests/unit/services/contacts/api.test.ts tests/unit/services/flows/api.test.ts tests/unit/services/flowproperties/api.test.ts tests/unit/services/unitgroups/api.test.ts tests/unit/services/sources/api.test.ts tests/unit/services/processes/api.test.ts
- npx jest --runInBand --testTimeout=20000 tests/unit/pages/Contacts/ContactEdit.test.tsx
- npx jest --runInBand --testTimeout=20000 tests/unit/pages/Processes/Components/edit.test.tsx tests/unit/pages/Contacts/index.test.tsx tests/unit/pages/Flows/index.test.tsx tests/unit/pages/Flowproperties/index.test.tsx tests/unit/pages/Unitgroups/index.test.tsx tests/unit/pages/Sources/index.test.tsx
- npm run tsc -- --pretty false
- npx eslint --ext .ts,.tsx src/pages/Contacts/Components/edit.tsx src/pages/Contacts/index.tsx src/pages/Flows/index.tsx src/pages/Flowproperties/index.tsx src/pages/Processes/Components/edit.tsx src/pages/Sources/Components/edit.tsx src/pages/Sources/index.tsx src/services/general/api.ts src/services/processes/api.ts src/services/supabase/data.ts tests/unit/pages/Contacts/ContactEdit.test.tsx tests/unit/services/general/api.test.ts tests/unit/services/processes/api.test.ts

## Risks / Rollback
- Database-side rule_verification recomputation is still deferred; this cutover preserves current UI behavior by overlaying the locally computed value onto the adapted command result row.

## Workspace Integration
- Workspace integration remains pending until lca-workspace later bumps tiangong-lca-next after the child PRs merge.