### PR TITLE
feat: add 'Reviewer Rejected' message to review detail pages in English and Chinese

### DIFF
--- a/src/locales/en-US/pages_review.ts
+++ b/src/locales/en-US/pages_review.ts
@@ -103,6 +103,7 @@ export default {
   'pages.reviewDetail.submit_review': 'Submit Review',
   'pages.reviewDetail.assign_reviewers_temporary': 'Assign Reviewers Temporarily',
   'pages.reviewDetail.assign_reviewers': 'Assign Reviewers',
+  'pages.reviewDetail.reviewer_rejected': 'Reviewer Rejected',
   'pages.reviewDetail.revoke_reviewer': 'Revoke Reviewer',
   'pages.reviewDetail.submit_comments_temporary': 'Submit Comments Temporarily',
   'pages.reviewDetail.submit_comments': 'Submit Comments',

--- a/src/locales/zh-CN/pages_review.ts
+++ b/src/locales/zh-CN/pages_review.ts
@@ -103,6 +103,7 @@ export default {
   'pages.reviewDetail.submit_review': '提交审核',
   'pages.reviewDetail.assign_reviewers_temporary': '临时分配审核员',
   'pages.reviewDetail.assign_reviewers': '分配审核员',
+  'pages.reviewDetail.reviewer_rejected': '审核员驳回处理',
   'pages.reviewDetail.revoke_reviewer': '移除审核员',
   'pages.reviewDetail.submit_comments_temporary': '暂存评审数据',
   'pages.reviewDetail.submit_comments': '提交评审数据',


### PR DESCRIPTION
## Summary
- add the missing `Reviewer Rejected` review status copy to the English review detail locale
- add the matching Chinese locale copy for the same review detail state

## Testing
- not run (locale text change only)