### PR TITLE
fix: 收口 next 审核与系统管理残留读侧权限边界

### DIFF
--- a/src/components/AccessDenied/index.tsx
+++ b/src/components/AccessDenied/index.tsx
@@ -1,0 +1,26 @@
+import { FormattedMessage } from '@umijs/max';
+
+type AccessDeniedProps = {
+  titleId?: string;
+  titleDefaultMessage?: string;
+  messageId?: string;
+  messageDefaultMessage?: string;
+};
+
+export default function AccessDenied({
+  titleId = 'pages.accessDenied.title',
+  titleDefaultMessage = '403',
+  messageId = 'pages.accessDenied.message',
+  messageDefaultMessage = 'You do not have permission to access this page.',
+}: AccessDeniedProps) {
+  return (
+    <div data-testid='access-denied'>
+      <h3>
+        <FormattedMessage id={titleId} defaultMessage={titleDefaultMessage} />
+      </h3>
+      <p>
+        <FormattedMessage id={messageId} defaultMessage={messageDefaultMessage} />
+      </p>
+    </div>
+  );
+}

--- a/src/components/AllTeams/index.tsx
+++ b/src/components/AllTeams/index.tsx
@@ -337,7 +337,7 @@ const TableList: FC<TableListProps> = ({ systemUserRole, tableType }) => {
             pageSize: 10,
           }}
           request={async (params: { pageSize: number; current: number }) => {
-            if (tableType === 'manageSystem' && !systemUserRole) {
+            if (!systemUserRole) {
               return {
                 data: [],
                 success: true,

--- a/src/components/AllTeams/index.tsx
+++ b/src/components/AllTeams/index.tsx
@@ -246,6 +246,13 @@ const TableList: FC<TableListProps> = ({ systemUserRole, tableType }) => {
             }}
             dataSource={tableData}
             request={async (params: { pageSize: number; current: number }) => {
+              if (!systemUserRole) {
+                return {
+                  data: [],
+                  success: true,
+                  total: 0,
+                };
+              }
               if (keyWord.length > 0) {
                 const result = await getTeamsByKeyword(keyWord);
                 setTableData(result.data || []);
@@ -330,6 +337,13 @@ const TableList: FC<TableListProps> = ({ systemUserRole, tableType }) => {
             pageSize: 10,
           }}
           request={async (params: { pageSize: number; current: number }) => {
+            if (tableType === 'manageSystem' && !systemUserRole) {
+              return {
+                data: [],
+                success: true,
+                total: 0,
+              };
+            }
             if (keyWord.length > 0) {
               return getTeamsByKeyword(keyWord);
             }

--- a/src/pages/ManageSystem/index.tsx
+++ b/src/pages/ManageSystem/index.tsx
@@ -254,13 +254,6 @@ const ManageSystem = () => {
             sort,
           ) => {
             try {
-              if (!userData?.role) {
-                return {
-                  data: [],
-                  success: true,
-                  total: 0,
-                };
-              }
               setMembersLoading(true);
               return await getSystemMembersApi(params, sort);
             } catch (error) {

--- a/src/pages/ManageSystem/index.tsx
+++ b/src/pages/ManageSystem/index.tsx
@@ -1,3 +1,4 @@
+import AccessDenied from '@/components/AccessDenied';
 import AllTeams from '@/components/AllTeams';
 import { ListPagination } from '@/services/general/data';
 import {
@@ -17,6 +18,7 @@ import AddMemberModal from './Components/AddMemberModal';
 const ManageSystem = () => {
   const [activeTabKey, setActiveTabKey] = useState('teams');
   const [loading, setLoading] = useState(false);
+  const [authResolved, setAuthResolved] = useState(false);
   const [membersLoading, setMembersLoading] = useState(false);
   const [userData, setUserData] = useState<{ user_id: string; role: string } | null>(null);
   const actionRef = useRef<any>();
@@ -32,6 +34,7 @@ const ManageSystem = () => {
     } catch (error) {
       console.error(error);
     } finally {
+      setAuthResolved(true);
       setLoading(false);
     }
   };
@@ -39,6 +42,9 @@ const ManageSystem = () => {
   useEffect(() => {
     checkUserAuth();
   }, []);
+
+  const isAuthorized =
+    userData?.role === 'admin' || userData?.role === 'owner' || userData?.role === 'member';
 
   const onTabChange = (key: string) => {
     setActiveTabKey(key);
@@ -296,7 +302,13 @@ const ManageSystem = () => {
 
   return (
     <PageContainer title={<FormattedMessage id='menu.manageSystem' />}>
-      <Tabs activeKey={activeTabKey} onChange={onTabChange} tabPosition='left' items={tabs} />
+      {!authResolved ? (
+        <Spin spinning={loading} />
+      ) : !isAuthorized ? (
+        <AccessDenied />
+      ) : (
+        <Tabs activeKey={activeTabKey} onChange={onTabChange} tabPosition='left' items={tabs} />
+      )}
     </PageContainer>
   );
 };

--- a/src/pages/Review/index.tsx
+++ b/src/pages/Review/index.tsx
@@ -1,3 +1,4 @@
+import AccessDenied from '@/components/AccessDenied';
 import { getReviewUserRoleApi } from '@/services/roles/api';
 import { PageContainer } from '@ant-design/pro-components';
 import { FormattedMessage } from '@umijs/max';
@@ -7,8 +8,9 @@ import AssignmentReview from './Components/AssignmentReview';
 import ReviewMember from './Components/ReviewMember';
 
 const Review = () => {
-  const [activeTabKey, setActiveTabKey] = useState('unassigned');
+  const [activeTabKey, setActiveTabKey] = useState('');
   const [loading, setLoading] = useState(false);
+  const [authResolved, setAuthResolved] = useState(false);
   const [userData, setUserData] = useState<{ user_id: string; role: string } | null>(null);
   const actionRef = useRef<any>();
   const unassignedTableRef = useRef<any>();
@@ -22,10 +24,10 @@ const Review = () => {
     try {
       const userData = await getReviewUserRoleApi();
       setUserData(userData);
-      unassignedTableRef.current?.reload();
     } catch (error) {
       console.error(error);
     } finally {
+      setAuthResolved(true);
       setLoading(false);
     }
   };
@@ -58,97 +60,100 @@ const Review = () => {
     }
   };
 
-  const tabs =
-    userData?.role === 'review-admin'
-      ? [
-          {
-            key: 'unassigned',
-            label: <FormattedMessage id='pages.review.tabs.unassigned' />,
-            children: (
-              <AssignmentReview
-                actionRef={unassignedTableRef}
-                tableType='unassigned'
-                userData={userData}
-              />
-            ),
-          },
-          {
-            key: 'assigned',
-            label: <FormattedMessage id='pages.review.tabs.assigned' />,
-            children: (
-              <AssignmentReview
-                actionRef={assignedTableRef}
-                tableType='assigned'
-                userData={userData}
-              />
-            ),
-          },
-          {
-            key: 'rejected',
-            label: <FormattedMessage id='pages.review.tabs.rejectedTask' />,
-            children: (
-              <AssignmentReview
-                actionRef={rejectedTableRef}
-                tableType='admin-rejected'
-                userData={userData}
-              />
-            ),
-          },
-          {
-            key: 'members',
-            label: <FormattedMessage id='pages.review.tabs.members' />,
-            children: <ReviewMember userData={userData} />,
-          },
-        ]
-      : [
-          {
-            key: 'reviewed',
-            label: <FormattedMessage id='pages.review.tabs.reviewed' />,
-            children: (
-              <AssignmentReview
-                actionRef={reviewedTableRef}
-                tableType='reviewed'
-                userData={userData}
-              />
-            ),
-          },
-          {
-            key: 'pending',
-            label: <FormattedMessage id='pages.review.tabs.pending' />,
-            children: (
-              <AssignmentReview
-                actionRef={pendingTableRef}
-                tableType='pending'
-                userData={userData}
-              />
-            ),
-          },
-          {
-            key: 'rejected',
-            label: <FormattedMessage id='pages.review.tabs.rejected' />,
-            children: (
-              <AssignmentReview
-                actionRef={rejectedTableRef}
-                tableType='reviewer-rejected'
-                userData={userData}
-              />
-            ),
-          },
-        ];
+  const isReviewAdmin = userData?.role === 'review-admin';
+  const isReviewMember = userData?.role === 'review-member';
+  const isAuthorized = isReviewAdmin || isReviewMember;
+
+  const tabs = isReviewAdmin
+    ? [
+        {
+          key: 'unassigned',
+          label: <FormattedMessage id='pages.review.tabs.unassigned' />,
+          children: (
+            <AssignmentReview
+              actionRef={unassignedTableRef}
+              tableType='unassigned'
+              userData={userData}
+            />
+          ),
+        },
+        {
+          key: 'assigned',
+          label: <FormattedMessage id='pages.review.tabs.assigned' />,
+          children: (
+            <AssignmentReview
+              actionRef={assignedTableRef}
+              tableType='assigned'
+              userData={userData}
+            />
+          ),
+        },
+        {
+          key: 'rejected',
+          label: <FormattedMessage id='pages.review.tabs.rejectedTask' />,
+          children: (
+            <AssignmentReview
+              actionRef={rejectedTableRef}
+              tableType='admin-rejected'
+              userData={userData}
+            />
+          ),
+        },
+        {
+          key: 'members',
+          label: <FormattedMessage id='pages.review.tabs.members' />,
+          children: <ReviewMember userData={userData} />,
+        },
+      ]
+    : [
+        {
+          key: 'reviewed',
+          label: <FormattedMessage id='pages.review.tabs.reviewed' />,
+          children: (
+            <AssignmentReview
+              actionRef={reviewedTableRef}
+              tableType='reviewed'
+              userData={userData}
+            />
+          ),
+        },
+        {
+          key: 'pending',
+          label: <FormattedMessage id='pages.review.tabs.pending' />,
+          children: (
+            <AssignmentReview actionRef={pendingTableRef} tableType='pending' userData={userData} />
+          ),
+        },
+        {
+          key: 'rejected',
+          label: <FormattedMessage id='pages.review.tabs.rejected' />,
+          children: (
+            <AssignmentReview
+              actionRef={rejectedTableRef}
+              tableType='reviewer-rejected'
+              userData={userData}
+            />
+          ),
+        },
+      ];
 
   useEffect(() => {
-    if (userData?.role === 'review-member' && activeTabKey !== 'reviewed') {
-      setActiveTabKey('reviewed');
-      if (reviewedTableRef.current) {
-        reviewedTableRef.current.reload();
-      }
+    if (!isAuthorized) {
+      setActiveTabKey('');
+      return;
     }
-  }, [userData]);
+
+    setActiveTabKey(isReviewAdmin ? 'unassigned' : 'reviewed');
+  }, [isAuthorized, isReviewAdmin]);
 
   return (
     <PageContainer title={<FormattedMessage id='pages.review.title' />}>
       <Spin spinning={loading}>
-        <Tabs activeKey={activeTabKey} onChange={onTabChange} tabPosition='left' items={tabs} />
+        {!authResolved ? null : !isAuthorized ? (
+          <AccessDenied />
+        ) : (
+          <Tabs activeKey={activeTabKey} onChange={onTabChange} tabPosition='left' items={tabs} />
+        )}
       </Spin>
     </PageContainer>
   );

--- a/src/services/comments/api.ts
+++ b/src/services/comments/api.ts
@@ -7,11 +7,90 @@ type ReviewCommentCommandFunctionName =
   | 'app_review_save_comment_draft'
   | 'app_review_submit_comment';
 
+type ReviewCommentRpcRow = {
+  review_id: string;
+  reviewer_id: string;
+  state_code: number;
+  json: any;
+  created_at?: string;
+  modified_at?: string;
+};
+
+type ReviewMemberQueueRpcRow = {
+  id: string;
+  review_state_code?: number;
+  reviewer_id?: string[] | null;
+  json: any;
+  deadline?: string | null;
+  created_at?: string;
+  modified_at?: string;
+  comment_state_code?: number;
+  comment_json?: any;
+  comment_created_at?: string;
+  comment_modified_at?: string;
+  total_count?: number | string | null;
+};
+
 async function invokeReviewCommentCommand<Row extends Record<string, unknown>>(
   functionName: ReviewCommentCommandFunctionName,
   body: Record<string, unknown>,
 ) {
   return invokeDatasetCommand<Row>(functionName as never, body);
+}
+
+function normalizeQueueResult(row: ReviewMemberQueueRpcRow, reviewerId: string) {
+  return {
+    review_id: row.id,
+    reviewer_id: reviewerId,
+    state_code: row.comment_state_code,
+    json: row.comment_json,
+    created_at: row.comment_created_at,
+    modified_at: row.comment_modified_at,
+    reviews: {
+      id: row.id,
+      state_code: row.review_state_code,
+      reviewer_id: row.reviewer_id,
+      json: row.json,
+      deadline: row.deadline,
+      created_at: row.created_at,
+      modified_at: row.modified_at,
+    },
+  };
+}
+
+async function getReviewMemberQueueComments(
+  status: 'reviewed' | 'pending' | 'reviewer-rejected',
+  params: {
+    current?: number;
+    pageSize?: number;
+  } = {},
+  sort: Record<string, SortOrder> = {},
+  user_id?: string,
+) {
+  const normalizedSort = sort ?? {};
+  const sortBy = Object.keys(normalizedSort)[0] ?? 'modified_at';
+  const orderBy = normalizedSort[sortBy] ?? 'descend';
+  const userId = user_id ?? (await getUserId());
+
+  if (!userId) {
+    return { error: true, data: [] };
+  }
+
+  const { data, error } = await supabase.rpc('qry_review_get_member_queue_items', {
+    p_status: status,
+    p_page: params.current ?? 1,
+    p_page_size: params.pageSize ?? 10,
+    p_sort_by: sortBy,
+    p_sort_order: orderBy,
+  });
+
+  const rows = (data ?? []) as ReviewMemberQueueRpcRow[];
+
+  return {
+    data: rows.map((row) => normalizeQueueResult(row, userId)),
+    error,
+    count: Number(rows?.[0]?.total_count ?? 0) || 0,
+  };
 }
 
 export async function addCommentApi(data: any) {
@@ -62,27 +141,28 @@ export async function getCommentApi(
   reviewId: string,
   actionType: 'assigned' | 'review' | 'reviewer-rejected' | 'admin-rejected',
 ) {
-  if (['review', 'reviewer-rejected', 'admin-rejected'].includes(actionType)) {
-    const userId = await getUserId();
-
-    if (!userId) {
-      return { error: true, data: [] };
-    }
-    let query = supabase.from('comments').select('*').eq('review_id', reviewId);
-
-    if (actionType === 'admin-rejected') {
-      const { data, error } = await query;
-      return { data, error };
-    }
+  if (['assigned', 'review', 'reviewer-rejected', 'admin-rejected'].includes(actionType)) {
     if (actionType === 'review' || actionType === 'reviewer-rejected') {
-      query = query.eq('reviewer_id', userId);
-      const { data, error } = await query;
-      return { data, error };
+      const userId = await getUserId();
+
+      if (!userId) {
+        return { error: true, data: [] };
+      }
     }
-  }
-  if (actionType === 'assigned') {
-    const { data, error } = await supabase.from('comments').select('*').eq('review_id', reviewId);
-    return { data, error };
+
+    const scope = actionType === 'assigned' || actionType === 'admin-rejected' ? 'all' : 'mine';
+    const { data, error } = await supabase.rpc('qry_review_get_comment_items', {
+      p_review_id: reviewId,
+      p_scope: scope,
+    });
+
+    return {
+      data: ((data ?? []) as ReviewCommentRpcRow[]).map((row) => ({
+        ...row,
+        json: row?.json ?? {},
+      })),
+      error,
+    };
   }
   return { data: [], error: true };
 }
@@ -95,28 +175,7 @@ export async function getReviewedComment(
   sort: Record<string, SortOrder> = {},
   user_id?: string,
 ) {
-  const normalizedSort = sort ?? {};
-  const sortBy = Object.keys(normalizedSort)[0] ?? 'modified_at';
-  const orderBy = normalizedSort[sortBy] ?? 'descend';
-
-  const userId = user_id ?? (await getUserId());
-
-  if (!userId) {
-    return { error: true, data: [] };
-  }
-
-  const pageSize = params.pageSize ?? 10;
-  const currentPage = params.current ?? 1;
-
-  const result = await supabase
-    .from('comments')
-    .select('review_id, reviews!inner(*)', { count: 'exact' })
-    .eq('reviewer_id', userId)
-    .in('state_code', [1, 2, -3])
-    .filter('reviews.state_code', 'gt', 0)
-    .order(sortBy, { ascending: orderBy === 'ascend' })
-    .range((currentPage - 1) * pageSize, currentPage * pageSize - 1);
-  return result;
+  return getReviewMemberQueueComments('reviewed', params, sort, user_id);
 }
 
 export async function getPendingComment(
@@ -127,27 +186,7 @@ export async function getPendingComment(
   sort: Record<string, SortOrder> = {},
   user_id?: string,
 ) {
-  const normalizedSort = sort ?? {};
-  const sortBy = Object.keys(normalizedSort)[0] ?? 'modified_at';
-  const orderBy = normalizedSort[sortBy] ?? 'descend';
-  const userId = user_id ?? (await getUserId());
-
-  if (!userId) {
-    return { error: true, data: [] };
-  }
-
-  const pageSize = params.pageSize ?? 10;
-  const currentPage = params.current ?? 1;
-
-  const result = await supabase
-    .from('comments')
-    .select('review_id, reviews!inner(*)', { count: 'exact' })
-    .eq('reviewer_id', userId)
-    .eq('state_code', 0)
-    .filter('reviews.state_code', 'gt', 0)
-    .order(sortBy, { ascending: orderBy === 'ascend' })
-    .range((currentPage - 1) * pageSize, currentPage * pageSize - 1);
-  return result;
+  return getReviewMemberQueueComments('pending', params, sort, user_id);
 }
 
 export async function getRejectedComment(
@@ -158,27 +197,7 @@ export async function getRejectedComment(
   sort: Record<string, SortOrder> = {},
   user_id?: string,
 ) {
-  const normalizedSort = sort ?? {};
-  const sortBy = Object.keys(normalizedSort)[0] ?? 'modified_at';
-  const orderBy = normalizedSort[sortBy] ?? 'descend';
-  const userId = user_id ?? (await getUserId());
-
-  if (!userId) {
-    return { error: true, data: [] };
-  }
-
-  const pageSize = params.pageSize ?? 10;
-  const currentPage = params.current ?? 1;
-
-  const result = await supabase
-    .from('comments')
-    .select('review_id, reviews!inner(*)', { count: 'exact' })
-    .eq('reviewer_id', userId)
-    .eq('state_code', -1)
-    .eq('reviews.state_code', -1)
-    .order(sortBy, { ascending: orderBy === 'ascend' })
-    .range((currentPage - 1) * pageSize, currentPage * pageSize - 1);
-  return result;
+  return getReviewMemberQueueComments('reviewer-rejected', params, sort, user_id);
 }
 
 export async function getUserManageComments() {
@@ -191,18 +210,31 @@ export async function getUserManageComments() {
 }
 
 export async function getReviewerIdsByReviewId(reviewId: string) {
-  const { data } = await supabase
-    .from('comments')
-    .select('state_code,reviewer_id')
-    .eq('review_id', reviewId);
-  return data;
+  const { data, error } = await getCommentApi(reviewId, 'assigned');
+
+  if (error) {
+    return [];
+  }
+
+  return (data ?? []).map((comment) => ({
+    state_code: comment.state_code,
+    reviewer_id: comment.reviewer_id,
+  }));
 }
 
 export async function getRejectedCommentsByReviewIds(reviewIds: string[]) {
-  const result = await supabase
-    .from('comments')
-    .select('json')
-    .in('review_id', reviewIds)
-    .eq('state_code', -1);
-  return result;
+  const results = await Promise.all(
+    reviewIds.map((reviewId) => getCommentApi(reviewId, 'admin-rejected')),
+  );
+  const firstError = results.find((result) => result.error)?.error ?? null;
+  const data = results.flatMap((result) =>
+    (result.data ?? [])
+      .filter((comment) => comment.state_code === -1)
+      .map((comment) => ({ json: comment.json })),
+  );
+
+  return {
+    data,
+    error: firstError,
+  };
 }

--- a/src/services/comments/api.ts
+++ b/src/services/comments/api.ts
@@ -60,11 +60,11 @@ function normalizeQueueResult(row: ReviewMemberQueueRpcRow, reviewerId: string) 
 
 async function getReviewMemberQueueComments(
   status: 'reviewed' | 'pending' | 'reviewer-rejected',
-  params: {
+  params?: {
     current?: number;
     pageSize?: number;
-  } = {},
-  sort: Record<string, SortOrder> = {},
+  },
+  sort?: Record<string, SortOrder>,
   user_id?: string,
 ) {
   const normalizedSort = sort ?? {};
@@ -78,13 +78,13 @@ async function getReviewMemberQueueComments(
 
   const { data, error } = await supabase.rpc('qry_review_get_member_queue_items', {
     p_status: status,
-    p_page: params.current ?? 1,
-    p_page_size: params.pageSize ?? 10,
+    p_page: params?.current ?? 1,
+    p_page_size: params?.pageSize ?? 10,
     p_sort_by: sortBy,
     p_sort_order: orderBy,
   });
 
-  const rows = (data ?? []) as ReviewMemberQueueRpcRow[];
+  const rows = (Array.isArray(data) ? data : []) as ReviewMemberQueueRpcRow[];
 
   return {
     data: rows.map((row) => normalizeQueueResult(row, userId)),
@@ -155,9 +155,10 @@ export async function getCommentApi(
       p_review_id: reviewId,
       p_scope: scope,
     });
+    const rows = (Array.isArray(data) ? data : []) as ReviewCommentRpcRow[];
 
     return {
-      data: ((data ?? []) as ReviewCommentRpcRow[]).map((row) => ({
+      data: rows.map((row) => ({
         ...row,
         json: row?.json ?? {},
       })),
@@ -216,7 +217,7 @@ export async function getReviewerIdsByReviewId(reviewId: string) {
     return [];
   }
 
-  return (data ?? []).map((comment) => ({
+  return data.map((comment) => ({
     state_code: comment.state_code,
     reviewer_id: comment.reviewer_id,
   }));
@@ -228,7 +229,7 @@ export async function getRejectedCommentsByReviewIds(reviewIds: string[]) {
   );
   const firstError = results.find((result) => result.error)?.error ?? null;
   const data = results.flatMap((result) =>
-    (result.data ?? [])
+    result.data
       .filter((comment) => comment.state_code === -1)
       .map((comment) => ({ json: comment.json })),
   );

--- a/src/services/reviews/api.ts
+++ b/src/services/reviews/api.ts
@@ -239,9 +239,7 @@ export async function getReviewerIdsApi(reviewIds: React.Key[]) {
 
   return Array.from(
     new Set(
-      (data ?? []).flatMap((item: any) =>
-        Array.isArray(item?.reviewer_id) ? item.reviewer_id : [],
-      ),
+      data.flatMap((item: any) => (Array.isArray(item?.reviewer_id) ? item.reviewer_id : [])),
     ),
   );
 }
@@ -250,7 +248,7 @@ export async function getReviewsDetail(id: string) {
   const { data } = await getReviewItemsRpc({
     reviewIds: [id],
   });
-  return data?.[0] ?? null;
+  return data.length > 0 ? data[0] : null;
 }
 
 export async function getReviewsDetailByReviewIds(reviewIds: React.Key[]) {
@@ -304,9 +302,10 @@ export async function getReviewsTableDataOfReviewMember(
     }))
     .filter((item) => item.id);
   const modelResult = await getLifeCyclesByIdAndVersion(processes);
+  const lifecycleModels = Array.isArray(modelResult?.data) ? modelResult.data : [];
 
   return Promise.resolve({
-    data: rows.map((row) => mapReviewRowToTableData(row, lang, modelResult?.data ?? [])),
+    data: rows.map((row) => mapReviewRowToTableData(row, lang, lifecycleModels)),
     page: params?.current ?? 1,
     success: true,
     total: normalizeTotalCount(rows[0]?.total_count),
@@ -347,13 +346,14 @@ export async function getReviewsTableDataOfReviewAdmin(
     }))
     .filter((item) => item.id);
   const modelResult = await getLifeCyclesByIdAndVersion(processes);
+  const lifecycleModels = Array.isArray(modelResult?.data) ? modelResult.data : [];
 
   return Promise.resolve({
     data: rows.map((row) =>
       mapReviewRowToTableData(
         row,
         lang,
-        modelResult?.data ?? [],
+        lifecycleModels,
         Array.isArray(row.comment_state_codes)
           ? row.comment_state_codes
               .map((stateCode) => ({ state_code: Number(stateCode) }))

--- a/src/services/reviews/api.ts
+++ b/src/services/reviews/api.ts
@@ -6,7 +6,6 @@ import {
 import { getLifeCyclesByIdAndVersion } from '@/services/lifeCycleModels/api';
 import { supabase } from '@/services/supabase';
 import { getUserId } from '@/services/users/api';
-import { getPendingComment, getRejectedComment, getReviewedComment } from '../comments/api';
 import { getLangText } from '../general/util';
 import { getProcessDetailByIdAndVersion } from '../processes/api';
 import { genProcessName } from '../processes/util';
@@ -28,6 +27,40 @@ type DataNotificationRpcRow = {
   state_code: number;
   json: any;
   modified_at: string;
+  total_count?: number | string | null;
+};
+
+type ReviewItemRpcRow = {
+  id: string;
+  data_id?: string;
+  data_version?: string;
+  state_code?: number;
+  reviewer_id?: string[] | null;
+  json: any;
+  deadline?: string | null;
+  created_at?: string;
+  modified_at?: string;
+};
+
+type ReviewAdminQueueRpcRow = ReviewItemRpcRow & {
+  comment_state_codes?: number[] | null;
+  total_count?: number | string | null;
+};
+
+type ReviewMemberQueueRpcRow = {
+  id: string;
+  data_id?: string;
+  data_version?: string;
+  review_state_code?: number;
+  reviewer_id?: string[] | null;
+  json: any;
+  deadline?: string | null;
+  created_at?: string;
+  modified_at?: string;
+  comment_state_code?: number;
+  comment_json?: any;
+  comment_created_at?: string;
+  comment_modified_at?: string;
   total_count?: number | string | null;
 };
 
@@ -60,6 +93,63 @@ async function invokeReviewWorkflowCommandBatch<Row extends Record<string, unkno
     count: null,
     status: firstError?.status ?? 200,
     statusText: firstError?.statusText ?? 'OK',
+  };
+}
+
+function normalizeTotalCount(value: number | string | null | undefined) {
+  return Number(value ?? 0) || 0;
+}
+
+function mapReviewRowToTableData(
+  row: ReviewItemRpcRow,
+  lang: string,
+  lifecycleModels: any[],
+  comments: { state_code: number }[] = [],
+) {
+  const model = lifecycleModels?.find(
+    (candidate) =>
+      candidate.id === row?.json?.data?.id && candidate.version === row?.json?.data?.version,
+  );
+  const modelName =
+    model?.json?.lifeCycleModelDataSet?.lifeCycleModelInformation?.dataSetInformation?.name;
+
+  return {
+    key: row.id,
+    id: row.id,
+    isFromLifeCycle: Boolean(model),
+    name:
+      (model
+        ? genProcessName(modelName ?? {}, lang)
+        : genProcessName(row?.json?.data?.name ?? {}, lang)) || '-',
+    teamName: getLangText(row?.json?.team?.name ?? {}, lang),
+    userName: row?.json?.user?.name ?? row?.json?.user?.email ?? '-',
+    createAt: row.created_at ? new Date(row.created_at).toISOString() : undefined,
+    modifiedAt: row.modified_at ? new Date(row.modified_at).toISOString() : undefined,
+    deadline: row.deadline ? new Date(row.deadline).toISOString() : row.deadline,
+    json: row?.json,
+    comments,
+    modelData: model
+      ? { id: model.id, version: model.version, json: model.json, json_tg: model.json_tg }
+      : null,
+  };
+}
+
+async function getReviewItemsRpc(params: {
+  reviewIds?: string[];
+  dataId?: string | null;
+  dataVersion?: string | null;
+  stateCodes?: number[];
+}) {
+  const { data, error } = await supabase.rpc('qry_review_get_items', {
+    p_review_ids: params.reviewIds?.length ? params.reviewIds : null,
+    p_data_id: params.dataId ?? null,
+    p_data_version: params.dataVersion ?? null,
+    p_state_codes: params.stateCodes?.length ? params.stateCodes : null,
+  });
+
+  return {
+    data: (data ?? []) as ReviewItemRpcRow[],
+    error,
   };
 }
 
@@ -143,7 +233,9 @@ export async function updateReviewApi(reviewIds: React.Key[], data: any) {
 }
 
 export async function getReviewerIdsApi(reviewIds: React.Key[]) {
-  const { data } = await supabase.from('reviews').select('reviewer_id').in('id', reviewIds);
+  const { data } = await getReviewItemsRpc({
+    reviewIds: reviewIds.map(String),
+  });
 
   return Array.from(
     new Set(
@@ -155,12 +247,16 @@ export async function getReviewerIdsApi(reviewIds: React.Key[]) {
 }
 
 export async function getReviewsDetail(id: string) {
-  const { data } = await supabase.from('reviews').select('*').eq('id', id).single();
-  return data;
+  const { data } = await getReviewItemsRpc({
+    reviewIds: [id],
+  });
+  return data?.[0] ?? null;
 }
 
 export async function getReviewsDetailByReviewIds(reviewIds: React.Key[]) {
-  const { data } = await supabase.from('reviews').select('*').in('id', reviewIds);
+  const { data } = await getReviewItemsRpc({
+    reviewIds: reviewIds.map(String),
+  });
   return data;
 }
 
@@ -171,88 +267,50 @@ export async function getReviewsTableDataOfReviewMember(
   lang: string,
   userData?: { user_id: string | undefined },
 ) {
-  let commentResult: any = [];
-
-  switch (type) {
-    case 'reviewed': {
-      const userId = userData?.user_id ?? (await getUserId());
-      if (userId) {
-        commentResult = await getReviewedComment(params, sort, userId);
-      }
-      break;
-    }
-    case 'pending': {
-      const userId = userData?.user_id ?? (await getUserId());
-      if (userId) {
-        commentResult = await getPendingComment(params, sort, userId);
-      }
-      break;
-    }
-    case 'reviewer-rejected': {
-      const userId = userData?.user_id ?? (await getUserId());
-      if (userId) {
-        commentResult = await getRejectedComment(params, sort, userId);
-      }
-      break;
-    }
-  }
-  if (commentResult.error || !commentResult.data || !commentResult.data.length) {
+  const userId = userData?.user_id ?? (await getUserId());
+  if (!userId) {
     return Promise.resolve({
       data: [],
       success: true,
       total: 0,
     });
-  } else {
-    const reviews: any[] = [];
-    commentResult.data.forEach((c: any) => {
-      if (c.reviews) {
-        reviews.push({ ...c.reviews });
-      }
-    });
+  }
 
-    const processes: { id: string; version: string }[] = [];
-    reviews.forEach((i) => {
-      const id = i?.json?.data?.id;
-      const version = i?.json?.data?.version;
-      if (id) {
-        processes.push({ id, version });
-      }
-    });
-    const modelResult = await getLifeCyclesByIdAndVersion(processes);
-    let data = reviews.map((i: any) => {
-      const model = modelResult?.data?.find(
-        (j) => j.id === i?.json?.data?.id && j.version === i?.json?.data?.version,
-      );
-      const modelName =
-        model?.json?.lifeCycleModelDataSet?.lifeCycleModelInformation?.dataSetInformation?.name;
-      return {
-        key: i.id,
-        id: i.id,
-        isFromLifeCycle: model ? true : false,
-        name:
-          (model
-            ? genProcessName(modelName ?? {}, lang)
-            : genProcessName(i?.json?.data?.name ?? {}, lang)) || '-',
-        teamName: getLangText(i?.json?.team?.name ?? {}, lang),
-        userName: i?.json?.user?.name ?? i?.json?.user?.email ?? '-',
-        createAt: new Date(i.created_at).toISOString(),
-        modifiedAt: new Date(i?.modified_at).toISOString(),
-        deadline: i?.deadline ? new Date(i?.deadline).toISOString() : i?.deadline,
-        json: i?.json,
-        // Store complete model data for subtable preloading
-        modelData: model
-          ? { id: model.id, version: model.version, json: model.json, json_tg: model.json_tg }
-          : null,
-      };
-    });
+  const normalizedSort = sort ?? {};
+  const sortBy = Object.keys(normalizedSort)[0] ?? 'modified_at';
+  const orderBy = normalizedSort[sortBy] ?? 'descend';
 
+  const { data, error } = await supabase.rpc('qry_review_get_member_queue_items', {
+    p_status: type,
+    p_page: params.current ?? 1,
+    p_page_size: params.pageSize ?? 10,
+    p_sort_by: sortBy,
+    p_sort_order: orderBy,
+  });
+
+  const rows = (data ?? []) as ReviewMemberQueueRpcRow[];
+  if (error || rows.length === 0) {
     return Promise.resolve({
-      data: data,
-      page: params?.current ?? 1,
+      data: [],
       success: true,
-      total: commentResult?.count ?? 0,
+      total: 0,
     });
   }
+
+  const processes = rows
+    .map((row) => ({
+      id: row?.json?.data?.id,
+      version: row?.json?.data?.version,
+    }))
+    .filter((item) => item.id);
+  const modelResult = await getLifeCyclesByIdAndVersion(processes);
+
+  return Promise.resolve({
+    data: rows.map((row) => mapReviewRowToTableData(row, lang, modelResult?.data ?? [])),
+    page: params?.current ?? 1,
+    success: true,
+    total: normalizeTotalCount(rows[0]?.total_count),
+  });
 }
 
 export async function getReviewsTableDataOfReviewAdmin(
@@ -261,112 +319,67 @@ export async function getReviewsTableDataOfReviewAdmin(
   type: 'unassigned' | 'assigned' | 'admin-rejected',
   lang: string,
 ) {
-  const sortBy = Object.keys(sort)[0] ?? 'modified_at';
-  const orderBy = sort[sortBy] ?? 'descend';
-  let query = supabase
-    .from('reviews')
-    .select('*', { count: 'exact' })
-    .order(sortBy, { ascending: orderBy === 'ascend' })
-    .range(
-      ((params.current ?? 1) - 1) * (params.pageSize ?? 10),
-      (params.current ?? 1) * (params.pageSize ?? 10) - 1,
-    );
-  switch (type) {
-    case 'unassigned': {
-      query = query.eq('state_code', 0);
-      break;
-    }
-    case 'assigned': {
-      query = query.eq('state_code', 1).select('*, comments(state_code)');
-      break;
-    }
-    case 'admin-rejected': {
-      query = query.eq('state_code', -1);
-      break;
-    }
-  }
+  const normalizedSort = sort ?? {};
+  const sortBy = Object.keys(normalizedSort)[0] ?? 'modified_at';
+  const orderBy = normalizedSort[sortBy] ?? 'descend';
 
-  const result = await query;
+  const { data, error } = await supabase.rpc('qry_review_get_admin_queue_items', {
+    p_status: type,
+    p_page: params.current ?? 1,
+    p_page_size: params.pageSize ?? 10,
+    p_sort_by: sortBy,
+    p_sort_order: orderBy,
+  });
 
-  if (result?.data) {
-    if (result?.data.length === 0) {
-      return Promise.resolve({
-        data: [],
-        success: true,
-        total: 0,
-      });
-    }
-    const processes: { id: string; version: string }[] = [];
-    result?.data.forEach((i) => {
-      const id = i?.json?.data?.id;
-      const version = i?.json?.data?.version;
-      if (id) {
-        processes.push({ id, version });
-      }
-    });
-    const modelResult = await getLifeCyclesByIdAndVersion(processes);
-    let data = result?.data.map((i: any) => {
-      const model = modelResult?.data?.find(
-        (j) => j.id === i?.json?.data?.id && j.version === i?.json?.data?.version,
-      );
-      const modelName =
-        model?.json?.lifeCycleModelDataSet?.lifeCycleModelInformation?.dataSetInformation?.name;
-      return {
-        key: i.id,
-        id: i.id,
-        isFromLifeCycle: model ? true : false,
-        name:
-          (model
-            ? genProcessName(modelName ?? {}, lang)
-            : genProcessName(i?.json?.data?.name ?? {}, lang)) || '-',
-        teamName: getLangText(i?.json?.team?.name ?? {}, lang),
-        userName: i?.json?.user?.name ?? i?.json?.user?.email ?? '-',
-        createAt: new Date(i.created_at).toISOString(),
-        modifiedAt: new Date(i?.modified_at).toISOString(),
-        deadline: i?.deadline ? new Date(i?.deadline).toISOString() : i?.deadline,
-        json: i?.json,
-        comments: Array.isArray(i?.comments)
-          ? i.comments.filter((comment: { state_code: number }) =>
-              isCurrentAssignedReviewerCommentState(comment.state_code),
-            )
-          : [],
-        modelData: model
-          ? { id: model.id, version: model.version, json: model.json, json_tg: model.json_tg }
-          : null,
-      };
-    });
-
+  const rows = (data ?? []) as ReviewAdminQueueRpcRow[];
+  if (error || rows.length === 0) {
     return Promise.resolve({
-      data: data,
-      page: params?.current ?? 1,
+      data: [],
       success: true,
-      total: result?.count ?? 0,
+      total: 0,
     });
   }
+
+  const processes = rows
+    .map((row) => ({
+      id: row?.json?.data?.id,
+      version: row?.json?.data?.version,
+    }))
+    .filter((item) => item.id);
+  const modelResult = await getLifeCyclesByIdAndVersion(processes);
+
   return Promise.resolve({
-    data: [],
+    data: rows.map((row) =>
+      mapReviewRowToTableData(
+        row,
+        lang,
+        modelResult?.data ?? [],
+        Array.isArray(row.comment_state_codes)
+          ? row.comment_state_codes
+              .map((stateCode) => ({ state_code: Number(stateCode) }))
+              .filter((comment) => isCurrentAssignedReviewerCommentState(comment.state_code))
+          : [],
+      ),
+    ),
+    page: params?.current ?? 1,
     success: true,
-    total: 0,
+    total: normalizeTotalCount(rows[0]?.total_count),
   });
 }
 
 export async function getReviewsByProcess(processId: string, processVersion: string) {
-  const result = await supabase
-    .from('reviews')
-    .select('*')
-    .filter('json->data->>id', 'eq', processId)
-    .filter('json->data->>version', 'eq', processVersion);
-  return result;
+  return getReviewItemsRpc({
+    dataId: processId,
+    dataVersion: processVersion,
+  });
 }
 
 export async function getRejectReviewsByProcess(processId: string, processVersion: string) {
-  const result = await supabase
-    .from('reviews')
-    .select('id')
-    .filter('json->data->>id', 'eq', processId)
-    .filter('json->data->>version', 'eq', processVersion)
-    .eq('state_code', -1);
-  return result;
+  return getReviewItemsRpc({
+    dataId: processId,
+    dataVersion: processVersion,
+    stateCodes: [-1],
+  });
 }
 
 export async function getNotifyReviews(

--- a/tests/integration/manageSystem/ManageSystemWorkflow.integration.test.tsx
+++ b/tests/integration/manageSystem/ManageSystemWorkflow.integration.test.tsx
@@ -676,4 +676,18 @@ describe('ManageSystem workflows', () => {
       expect(mockGetSystemMembersApi).toHaveBeenCalled();
     });
   });
+
+  it('renders access denied and does not mount system tables for users without a system role', async () => {
+    mockGetSystemUserRoleApi.mockResolvedValue(null);
+
+    renderWithProviders(<ManageSystem />);
+
+    await waitFor(() => {
+      expect(mockGetSystemUserRoleApi).toHaveBeenCalled();
+    });
+
+    expect(screen.getByTestId('access-denied')).toBeInTheDocument();
+    expect(screen.queryByTestId('all-teams')).not.toBeInTheDocument();
+    expect(mockGetSystemMembersApi).not.toHaveBeenCalled();
+  });
 });

--- a/tests/integration/reviews/ReviewAuth.integration.test.tsx
+++ b/tests/integration/reviews/ReviewAuth.integration.test.tsx
@@ -157,7 +157,24 @@ describe('Review page authentication workflow', () => {
     );
     expect(consoleSpy).toHaveBeenCalledWith(error);
     expect(assignmentReloads.unassigned).toBeUndefined();
+    expect(screen.getByTestId('access-denied')).toBeInTheDocument();
 
     consoleSpy.mockRestore();
+  });
+
+  it('renders access denied instead of reviewer tabs for users without a review role', async () => {
+    mockGetReviewUserRoleApi.mockResolvedValue(null);
+
+    renderWithProviders(<Review />);
+
+    await waitFor(() => expect(mockGetReviewUserRoleApi).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.getByTestId('spin')).toHaveAttribute('data-spinning', 'false'),
+    );
+
+    expect(screen.getByTestId('access-denied')).toBeInTheDocument();
+    expect(screen.queryByTestId('tabs')).not.toBeInTheDocument();
+    expect(assignmentReloads.unassigned).toBeUndefined();
+    expect(assignmentReloads.reviewed).toBeUndefined();
   });
 });

--- a/tests/unit/components/AllTeams.test.tsx
+++ b/tests/unit/components/AllTeams.test.tsx
@@ -355,6 +355,15 @@ describe('AllTeams component', () => {
     expect(mockGetAllTableTeams).toHaveBeenCalledWith({ pageSize: 10, current: 1 }, 'joinTeam');
   });
 
+  it('returns an empty join-team table when the system role is missing', async () => {
+    renderAllTeams({ tableType: 'joinTeam', systemUserRole: undefined });
+
+    await waitFor(() => {
+      expect(mockGetAllTableTeams).not.toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId('row-t1')).not.toBeInTheDocument();
+  });
+
   it('searches by keyword in join-team view', async () => {
     renderAllTeams({ tableType: 'joinTeam' });
 

--- a/tests/unit/pages/ManageSystem/index.test.tsx
+++ b/tests/unit/pages/ManageSystem/index.test.tsx
@@ -378,13 +378,13 @@ describe('ManageSystem page', () => {
 
     render(<ManageSystemPage />);
 
-    fireEvent.click(await screen.findByRole('button', { name: 'pages.manageSystem.tabs.members' }));
-
     await waitFor(() => {
-      expect(screen.getByTestId('pro-table')).toBeInTheDocument();
+      expect(screen.getByTestId('access-denied')).toBeInTheDocument();
     });
     expect(mockGetSystemMembersApi).not.toHaveBeenCalled();
-    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
+    expect(
+      screen.queryByRole('button', { name: 'pages.manageSystem.tabs.members' }),
+    ).not.toBeInTheDocument();
   });
 
   it('logs member-loading failures and falls back to an empty table', async () => {
@@ -404,7 +404,7 @@ describe('ManageSystem page', () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it('logs auth-loading failures and keeps rendering the teams tab', async () => {
+  it('logs auth-loading failures and falls back to access denied', async () => {
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     mockGetSystemUserRoleApi.mockRejectedValueOnce(new Error('auth failed'));
 
@@ -414,7 +414,9 @@ describe('ManageSystem page', () => {
       expect(consoleErrorSpy).toHaveBeenCalled();
     });
 
-    expect(screen.getByTestId('all-teams')).toHaveTextContent('manageSystem:none');
+    expect(screen.getByTestId('access-denied')).toHaveTextContent(
+      'You do not have permission to access this page.',
+    );
     consoleErrorSpy.mockRestore();
   });
 

--- a/tests/unit/pages/Review/index.test.tsx
+++ b/tests/unit/pages/Review/index.test.tsx
@@ -122,7 +122,7 @@ describe('Review page', () => {
     });
   });
 
-  it('forces review members onto the reviewed tab and reloads that table', async () => {
+  it('forces review members onto the reviewed tab without requiring an initial reload', async () => {
     mockGetReviewUserRoleApi.mockResolvedValueOnce({ user_id: 'user-2', role: 'review-member' });
 
     render(<ReviewPage />);
@@ -130,9 +130,7 @@ describe('Review page', () => {
     await waitFor(() => {
       expect(screen.getByTestId('assignment-reviewed')).toHaveTextContent('reviewed:review-member');
     });
-    await waitFor(() => {
-      expect(assignmentReloads.reviewed).toHaveBeenCalled();
-    });
+    expect(assignmentReloads.reviewed).not.toHaveBeenCalled();
 
     expect(
       screen.queryByRole('button', { name: 'pages.review.tabs.unassigned' }),
@@ -157,11 +155,11 @@ describe('Review page', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('assignment-reviewed')).toHaveTextContent('reviewed:review-member');
-      expect(assignmentReloads.reviewed).toHaveBeenCalledTimes(2);
+      expect(assignmentReloads.reviewed).toHaveBeenCalledTimes(1);
     });
   });
 
-  it('logs errors from role loading and still clears the spinner wrapper', async () => {
+  it('logs errors from role loading and falls back to access denied', async () => {
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     mockGetReviewUserRoleApi.mockRejectedValueOnce(new Error('load failed'));
 
@@ -171,6 +169,9 @@ describe('Review page', () => {
       expect(consoleErrorSpy).toHaveBeenCalled();
     });
     expect(screen.getByTestId('spin')).toBeInTheDocument();
+    expect(screen.getByTestId('access-denied')).toHaveTextContent(
+      'You do not have permission to access this page.',
+    );
 
     consoleErrorSpy.mockRestore();
   });

--- a/tests/unit/services/comments/api.test.ts
+++ b/tests/unit/services/comments/api.test.ts
@@ -1,12 +1,6 @@
 /**
  * Tests for comments service API functions
  * Path: src/services/comments/api.ts
- *
- * Coverage focuses on:
- * - Comment CRUD operations (used in review workflow)
- * - Reviewer-specific comment updates (used in review progress tracking)
- * - Comment retrieval by review type (used in assigned/review tabs)
- * - Review state queries (used in comment filtering)
  */
 
 import {
@@ -27,6 +21,7 @@ import {
 jest.mock('@/services/supabase', () => ({
   supabase: {
     from: jest.fn(),
+    rpc: jest.fn(),
     auth: {
       getSession: jest.fn(),
     },
@@ -53,6 +48,7 @@ jest.mock('@/services/general/api', () => ({
 const {
   supabase: {
     from: mockFrom,
+    rpc: mockRpc,
     auth: { getSession: mockAuthGetSession },
     functions: { invoke: mockFunctionsInvoke },
   },
@@ -62,21 +58,10 @@ const { getUserId: mockGetUserId } = jest.requireMock('@/services/users/api');
 const { invokeDatasetCommand: mockInvokeDatasetCommand } =
   jest.requireMock('@/services/general/api');
 
-const createPagedCommentsQueryBuilder = (resolvedValue: any) => {
-  const builder: any = {
-    select: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    in: jest.fn().mockReturnThis(),
-    filter: jest.fn().mockReturnThis(),
-    order: jest.fn().mockReturnThis(),
-    range: jest.fn().mockResolvedValue(resolvedValue),
-  };
-  return builder;
-};
-
 describe('Comments API service (src/services/comments/api.ts)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetUserId.mockResolvedValue('current-user-id');
   });
 
   describe('review workflow comment command wrappers', () => {
@@ -132,15 +117,13 @@ describe('Comments API service (src/services/comments/api.ts)', () => {
     });
   });
 
-  describe('addCommentApi', () => {
-    it('returns a structured deprecation error', async () => {
-      const mockData = {
+  describe('legacy mutations', () => {
+    it('returns a structured deprecation error from addCommentApi', async () => {
+      const result = await addCommentApi({
         review_id: 'review-123',
         reviewer_id: 'user-123',
         content: 'Test comment',
-      };
-
-      const result = await addCommentApi(mockData);
+      });
 
       expect(mockFrom).not.toHaveBeenCalled();
       expect(result).toEqual({
@@ -152,10 +135,8 @@ describe('Comments API service (src/services/comments/api.ts)', () => {
         },
       });
     });
-  });
 
-  describe('updateCommentByreviewerApi', () => {
-    it('returns a structured deprecation error', async () => {
+    it('returns a structured deprecation error from updateCommentByreviewerApi', async () => {
       const result = await updateCommentByreviewerApi('review-123', 'user-123', {
         content: 'Updated',
       });
@@ -170,10 +151,8 @@ describe('Comments API service (src/services/comments/api.ts)', () => {
         },
       });
     });
-  });
 
-  describe('updateCommentApi', () => {
-    it('returns a structured deprecation error without touching legacy edge handlers', async () => {
+    it('returns a structured deprecation error from updateCommentApi', async () => {
       const result = await updateCommentApi('review-123', { content: 'Updated' }, 'assigned');
 
       expect(mockAuthGetSession).not.toHaveBeenCalled();
@@ -190,156 +169,136 @@ describe('Comments API service (src/services/comments/api.ts)', () => {
   });
 
   describe('getCommentApi', () => {
-    it('fetches comments for review action type with current user as reviewer', async () => {
-      mockGetUserId.mockResolvedValue('current-user-id');
-
-      const mockData = [{ id: 'comment-1', content: 'Comment 1', reviewer_id: 'current-user-id' }];
-
-      const mockSelect = jest.fn().mockReturnThis();
-      const mockEqReviewId = jest.fn().mockReturnThis();
-      const mockEqReviewerId = jest.fn().mockResolvedValue({ data: mockData, error: null });
-
-      (mockFrom as jest.Mock).mockReturnValue({
-        select: mockSelect.mockReturnValue({
-          eq: mockEqReviewId.mockReturnValue({
-            eq: mockEqReviewerId,
-          }),
-        }),
+    it('fetches reviewer-scoped comments for review action type', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: [{ review_id: 'review-123', reviewer_id: 'current-user-id', json: null }],
+        error: null,
       });
 
       const result = await getCommentApi('review-123', 'review');
 
       expect(mockGetUserId).toHaveBeenCalledTimes(1);
-      expect(mockFrom).toHaveBeenCalledWith('comments');
-      expect(mockSelect).toHaveBeenCalledWith('*');
-      expect(mockEqReviewId).toHaveBeenCalledWith('review_id', 'review-123');
-      expect(mockEqReviewerId).toHaveBeenCalledWith('reviewer_id', 'current-user-id');
-      expect(result).toEqual({ data: mockData, error: null });
-    });
-
-    it('returns error when user ID is not available for review action', async () => {
-      mockGetUserId.mockResolvedValue('');
-
-      const result = await getCommentApi('review-123', 'review');
-
-      expect(result).toEqual({ error: true, data: [] });
-    });
-
-    it('fetches admin-rejected comments without narrowing to the current reviewer', async () => {
-      mockGetUserId.mockResolvedValue('current-user-id');
-
-      const mockData = [{ id: 'comment-1', content: 'Admin rejected' }];
-      const mockSelect = jest.fn().mockReturnThis();
-      const mockEqReviewId = jest.fn().mockResolvedValue({ data: mockData, error: null });
-
-      (mockFrom as jest.Mock).mockReturnValue({
-        select: mockSelect.mockReturnValue({
-          eq: mockEqReviewId,
-        }),
+      expect(mockRpc).toHaveBeenCalledWith('qry_review_get_comment_items', {
+        p_review_id: 'review-123',
+        p_scope: 'mine',
       });
-
-      const result = await getCommentApi('review-123', 'admin-rejected');
-
-      expect(mockGetUserId).toHaveBeenCalledTimes(1);
-      expect(mockEqReviewId).toHaveBeenCalledWith('review_id', 'review-123');
-      expect(result).toEqual({ data: mockData, error: null });
+      expect(result).toEqual({
+        data: [{ review_id: 'review-123', reviewer_id: 'current-user-id', json: {} }],
+        error: null,
+      });
     });
 
-    it('treats reviewer-rejected comments the same as review comments for reviewer filtering', async () => {
-      mockGetUserId.mockResolvedValue('current-user-id');
-
-      const mockData = [{ id: 'comment-2', content: 'Rejected by reviewer' }];
-      const mockSelect = jest.fn().mockReturnThis();
-      const mockEqReviewId = jest.fn().mockReturnThis();
-      const mockEqReviewerId = jest.fn().mockResolvedValue({ data: mockData, error: null });
-
-      (mockFrom as jest.Mock).mockReturnValue({
-        select: mockSelect.mockReturnValue({
-          eq: mockEqReviewId.mockReturnValue({
-            eq: mockEqReviewerId,
-          }),
-        }),
-      });
+    it('returns error when user ID is not available for reviewer-scoped actions', async () => {
+      mockGetUserId.mockResolvedValueOnce('');
 
       const result = await getCommentApi('review-123', 'reviewer-rejected');
 
-      expect(mockEqReviewerId).toHaveBeenCalledWith('reviewer_id', 'current-user-id');
-      expect(result).toEqual({ data: mockData, error: null });
+      expect(mockRpc).not.toHaveBeenCalled();
+      expect(result).toEqual({ error: true, data: [] });
     });
 
     it('fetches all comments for assigned action type', async () => {
-      const mockData = [
-        { id: 'comment-1', content: 'Comment 1' },
-        { id: 'comment-2', content: 'Comment 2' },
-      ];
-
-      const mockSelect = jest.fn().mockReturnThis();
-      const mockEqReviewId = jest.fn().mockResolvedValue({ data: mockData, error: null });
-
-      (mockFrom as jest.Mock).mockReturnValue({
-        select: mockSelect.mockReturnValue({
-          eq: mockEqReviewId,
-        }),
+      mockRpc.mockResolvedValueOnce({
+        data: [{ review_id: 'review-123', reviewer_id: 'user-1', json: { note: 1 } }],
+        error: null,
       });
 
       const result = await getCommentApi('review-123', 'assigned');
 
-      expect(mockFrom).toHaveBeenCalledWith('comments');
-      expect(mockSelect).toHaveBeenCalledWith('*');
-      expect(mockEqReviewId).toHaveBeenCalledWith('review_id', 'review-123');
-      expect(result).toEqual({ data: mockData, error: null });
+      expect(mockGetUserId).not.toHaveBeenCalled();
+      expect(mockRpc).toHaveBeenCalledWith('qry_review_get_comment_items', {
+        p_review_id: 'review-123',
+        p_scope: 'all',
+      });
+      expect(result).toEqual({
+        data: [{ review_id: 'review-123', reviewer_id: 'user-1', json: { note: 1 } }],
+        error: null,
+      });
+    });
+
+    it('fetches admin-rejected comments without reviewer narrowing', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: [{ review_id: 'review-123', reviewer_id: 'user-2', json: { reason: 'reject' } }],
+        error: null,
+      });
+
+      const result = await getCommentApi('review-123', 'admin-rejected');
+
+      expect(mockGetUserId).not.toHaveBeenCalled();
+      expect(mockRpc).toHaveBeenCalledWith('qry_review_get_comment_items', {
+        p_review_id: 'review-123',
+        p_scope: 'all',
+      });
+      expect(result.error).toBeNull();
     });
 
     it('returns error for invalid action type', async () => {
       const result = await getCommentApi('review-123', 'invalid' as any);
 
+      expect(mockRpc).not.toHaveBeenCalled();
       expect(result).toEqual({ data: [], error: true });
     });
   });
 
-  describe('getReviewedComment', () => {
-    it('fetches reviewed comments for current user', async () => {
-      mockGetUserId.mockResolvedValue('current-user-id');
-
-      const mockData = [{ review_id: 'review-1' }, { review_id: 'review-2' }];
-
-      const supabaseResult = { data: mockData, error: null };
-      const builder = createPagedCommentsQueryBuilder(supabaseResult);
-      (mockFrom as jest.Mock).mockReturnValue(builder);
+  describe('review member queue queries', () => {
+    it('fetches reviewed comments for current user with default paging', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: [
+          {
+            id: 'review-1',
+            review_state_code: 2,
+            reviewer_id: ['current-user-id'],
+            json: { data: { id: 'process-1' } },
+            comment_state_code: 1,
+            comment_json: { summary: 'ok' },
+            comment_created_at: '2024-04-01T00:00:00.000Z',
+            comment_modified_at: '2024-04-02T00:00:00.000Z',
+            total_count: 2,
+          },
+        ],
+        error: null,
+      });
 
       const result = await getReviewedComment();
 
       expect(mockGetUserId).toHaveBeenCalledTimes(1);
-      expect(builder.select).toHaveBeenCalledWith('review_id, reviews!inner(*)', {
-        count: 'exact',
+      expect(mockRpc).toHaveBeenCalledWith('qry_review_get_member_queue_items', {
+        p_status: 'reviewed',
+        p_page: 1,
+        p_page_size: 10,
+        p_sort_by: 'modified_at',
+        p_sort_order: 'descend',
       });
-      expect(builder.eq).toHaveBeenCalledWith('reviewer_id', 'current-user-id');
-      expect(builder.in).toHaveBeenCalledWith('state_code', [1, 2, -3]);
-      expect(builder.filter).toHaveBeenCalledWith('reviews.state_code', 'gt', 0);
-      expect(builder.order).toHaveBeenCalledWith('modified_at', { ascending: false });
-      expect(builder.range).toHaveBeenCalledWith(0, 9);
-      expect(result).toEqual(supabaseResult);
-    });
-
-    it('fetches reviewed comments for specific user ID', async () => {
-      const supabaseResult = { data: [], error: null };
-      const builder = createPagedCommentsQueryBuilder(supabaseResult);
-      (mockFrom as jest.Mock).mockReturnValue(builder);
-
-      await getReviewedComment(undefined, undefined, 'specific-user-id');
-
-      expect(mockGetUserId).not.toHaveBeenCalled();
-      expect(builder.eq).toHaveBeenCalledWith('reviewer_id', 'specific-user-id');
-      expect(builder.in).toHaveBeenCalledWith('state_code', [1, 2, -3]);
-      expect(builder.filter).toHaveBeenCalledWith('reviews.state_code', 'gt', 0);
-      expect(builder.order).toHaveBeenCalledWith('modified_at', { ascending: false });
-      expect(builder.range).toHaveBeenCalledWith(0, 9);
+      expect(result).toEqual({
+        data: [
+          {
+            review_id: 'review-1',
+            reviewer_id: 'current-user-id',
+            state_code: 1,
+            json: { summary: 'ok' },
+            created_at: '2024-04-01T00:00:00.000Z',
+            modified_at: '2024-04-02T00:00:00.000Z',
+            reviews: {
+              id: 'review-1',
+              state_code: 2,
+              reviewer_id: ['current-user-id'],
+              json: { data: { id: 'process-1' } },
+              deadline: undefined,
+              created_at: undefined,
+              modified_at: undefined,
+            },
+          },
+        ],
+        error: null,
+        count: 2,
+      });
     });
 
     it('supports explicit paging and ascending sorting for reviewed comments', async () => {
-      const supabaseResult = { data: [{ review_id: 'review-3' }], error: null };
-      const builder = createPagedCommentsQueryBuilder(supabaseResult);
-      (mockFrom as jest.Mock).mockReturnValue(builder);
+      mockRpc.mockResolvedValueOnce({
+        data: [{ id: 'review-2', total_count: '1' }],
+        error: null,
+      });
 
       const result = await getReviewedComment(
         { current: 2, pageSize: 5 },
@@ -347,98 +306,54 @@ describe('Comments API service (src/services/comments/api.ts)', () => {
         'specific-user-id',
       );
 
-      expect(builder.order).toHaveBeenCalledWith('created_at', { ascending: true });
-      expect(builder.range).toHaveBeenCalledWith(5, 9);
-      expect(result).toEqual(supabaseResult);
+      expect(mockGetUserId).not.toHaveBeenCalled();
+      expect(mockRpc).toHaveBeenCalledWith('qry_review_get_member_queue_items', {
+        p_status: 'reviewed',
+        p_page: 2,
+        p_page_size: 5,
+        p_sort_by: 'created_at',
+        p_sort_order: 'ascend',
+      });
+      expect(result.count).toBe(1);
+      expect(result.data[0].reviewer_id).toBe('specific-user-id');
     });
 
-    it('returns error when user ID is not available', async () => {
-      mockGetUserId.mockResolvedValue('');
+    it('returns error when user ID is not available for reviewed queue', async () => {
+      mockGetUserId.mockResolvedValueOnce('');
 
       const result = await getReviewedComment();
 
+      expect(mockRpc).not.toHaveBeenCalled();
       expect(result).toEqual({ error: true, data: [] });
     });
 
-    it('falls back to default sort and paging when params or sort contain nullish values', async () => {
-      const supabaseResult = { data: [{ review_id: 'review-nullish' }], error: null };
-      const builder = createPagedCommentsQueryBuilder(supabaseResult);
-      (mockFrom as jest.Mock).mockReturnValue(builder);
-
-      const result = await getReviewedComment(
-        { current: null as any, pageSize: null as any },
-        null as any,
-        'specific-user-id',
-      );
-
-      expect(builder.order).toHaveBeenCalledWith('modified_at', { ascending: false });
-      expect(builder.range).toHaveBeenCalledWith(0, 9);
-      expect(result).toEqual(supabaseResult);
-    });
-  });
-
-  describe('getPendingComment', () => {
-    it('fetches pending comments for current user', async () => {
-      mockGetUserId.mockResolvedValue('current-user-id');
-
-      const mockData = [{ review_id: 'review-1' }];
-
-      const supabaseResult = { data: mockData, error: null };
-      const builder = createPagedCommentsQueryBuilder(supabaseResult);
-      (mockFrom as jest.Mock).mockReturnValue(builder);
-
-      const result = await getPendingComment();
-
-      expect(builder.eq).toHaveBeenNthCalledWith(1, 'reviewer_id', 'current-user-id');
-      expect(builder.eq).toHaveBeenNthCalledWith(2, 'state_code', 0);
-      expect(builder.filter).toHaveBeenCalledWith('reviews.state_code', 'gt', 0);
-      expect(builder.order).toHaveBeenCalledWith('modified_at', { ascending: false });
-      expect(builder.range).toHaveBeenCalledWith(0, 9);
-      expect(result).toEqual(supabaseResult);
-    });
-
-    it('returns error when user ID is not available', async () => {
-      mockGetUserId.mockResolvedValue('');
-
-      const result = await getPendingComment();
-
-      expect(result).toEqual({ error: true, data: [] });
-    });
-
-    it('supports explicit paging and ascending sorting for pending comments', async () => {
-      const supabaseResult = { data: [{ review_id: 'review-pending' }], error: null };
-      const builder = createPagedCommentsQueryBuilder(supabaseResult);
-      (mockFrom as jest.Mock).mockReturnValue(builder);
+    it('fetches pending comments with default fallbacks when params are nullish', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: [{ id: 'review-pending-defaults', total_count: null }],
+        error: null,
+      });
 
       const result = await getPendingComment(
-        { current: 3, pageSize: 2 },
-        { created_at: 'ascend' } as any,
-        'specific-user-id',
+        { current: null as any, pageSize: null as any },
+        null as any,
+        'user-1',
       );
 
-      expect(builder.order).toHaveBeenCalledWith('created_at', { ascending: true });
-      expect(builder.range).toHaveBeenCalledWith(4, 5);
-      expect(result).toEqual(supabaseResult);
+      expect(mockRpc).toHaveBeenCalledWith('qry_review_get_member_queue_items', {
+        p_status: 'pending',
+        p_page: 1,
+        p_page_size: 10,
+        p_sort_by: 'modified_at',
+        p_sort_order: 'descend',
+      });
+      expect(result.count).toBe(0);
     });
 
-    it('falls back to default sort when the pending-comments sort input is null', async () => {
-      const supabaseResult = { data: [{ review_id: 'review-pending-defaults' }], error: null };
-      const builder = createPagedCommentsQueryBuilder(supabaseResult);
-      (mockFrom as jest.Mock).mockReturnValue(builder);
-
-      const result = await getPendingComment({ current: 1, pageSize: 1 }, null as any, 'user-1');
-
-      expect(builder.order).toHaveBeenCalledWith('modified_at', { ascending: false });
-      expect(builder.range).toHaveBeenCalledWith(0, 0);
-      expect(result).toEqual(supabaseResult);
-    });
-  });
-
-  describe('getRejectedComment', () => {
-    it('fetches rejected comments for the reviewer with paging and sort applied', async () => {
-      const supabaseResult = { data: [{ review_id: 'review-rejected' }], error: null };
-      const builder = createPagedCommentsQueryBuilder(supabaseResult);
-      (mockFrom as jest.Mock).mockReturnValue(builder);
+    it('fetches rejected comments with explicit paging and sort', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: [{ id: 'review-rejected', total_count: 1 }],
+        error: null,
+      });
 
       const result = await getRejectedComment(
         { current: 2, pageSize: 4 },
@@ -446,36 +361,15 @@ describe('Comments API service (src/services/comments/api.ts)', () => {
         'specific-user-id',
       );
 
-      expect(builder.eq).toHaveBeenNthCalledWith(1, 'reviewer_id', 'specific-user-id');
-      expect(builder.eq).toHaveBeenNthCalledWith(2, 'state_code', -1);
-      expect(builder.eq).toHaveBeenNthCalledWith(3, 'reviews.state_code', -1);
-      expect(builder.order).toHaveBeenCalledWith('created_at', { ascending: true });
-      expect(builder.range).toHaveBeenCalledWith(4, 7);
-      expect(result).toEqual(supabaseResult);
-    });
-
-    it('returns error when user ID is not available for rejected comments', async () => {
-      mockGetUserId.mockResolvedValue('');
-
-      const result = await getRejectedComment();
-
-      expect(result).toEqual({ error: true, data: [] });
-    });
-
-    it('falls back to default sort and paging for rejected comments when inputs are nullish', async () => {
-      const supabaseResult = { data: [{ review_id: 'review-rejected-defaults' }], error: null };
-      const builder = createPagedCommentsQueryBuilder(supabaseResult);
-      (mockFrom as jest.Mock).mockReturnValue(builder);
-
-      const result = await getRejectedComment(
-        { current: null as any, pageSize: null as any },
-        null as any,
-        'specific-user-id',
-      );
-
-      expect(builder.order).toHaveBeenCalledWith('modified_at', { ascending: false });
-      expect(builder.range).toHaveBeenCalledWith(0, 9);
-      expect(result).toEqual(supabaseResult);
+      expect(mockRpc).toHaveBeenCalledWith('qry_review_get_member_queue_items', {
+        p_status: 'reviewer-rejected',
+        p_page: 2,
+        p_page_size: 4,
+        p_sort_by: 'created_at',
+        p_sort_order: 'ascend',
+      });
+      expect(result.count).toBe(1);
+      expect(result.data[0].reviewer_id).toBe('specific-user-id');
     });
   });
 
@@ -493,7 +387,7 @@ describe('Comments API service (src/services/comments/api.ts)', () => {
         filter: mockFilter,
       };
 
-      (mockFrom as jest.Mock).mockReturnValue(builder);
+      mockFrom.mockReturnValue(builder);
 
       const result = await getUserManageComments();
 
@@ -507,70 +401,83 @@ describe('Comments API service (src/services/comments/api.ts)', () => {
     });
   });
 
-  describe('getReviewerIdsByReviewId', () => {
-    it('fetches reviewer IDs and state codes for a review', async () => {
-      const mockData = [
+  describe('aggregation helpers', () => {
+    it('maps reviewer ids and state codes from assigned-scope comments', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: [
+          { reviewer_id: 'user-1', state_code: 0, json: {} },
+          { reviewer_id: 'user-2', state_code: 1, json: {} },
+        ],
+        error: null,
+      });
+
+      const result = await getReviewerIdsByReviewId('review-123');
+
+      expect(mockRpc).toHaveBeenCalledWith('qry_review_get_comment_items', {
+        p_review_id: 'review-123',
+        p_scope: 'all',
+      });
+      expect(result).toEqual([
         { reviewer_id: 'user-1', state_code: 0 },
         { reviewer_id: 'user-2', state_code: 1 },
-      ];
+      ]);
+    });
 
-      const mockSelect = jest.fn().mockReturnThis();
-      const mockEq = jest.fn().mockResolvedValue({ data: mockData, error: null });
-
-      (mockFrom as jest.Mock).mockReturnValue({
-        select: mockSelect.mockReturnValue({
-          eq: mockEq,
-        }),
-      });
+    it('returns empty array when reviewer id lookup fails', async () => {
+      mockRpc.mockResolvedValueOnce({ data: [], error: { message: 'db failed' } });
 
       const result = await getReviewerIdsByReviewId('review-123');
 
-      expect(mockFrom).toHaveBeenCalledWith('comments');
-      expect(mockSelect).toHaveBeenCalledWith('state_code,reviewer_id');
-      expect(mockEq).toHaveBeenCalledWith('review_id', 'review-123');
-      expect(result).toEqual(mockData);
+      expect(result).toEqual([]);
     });
 
-    it('returns null when data is null', async () => {
-      const mockSelect = jest.fn().mockReturnThis();
-      const mockEq = jest.fn().mockResolvedValue({ data: null, error: null });
-
-      (mockFrom as jest.Mock).mockReturnValue({
-        select: mockSelect.mockReturnValue({
-          eq: mockEq,
-        }),
-      });
-
-      const result = await getReviewerIdsByReviewId('review-123');
-
-      expect(mockFrom).toHaveBeenCalledWith('comments');
-      expect(mockSelect).toHaveBeenCalledWith('state_code,reviewer_id');
-      expect(mockEq).toHaveBeenCalledWith('review_id', 'review-123');
-      expect(result).toBeNull();
-    });
-  });
-
-  describe('getRejectedCommentsByReviewIds', () => {
-    it('fetches rejected comment payloads for the provided review ids', async () => {
-      const mockResult = {
-        data: [{ json: { reason: 'Rejected' } }],
-        error: null,
-      };
-      const builder: any = {
-        select: jest.fn().mockReturnThis(),
-        in: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockResolvedValue(mockResult),
-      };
-
-      (mockFrom as jest.Mock).mockReturnValue(builder);
+    it('aggregates admin-rejected comments per review id and filters rejected rows only', async () => {
+      mockRpc
+        .mockResolvedValueOnce({
+          data: [
+            { state_code: -1, json: { reason: 'Rejected A' } },
+            { state_code: 1, json: { reason: 'Approved' } },
+          ],
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: [{ state_code: -1, json: { reason: 'Rejected B' } }],
+          error: null,
+        });
 
       const result = await getRejectedCommentsByReviewIds(['review-1', 'review-2']);
 
-      expect(mockFrom).toHaveBeenCalledWith('comments');
-      expect(builder.select).toHaveBeenCalledWith('json');
-      expect(builder.in).toHaveBeenCalledWith('review_id', ['review-1', 'review-2']);
-      expect(builder.eq).toHaveBeenCalledWith('state_code', -1);
-      expect(result).toEqual(mockResult);
+      expect(mockRpc).toHaveBeenNthCalledWith(1, 'qry_review_get_comment_items', {
+        p_review_id: 'review-1',
+        p_scope: 'all',
+      });
+      expect(mockRpc).toHaveBeenNthCalledWith(2, 'qry_review_get_comment_items', {
+        p_review_id: 'review-2',
+        p_scope: 'all',
+      });
+      expect(result).toEqual({
+        data: [{ json: { reason: 'Rejected A' } }, { json: { reason: 'Rejected B' } }],
+        error: null,
+      });
+    });
+
+    it('surfaces the first aggregation error while keeping successful rejected rows', async () => {
+      mockRpc
+        .mockResolvedValueOnce({
+          data: [{ state_code: -1, json: { reason: 'Rejected A' } }],
+          error: { message: 'partial failure' },
+        })
+        .mockResolvedValueOnce({
+          data: [{ state_code: -1, json: { reason: 'Rejected B' } }],
+          error: null,
+        });
+
+      const result = await getRejectedCommentsByReviewIds(['review-1', 'review-2']);
+
+      expect(result).toEqual({
+        data: [{ json: { reason: 'Rejected A' } }, { json: { reason: 'Rejected B' } }],
+        error: { message: 'partial failure' },
+      });
     });
   });
 });

--- a/tests/unit/services/comments/api.test.ts
+++ b/tests/unit/services/comments/api.test.ts
@@ -216,6 +216,20 @@ describe('Comments API service (src/services/comments/api.ts)', () => {
       });
     });
 
+    it('falls back to an empty comment list when the rpc payload is not an array', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: null,
+        error: null,
+      });
+
+      const result = await getCommentApi('review-123', 'assigned');
+
+      expect(result).toEqual({
+        data: [],
+        error: null,
+      });
+    });
+
     it('fetches admin-rejected comments without reviewer narrowing', async () => {
       mockRpc.mockResolvedValueOnce({
         data: [{ review_id: 'review-123', reviewer_id: 'user-2', json: { reason: 'reject' } }],
@@ -349,6 +363,28 @@ describe('Comments API service (src/services/comments/api.ts)', () => {
       expect(result.count).toBe(0);
     });
 
+    it('uses wrapper defaults and falls back to an empty pending queue when rpc data is missing', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: null,
+        error: null,
+      });
+
+      const result = await getPendingComment(undefined, undefined, 'user-1');
+
+      expect(mockRpc).toHaveBeenCalledWith('qry_review_get_member_queue_items', {
+        p_status: 'pending',
+        p_page: 1,
+        p_page_size: 10,
+        p_sort_by: 'modified_at',
+        p_sort_order: 'descend',
+      });
+      expect(result).toEqual({
+        data: [],
+        error: null,
+        count: 0,
+      });
+    });
+
     it('fetches rejected comments with explicit paging and sort', async () => {
       mockRpc.mockResolvedValueOnce({
         data: [{ id: 'review-rejected', total_count: 1 }],
@@ -369,6 +405,25 @@ describe('Comments API service (src/services/comments/api.ts)', () => {
         p_sort_order: 'ascend',
       });
       expect(result.count).toBe(1);
+      expect(result.data[0].reviewer_id).toBe('specific-user-id');
+    });
+
+    it('uses wrapper defaults for rejected comments when params and sort are omitted', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: [{ id: 'review-rejected-defaults', total_count: 0 }],
+        error: null,
+      });
+
+      const result = await getRejectedComment(undefined, undefined, 'specific-user-id');
+
+      expect(mockRpc).toHaveBeenCalledWith('qry_review_get_member_queue_items', {
+        p_status: 'reviewer-rejected',
+        p_page: 1,
+        p_page_size: 10,
+        p_sort_by: 'modified_at',
+        p_sort_order: 'descend',
+      });
+      expect(result.count).toBe(0);
       expect(result.data[0].reviewer_id).toBe('specific-user-id');
     });
   });

--- a/tests/unit/services/reviews/api.test.ts
+++ b/tests/unit/services/reviews/api.test.ts
@@ -476,6 +476,14 @@ describe('getReviewsDetail', () => {
     });
     expect(result).toEqual({ id: 'review-1' });
   });
+
+  it('returns null when the review id cannot be found', async () => {
+    mockRpc.mockResolvedValueOnce({ data: [], error: null });
+
+    const result = await reviewsApi.getReviewsDetail('missing-review');
+
+    expect(result).toBeNull();
+  });
 });
 
 describe('getReviewsDetailByReviewIds', () => {
@@ -874,6 +882,50 @@ describe('getReviewsTableDataOfReviewMember', () => {
     expect(mockGenProcessName).toHaveBeenCalledWith({}, 'en');
     expect(result.data[0].name).toBe('-');
   });
+
+  it('uses default sorting, lifecycle fallbacks, and undefined timestamps when optional inputs are missing', async () => {
+    mockGetUserId.mockResolvedValueOnce('reviewer-default-sort');
+    mockRpc.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'review-member-default-sort',
+          reviewer_id: ['reviewer-default-sort'],
+          json: {
+            data: {
+              id: 'plain-process-default-sort',
+              version: '01.00.000',
+            },
+            user: {},
+          },
+        },
+      ],
+      error: null,
+    });
+    mockGetLifeCyclesByIdAndVersion.mockResolvedValueOnce(undefined);
+
+    const result = await reviewsApi.getReviewsTableDataOfReviewMember(
+      { pageSize: 10, current: 1 },
+      undefined,
+      'reviewed',
+      'en',
+    );
+
+    expect(mockRpc).toHaveBeenCalledWith('qry_review_get_member_queue_items', {
+      p_status: 'reviewed',
+      p_page: 1,
+      p_page_size: 10,
+      p_sort_by: 'modified_at',
+      p_sort_order: 'descend',
+    });
+    expect(result.data[0]).toMatchObject({
+      id: 'review-member-default-sort',
+      createAt: undefined,
+      modifiedAt: undefined,
+      deadline: undefined,
+      name: '-',
+      userName: '-',
+    });
+  });
 });
 
 describe('getReviewsTableDataOfReviewAdmin', () => {
@@ -1206,6 +1258,49 @@ describe('getReviewsTableDataOfReviewAdmin', () => {
 
     expect(mockGenProcessName).toHaveBeenCalledWith({}, 'en');
     expect(result.data[0].name).toBe('-');
+  });
+
+  it('uses default sorting and lifecycle fallbacks when optional admin queue inputs are missing', async () => {
+    mockRpc.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'review-admin-default-sort',
+          comment_state_codes: [0],
+          json: {
+            data: {
+              id: 'plain-admin-default-sort',
+              version: '01.00.000',
+            },
+            user: {},
+          },
+        },
+      ],
+      error: null,
+    });
+    mockGetLifeCyclesByIdAndVersion.mockResolvedValueOnce(undefined);
+
+    const result = await reviewsApi.getReviewsTableDataOfReviewAdmin(
+      { pageSize: 10, current: 1 },
+      undefined,
+      'assigned',
+      'en',
+    );
+
+    expect(mockRpc).toHaveBeenCalledWith('qry_review_get_admin_queue_items', {
+      p_status: 'assigned',
+      p_page: 1,
+      p_page_size: 10,
+      p_sort_by: 'modified_at',
+      p_sort_order: 'descend',
+    });
+    expect(result.data[0]).toMatchObject({
+      id: 'review-admin-default-sort',
+      createAt: undefined,
+      modifiedAt: undefined,
+      comments: [{ state_code: 0 }],
+      name: '-',
+      userName: '-',
+    });
   });
 });
 

--- a/tests/unit/services/reviews/api.test.ts
+++ b/tests/unit/services/reviews/api.test.ts
@@ -426,23 +426,24 @@ describe('updateReviewApi', () => {
 
 describe('getReviewerIdsApi', () => {
   it('returns deduplicated reviewer ids when supabase responds with multiple rows', async () => {
-    const supabaseResult = {
+    mockRpc.mockResolvedValueOnce({
       data: [{ reviewer_id: ['user-1', 'user-2'] }, { reviewer_id: ['user-2', 'user-3'] }],
-    };
-    const builder = createQueryBuilder(supabaseResult);
-    mockFrom.mockReturnValueOnce(builder);
+      error: null,
+    });
 
     const result = await reviewsApi.getReviewerIdsApi(['review-1', 'review-2']);
 
-    expect(mockFrom).toHaveBeenCalledWith('reviews');
-    expect(builder.select).toHaveBeenCalledWith('reviewer_id');
-    expect(builder.in).toHaveBeenCalledWith('id', ['review-1', 'review-2']);
+    expect(mockRpc).toHaveBeenCalledWith('qry_review_get_items', {
+      p_review_ids: ['review-1', 'review-2'],
+      p_data_id: null,
+      p_data_version: null,
+      p_state_codes: null,
+    });
     expect(result).toEqual(['user-1', 'user-2', 'user-3']);
   });
 
   it('returns empty array when supabase payload is missing', async () => {
-    const builder = createQueryBuilder({ data: null });
-    mockFrom.mockReturnValueOnce(builder);
+    mockRpc.mockResolvedValueOnce({ data: null, error: null });
 
     const result = await reviewsApi.getReviewerIdsApi(['review-1']);
 
@@ -450,10 +451,10 @@ describe('getReviewerIdsApi', () => {
   });
 
   it('ignores reviewer rows whose reviewer_id is not an array', async () => {
-    const builder = createQueryBuilder({
+    mockRpc.mockResolvedValueOnce({
       data: [{ reviewer_id: ['user-1'] }, { reviewer_id: 'user-2' }, { reviewer_id: null }, {}],
+      error: null,
     });
-    mockFrom.mockReturnValueOnce(builder);
 
     const result = await reviewsApi.getReviewerIdsApi(['review-1']);
 
@@ -463,58 +464,68 @@ describe('getReviewerIdsApi', () => {
 
 describe('getReviewsDetail', () => {
   it('returns review detail for given id', async () => {
-    const supabaseResult = { data: { id: 'review-1' } };
-    const builder = createQueryBuilder(supabaseResult);
-    mockFrom.mockReturnValueOnce(builder);
+    mockRpc.mockResolvedValueOnce({ data: [{ id: 'review-1' }], error: null });
 
     const result = await reviewsApi.getReviewsDetail('review-1');
 
-    expect(builder.select).toHaveBeenCalledWith('*');
-    expect(builder.eq).toHaveBeenCalledWith('id', 'review-1');
+    expect(mockRpc).toHaveBeenCalledWith('qry_review_get_items', {
+      p_review_ids: ['review-1'],
+      p_data_id: null,
+      p_data_version: null,
+      p_state_codes: null,
+    });
     expect(result).toEqual({ id: 'review-1' });
   });
 });
 
 describe('getReviewsDetailByReviewIds', () => {
   it('returns review list for ids', async () => {
-    const supabaseResult = { data: [{ id: 'review-1' }, { id: 'review-2' }] };
-    const builder = createQueryBuilder(supabaseResult);
-    mockFrom.mockReturnValueOnce(builder);
+    mockRpc.mockResolvedValueOnce({
+      data: [{ id: 'review-1' }, { id: 'review-2' }],
+      error: null,
+    });
 
     const result = await reviewsApi.getReviewsDetailByReviewIds(['review-1', 'review-2']);
 
-    expect(builder.in).toHaveBeenCalledWith('id', ['review-1', 'review-2']);
-    expect(result).toEqual(supabaseResult.data);
+    expect(mockRpc).toHaveBeenCalledWith('qry_review_get_items', {
+      p_review_ids: ['review-1', 'review-2'],
+      p_data_id: null,
+      p_data_version: null,
+      p_state_codes: null,
+    });
+    expect(result).toEqual([{ id: 'review-1' }, { id: 'review-2' }]);
   });
 });
 
 describe('getReviewsByProcess', () => {
   it('queries reviews by process id and version', async () => {
-    const supabaseResult = { data: [{ id: 'review-1' }], error: null };
-    const builder = createQueryBuilder(supabaseResult);
-    mockFrom.mockReturnValueOnce(builder);
+    mockRpc.mockResolvedValueOnce({ data: [{ id: 'review-1' }], error: null });
 
     const result = await reviewsApi.getReviewsByProcess('process-1', '1.0');
 
-    expect(builder.filter).toHaveBeenCalledWith('json->data->>id', 'eq', 'process-1');
-    expect(builder.filter).toHaveBeenCalledWith('json->data->>version', 'eq', '1.0');
-    expect(result).toEqual(supabaseResult);
+    expect(mockRpc).toHaveBeenCalledWith('qry_review_get_items', {
+      p_review_ids: null,
+      p_data_id: 'process-1',
+      p_data_version: '1.0',
+      p_state_codes: null,
+    });
+    expect(result).toEqual({ data: [{ id: 'review-1' }], error: null });
   });
 });
 
 describe('getRejectReviewsByProcess', () => {
   it('queries rejected reviews by process id and version', async () => {
-    const supabaseResult = { data: [{ id: 'review-1' }], error: null };
-    const builder = createQueryBuilder(supabaseResult);
-    mockFrom.mockReturnValueOnce(builder);
+    mockRpc.mockResolvedValueOnce({ data: [{ id: 'review-1' }], error: null });
 
     const result = await reviewsApi.getRejectReviewsByProcess('process-1', '1.0');
 
-    expect(builder.select).toHaveBeenCalledWith('id');
-    expect(builder.filter).toHaveBeenCalledWith('json->data->>id', 'eq', 'process-1');
-    expect(builder.filter).toHaveBeenCalledWith('json->data->>version', 'eq', '1.0');
-    expect(builder.eq).toHaveBeenCalledWith('state_code', -1);
-    expect(result).toEqual(supabaseResult);
+    expect(mockRpc).toHaveBeenCalledWith('qry_review_get_items', {
+      p_review_ids: null,
+      p_data_id: 'process-1',
+      p_data_version: '1.0',
+      p_state_codes: [-1],
+    });
+    expect(result).toEqual({ data: [{ id: 'review-1' }], error: null });
   });
 });
 
@@ -529,12 +540,12 @@ describe('getReviewsTableDataOfReviewMember', () => {
       'en',
     );
 
-    expect(mockGetReviewedComment).not.toHaveBeenCalled();
+    expect(mockRpc).not.toHaveBeenCalled();
     expect(result).toEqual({ data: [], success: true, total: 0 });
   });
 
   it('returns empty table when pending comment query returns error', async () => {
-    mockGetPendingComment.mockResolvedValueOnce({ error: { message: 'db failed' }, data: null });
+    mockRpc.mockResolvedValueOnce({ error: { message: 'db failed' }, data: null });
 
     const result = await reviewsApi.getReviewsTableDataOfReviewMember(
       { pageSize: 10, current: 1 },
@@ -544,17 +555,19 @@ describe('getReviewsTableDataOfReviewMember', () => {
       { user_id: 'reviewer-1' },
     );
 
-    expect(mockGetPendingComment).toHaveBeenCalledWith(
-      { pageSize: 10, current: 1 },
-      {},
-      'reviewer-1',
-    );
+    expect(mockRpc).toHaveBeenCalledWith('qry_review_get_member_queue_items', {
+      p_status: 'pending',
+      p_page: 1,
+      p_page_size: 10,
+      p_sort_by: 'modified_at',
+      p_sort_order: 'descend',
+    });
     expect(result).toEqual({ data: [], success: true, total: 0 });
   });
 
   it('resolves pending comments with getUserId when userData is omitted', async () => {
     mockGetUserId.mockResolvedValueOnce('pending-reviewer');
-    mockGetPendingComment.mockResolvedValueOnce({ data: [], error: null });
+    mockRpc.mockResolvedValueOnce({ data: [], error: null });
 
     const result = await reviewsApi.getReviewsTableDataOfReviewMember(
       { pageSize: 10, current: 1 },
@@ -563,44 +576,47 @@ describe('getReviewsTableDataOfReviewMember', () => {
       'en',
     );
 
-    expect(mockGetPendingComment).toHaveBeenCalledWith(
-      { pageSize: 10, current: 1 },
-      {},
-      'pending-reviewer',
-    );
+    expect(mockRpc).toHaveBeenCalledWith('qry_review_get_member_queue_items', {
+      p_status: 'pending',
+      p_page: 1,
+      p_page_size: 10,
+      p_sort_by: 'modified_at',
+      p_sort_order: 'descend',
+    });
     expect(result).toEqual({ data: [], success: true, total: 0 });
   });
 
   it('maps reviewer-rejected comments with lifecycle model enrichment', async () => {
-    const commentPayload = {
+    mockRpc.mockResolvedValueOnce({
       data: [
         {
-          reviews: {
-            id: 'review-1',
-            created_at: '2024-04-01T00:00:00.000Z',
-            modified_at: '2024-04-02T00:00:00.000Z',
-            deadline: '2024-04-20T00:00:00.000Z',
-            json: {
-              data: {
-                id: 'process-1',
-                version: '01.00.000',
-                name: {
-                  baseName: { en: 'Fallback Base' },
-                  treatmentStandardsRoutes: { en: 'Fallback Route' },
-                  mixAndLocationTypes: { en: 'Fallback Mix' },
-                  functionalUnitFlowProperties: { en: 'Fallback Unit' },
-                },
+          id: 'review-1',
+          created_at: '2024-04-01T00:00:00.000Z',
+          modified_at: '2024-04-02T00:00:00.000Z',
+          deadline: '2024-04-20T00:00:00.000Z',
+          review_state_code: -1,
+          reviewer_id: ['reviewer-1'],
+          comment_state_code: -1,
+          json: {
+            data: {
+              id: 'process-1',
+              version: '01.00.000',
+              name: {
+                baseName: { en: 'Fallback Base' },
+                treatmentStandardsRoutes: { en: 'Fallback Route' },
+                mixAndLocationTypes: { en: 'Fallback Mix' },
+                functionalUnitFlowProperties: { en: 'Fallback Unit' },
               },
-              team: { name: { en: 'Team A' } },
-              user: { email: 'reviewer@example.com' },
             },
+            team: { name: { en: 'Team A' } },
+            user: { email: 'reviewer@example.com' },
           },
+          comment_json: { comment: { message: 'reject' } },
+          total_count: 1,
         },
       ],
-      count: 1,
       error: null,
-    };
-    mockGetRejectedComment.mockResolvedValueOnce(commentPayload);
+    });
     mockGetLifeCyclesByIdAndVersion.mockResolvedValueOnce({
       data: [
         {
@@ -633,11 +649,13 @@ describe('getReviewsTableDataOfReviewMember', () => {
       { user_id: 'reviewer-1' },
     );
 
-    expect(mockGetRejectedComment).toHaveBeenCalledWith(
-      { pageSize: 10, current: 2 },
-      { modified_at: 'descend' },
-      'reviewer-1',
-    );
+    expect(mockRpc).toHaveBeenCalledWith('qry_review_get_member_queue_items', {
+      p_status: 'reviewer-rejected',
+      p_page: 2,
+      p_page_size: 10,
+      p_sort_by: 'modified_at',
+      p_sort_order: 'descend',
+    });
     expect(mockGetLifeCyclesByIdAndVersion).toHaveBeenCalledWith([
       { id: 'process-1', version: '01.00.000' },
     ]);
@@ -661,26 +679,26 @@ describe('getReviewsTableDataOfReviewMember', () => {
 
   it('falls back to review payload fields when no lifecycle model matches', async () => {
     mockGetUserId.mockResolvedValueOnce('reviewer-fallback');
-    mockGetReviewedComment.mockResolvedValueOnce({
+    mockRpc.mockResolvedValueOnce({
       data: [
         {
-          reviews: {
-            id: 'review-fallback',
-            created_at: '2024-06-01T00:00:00.000Z',
-            modified_at: '2024-06-02T00:00:00.000Z',
-            json: {
-              data: {
-                id: 'process-fallback',
-                version: '02.00.000',
-                name: {
-                  baseName: { en: 'Fallback Base' },
-                  treatmentStandardsRoutes: { en: 'Fallback Route' },
-                  mixAndLocationTypes: { en: 'Fallback Mix' },
-                  functionalUnitFlowProperties: { en: 'Fallback Unit' },
-                },
+          id: 'review-fallback',
+          created_at: '2024-06-01T00:00:00.000Z',
+          modified_at: '2024-06-02T00:00:00.000Z',
+          reviewer_id: ['reviewer-fallback'],
+          comment_state_code: 1,
+          json: {
+            data: {
+              id: 'process-fallback',
+              version: '02.00.000',
+              name: {
+                baseName: { en: 'Fallback Base' },
+                treatmentStandardsRoutes: { en: 'Fallback Route' },
+                mixAndLocationTypes: { en: 'Fallback Mix' },
+                functionalUnitFlowProperties: { en: 'Fallback Unit' },
               },
-              user: { email: 'fallback@example.com' },
             },
+            user: { email: 'fallback@example.com' },
           },
         },
       ],
@@ -695,7 +713,13 @@ describe('getReviewsTableDataOfReviewMember', () => {
       'en',
     );
 
-    expect(mockGetReviewedComment).toHaveBeenCalledWith({} as any, {}, 'reviewer-fallback');
+    expect(mockRpc).toHaveBeenCalledWith('qry_review_get_member_queue_items', {
+      p_status: 'reviewed',
+      p_page: 1,
+      p_page_size: 10,
+      p_sort_by: 'modified_at',
+      p_sort_order: 'descend',
+    });
     expect(result).toEqual({
       data: [
         {
@@ -721,6 +745,7 @@ describe('getReviewsTableDataOfReviewMember', () => {
             },
             user: { email: 'fallback@example.com' },
           },
+          comments: [],
           modelData: null,
         },
       ],
@@ -732,24 +757,23 @@ describe('getReviewsTableDataOfReviewMember', () => {
 
   it('uses lifecycle fallbacks and missing-user placeholders for reviewer-rejected rows', async () => {
     mockGetUserId.mockResolvedValueOnce('reviewer-fallback');
-    mockGetRejectedComment.mockResolvedValueOnce({
+    mockRpc.mockResolvedValueOnce({
       data: [
         {
-          reviews: {
-            id: 'review-rejected-fallback',
-            created_at: '2024-07-01T00:00:00.000Z',
-            modified_at: '2024-07-02T00:00:00.000Z',
-            json: {
-              data: {
-                id: 'process-model-fallback',
-                version: '01.00.000',
-              },
-              user: {},
+          id: 'review-rejected-fallback',
+          created_at: '2024-07-01T00:00:00.000Z',
+          modified_at: '2024-07-02T00:00:00.000Z',
+          reviewer_id: ['reviewer-fallback'],
+          comment_state_code: -1,
+          json: {
+            data: {
+              id: 'process-model-fallback',
+              version: '01.00.000',
             },
+            user: {},
           },
         },
       ],
-      count: 1,
       error: null,
     });
     mockGetLifeCyclesByIdAndVersion.mockResolvedValueOnce({
@@ -776,11 +800,6 @@ describe('getReviewsTableDataOfReviewMember', () => {
       'en',
     );
 
-    expect(mockGetRejectedComment).toHaveBeenCalledWith(
-      { pageSize: 10, current: 1 },
-      {},
-      'reviewer-fallback',
-    );
     expect(result.data[0]).toMatchObject({
       isFromLifeCycle: true,
       name: '-',
@@ -789,18 +808,17 @@ describe('getReviewsTableDataOfReviewMember', () => {
   });
 
   it('falls back to "-" when a matched lifecycle model name resolves to an empty process name', async () => {
-    mockGetReviewedComment.mockResolvedValueOnce({
+    mockRpc.mockResolvedValueOnce({
       data: [
         {
-          reviews: {
-            id: 'review-member-empty-model-name',
-            created_at: '2024-07-01T00:00:00.000Z',
-            modified_at: '2024-07-02T00:00:00.000Z',
-            json: { data: { id: 'model-process', version: '01.00.000' }, user: { email: 'x@y.z' } },
-          },
+          id: 'review-member-empty-model-name',
+          created_at: '2024-07-01T00:00:00.000Z',
+          modified_at: '2024-07-02T00:00:00.000Z',
+          reviewer_id: ['reviewer-1'],
+          comment_state_code: 1,
+          json: { data: { id: 'model-process', version: '01.00.000' }, user: { email: 'x@y.z' } },
         },
       ],
-      count: 1,
       error: null,
     });
     mockGetLifeCyclesByIdAndVersion.mockResolvedValueOnce({
@@ -829,18 +847,17 @@ describe('getReviewsTableDataOfReviewMember', () => {
   });
 
   it('falls back to "-" when a non-lifecycle review row has no process name payload', async () => {
-    mockGetReviewedComment.mockResolvedValueOnce({
+    mockRpc.mockResolvedValueOnce({
       data: [
         {
-          reviews: {
-            id: 'review-member-empty-review-name',
-            created_at: '2024-07-01T00:00:00.000Z',
-            modified_at: '2024-07-02T00:00:00.000Z',
-            json: { data: { id: 'plain-process', version: '01.00.000' }, user: { email: 'x@y.z' } },
-          },
+          id: 'review-member-empty-review-name',
+          created_at: '2024-07-01T00:00:00.000Z',
+          modified_at: '2024-07-02T00:00:00.000Z',
+          reviewer_id: ['reviewer-1'],
+          comment_state_code: 1,
+          json: { data: { id: 'plain-process', version: '01.00.000' }, user: { email: 'x@y.z' } },
         },
       ],
-      count: 1,
       error: null,
     });
     mockGetLifeCyclesByIdAndVersion.mockResolvedValueOnce({ data: [] });
@@ -861,8 +878,7 @@ describe('getReviewsTableDataOfReviewMember', () => {
 
 describe('getReviewsTableDataOfReviewAdmin', () => {
   it('returns empty table for unassigned type when no rows exist', async () => {
-    const builder = createQueryBuilder({ data: [], count: 0 });
-    mockFrom.mockReturnValueOnce(builder);
+    mockRpc.mockResolvedValueOnce({ data: [], error: null });
 
     const result = await reviewsApi.getReviewsTableDataOfReviewAdmin(
       { pageSize: 10, current: 1 },
@@ -871,34 +887,44 @@ describe('getReviewsTableDataOfReviewAdmin', () => {
       'en',
     );
 
-    expect(builder.eq).toHaveBeenCalledWith('state_code', 0);
+    expect(mockRpc).toHaveBeenCalledWith('qry_review_get_admin_queue_items', {
+      p_status: 'unassigned',
+      p_page: 1,
+      p_page_size: 10,
+      p_sort_by: 'modified_at',
+      p_sort_order: 'descend',
+    });
     expect(result).toEqual({ data: [], success: true, total: 0 });
   });
 
   it('applies assigned query filters and maps table data', async () => {
-    const reviewRow = {
-      id: 'review-10',
-      created_at: '2024-04-01T00:00:00.000Z',
-      modified_at: '2024-04-03T00:00:00.000Z',
-      deadline: null,
-      comments: [{ state_code: 1 }, { state_code: -3 }, { state_code: -2 }],
-      json: {
-        data: {
-          id: 'process-2',
-          version: '01.00.000',
-          name: {
-            baseName: { en: 'Review Base' },
-            treatmentStandardsRoutes: { en: 'Review Route' },
-            mixAndLocationTypes: { en: 'Review Mix' },
-            functionalUnitFlowProperties: { en: 'Review Unit' },
+    mockRpc.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'review-10',
+          created_at: '2024-04-01T00:00:00.000Z',
+          modified_at: '2024-04-03T00:00:00.000Z',
+          deadline: null,
+          comment_state_codes: [1, -3, -2],
+          total_count: 1,
+          json: {
+            data: {
+              id: 'process-2',
+              version: '01.00.000',
+              name: {
+                baseName: { en: 'Review Base' },
+                treatmentStandardsRoutes: { en: 'Review Route' },
+                mixAndLocationTypes: { en: 'Review Mix' },
+                functionalUnitFlowProperties: { en: 'Review Unit' },
+              },
+            },
+            team: { name: { en: 'Ops Team' } },
+            user: { name: 'Alice Reviewer' },
           },
         },
-        team: { name: { en: 'Ops Team' } },
-        user: { name: 'Alice Reviewer' },
-      },
-    };
-    const builder = createQueryBuilder({ data: [reviewRow], count: 1 });
-    mockFrom.mockReturnValueOnce(builder);
+      ],
+      error: null,
+    });
     mockGetLifeCyclesByIdAndVersion.mockResolvedValueOnce({ data: [] });
 
     const result = await reviewsApi.getReviewsTableDataOfReviewAdmin(
@@ -908,10 +934,13 @@ describe('getReviewsTableDataOfReviewAdmin', () => {
       'en',
     );
 
-    expect(builder.order).toHaveBeenCalledWith('modified_at', { ascending: false });
-    expect(builder.eq).toHaveBeenCalledWith('state_code', 1);
-    expect(builder.select).toHaveBeenCalledWith('*, comments(state_code)');
-    expect(builder.filter).not.toHaveBeenCalled();
+    expect(mockRpc).toHaveBeenCalledWith('qry_review_get_admin_queue_items', {
+      p_status: 'assigned',
+      p_page: 2,
+      p_page_size: 10,
+      p_sort_by: 'modified_at',
+      p_sort_order: 'descend',
+    });
     expect(result.success).toBe(true);
     expect(result).toHaveProperty('page', 2);
     expect(result.total).toBe(1);
@@ -927,29 +956,33 @@ describe('getReviewsTableDataOfReviewAdmin', () => {
   });
 
   it('falls back to an empty comments array when assigned review comments are not arrays', async () => {
-    const reviewRow = {
-      id: 'review-10-no-array-comments',
-      created_at: '2024-04-01T00:00:00.000Z',
-      modified_at: '2024-04-03T00:00:00.000Z',
-      deadline: null,
-      comments: { state_code: 1 },
-      json: {
-        data: {
-          id: 'process-2',
-          version: '01.00.000',
-          name: {
-            baseName: { en: 'Review Base' },
-            treatmentStandardsRoutes: { en: 'Review Route' },
-            mixAndLocationTypes: { en: 'Review Mix' },
-            functionalUnitFlowProperties: { en: 'Review Unit' },
+    mockRpc.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'review-10-no-array-comments',
+          created_at: '2024-04-01T00:00:00.000Z',
+          modified_at: '2024-04-03T00:00:00.000Z',
+          deadline: null,
+          comment_state_codes: null,
+          total_count: 1,
+          json: {
+            data: {
+              id: 'process-2',
+              version: '01.00.000',
+              name: {
+                baseName: { en: 'Review Base' },
+                treatmentStandardsRoutes: { en: 'Review Route' },
+                mixAndLocationTypes: { en: 'Review Mix' },
+                functionalUnitFlowProperties: { en: 'Review Unit' },
+              },
+            },
+            team: { name: { en: 'Ops Team' } },
+            user: { name: 'Alice Reviewer' },
           },
         },
-        team: { name: { en: 'Ops Team' } },
-        user: { name: 'Alice Reviewer' },
-      },
-    };
-    const builder = createQueryBuilder({ data: [reviewRow], count: 1 });
-    mockFrom.mockReturnValueOnce(builder);
+      ],
+      error: null,
+    });
     mockGetLifeCyclesByIdAndVersion.mockResolvedValueOnce({ data: [] });
 
     const result = await reviewsApi.getReviewsTableDataOfReviewAdmin(
@@ -967,8 +1000,7 @@ describe('getReviewsTableDataOfReviewAdmin', () => {
   });
 
   it('returns default empty response when query result has no data field', async () => {
-    const builder = createQueryBuilder({ count: 0 });
-    mockFrom.mockReturnValueOnce(builder);
+    mockRpc.mockResolvedValueOnce({ count: 0, error: null });
 
     const result = await reviewsApi.getReviewsTableDataOfReviewAdmin(
       { pageSize: 10, current: 1 },
@@ -977,12 +1009,18 @@ describe('getReviewsTableDataOfReviewAdmin', () => {
       'en',
     );
 
-    expect(builder.eq).toHaveBeenCalledWith('state_code', -1);
+    expect(mockRpc).toHaveBeenCalledWith('qry_review_get_admin_queue_items', {
+      p_status: 'admin-rejected',
+      p_page: 1,
+      p_page_size: 10,
+      p_sort_by: 'modified_at',
+      p_sort_order: 'ascend',
+    });
     expect(result).toEqual({ data: [], success: true, total: 0 });
   });
 
   it('maps admin-rejected rows with lifecycle model metadata and fallbacks', async () => {
-    const builder = createQueryBuilder({
+    mockRpc.mockResolvedValueOnce({
       data: [
         {
           id: 'review-admin-model',
@@ -1005,8 +1043,8 @@ describe('getReviewsTableDataOfReviewAdmin', () => {
           },
         },
       ],
+      error: null,
     });
-    mockFrom.mockReturnValueOnce(builder);
     mockGetLifeCyclesByIdAndVersion.mockResolvedValueOnce({
       data: [
         {
@@ -1038,7 +1076,6 @@ describe('getReviewsTableDataOfReviewAdmin', () => {
       'en',
     );
 
-    expect(builder.eq).toHaveBeenCalledWith('state_code', -1);
     expect(result).toEqual({
       data: [
         {
@@ -1093,7 +1130,7 @@ describe('getReviewsTableDataOfReviewAdmin', () => {
   });
 
   it('uses lifecycle and user fallbacks for admin rows when names are missing', async () => {
-    const builder = createQueryBuilder({
+    mockRpc.mockResolvedValueOnce({
       data: [
         {
           id: 'review-admin-fallback',
@@ -1109,8 +1146,8 @@ describe('getReviewsTableDataOfReviewAdmin', () => {
           comments: [],
         },
       ],
+      error: null,
     });
-    mockFrom.mockReturnValueOnce(builder);
     mockGetLifeCyclesByIdAndVersion.mockResolvedValueOnce({
       data: [
         {
@@ -1142,7 +1179,7 @@ describe('getReviewsTableDataOfReviewAdmin', () => {
   });
 
   it('falls back to "-" when a non-lifecycle admin row has no process name payload', async () => {
-    const builder = createQueryBuilder({
+    mockRpc.mockResolvedValueOnce({
       data: [
         {
           id: 'review-admin-empty-review-name',
@@ -1155,8 +1192,8 @@ describe('getReviewsTableDataOfReviewAdmin', () => {
           comments: [],
         },
       ],
+      error: null,
     });
-    mockFrom.mockReturnValueOnce(builder);
     mockGetLifeCyclesByIdAndVersion.mockResolvedValueOnce({ data: [] });
     mockGenProcessName.mockReturnValueOnce('');
 


### PR DESCRIPTION
Closes #341

## Summary
- 为 /review 与 /manageSystem 增加明确的无权限拒绝访问页面，不再默认落入 reviewer 或系统管理视图。
- 将 Review 相关读链路从浏览器直读 reviews/comments 收口到 review query RPC，覆盖审核列表、详情与 comment 查询路径。

## Key Decisions
- 保留页面层既有 service API 形状，主要在 services/reviews 和 services/comments 内部切换到 RPC，降低页面改动面。
- AllTeams 在无系统管理角色时直接返回空结果，避免继续触发系统视角数据加载。

## Validation
- npm test -- --runInBand tests/unit/services/reviews/api.test.ts tests/unit/services/comments/api.test.ts tests/integration/reviews/ReviewAuth.integration.test.tsx tests/integration/manageSystem/ManageSystemWorkflow.integration.test.tsx

## Risks / Rollback
- workspace 仍需在子仓 PR 合并后按流程更新 tiangong-lca-next 子模块指针。

## Workspace Integration
- 子仓 PR 合并后，需要在 lca-workspace 按正常流程 bump tiangong-lca-next 指针。