### PR TITLE
chore: harden Supabase workflow and reconcile main drift

### DIFF
--- a/.github/workflows/supabase-dev.yml
+++ b/.github/workflows/supabase-dev.yml
@@ -10,6 +10,7 @@ jobs:
     name: Deploy Supabase Migrations to Dev
     runs-on: ubuntu-latest
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DEV_DB_PASSWORD }}
       SUPABASE_PROJECT_ID: ${{ vars.SUPABASE_DEV_PROJECT_ID }}

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -231,6 +231,8 @@ Use this flow when a task requires the frontend or CLI to connect to `main`, inc
 ## Recovery checklist
 
 - If local and remote migration histories diverge, inspect them with `npx supabase migration list` before changing anything else.
+- If `main` was changed manually on the remote database, stop making more remote schema edits, branch from Git `main`, link to the `main` project, and run `npx supabase db pull -f <name>` to capture the remote drift as a reconciliation migration instead of hand-writing a second destructive migration.
+- Review the pulled SQL so it contains only the intended remote-only changes, merge that hotfix back to Git `main`, and then back-merge `main` into `dev` so both branches inherit the repaired migration history.
 - If history is wrong on the remote side, use `npx supabase migration repair` intentionally, then re-check the result.
 - If `dev` or a preview branch reaches `MIGRATIONS_FAILED`, inspect the branch logs, fix the migration in Git, and prefer recreating the failed branch instead of hand-editing branch state.
 - If `dev` is recreated, refresh any local branch credentials files and confirm `[remotes.dev].project_id` again.

--- a/docs/agents/supabase-branching_CN.md
+++ b/docs/agents/supabase-branching_CN.md
@@ -231,6 +231,8 @@ npm start
 ## 恢复检查清单
 
 - 如果本地和远端 migration history 不一致，先用 `npx supabase migration list` 看清楚差异，再做下一步。
+- 如果远端 `main` 数据库被手工改过 schema，先停止继续手改远端，从 Git `main` 拉 hotfix 分支，连接 `main` 对应项目后执行 `npx supabase db pull -f <name>`，把这次远端漂移回收到一个“对账型 migration”里，而不是再手写一份二次破坏性 migration。
+- 检查 `db pull` 生成的 SQL，确认里面只有预期的远端独有改动；随后先合回 Git `main`，再把 `main` 反向合并到 `dev`，让两条分支共享修复后的 migration 历史。
 - 如果远端 history 记录错了，再有意识地执行 `npx supabase migration repair`，执行后重新核对结果。
 - 如果 `dev` 或 preview branch 进入 `MIGRATIONS_FAILED`，先看 branch logs，在 Git 中修正 migration，然后优先重建失败分支，而不是手工硬改 branch 状态。
 - 如果重建了 `dev`，记得刷新本地 branch 凭据文件，并再次确认 `[remotes.dev].project_id`。

--- a/supabase/migrations/20260410105500_reconcile_main_remove_embedding_columns.sql
+++ b/supabase/migrations/20260410105500_reconcile_main_remove_embedding_columns.sql
@@ -1,0 +1,11 @@
+-- Reconcile intentional remote-only schema drift on main.
+-- These columns and HNSW indexes were already removed manually on remote main.
+
+drop index if exists public.flows_embedding_hnsw_idx;
+alter table public.flows drop column if exists embedding;
+
+drop index if exists public.processes_embedding_hnsw_idx;
+alter table public.processes drop column if exists embedding;
+
+drop index if exists public.lifecyclemodels_embedding_hnsw_idx;
+alter table public.lifecyclemodels drop column if exists embedding;


### PR DESCRIPTION
Refs #286

## Summary
- force JavaScript-based GitHub Actions in the Supabase dev workflow onto Node 24 to avoid the current Node 20 deprecation warning from `supabase/setup-cli@v1`
- document the recovery path for remote-only `main` schema drift so manual SQL changes are reconciled back into committed migrations with `db pull`
- add an idempotent reconciliation migration for the manual removal of `embedding` columns from `public.flows`, `public.processes`, and `public.lifecyclemodels`

## Validation
- `git diff --check`
- `npx supabase db reset --local`
- `npx supabase db push --db-url "$SUPABASE_DB_URL" --dry-run`
- `npx supabase db push --db-url "$SUPABASE_DB_URL"`
- verified remote `main` no longer has those three `embedding` columns and now records migration `20260410105500`

## Notes
- `supabase/setup-cli@v1` is still published as a Node 20 action upstream, so this change opts the workflow into the runner-side Node 24 compatibility path without pinning to an unreleased upstream ref.
- A full `db pull` was intentionally not committed because remote `main` also contains unrelated trigger/ACL drift that would hardcode environment-specific webhook URLs and secrets into Git.
- This PR only reconciles the confirmed intentional schema change from the manual SQL operation.
