### PR TITLE
merge dev into main

### DIFF
--- a/supabase/migrations/20260404123557_access_control_add_state_role_constraints_and_audit.sql
+++ b/supabase/migrations/20260404123557_access_control_add_state_role_constraints_and_audit.sql
@@ -55,7 +55,7 @@ alter table public.flowproperties
 
 alter table public.flowproperties
   add constraint flowproperties_state_code_check
-  check (state_code in (0, 100, 200));
+  check (state_code in (0, 20, 100, 200));
 
 alter table public.flows
   drop constraint if exists flows_state_code_check;


### PR DESCRIPTION
Closes #327

## Summary
- Promote the flowproperties migration fix from dev into main.
- Unblock the first failed production Supabase migration step.

## Key Decisions
- Use the standard promote path dev -> main for tiangong-lca-next.
- Keep the promote scoped to the merged issue-327 fix.

## Validation
- Verified dev already contains the merged fix from #328.
- Verified no open PR currently targets main.

## Risks / Rollback
- Merging to main will re-trigger Supabase production sync.
- A separate retry or migration repair may still be needed if Supabase does not auto-recover.

## Workspace Integration
- Workspace integration remains pending after merge.