### PR TITLE
fix: persist rule verification on draft save

### DIFF
--- a/src/services/contacts/api.ts
+++ b/src/services/contacts/api.ts
@@ -92,6 +92,7 @@ export async function updateContact(id: string, version: string, data: any) {
       version,
       table: 'contacts',
       jsonOrdered: newData,
+      ruleVerification: rule_verification,
     },
     {
       ruleVerification: rule_verification,

--- a/src/services/flowproperties/api.ts
+++ b/src/services/flowproperties/api.ts
@@ -93,6 +93,7 @@ export async function updateFlowproperties(id: string, version: string, data: an
       version,
       table: 'flowproperties',
       jsonOrdered: newData,
+      ruleVerification: rule_verification,
     },
     {
       ruleVerification: rule_verification,

--- a/src/services/flows/api.ts
+++ b/src/services/flows/api.ts
@@ -149,6 +149,7 @@ export async function updateFlows(id: string, version: string, data: any) {
       version,
       table: 'flows',
       jsonOrdered: newData,
+      ruleVerification: rule_verification,
     },
     {
       ruleVerification: rule_verification,

--- a/src/services/processes/api.ts
+++ b/src/services/processes/api.ts
@@ -248,6 +248,7 @@ export async function updateProcess(
       table: 'processes',
       jsonOrdered: newData,
       modelId,
+      ruleVerification: rule_verification,
     },
     {
       ruleVerification: rule_verification,

--- a/src/services/sources/api.ts
+++ b/src/services/sources/api.ts
@@ -92,6 +92,7 @@ export async function updateSource(id: string, version: string, data: any) {
       version,
       table: 'sources',
       jsonOrdered: newData,
+      ruleVerification: rule_verification,
     },
     {
       ruleVerification: rule_verification,

--- a/src/services/unitgroups/api.ts
+++ b/src/services/unitgroups/api.ts
@@ -93,6 +93,7 @@ export async function updateUnitGroup(id: string, version: string, data: any) {
       version,
       table: 'unitgroups',
       jsonOrdered: newData,
+      ruleVerification: rule_verification,
     },
     {
       ruleVerification: rule_verification,

--- a/supabase/migrations/20260404153000_access_control_add_dataset_command_rpcs.sql
+++ b/supabase/migrations/20260404153000_access_control_add_dataset_command_rpcs.sql
@@ -4,6 +4,7 @@ create or replace function public.cmd_dataset_save_draft(
   p_version text,
   p_json_ordered jsonb,
   p_model_id uuid default null,
+  p_rule_verification boolean default null,
   p_audit jsonb default '{}'::jsonb
 ) returns jsonb
 language plpgsql
@@ -128,6 +129,20 @@ begin
       'update public.%I as t
           set json_ordered = $1::json,
               model_id = $2,
+              rule_verification = $3,
+              modified_at = now()
+        where t.id = $4
+          and t.version = $5
+      returning to_jsonb(t)',
+      p_table
+    )
+      into v_updated_row
+      using p_json_ordered, p_model_id, p_rule_verification, p_id, p_version;
+  else
+    execute format(
+      'update public.%I as t
+          set json_ordered = $1::json,
+              rule_verification = $2,
               modified_at = now()
         where t.id = $3
           and t.version = $4
@@ -135,19 +150,7 @@ begin
       p_table
     )
       into v_updated_row
-      using p_json_ordered, p_model_id, p_id, p_version;
-  else
-    execute format(
-      'update public.%I as t
-          set json_ordered = $1::json,
-              modified_at = now()
-        where t.id = $2
-          and t.version = $3
-      returning to_jsonb(t)',
-      p_table
-    )
-      into v_updated_row
-      using p_json_ordered, p_id, p_version;
+      using p_json_ordered, p_rule_verification, p_id, p_version;
   end if;
 
   insert into public.command_audit_log (
@@ -458,14 +461,14 @@ begin
 end;
 $$;
 
-revoke all on function public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, jsonb) from public;
+revoke all on function public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, boolean, jsonb) from public;
 revoke all on function public.cmd_dataset_assign_team(text, uuid, text, uuid, jsonb) from public;
 revoke all on function public.cmd_dataset_publish(text, uuid, text, jsonb) from public;
 
-grant execute on function public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, jsonb) to authenticated;
+grant execute on function public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, boolean, jsonb) to authenticated;
 grant execute on function public.cmd_dataset_assign_team(text, uuid, text, uuid, jsonb) to authenticated;
 grant execute on function public.cmd_dataset_publish(text, uuid, text, jsonb) to authenticated;
 
-grant execute on function public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, jsonb) to service_role;
+grant execute on function public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, boolean, jsonb) to service_role;
 grant execute on function public.cmd_dataset_assign_team(text, uuid, text, uuid, jsonb) to service_role;
 grant execute on function public.cmd_dataset_publish(text, uuid, text, jsonb) to service_role;

--- a/supabase/migrations/20260405213000_access_control_complete_dataset_command_cutover.sql
+++ b/supabase/migrations/20260405213000_access_control_complete_dataset_command_cutover.sql
@@ -1,9 +1,12 @@
+drop function if exists public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, jsonb);
+
 create or replace function public.cmd_dataset_save_draft(
   p_table text,
   p_id uuid,
   p_version text,
   p_json_ordered jsonb,
   p_model_id uuid default null,
+  p_rule_verification boolean default null,
   p_audit jsonb default '{}'::jsonb
 ) returns jsonb
 language plpgsql
@@ -119,6 +122,20 @@ begin
       'update public.%I as t
           set json_ordered = $1::json,
               model_id = coalesce($2, t.model_id),
+              rule_verification = $3,
+              modified_at = now()
+        where t.id = $4
+          and t.version = $5
+      returning to_jsonb(t)',
+      p_table
+    )
+      into v_updated_row
+      using p_json_ordered, p_model_id, p_rule_verification, p_id, p_version;
+  else
+    execute format(
+      'update public.%I as t
+          set json_ordered = $1::json,
+              rule_verification = $2,
               modified_at = now()
         where t.id = $3
           and t.version = $4
@@ -126,19 +143,7 @@ begin
       p_table
     )
       into v_updated_row
-      using p_json_ordered, p_model_id, p_id, p_version;
-  else
-    execute format(
-      'update public.%I as t
-          set json_ordered = $1::json,
-              modified_at = now()
-        where t.id = $2
-          and t.version = $3
-      returning to_jsonb(t)',
-      p_table
-    )
-      into v_updated_row
-      using p_json_ordered, p_id, p_version;
+      using p_json_ordered, p_rule_verification, p_id, p_version;
   end if;
 
   insert into public.command_audit_log (
@@ -450,11 +455,14 @@ revoke insert, update, delete on table public.flows from anon, authenticated;
 revoke insert, update, delete on table public.processes from anon, authenticated;
 revoke insert, update, delete on table public.lifecyclemodels from anon, authenticated;
 
+revoke all on function public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, boolean, jsonb) from public;
 revoke all on function public.cmd_dataset_create(text, uuid, jsonb, uuid, boolean, jsonb) from public;
 revoke all on function public.cmd_dataset_delete(text, uuid, text, jsonb) from public;
 
+grant execute on function public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, boolean, jsonb) to authenticated;
 grant execute on function public.cmd_dataset_create(text, uuid, jsonb, uuid, boolean, jsonb) to authenticated;
 grant execute on function public.cmd_dataset_delete(text, uuid, text, jsonb) to authenticated;
 
+grant execute on function public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, boolean, jsonb) to service_role;
 grant execute on function public.cmd_dataset_create(text, uuid, jsonb, uuid, boolean, jsonb) to service_role;
 grant execute on function public.cmd_dataset_delete(text, uuid, text, jsonb) to service_role;

--- a/supabase/tests/20260404_dataset_command_rpcs.sql
+++ b/supabase/tests/20260404_dataset_command_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(11);
+select plan(13);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -185,6 +185,7 @@ select is(
       }
     }'::jsonb,
     null,
+    false,
     '{"command":"dataset_save_draft"}'::jsonb
   )->>'ok',
   'true',
@@ -200,6 +201,16 @@ select is(
   'cmd_dataset_save_draft updates json_ordered'
 );
 
+select ok(
+  (
+    select rule_verification = false
+    from public.contacts
+    where id = '31000000-0000-0000-0000-000000000001'
+      and version = '01.00.000'
+  ),
+  'cmd_dataset_save_draft updates rule_verification when provided'
+);
+
 reset role;
 
 set local role authenticated;
@@ -211,6 +222,7 @@ select is(
     '31000000-0000-0000-0000-000000000001',
     '01.00.000',
     '{}'::jsonb,
+    null,
     null,
     '{}'::jsonb
   )->>'code',
@@ -225,10 +237,10 @@ select set_config('request.jwt.claim.sub', '11000000-0000-0000-0000-000000000001
 
 select is(
   public.cmd_dataset_save_draft(
-    'processes',
-    '31000000-0000-0000-0000-000000000003',
-    '01.00.000',
-    '{
+    p_table => 'processes',
+    p_id => '31000000-0000-0000-0000-000000000003',
+    p_version => '01.00.000',
+    p_json_ordered => '{
       "processDataSet": {
         "administrativeInformation": {
           "publicationAndOwnership": {
@@ -237,8 +249,7 @@ select is(
         }
       }
     }'::jsonb,
-    null,
-    '{}'::jsonb
+    p_audit => '{}'::jsonb
   )->>'ok',
   'true',
   'process draft save works when modelId is omitted'
@@ -251,6 +262,20 @@ select is(
      and version = '01.00.000'),
   '41000000-0000-0000-0000-000000000001',
   'cmd_dataset_save_draft preserves the existing process model_id when modelId is omitted'
+);
+
+select is(
+  (
+    select case
+      when rule_verification is null then 'null'
+      else rule_verification::text
+    end
+    from public.processes
+    where id = '31000000-0000-0000-0000-000000000003'
+      and version = '01.00.000'
+  ),
+  'null',
+  'cmd_dataset_save_draft clears existing process rule_verification when omitted'
 );
 
 select is(
@@ -267,6 +292,7 @@ select is(
         }
       }
     }'::jsonb,
+    null,
     null,
     '{}'::jsonb
   )->>'code',

--- a/tests/unit/services/contacts/api.test.ts
+++ b/tests/unit/services/contacts/api.test.ts
@@ -172,6 +172,7 @@ describe('Contacts API Service', () => {
           version: 'v1.0',
           table: 'contacts',
           jsonOrdered: expect.any(Object),
+          ruleVerification: true,
         },
         {
           ruleVerification: true,
@@ -271,6 +272,7 @@ describe('Contacts API Service', () => {
           jsonOrdered: expect.objectContaining({
             contactDataSet: expect.any(Object),
           }),
+          ruleVerification: true,
         },
         {
           ruleVerification: true,

--- a/tests/unit/services/flowproperties/api.test.ts
+++ b/tests/unit/services/flowproperties/api.test.ts
@@ -240,6 +240,7 @@ describe('FlowProperties API Service (src/services/flowproperties/api.ts)', () =
           version: mockVersion,
           table: 'flowproperties',
           jsonOrdered: mockOrderedData,
+          ruleVerification: true,
         },
         {
           ruleVerification: true,
@@ -327,6 +328,7 @@ describe('FlowProperties API Service (src/services/flowproperties/api.ts)', () =
           id: 'id',
           version: '01.00.000',
           table: 'flowproperties',
+          ruleVerification: true,
         }),
         expect.objectContaining({
           ruleVerification: true,
@@ -358,6 +360,7 @@ describe('FlowProperties API Service (src/services/flowproperties/api.ts)', () =
         'app_dataset_save_draft',
         expect.objectContaining({
           jsonOrdered: { ordered: true, fallback: 'raw-update' },
+          ruleVerification: true,
         }),
         expect.objectContaining({
           ruleVerification: true,

--- a/tests/unit/services/flows/api.test.ts
+++ b/tests/unit/services/flows/api.test.ts
@@ -333,6 +333,7 @@ describe('updateFlows', () => {
         version: '01.00.000',
         table: 'flows',
         jsonOrdered: expect.objectContaining({ id: 'flow-id' }),
+        ruleVerification: true,
       },
       {
         ruleVerification: true,
@@ -410,6 +411,7 @@ describe('updateFlows', () => {
         id: 'flow-id',
         version: '01.00.000',
         table: 'flows',
+        ruleVerification: true,
       }),
       expect.objectContaining({
         ruleVerification: true,

--- a/tests/unit/services/processes/api.test.ts
+++ b/tests/unit/services/processes/api.test.ts
@@ -428,6 +428,7 @@ describe('updateProcess', () => {
         table: 'processes',
         jsonOrdered: { ordered: true },
         modelId: undefined,
+        ruleVerification: true,
       },
       {
         ruleVerification: true,
@@ -480,6 +481,7 @@ describe('updateProcess', () => {
         table: 'processes',
         jsonOrdered: { ordered: true },
         modelId: 'model-x',
+        ruleVerification: false,
       },
       {
         ruleVerification: false,

--- a/tests/unit/services/sources/api.test.ts
+++ b/tests/unit/services/sources/api.test.ts
@@ -285,6 +285,7 @@ describe('Sources API Service (src/services/sources/api.ts)', () => {
           version: mockVersion,
           table: 'sources',
           jsonOrdered: mockOrderedData,
+          ruleVerification: true,
         },
         {
           ruleVerification: true,
@@ -391,6 +392,7 @@ describe('Sources API Service (src/services/sources/api.ts)', () => {
           version: mockVersion,
           table: 'sources',
           jsonOrdered: rawOrderedData,
+          ruleVerification: true,
         },
         {
           ruleVerification: true,

--- a/tests/unit/services/unitgroups/api.test.ts
+++ b/tests/unit/services/unitgroups/api.test.ts
@@ -305,6 +305,7 @@ describe('updateUnitGroup', () => {
         version: '01.00.000',
         table: 'unitgroups',
         jsonOrdered: { updated: true },
+        ruleVerification: true,
       },
       {
         ruleVerification: true,
@@ -340,6 +341,7 @@ describe('updateUnitGroup', () => {
         version: '01.00.000',
         table: 'unitgroups',
         jsonOrdered: expect.any(Object),
+        ruleVerification: true,
       },
       {
         ruleVerification: true,


### PR DESCRIPTION
Closes #291

## Summary
- Add ruleVerification back to dataset save-draft request bodies for contacts, sources, unitgroups, flowproperties, flows, and processes.
- Update cmd_dataset_save_draft to persist rule_verification and clear it to null when callers omit the field.
- Preserve process model_id fallback behavior and keep rule_verification out of authorization decisions in this follow-up.

## Validation
- npm run jest -- --runInBand tests/unit/services/contacts/api.test.ts tests/unit/services/sources/api.test.ts tests/unit/services/unitgroups/api.test.ts tests/unit/services/flowproperties/api.test.ts tests/unit/services/flows/api.test.ts tests/unit/services/processes/api.test.ts
- npx supabase db reset --local --yes
- npx supabase test db --local supabase/tests/20260404_dataset_command_rpcs.sql
- The repo pre-push coverage run executed 3554/3554 tests successfully, but still exited non-zero because the current global coverage gate remains below 100% (99.05% statements, 98.12% branches, 99.06% functions, 99.06% lines).

## Risks / Rollback
- Low risk in the changed path; the only broader validation issue observed was the repo-global coverage gate noted above.

## Workspace Integration
- Requires later lca-workspace submodule integration after merge.