### PR TITLE
feat: add default compliance templates and enhance review comment handling

### DIFF
--- a/src/pages/Review/Components/reviewProcess/index.tsx
+++ b/src/pages/Review/Components/reviewProcess/index.tsx
@@ -11,6 +11,7 @@ import {
   saveReviewCommentDraftApi,
   submitReviewCommentApi,
 } from '@/services/comments/api';
+import { jsonToList } from '@/services/general/util';
 import { getProcessDetail } from '@/services/processes/api';
 import { genProcessFromData } from '@/services/processes/util';
 import { getUserTeamId } from '@/services/roles/api';
@@ -34,6 +35,125 @@ type Props = {
   tabType: 'assigned' | 'review' | 'reviewer-rejected' | 'admin-rejected';
   hideButton?: boolean;
 };
+
+const DEFAULT_REVIEW_COMPLIANCES = [
+  {
+    'common:referenceToComplianceSystem': {
+      '@refObjectId': '1ea48531-e397-4ca7-ac08-056e4fa11826',
+      '@type': 'source data set',
+      '@uri': '../sources/1ea48531-e397-4ca7-ac08-056e4fa11826.xml',
+      '@version': '20.20.002',
+      'common:shortDescription': [
+        {
+          '@xml:lang': 'en',
+          '#text':
+            'ISO 14040 Environmental Management – Life Cycle Assessment – Principles and Framework, 2006',
+        },
+      ],
+    },
+    'common:approvalOfOverallCompliance': 'Fully compliant',
+    'common:nomenclatureCompliance': 'Not defined',
+    'common:methodologicalCompliance': 'Fully compliant',
+    'common:reviewCompliance': 'Fully compliant',
+    'common:documentationCompliance': 'Not defined',
+    'common:qualityCompliance': 'Not defined',
+  },
+  {
+    'common:approvalOfOverallCompliance': 'Fully compliant',
+    'common:nomenclatureCompliance': 'Not defined',
+    'common:methodologicalCompliance': 'Fully compliant',
+    'common:reviewCompliance': 'Not defined',
+    'common:documentationCompliance': 'Fully compliant',
+    'common:qualityCompliance': 'Not defined',
+    'common:referenceToComplianceSystem': {
+      '@refObjectId': '1adb438d-4a8b-4919-885e-0a66da3c0f2a',
+      '@type': 'source data set',
+      '@uri': '../sources/1adb438d-4a8b-4919-885e-0a66da3c0f2a.xml',
+      '@version': '20.20.002',
+      'common:shortDescription': [
+        {
+          '@xml:lang': 'en',
+          '#text':
+            'ISO 14044:2006. Environmental Management – Life Cycle Assessment – Requirements and guidelines.',
+        },
+      ],
+    },
+  },
+  {
+    'common:approvalOfOverallCompliance': 'Fully compliant',
+    'common:nomenclatureCompliance': 'Fully compliant',
+    'common:methodologicalCompliance': 'Fully compliant',
+    'common:reviewCompliance': 'Fully compliant',
+    'common:documentationCompliance': 'Fully compliant',
+    'common:qualityCompliance': 'Not defined',
+    'common:referenceToComplianceSystem': {
+      '@refObjectId': 'd92a1a12-2545-49e2-a585-55c259997756',
+      '@type': 'source data set',
+      '@uri': '../sources/d92a1a12-2545-49e2-a585-55c259997756.xml',
+      '@version': '20.20.002',
+      'common:shortDescription': [
+        {
+          '@xml:lang': 'en',
+          '#text': 'ILCD Data Network - Entry-level',
+        },
+      ],
+    },
+  },
+  {
+    'common:approvalOfOverallCompliance': 'Fully compliant',
+    'common:nomenclatureCompliance': 'Fully compliant',
+    'common:methodologicalCompliance': 'Not defined',
+    'common:reviewCompliance': 'Not defined',
+    'common:documentationCompliance': 'Not defined',
+    'common:qualityCompliance': 'Not defined',
+    'common:referenceToComplianceSystem': {
+      '@refObjectId': 'c84c4185-d1b0-44fc-823e-d2ec630c7906',
+      '@type': 'source data set',
+      '@uri': '../sources/c84c4185-d1b0-44fc-823e-d2ec630c7906.xml',
+      '@version': '00.00.001',
+      'common:shortDescription': [
+        {
+          '@xml:lang': 'en',
+          '#text': 'Environmental Footprint (EF) 3.1',
+        },
+      ],
+    },
+  },
+  {
+    'common:approvalOfOverallCompliance': 'Fully compliant',
+    'common:nomenclatureCompliance': 'Fully compliant',
+    'common:methodologicalCompliance': 'Fully compliant',
+    'common:reviewCompliance': 'Fully compliant',
+    'common:documentationCompliance': 'Fully compliant',
+    'common:qualityCompliance': 'Fully compliant',
+    'common:referenceToComplianceSystem': {
+      '@refObjectId': '779fb9ea-de54-4707-b7fc-6154661552b5',
+      '@type': 'source data set',
+      '@uri': '../sources/779fb9ea-de54-4707-b7fc-6154661552b5.xml',
+      '@version': '01.00.000',
+      'common:shortDescription': [
+        {
+          '@xml:lang': 'en',
+          '#text':
+            'Commission Recommendation (EU) 2021/2279. (Annex I. Product Environmental Footprint Method)',
+        },
+      ],
+    },
+  },
+];
+
+const hasMeaningfulCommentItems = (value: any) =>
+  jsonToList(value).some((item: any) => {
+    if (!item) {
+      return false;
+    }
+
+    if (Object.prototype.toString.call(item) !== '[object Object]') {
+      return true;
+    }
+
+    return Object.keys(item).length > 0;
+  });
 
 const ReviewProcessDetail: FC<Props> = ({
   id,
@@ -116,124 +236,23 @@ const ReviewProcessDetail: FC<Props> = ({
       if (!error && data && data.length) {
         const allReviews: any[] = [];
         const allCompliance: any[] = [];
+        let hasSeededDefaultCompliance = false;
         data.forEach((item: any) => {
-          if (item?.json?.modellingAndValidation?.validation?.review) {
-            allReviews.push(...item?.json?.modellingAndValidation.validation.review);
+          const reviewItems = jsonToList(item?.json?.modellingAndValidation?.validation?.review);
+          if (reviewItems.length) {
+            allReviews.push(...reviewItems);
           }
-          // No review data has been saved yet.
-          if (!item.json && tabType === 'review' && type === 'edit') {
-            allCompliance.push(
-              ...[
-                {
-                  'common:referenceToComplianceSystem': {
-                    '@refObjectId': '1ea48531-e397-4ca7-ac08-056e4fa11826',
-                    '@type': 'source data set',
-                    '@uri': '../sources/1ea48531-e397-4ca7-ac08-056e4fa11826.xml',
-                    '@version': '20.20.002',
-                    'common:shortDescription': [
-                      {
-                        '@xml:lang': 'en',
-                        '#text':
-                          'ISO 14040 Environmental Management – Life Cycle Assessment – Principles and Framework, 2006',
-                      },
-                    ],
-                  },
-                  'common:approvalOfOverallCompliance': 'Fully compliant',
-                  'common:nomenclatureCompliance': 'Not defined',
-                  'common:methodologicalCompliance': 'Fully compliant',
-                  'common:reviewCompliance': 'Fully compliant',
-                  'common:documentationCompliance': 'Not defined',
-                  'common:qualityCompliance': 'Not defined',
-                },
-                {
-                  'common:approvalOfOverallCompliance': 'Fully compliant',
-                  'common:nomenclatureCompliance': 'Not defined',
-                  'common:methodologicalCompliance': 'Fully compliant',
-                  'common:reviewCompliance': 'Not defined',
-                  'common:documentationCompliance': 'Fully compliant',
-                  'common:qualityCompliance': 'Not defined',
-                  'common:referenceToComplianceSystem': {
-                    '@refObjectId': '1adb438d-4a8b-4919-885e-0a66da3c0f2a',
-                    '@type': 'source data set',
-                    '@uri': '../sources/1adb438d-4a8b-4919-885e-0a66da3c0f2a.xml',
-                    '@version': '20.20.002',
-                    'common:shortDescription': [
-                      {
-                        '@xml:lang': 'en',
-                        '#text':
-                          'ISO 14044:2006. Environmental Management – Life Cycle Assessment – Requirements and guidelines.',
-                      },
-                    ],
-                  },
-                },
-                {
-                  'common:approvalOfOverallCompliance': 'Fully compliant',
-                  'common:nomenclatureCompliance': 'Fully compliant',
-                  'common:methodologicalCompliance': 'Fully compliant',
-                  'common:reviewCompliance': 'Fully compliant',
-                  'common:documentationCompliance': 'Fully compliant',
-                  'common:qualityCompliance': 'Not defined',
-                  'common:referenceToComplianceSystem': {
-                    '@refObjectId': 'd92a1a12-2545-49e2-a585-55c259997756',
-                    '@type': 'source data set',
-                    '@uri': '../sources/d92a1a12-2545-49e2-a585-55c259997756.xml',
-                    '@version': '20.20.002',
-                    'common:shortDescription': [
-                      {
-                        '@xml:lang': 'en',
-                        '#text': 'ILCD Data Network - Entry-level',
-                      },
-                    ],
-                  },
-                },
-                {
-                  'common:approvalOfOverallCompliance': 'Fully compliant',
-                  'common:nomenclatureCompliance': 'Fully compliant',
-                  'common:methodologicalCompliance': 'Not defined',
-                  'common:reviewCompliance': 'Not defined',
-                  'common:documentationCompliance': 'Not defined',
-                  'common:qualityCompliance': 'Not defined',
-                  'common:referenceToComplianceSystem': {
-                    '@refObjectId': 'c84c4185-d1b0-44fc-823e-d2ec630c7906',
-                    '@type': 'source data set',
-                    '@uri': '../sources/c84c4185-d1b0-44fc-823e-d2ec630c7906.xml',
-                    '@version': '00.00.001',
-                    'common:shortDescription': [
-                      {
-                        '@xml:lang': 'en',
-                        '#text': 'Environmental Footprint (EF) 3.1',
-                      },
-                    ],
-                  },
-                },
-                {
-                  'common:approvalOfOverallCompliance': 'Fully compliant',
-                  'common:nomenclatureCompliance': 'Fully compliant',
-                  'common:methodologicalCompliance': 'Fully compliant',
-                  'common:reviewCompliance': 'Fully compliant',
-                  'common:documentationCompliance': 'Fully compliant',
-                  'common:qualityCompliance': 'Fully compliant',
-                  'common:referenceToComplianceSystem': {
-                    '@refObjectId': '779fb9ea-de54-4707-b7fc-6154661552b5',
-                    '@type': 'source data set',
-                    '@uri': '../sources/779fb9ea-de54-4707-b7fc-6154661552b5.xml',
-                    '@version': '01.00.000',
-                    'common:shortDescription': [
-                      {
-                        '@xml:lang': 'en',
-                        '#text':
-                          'Commission Recommendation (EU) 2021/2279. (Annex I. Product Environmental Footprint Method)',
-                      },
-                    ],
-                  },
-                },
-              ],
-            );
-          }
-          if (item?.json?.modellingAndValidation?.complianceDeclarations?.compliance) {
-            allCompliance.push(
-              ...item?.json?.modellingAndValidation.complianceDeclarations.compliance,
-            );
+
+          const complianceItems = jsonToList(
+            item?.json?.modellingAndValidation?.complianceDeclarations?.compliance,
+          );
+
+          if (hasMeaningfulCommentItems(complianceItems)) {
+            allCompliance.push(...complianceItems);
+          } else if (tabType === 'review' && type === 'edit' && !hasSeededDefaultCompliance) {
+            // Keep reviewer defaults visible even when the comment row exists but its json is empty.
+            allCompliance.push(...DEFAULT_REVIEW_COMPLIANCES);
+            hasSeededDefaultCompliance = true;
           }
         });
         if (result?.data?.json?.processDataSet) {

--- a/tests/unit/pages/Review/Components/ReviewProcess.test.tsx
+++ b/tests/unit/pages/Review/Components/ReviewProcess.test.tsx
@@ -470,7 +470,7 @@ describe('ReviewProcessDetail component', () => {
   it('merges review defaults and saved reviewer comments before hydrating the form', async () => {
     mockGetCommentApi.mockResolvedValueOnce({
       data: [
-        { json: null },
+        { json: {} },
         {
           json: {
             modellingAndValidation: {
@@ -503,6 +503,37 @@ describe('ReviewProcessDetail component', () => {
         { id: 'compliance-comment-1' },
         expect.objectContaining({
           'common:referenceToComplianceSystem': expect.any(Object),
+        }),
+      ]),
+    );
+  });
+
+  it('hydrates default compliance templates for normalized empty reviewer comments', async () => {
+    mockGetCommentApi.mockResolvedValueOnce({
+      data: [{ json: {} }],
+      error: null,
+    });
+    mockGenProcessFromData.mockImplementation((data: any) => data);
+
+    renderComponent({ tabType: 'review', type: 'edit' });
+
+    fireEvent.click(screen.getAllByRole('button')[0]);
+
+    await waitFor(() => expect(mockGenProcessFromData).toHaveBeenCalled());
+
+    const mergedData = mockGenProcessFromData.mock.calls.at(-1)?.[0];
+    expect(mergedData.modellingAndValidation.validation.review).toEqual([
+      {
+        'common:scope': [{ '@name': undefined }],
+      },
+    ]);
+    expect(mergedData.modellingAndValidation.complianceDeclarations.compliance).toHaveLength(5);
+    expect(mergedData.modellingAndValidation.complianceDeclarations.compliance).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          'common:referenceToComplianceSystem': expect.objectContaining({
+            '@refObjectId': '1ea48531-e397-4ca7-ac08-056e4fa11826',
+          }),
         }),
       ]),
     );
@@ -882,7 +913,7 @@ describe('ReviewProcessDetail component', () => {
     ]);
   });
 
-  it('falls back to default review and compliance placeholders when saved review comments are empty', async () => {
+  it('restores default compliance templates when saved review comments are empty', async () => {
     mockGetProcessDetail.mockResolvedValueOnce({
       data: {
         id: 'process-1',
@@ -925,7 +956,16 @@ describe('ReviewProcessDetail component', () => {
         'common:scope': [{ '@name': undefined }],
       },
     ]);
-    expect(merged.modellingAndValidation.complianceDeclarations.compliance).toEqual([{}]);
+    expect(merged.modellingAndValidation.complianceDeclarations.compliance).toHaveLength(5);
+    expect(merged.modellingAndValidation.complianceDeclarations.compliance).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          'common:referenceToComplianceSystem': expect.objectContaining({
+            '@refObjectId': '1ea48531-e397-4ca7-ac08-056e4fa11826',
+          }),
+        }),
+      ]),
+    );
   });
 
   it('merges persisted review arrays into existing non-review arrays', async () => {


### PR DESCRIPTION
## Branch Contract

- Base branch: `dev`
- Validated environment: `N/A (unit-test only)`
- Back-merge required after merge?: `No`
- Root workspace integration expected?: `No`

- [x] This PR targets `dev`.
- [x] I confirm this repo's GitHub default branch may still appear as `main`, but routine feature and fix PRs must target `dev`.
- [ ] If this change actually started from `main`, I documented why this is a hotfix or production-only exception.

## Linked Issue

Closes #

## Summary

- hydrate default compliance templates when normalized reviewer comments are empty
- preserve existing review payloads while merging assigned review comments into arrays and objects
- extend `ReviewProcess` unit coverage for hydration, fallback, and merge scenarios

## Validation

- `npm run test:ci -- --runInBand --testTimeout=20000 --no-coverage --runTestsByPath tests/unit/pages/Review/Components/ReviewProcess.test.tsx`
- `npm run lint` *(fails in existing repo-wide `tsc` over `supabase/functions/**` Deno/JSR imports and globals unrelated to this branch)*

## Risks / Follow-up

- Full repo lint/gate validation still depends on resolving the existing `supabase/functions/**` TypeScript baseline outside this change.
