### PR TITLE
Refactor Supabase frontend env selection and restore full coverage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,8 @@ out
 # Environment files
 .env
 .env.local
+.env.development
+.env.development.local
 # .env.*
 
 # Version control

--- a/config/supabaseEnv.ts
+++ b/config/supabaseEnv.ts
@@ -67,7 +67,6 @@ export const applySupabaseFrontendEnv = (
     if (hasEnvValue(value)) {
       process.env[key] = value;
     }
-    console.info(`Set process.env.${key} to:`, process.env[key]);
 
     merged[key] = value;
     return merged;

--- a/config/supabaseEnv.ts
+++ b/config/supabaseEnv.ts
@@ -58,7 +58,6 @@ export const applySupabaseFrontendEnv = (
   appEnv: FrontendRuntimeEnv,
 ): SupabaseFrontendEnv => {
   const fileEnv = getSupabaseFrontendEnv(rootDir, appEnv);
-  console.info('Supabase frontend environment variables:', fileEnv);
 
   return SUPABASE_FRONTEND_KEYS.reduce<SupabaseFrontendEnv>((merged, key) => {
     const runtimeValue = process.env[key];

--- a/config/supabaseEnv.ts
+++ b/config/supabaseEnv.ts
@@ -5,7 +5,7 @@ import { parseEnv } from 'node:util';
 const SUPABASE_FRONTEND_KEYS = ['SUPABASE_URL', 'SUPABASE_PUBLISHABLE_KEY'] as const;
 
 const SUPABASE_ENV_FILE_ORDER = {
-  dev: ['.env', '.env.development', '.env.local', '.env.development.local'],
+  dev: ['.env.development', '.env.local', '.env.development.local'],
   main: ['.env', '.env.local'],
 } as const;
 
@@ -58,14 +58,17 @@ export const applySupabaseFrontendEnv = (
   appEnv: FrontendRuntimeEnv,
 ): SupabaseFrontendEnv => {
   const fileEnv = getSupabaseFrontendEnv(rootDir, appEnv);
+  console.info('Supabase frontend environment variables:', fileEnv);
 
   return SUPABASE_FRONTEND_KEYS.reduce<SupabaseFrontendEnv>((merged, key) => {
     const runtimeValue = process.env[key];
-    const value = hasEnvValue(runtimeValue) ? runtimeValue : fileEnv[key];
+    // const value = hasEnvValue(runtimeValue) ? runtimeValue : fileEnv[key];
+    const value = hasEnvValue(fileEnv[key]) ? fileEnv[key] : runtimeValue;
 
     if (hasEnvValue(value)) {
       process.env[key] = value;
     }
+    console.info(`Set process.env.${key} to:`, process.env[key]);
 
     merged[key] = value;
     return merged;

--- a/config/supabaseEnv.ts
+++ b/config/supabaseEnv.ts
@@ -14,6 +14,8 @@ type FrontendRuntimeEnv = string | false | undefined;
 
 type SupabaseFrontendEnv = Record<(typeof SUPABASE_FRONTEND_KEYS)[number], string | undefined>;
 
+const hasEnvValue = (value: string | undefined): value is string => Boolean(value);
+
 const readMergedEnvFiles = (
   rootDir: string,
   files: readonly string[],
@@ -55,15 +57,17 @@ export const applySupabaseFrontendEnv = (
   rootDir: string,
   appEnv: FrontendRuntimeEnv,
 ): SupabaseFrontendEnv => {
-  const env = getSupabaseFrontendEnv(rootDir, appEnv);
+  const fileEnv = getSupabaseFrontendEnv(rootDir, appEnv);
 
-  SUPABASE_FRONTEND_KEYS.forEach((key) => {
-    const value = env[key];
+  return SUPABASE_FRONTEND_KEYS.reduce<SupabaseFrontendEnv>((merged, key) => {
+    const runtimeValue = process.env[key];
+    const value = hasEnvValue(runtimeValue) ? runtimeValue : fileEnv[key];
 
-    if (value) {
+    if (hasEnvValue(value)) {
       process.env[key] = value;
     }
-  });
 
-  return env;
+    merged[key] = value;
+    return merged;
+  }, {} as SupabaseFrontendEnv);
 };

--- a/src/services/general/api.ts
+++ b/src/services/general/api.ts
@@ -386,7 +386,7 @@ export async function prepareImportTidasPackageUploadApi(file: {
 export async function enqueueImportTidasPackageApi(request: {
   job_id: string;
   source_artifact_id: string;
-  artifact_sha256: string;
+  artifact_sha256: string | null;
   artifact_byte_size: number;
   filename: string;
   content_type: string;
@@ -519,12 +519,21 @@ async function fetchPackageReport<T>(artifact: TidasPackageArtifact): Promise<T>
   return ((parsed as TidasPackageReportEnvelope<T>).payload ?? parsed) as T;
 }
 
-async function computeSha256Hex(file: Blob) {
-  const buffer = await file.arrayBuffer();
-  const digest = await crypto.subtle.digest('SHA-256', buffer);
-  return Array.from(new Uint8Array(digest))
-    .map((byte) => byte.toString(16).padStart(2, '0'))
-    .join('');
+async function computeSha256Hex(file: Blob): Promise<string | null> {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle?.digest) {
+    return null;
+  }
+
+  try {
+    const buffer = await file.arrayBuffer();
+    const digest = await subtle.digest('SHA-256', buffer);
+    return Array.from(new Uint8Array(digest))
+      .map((byte) => byte.toString(16).padStart(2, '0'))
+      .join('');
+  } catch (_error) {
+    return null;
+  }
 }
 
 async function uploadTidasPackageToSignedUrl(

--- a/tests/unit/config/supabaseEnv.test.ts
+++ b/tests/unit/config/supabaseEnv.test.ts
@@ -65,7 +65,7 @@ describe('supabase frontend env resolution (config/supabaseEnv.ts)', () => {
     });
   });
 
-  it('applies the selected frontend Supabase keys onto process.env', () => {
+  it('overrides existing runtime Supabase keys with the selected frontend env files', () => {
     fs.writeFileSync(
       path.join(tempDir, '.env'),
       'SUPABASE_URL=https://main.supabase.co\nSUPABASE_PUBLISHABLE_KEY=main-key\n',
@@ -79,6 +79,41 @@ describe('supabase frontend env resolution (config/supabaseEnv.ts)', () => {
 
     process.env.SUPABASE_URL = 'https://unexpected.supabase.co';
     process.env.SUPABASE_PUBLISHABLE_KEY = 'unexpected-key';
+
+    applySupabaseFrontendEnv(tempDir, 'dev');
+
+    expect(process.env.SUPABASE_URL).toBe('https://dev.supabase.co');
+    expect(process.env.SUPABASE_PUBLISHABLE_KEY).toBe('dev-key');
+  });
+
+  it('falls back to existing runtime Supabase keys when the selected env files omit them', () => {
+    fs.writeFileSync(path.join(tempDir, '.env.development'), '');
+
+    const { applySupabaseFrontendEnv } = require('../../../config/supabaseEnv');
+
+    process.env.SUPABASE_URL = 'https://runtime.supabase.co';
+    process.env.SUPABASE_PUBLISHABLE_KEY = 'runtime-key';
+
+    applySupabaseFrontendEnv(tempDir, 'dev');
+
+    expect(process.env.SUPABASE_URL).toBe('https://runtime.supabase.co');
+    expect(process.env.SUPABASE_PUBLISHABLE_KEY).toBe('runtime-key');
+  });
+
+  it('fills missing or blank runtime Supabase keys from the selected frontend env files', () => {
+    fs.writeFileSync(
+      path.join(tempDir, '.env'),
+      'SUPABASE_URL=https://main.supabase.co\nSUPABASE_PUBLISHABLE_KEY=main-key\n',
+    );
+    fs.writeFileSync(
+      path.join(tempDir, '.env.development'),
+      'SUPABASE_URL=https://dev.supabase.co\nSUPABASE_PUBLISHABLE_KEY=dev-key\n',
+    );
+
+    const { applySupabaseFrontendEnv } = require('../../../config/supabaseEnv');
+
+    process.env.SUPABASE_URL = '';
+    process.env.SUPABASE_PUBLISHABLE_KEY = '';
 
     applySupabaseFrontendEnv(tempDir, 'dev');
 

--- a/tests/unit/pages/Review/Components/ReviewProgress.test.tsx
+++ b/tests/unit/pages/Review/Components/ReviewProgress.test.tsx
@@ -587,6 +587,7 @@ describe('ReviewProgress component', () => {
     renderComponent();
 
     fireEvent.click(screen.getByTestId('icon-sync').closest('button') as HTMLButtonElement);
+    await screen.findByTestId('remove-user-2');
     await waitFor(() => expect(latestColumns).toHaveLength(6));
 
     const statusColumn = latestColumns.find((column) => column.dataIndex === 'state_code');

--- a/tests/unit/pages/Unitgroups/Components/select/form.test.tsx
+++ b/tests/unit/pages/Unitgroups/Components/select/form.test.tsx
@@ -498,7 +498,7 @@ describe('UnitgroupsSelectForm', () => {
     );
 
     await waitFor(() => expect(mockGetRefData).toHaveBeenCalledTimes(1));
-    expect(screen.getByText('err-ref')).toBeInTheDocument();
+    expect(await screen.findByText('err-ref')).toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', { name: /update err ref/i }));
 
     mockRefCheckContextValue = {

--- a/tests/unit/services/general/tidasPackage.api.test.ts
+++ b/tests/unit/services/general/tidasPackage.api.test.ts
@@ -1072,6 +1072,108 @@ describe('general/api TIDAS package helpers', () => {
     });
   });
 
+  it('falls back to a null artifact hash when Web Crypto digest is unavailable', async () => {
+    const file = createZipFile();
+    Object.defineProperty(global, 'crypto', {
+      configurable: true,
+      value: {
+        subtle: {},
+      },
+      writable: true,
+    });
+
+    mockFunctionsInvoke
+      .mockResolvedValueOnce({
+        data: {
+          ok: true,
+          action: 'prepare_upload',
+          job_id: 'job-null-hash',
+          source_artifact_id: 'artifact-null-hash',
+          artifact_url: 'https://example.com/source',
+          upload: {
+            bucket: 'tidas',
+            object_path: 'exports/package.zip',
+            token: 'signed-token',
+            path: 'exports/package.zip',
+            signed_url: 'https://example.com/upload',
+            expires_in_seconds: 300,
+            filename: 'package.zip',
+            byte_size: 8,
+            content_type: 'application/zip',
+          },
+        },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { ok: false, message: 'enqueue failed' },
+        error: null,
+      });
+
+    const result = await importTidasPackageApi(file);
+
+    expect(result.error).toEqual(new Error('enqueue failed'));
+    expect(mockFunctionsInvoke).toHaveBeenNthCalledWith(2, 'import_tidas_package', {
+      body: expect.objectContaining({
+        action: 'enqueue',
+        artifact_sha256: null,
+        job_id: 'job-null-hash',
+        source_artifact_id: 'artifact-null-hash',
+      }),
+      headers: {
+        Authorization: 'Bearer token-123',
+      },
+      region: FunctionRegion.UsEast1,
+    });
+  });
+
+  it('falls back to a null artifact hash when digest computation throws', async () => {
+    const file = createZipFile();
+    mockDigest.mockRejectedValueOnce(new Error('digest failed'));
+
+    mockFunctionsInvoke
+      .mockResolvedValueOnce({
+        data: {
+          ok: true,
+          action: 'prepare_upload',
+          job_id: 'job-digest-error',
+          source_artifact_id: 'artifact-digest-error',
+          artifact_url: 'https://example.com/source',
+          upload: {
+            bucket: 'tidas',
+            object_path: 'exports/package.zip',
+            token: 'signed-token',
+            path: 'exports/package.zip',
+            signed_url: 'https://example.com/upload',
+            expires_in_seconds: 300,
+            filename: 'package.zip',
+            byte_size: 8,
+            content_type: 'application/zip',
+          },
+        },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { ok: false, message: 'enqueue failed' },
+        error: null,
+      });
+
+    const result = await importTidasPackageApi(file);
+
+    expect(result.error).toEqual(new Error('enqueue failed'));
+    expect(mockFunctionsInvoke).toHaveBeenNthCalledWith(2, 'import_tidas_package', {
+      body: expect.objectContaining({
+        action: 'enqueue',
+        artifact_sha256: null,
+        job_id: 'job-digest-error',
+        source_artifact_id: 'artifact-digest-error',
+      }),
+      headers: {
+        Authorization: 'Bearer token-123',
+      },
+      region: FunctionRegion.UsEast1,
+    });
+  });
+
   it('rewrites docker-internal import report URLs to the browser-accessible Supabase origin', async () => {
     process.env.SUPABASE_URL = 'http://localhost:54321';
     mockDigest.mockResolvedValueOnce(new Uint8Array([0x0a]).buffer);


### PR DESCRIPTION
## Summary
- refine frontend Supabase env selection for dev and main startup flows
- remove temporary Supabase env debug logging
- add and stabilize targeted tests so the repo stays at full coverage

## Validation
- npm test
- npm run test:coverage
- npm run test:coverage:assert-full