### PR TITLE
docs: add AI doc contracts for issue #346

### DIFF
--- a/.github/scripts/ai-doc-lint.mjs
+++ b/.github/scripts/ai-doc-lint.mjs
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const MARKDOWN_METADATA_KEYS = [
+  'docType',
+  'scope',
+  'status',
+  'authoritative',
+  'owner',
+  'language',
+  'whenToUse',
+  'whenToUpdate',
+  'checkPaths',
+  'lastReviewedAt',
+  'lastReviewedCommit',
+];
+
+const YAML_METADATA_KEYS = ['lastReviewedAt', 'lastReviewedCommit'];
+
+export function normalizePath(value) {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+/g, '/');
+}
+
+export function escapeRegex(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+export function globToRegExp(pattern) {
+  const normalized = normalizePath(pattern);
+  let output = '^';
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+    const next = normalized[index + 1];
+
+    if (char === '*') {
+      if (next === '*') {
+        output += '.*';
+        index += 1;
+      } else {
+        output += '[^/]*';
+      }
+      continue;
+    }
+
+    if (char === '?') {
+      output += '[^/]';
+      continue;
+    }
+
+    output += escapeRegex(char);
+  }
+
+  output += '$';
+  return new RegExp(output);
+}
+
+export function matchesPattern(filePath, pattern) {
+  return globToRegExp(pattern).test(normalizePath(filePath));
+}
+
+export function parseJsonCompatibleYaml(text, sourceLabel) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `${sourceLabel} is not valid JSON-compatible YAML. Phase 1 contract files must use JSON-compatible YAML syntax. ${error.message}`,
+    );
+  }
+}
+
+export function loadJsonCompatibleYaml(absPath, sourceLabel = absPath) {
+  return parseJsonCompatibleYaml(readFileSync(absPath, 'utf8'), sourceLabel);
+}
+
+export function parseFrontmatterKeys(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    return new Set();
+  }
+
+  return new Set(
+    Array.from(match[1].matchAll(/^([A-Za-z][A-Za-z0-9]*)\s*:/gm), (result) => result[1]),
+  );
+}
+
+export function missingMarkdownMetadata(text) {
+  const keys = parseFrontmatterKeys(text);
+  return MARKDOWN_METADATA_KEYS.filter((key) => !keys.has(key));
+}
+
+export function missingYamlMetadata(text, sourceLabel) {
+  const parsed = parseJsonCompatibleYaml(text, sourceLabel);
+  return YAML_METADATA_KEYS.filter((key) => !(key in parsed));
+}
+
+export function isKeyMarkdownDoc(relPath) {
+  const normalized = normalizePath(relPath);
+  return (
+    path.posix.basename(normalized) === 'AGENTS.md' ||
+    ((normalized.startsWith('ai/') || normalized.includes('/ai/')) && normalized.endsWith('.md'))
+  );
+}
+
+export function isKeyYamlContract(relPath) {
+  const normalized = normalizePath(relPath);
+  return normalized.endsWith('.yaml') && (normalized.startsWith('ai/') || normalized.includes('/ai/'));
+}
+
+export function detectImpactLayout(rootDir) {
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact-map.yaml'))) {
+    return 'workspace';
+  }
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact.yaml'))) {
+    return 'repo';
+  }
+  return 'none';
+}
+
+export function listImpactFiles(rootDir) {
+  const layout = detectImpactLayout(rootDir);
+
+  if (layout === 'repo') {
+    return [
+      {
+        absPath: path.join(rootDir, 'ai', 'doc-impact.yaml'),
+        relPath: 'ai/doc-impact.yaml',
+        baseDir: '',
+      },
+    ];
+  }
+
+  if (layout !== 'workspace') {
+    return [];
+  }
+
+  const rootImpact = path.join(rootDir, 'ai', 'doc-impact-map.yaml');
+  const results = [
+    {
+      absPath: rootImpact,
+      relPath: 'ai/doc-impact-map.yaml',
+      baseDir: '',
+    },
+  ];
+
+  for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+
+    const repoImpact = path.join(rootDir, entry.name, 'ai', 'doc-impact.yaml');
+    if (!existsSync(repoImpact)) {
+      continue;
+    }
+
+    results.push({
+      absPath: repoImpact,
+      relPath: normalizePath(path.join(entry.name, 'ai', 'doc-impact.yaml')),
+      baseDir: entry.name,
+    });
+  }
+
+  return results;
+}
+
+export function loadImpactFiles(rootDir) {
+  return listImpactFiles(rootDir).flatMap(({ absPath, relPath, baseDir }) => {
+    const parsed = loadJsonCompatibleYaml(absPath, relPath);
+    const rules = Array.isArray(parsed.rules) ? parsed.rules : [];
+
+    return rules.map((rule) => ({
+      source: relPath,
+      baseDir,
+      rule,
+    }));
+  });
+}
+
+export function resolveRulePath(baseDir, relPattern) {
+  if (!baseDir) {
+    return normalizePath(relPattern);
+  }
+  return normalizePath(path.posix.join(baseDir, relPattern));
+}
+
+export function matchRules(changedPaths, loadedRules) {
+  const matches = [];
+
+  for (const changedPath of changedPaths) {
+    for (const loaded of loadedRules) {
+      const triggers = Array.isArray(loaded.rule.triggers) ? loaded.rule.triggers : [];
+      if (
+        triggers.some((trigger) =>
+          matchesPattern(changedPath, resolveRulePath(loaded.baseDir, trigger.path)),
+        )
+      ) {
+        matches.push({
+          changedPath,
+          source: loaded.source,
+          rule: loaded.rule,
+          baseDir: loaded.baseDir,
+        });
+      }
+    }
+  }
+
+  return matches;
+}
+
+export function collectExpectedDocs(matches) {
+  const expected = new Map();
+
+  for (const match of matches) {
+    const requiredDocs = Array.isArray(match.rule.requiredDocs) ? match.rule.requiredDocs : [];
+    for (const doc of requiredDocs) {
+      const fullPath = resolveRulePath(match.baseDir, doc.path);
+      if (!expected.has(fullPath)) {
+        expected.set(fullPath, {
+          path: fullPath,
+          rules: new Set(),
+          changedPaths: new Set(),
+          modes: new Set(),
+        });
+      }
+
+      const entry = expected.get(fullPath);
+      entry.rules.add(match.rule.id);
+      entry.changedPaths.add(match.changedPath);
+      entry.modes.add(doc.mode);
+    }
+  }
+
+  return expected;
+}
+
+export function parseArgs(argv) {
+  const options = {
+    rootDir: process.cwd(),
+    mode: 'warn',
+    files: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--root') {
+      options.rootDir = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--mode') {
+      options.mode = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--base') {
+      options.base = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--head') {
+      options.head = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--files') {
+      options.files = argv[index + 1]
+        .split(',')
+        .map((value) => normalizePath(value.trim()))
+        .filter(Boolean);
+      index += 1;
+      continue;
+    }
+    if (arg === '--help') {
+      options.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+export function getChangedPaths({ rootDir, base, head, files }) {
+  if (files.length > 0) {
+    return [...new Set(files)];
+  }
+
+  if (!base || !head) {
+    throw new Error('Pass either --files or both --base and --head.');
+  }
+
+  const output = execFileSync('git', ['diff', '--name-only', `${base}...${head}`], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+
+  return [...new Set(output.split(/\r?\n/).map((value) => normalizePath(value.trim())).filter(Boolean))];
+}
+
+export function buildDocProblems({ rootDir, changedPaths }) {
+  const problems = [];
+
+  for (const relPath of changedPaths) {
+    const absPath = path.join(rootDir, relPath);
+    if (!existsSync(absPath)) {
+      continue;
+    }
+
+    if (isKeyMarkdownDoc(relPath)) {
+      const missing = missingMarkdownMetadata(readFileSync(absPath, 'utf8'));
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing Markdown metadata keys: ${missing.join(', ')}`,
+        });
+      }
+      continue;
+    }
+
+    if (isKeyYamlContract(relPath)) {
+      const missing = missingYamlMetadata(readFileSync(absPath, 'utf8'), relPath);
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing YAML metadata keys: ${missing.join(', ')}`,
+        });
+      }
+    }
+  }
+
+  return problems;
+}
+
+export function buildMissingDocProblems({ changedPaths, expectedDocs }) {
+  const changed = new Set(changedPaths);
+  const problems = [];
+
+  for (const entry of expectedDocs.values()) {
+    if (changed.has(entry.path)) {
+      continue;
+    }
+
+    problems.push({
+      type: 'missing-review',
+      path: entry.path,
+      message: `Expected reviewed doc was not touched. Triggered by ${Array.from(entry.changedPaths).join(', ')} via rule(s): ${Array.from(entry.rules).join(', ')}`,
+    });
+  }
+
+  return problems;
+}
+
+export function formatProblem(problem) {
+  return `- [${problem.type}] ${problem.path}: ${problem.message}`;
+}
+
+export function emitProblems(problems, mode) {
+  if (problems.length === 0) {
+    console.log('AI doc lint: no problems found.');
+    return;
+  }
+
+  const heading =
+    mode === 'enforce' ? 'AI doc lint found blocking problems:' : 'AI doc lint found warnings:';
+  const annotationLevel = mode === 'enforce' ? 'error' : 'warning';
+  console.log(heading);
+  for (const problem of problems) {
+    console.log(formatProblem(problem));
+    if (process.env.GITHUB_ACTIONS) {
+      console.log(`::${annotationLevel} file=${problem.path}::${problem.message}`);
+    }
+  }
+}
+
+export function run(options) {
+  const changedPaths = getChangedPaths(options);
+  if (changedPaths.length === 0) {
+    console.log('AI doc lint: no changed paths to inspect.');
+    return { problems: [], changedPaths, matchedRules: [] };
+  }
+
+  const loadedRules = loadImpactFiles(options.rootDir);
+  const matchedRules = matchRules(changedPaths, loadedRules);
+  const expectedDocs = collectExpectedDocs(matchedRules);
+  const problems = [
+    ...buildMissingDocProblems({ changedPaths, expectedDocs }),
+    ...buildDocProblems({ rootDir: options.rootDir, changedPaths }),
+  ];
+
+  emitProblems(problems, options.mode);
+
+  if (options.mode === 'enforce' && problems.length > 0) {
+    process.exitCode = 1;
+  }
+
+  return { problems, changedPaths, matchedRules };
+}
+
+function printHelp() {
+  console.log(`Usage: node .github/scripts/ai-doc-lint.mjs [--mode warn|enforce] [--base <sha> --head <sha> | --files <csv>] [--root <dir>]`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      printHelp();
+      process.exit(0);
+    }
+    run(options);
+  } catch (error) {
+    console.error(`AI doc lint error: ${error.message}`);
+    process.exit(2);
+  }
+}

--- a/.github/scripts/ai-doc-lint.test.mjs
+++ b/.github/scripts/ai-doc-lint.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  collectExpectedDocs,
+  detectImpactLayout,
+  globToRegExp,
+  isKeyMarkdownDoc,
+  loadImpactFiles,
+  matchRules,
+  missingMarkdownMetadata,
+  missingYamlMetadata,
+  normalizePath,
+} from './ai-doc-lint.mjs';
+
+test('normalizePath and globToRegExp support repo-relative matching', () => {
+  assert.equal(normalizePath('.\\tiangong-lca-next\\config\\routes.ts'), 'tiangong-lca-next/config/routes.ts');
+  assert.equal(globToRegExp('tiangong-lca-next/**').test('tiangong-lca-next/config/routes.ts'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/quality-rubric.md'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/nested/file.md'), false);
+});
+
+test('detectImpactLayout distinguishes workspace and repo roots', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-layout-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  assert.equal(detectImpactLayout(tempDir), 'none');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'repo');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact-map.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'workspace');
+});
+
+test('isKeyMarkdownDoc excludes YAML contract files', () => {
+  assert.equal(isKeyMarkdownDoc('ai/quality-rubric.md'), true);
+  assert.equal(isKeyMarkdownDoc('AGENTS.md'), true);
+  assert.equal(isKeyMarkdownDoc('ai/workspace.yaml'), false);
+});
+
+test('missingMarkdownMetadata detects absent frontmatter keys', () => {
+  const text = `---
+title: Example
+docType: contract
+scope: workspace
+status: draft
+authoritative: false
+owner: lca-workspace
+language: en
+whenToUse:
+  - x
+whenToUpdate:
+  - y
+checkPaths:
+  - ai/**
+lastReviewedAt: 2026-04-18
+---
+
+# Example
+`;
+
+  assert.deepEqual(missingMarkdownMetadata(text), ['lastReviewedCommit']);
+});
+
+test('missingYamlMetadata detects absent top-level review fields', () => {
+  const text = JSON.stringify({ version: 1, lastReviewedAt: '2026-04-18' });
+  assert.deepEqual(missingYamlMetadata(text, 'ai/example.yaml'), ['lastReviewedCommit']);
+});
+
+test('loadImpactFiles, matchRules, and collectExpectedDocs resolve repo-local paths', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+  mkdirSync(path.join(tempDir, 'subrepo', 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact-map.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'root-rule',
+            scope: 'workspace',
+            repo: 'lca-workspace',
+            triggers: [{ path: 'AGENTS.md', kind: 'doc-contract' }],
+            requiredDocs: [{ path: 'ai/workspace.yaml', mode: 'review_or_update' }],
+            reason: 'root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  writeFileSync(
+    path.join(tempDir, 'subrepo', 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'subrepo',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/task-router.md', mode: 'review_or_update' }],
+            reason: 'repo',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['AGENTS.md', 'subrepo/src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 2);
+  assert.equal(matches.length, 2);
+  assert.deepEqual([...expectedDocs.keys()].sort(), ['ai/workspace.yaml', 'subrepo/ai/task-router.md']);
+});
+
+test('loadImpactFiles supports repo-root mode', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-repo-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'example',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/validation.md', mode: 'review_or_update' }],
+            reason: 'repo-root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 1);
+  assert.equal(matches.length, 1);
+  assert.deepEqual([...expectedDocs.keys()], ['ai/validation.md']);
+});

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,0 +1,32 @@
+name: ai-doc-lint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ai-doc-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Run ai-doc-lint unit tests
+        run: node --test .github/scripts/ai-doc-lint.test.mjs
+
+      - name: Run ai-doc-lint
+        run: |
+          node .github/scripts/ai-doc-lint.mjs \
+            --mode enforce \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ Do not infer the daily trunk from GitHub UI defaults.
 
 ## Runtime Facts
 
+- Repo-local AI-doc maintenance is enforced by `.github/workflows/ai-doc-lint.yml` using the vendored `.github/scripts/ai-doc-lint.*` files.
 - Package manager: `npm`
 - Node baseline: `>=24`
 - Default local app target: `npm start` or `npm run start:dev` against the shared `dev` environment

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,144 +1,137 @@
-# AGENTS – Tiangong LCA Next
+---
+title: next AI Working Guide
+docType: contract
+scope: repo
+status: active
+authoritative: true
+owner: next
+language: en
+whenToUse:
+  - when a task may change shipped frontend behavior, route wiring, app-side service integration, or the repo test and release gates
+  - when routing work from the workspace root into tiangong-lca-next
+  - when deciding whether a change belongs here, in database-engine, in edge-functions, in next-docs, or in lca-workspace
+whenToUpdate:
+  - when branch, deploy, coverage, or ownership boundaries change
+  - when the app-side data-access contract changes
+  - when the repo-local AI bootstrap docs under ai/ change
+checkPaths:
+  - AGENTS.md
+  - README.md
+  - docs/agents/**
+  - ai/**/*.md
+  - ai/**/*.yaml
+  - package.json
+  - .nvmrc
+  - jest.config.cjs
+  - .husky/pre-push
+  - .github/workflows/**
+  - config/**
+  - src/**
+  - public/**
+  - docker/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 002be46cbcb8a650c30a0b8962defa50a4c8be93
+related:
+  - ai/repo.yaml
+  - ai/task-router.md
+  - ai/validation.md
+  - ai/architecture.md
+  - docs/agents/ai-dev-guide.md
+  - docs/agents/ai-testing-guide.md
+  - docs/agents/supabase-branching.md
+  - docs/agents/util_calculate.md
+---
 
-Use this file as the single entry point for coding agents.
+## Repo Contract
 
-> Language contract: agents load English docs only (no `_CN` suffix). Every edited English doc must update its `_CN` mirror in the same change.
+`tiangong-lca-next` owns shipped frontend behavior for TianGong LCA: routes, pages, shared UI components, app-side services, caches, and local product packaging surfaces. Start here when the task may change what users see or how the frontend talks to the backend.
 
-## Why This File Exists
+## AI Language And Load Order
 
-- Minimize context/token usage: start here, then open only the docs needed for the current task.
-- Keep requirements consistent across development, testing, and delivery.
+AI contract docs under `AGENTS.md` and `ai/**` are English-only canonical.
 
-## Runtime Baseline
+For legacy deep docs under `docs/agents/**`, keep this rule:
 
-- Node.js **>= 24** (`nvm use 24`; `.nvmrc` is `24`).
-- Stack: React 18 + `@umijs/max` 4 + Ant Design Pro 5 + TypeScript.
-- Supabase frontend env keys are prewired via committed runtime env files such as `.env` and `.env.development`: use `npm start` as the default entry point for the persistent Supabase `dev` branch, keep `npm run start:dev` as the equivalent explicit dev alias, and use `npm run start:main` only when a task explicitly needs the `main` database. Do not create ad-hoc Supabase clients outside `src/services/**`.
-- Database-side Edge Function SQL must read branch-specific Vault secrets. Standard webhook auth uses `project_url` and `project_secret_key`; legacy `generate_flow_embedding()` compatibility additionally uses `project_x_key`. Never hardcode branch URLs or service keys in SQL, migrations, or baseline dumps.
-- The Supabase schema source of truth now lives in `tiangong-lca/database-engine`. This repo is a consumer of that database. Do not author schema/config/migration changes here.
-- Do not add npm dependencies without explicit human approval.
+- if you edit an English file that already has a `_CN` mirror, update the mirror in the same change
 
-## Development Workflow Summary
+Load docs in this order:
 
-- This repository keeps GitHub default branch `main` as a platform exception, but the daily trunk is Git `dev`.
-- Routine branch progression is `feature/* -> dev -> main`.
-- Start normal work from the latest Git `dev`, then create a feature branch from `dev`.
-- Open routine feature and fix PRs into Git `dev`, not directly into Git `main`.
-- Use `npm start` for routine frontend work against the shared persistent Supabase `dev` branch; `npm run start:dev` remains the equivalent explicit alias.
-- Author schema changes in `tiangong-lca/database-engine`, then validate this frontend against the relevant local, preview, `dev`, or `main` environment. Do not use the shared remote `dev` database as the first place to invent schema changes from this repo.
-- After a PR merges into Git `dev`, verify the integrated result in the shared Supabase `dev` branch.
-- Promote validated changes by opening a PR from Git `dev` into Git `main`.
-- Use `main` only through the explicit `npm run start:main` workflow for task-specific verification, production investigation, or hotfix work.
-- Branch from Git `main` only when the work must start from production, such as a hotfix. After that work merges to `main`, back-merge `main` into `dev`.
-- Do not infer the daily trunk from GitHub default-branch UI alone; in this repository, routine work still starts from `dev`.
-- `docs/agents/supabase-branching.md` is the canonical detailed procedure for app-side environment selection in this repo and points to `database-engine` for database ownership.
-
-## Core Commands
-
-```bash
-npm install
-npm start
-npm run start:dev
-npm run start:main
-npm run lint
-npm test
-npm run test:coverage
-npm run test:coverage:assert-full
-npm run test:coverage:report
-npm run prepush:gate
-npm run test:ci -- tests/integration/<feature>/ --runInBand --testTimeout=20000 --no-coverage
-npm run build
-```
-
-Notes:
-
-- `npm start` and `npm run start:dev` are equivalent dev-target commands. `npm run start:main` is the explicit main-target command.
-- `npm test` runs the CI-style runner (`scripts/test-runner.cjs`): unit first, then integration.
-- The unit/src phase is capped at `--maxWorkers=50%` in the shared runner to avoid intermittent Jest worker `SIGSEGV` crashes during full local gates and pre-push hooks.
-- `npm run test:coverage` and `npm run test:coverage:report` already include `NODE_OPTIONS=--max-old-space-size=8192`; use the scripts directly for full coverage work.
-- `npm run test:coverage:assert-full` reads the latest coverage artifact and fails unless the repo is still at `100%` statements / branches / functions / lines with zero remaining queue files.
-- `npm run prepush:gate` is the authoritative full gate command: `lint + full coverage + strict 100% assertion`.
-- `.husky/pre-push` only auto-runs that heavy gate on local `main` pushes. PRs targeting `dev` or `main` must enforce the same command in GitHub Actions.
-- `npm run test:coverage:report` is the default coverage review artifact. It prints the global summary, category summary, closure-queue summary, shared-fixture batches, and the next 25 ordered incomplete files using full project-relative paths (no `...` truncation for file/cluster labels).
-- `node scripts/test-coverage-report.js --full` prints the full ordered incomplete-file queue. Use it to inspect the full file-by-file state or refresh the queue snapshot, not to subjectively re-rank by ROI.
-- For focused suites with extra flags, prefer `npm run test:ci -- <jest-args>` instead of nesting flags after `npm test`.
-
-## Token-Efficient Doc Routing
-
-Read only what matches the current task:
-
-1. Feature/page implementation
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. `ai/task-router.md`
+4. `ai/validation.md`
+5. `ai/architecture.md`
+6. only then load the deep doc that matches the task, such as:
    - `docs/agents/ai-dev-guide.md`
-2. Any test creation/debugging
-   - `docs/agents/ai-testing-guide.md` (first)
-   - `docs/agents/testing-patterns.md` (templates)
-   - `docs/agents/testing-troubleshooting.md` (failures/timeouts/handles)
-3. Lifecycle-model calculation changes
-   - `docs/agents/util_calculate.md`
-4. Test coverage backlog tracking
-   - `docs/agents/test_todo_list.md` (actionable source of truth)
-   - `docs/agents/test_improvement_plan.md` (long-term context and strategy)
-5. Team/data audit process tasks
-   - `docs/agents/team_management.md`
-   - `docs/agents/data_audit_instruction.md`
-6. Supabase Branching / environment configuration
+   - `docs/agents/ai-testing-guide.md`
    - `docs/agents/supabase-branching.md`
+   - `docs/agents/util_calculate.md`
 
-## Repo Landmarks
+Do not start with long plans, Chinese mirrors, or GitHub default-branch UI.
 
-- `config/routes.ts`: mirrored route branches (`/tgdata`, `/codata`, `/mydata`, `/tedata`).
-- `tiangong-lca/database-engine/supabase/**`: the database schema/config source of truth for the workspace. This repo no longer keeps a local `supabase/` source-of-truth tree.
-- `.env.supabase.*.local(.example)`: database-maintenance env files moved to `tiangong-lca/database-engine`; do not reintroduce or maintain them here.
-- `src/services/**`: only allowed boundary for Supabase calls.
-- `src/pages/<Feature>/`: page entry + `Components/` drawers/modals.
-- `src/components/**`, `src/contexts/**`, `types/**`: shared UI/context/types.
-- `tests/{unit,integration}/**`: Jest suites + shared helpers in `tests/helpers/**`.
-- `docker/volumes/functions/**`: synced self-hosted edge-functions mirror. Do not edit these files in `tiangong-lca-next`.
-- `docker/pull-edge-functions.sh`: the only supported way to refresh `docker/volumes/functions/**` in this repo.
+## Repo Ownership
 
-## UI Consistency / Ant Design First
+This repo owns:
 
-For `tiangong-lca-next`, UI consistency is a hard product requirement.
+- shipped product behavior under `src/**`
+- route wiring under `config/routes.ts`
+- app runtime setup under `config/**` and `src/app.tsx`
+- app-side Supabase and API access under `src/services/**`
+- shared UI, locale, and static-resource consumption under `src/components/**`, `src/locales/**`, and `public/**`
+- self-hosted mirror assets under `docker/**`
+- desktop packaging files under `electron/**`, `electron-builder.json`, and `icons/**`
 
-When implementing or modifying frontend UI in this repository, follow these rules:
+This repo does not own:
 
-1. Reuse existing shared components and established project patterns first.
-2. If no suitable shared abstraction exists, prefer Ant Design native components, documented props, built-in variants, and standard interaction patterns.
-3. For visual decisions that affect product consistency, prefer Ant Design theme tokens, component tokens, or established project token abstractions over ad-hoc hard-coded values.
-4. Avoid unnecessary custom visual styling. Custom CSS, inline styles, and local CSS modules are not the default path when Ant Design or existing shared abstractions can already satisfy the requirement.
-5. Custom styling is allowed only when Ant Design props, tokens, or existing shared abstractions cannot reasonably satisfy the requirement. In such cases, keep the override minimal, preserve the established visual language, and explain the reason in the PR description or code comments when it is not obvious.
-6. If a custom visual pattern starts repeating, extract it into a shared component or reusable abstraction instead of duplicating it locally.
+- database schema, migrations, seeds, or Supabase branch governance
+- Edge Function runtime behavior
+- public docs-site content
+- solver or compute-engine internals
+- workspace integration state after merge
 
-Clarification:
+Route those tasks to:
 
-- This rule targets product-facing visual styling and interaction consistency, not a total ban on layout code.
-- Local layout styling is acceptable when appropriate, but prefer existing project patterns and Ant Design layout primitives for simple composition before introducing one-off visual treatments.
+- `database-engine` for schema truth and Supabase branch governance
+- `edge-functions` for Edge runtime and API orchestration behavior
+- `next-docs` for public docs-site content
+- `calculator` for solver and compute behavior
+- `lca-workspace` for root integration after merge
 
-## Delivery Contract
+## Branch And Deploy Facts
 
-- Investigate first (`rg`, nearest feature, existing tests).
-- Keep business logic in services/utilities; React layers stay orchestration-focused.
-- Add/adjust tests matching scope.
-- Any code change is a hard requirement to keep repo-wide coverage at `100%` for statements, branches, functions, and lines.
-- `npm run lint` must pass.
-- Run focused Jest suites relevant to the change.
-- Run `npm run test:coverage:assert-full` whenever you need to verify the hard gate without rerunning coverage.
-- Before push from local `main`, the repo must pass `npm run prepush:gate`.
-- For PRs targeting `dev` or `main`, the same full gate must pass in GitHub Actions before merge.
-- On non-`main` working branches, use `npm run prepush:gate` manually when you need to preflight the exact protected-branch gate before opening or updating a PR.
-- If `npm run test:coverage:report` shows gaps, follow the ordered closure queue in `docs/agents/test_todo_list.md` one file at a time. If it shows no gaps, stay in maintenance mode and keep the repo at full closure.
-- Allowed queue exceptions: batch adjacent files that share the same mock/fixture/test harness, and fix blocking test-infrastructure issues first when they block the current file or its immediate neighbors.
-- If a queued file contains a provably unreachable or business-invalid branch, remove the dead branch without changing behavior instead of inventing synthetic tests, then continue queue order.
-- If test engineering changed (commands, coverage baseline, backlog status, workflow), sync `docs/agents/ai-testing-guide.md`, `docs/agents/test_todo_list.md`, and when strategic context changed also `docs/agents/test_improvement_plan.md`, plus all `_CN` mirrors.
-- Keep diffs scoped; update docs when expectations or workflows change.
-- Never hand-edit `docker/volumes/functions/**`; sync it via `./docker/pull-edge-functions.sh`.
+- GitHub default branch: `main`
+- True daily trunk: `dev`
+- Routine branch base: `dev`
+- Routine PR base: `dev`
+- Promote path: `dev -> main`
+- `main` pushes build and deploy the web app
+- `v*` tags build draft Electron releases
 
-## Documentation Maintenance
+Do not infer the daily trunk from GitHub UI defaults.
 
-When editing any English doc (`*.md` without `_CN`):
+## Runtime Facts
 
-1. Update the corresponding `_CN` mirror in the same commit.
-2. Keep command examples executable against current scripts.
-3. Avoid duplicating long guidance across files; link back to the source doc.
-4. If workflow changed, update this file first (entry-point accuracy).
-5. For testing-related changes, update `docs/agents/test_todo_list.md` first; if the long-term plan or baseline summary changed, update `docs/agents/test_improvement_plan.md` too.
+- Package manager: `npm`
+- Node baseline: `>=24`
+- Default local app target: `npm start` or `npm run start:dev` against the shared `dev` environment
+- Explicit main-target command: `npm run start:main`
+- App-side Supabase access belongs only in `src/services/**`
+- The authoritative full gate is `npm run prepush:gate`
+- Repo-wide coverage is expected to stay at `100%` for statements, branches, functions, and lines
+
+## Hard Boundaries
+
+- Do not author schema or migration truth here
+- Do not hand-edit `docker/volumes/functions/**`; refresh it via `docker/pull-edge-functions.sh`
+- Do not create ad-hoc Supabase clients outside `src/services/**`
+- Do not treat a merged repo PR here as workspace-delivery complete if the root repo still needs a submodule bump
+
+## Workspace Integration
+
+A merged PR in `tiangong-lca-next` is repo-complete, not delivery-complete.
+
+If the change must ship through the workspace:
+
+1. merge the child PR into `tiangong-lca-next`
+2. promote or select an eligible child SHA according to workspace policy
+3. update the `lca-workspace` submodule pointer deliberately

--- a/ai/architecture.md
+++ b/ai/architecture.md
@@ -1,0 +1,105 @@
+---
+title: next Architecture Notes
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: next
+language: en
+whenToUse:
+  - when you need a compact mental model of the frontend before editing routes, pages, services, or static resources
+  - when deciding which layer owns a behavior change
+  - when route families, caches, or app-side data boundaries are mentioned without exact paths
+whenToUpdate:
+  - when major route or service layers change
+  - when app-side data boundaries move
+  - when the current map becomes misleading
+checkPaths:
+  - ai/architecture.md
+  - ai/repo.yaml
+  - config/**
+  - src/**
+  - public/**
+  - docker/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 002be46cbcb8a650c30a0b8962defa50a4c8be93
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./task-router.md
+  - ./validation.md
+  - ../docs/agents/ai-dev-guide.md
+---
+
+## Repo Shape
+
+This repo is a Umi-based React SPA with service-first data access, mirrored route families, and a strict test and coverage gate.
+
+## Stable Path Map
+
+| Path group              | Role                                                     |
+| ----------------------- | -------------------------------------------------------- |
+| `config/routes.ts`      | route tree and mirrored route-family entrypoints         |
+| `config/config.ts`      | Umi runtime config                                       |
+| `config/supabaseEnv.ts` | app-side environment selection                           |
+| `src/app.tsx`           | runtime layout, auth redirect, dark mode, cache monitors |
+| `src/pages/**`          | feature pages and route-level UI behavior                |
+| `src/services/**`       | app-side data access and service logic                   |
+| `src/components/**`     | shared UI components and modal/task-center flows         |
+| `src/locales/**`        | UI strings                                               |
+| `public/**`             | static resource bundles consumed by the app              |
+| `docker/**`             | self-hosted sync helpers and mirrors                     |
+| `electron/**`           | desktop packaging surface                                |
+
+## Route And Data Model
+
+The app groups major product areas under route families such as:
+
+- `/tgdata`
+- `/codata`
+- `/mydata`
+- `/tedata`
+
+These routes typically connect pages to services instead of embedding raw data-client logic directly in the component tree.
+
+## Service-First Boundary
+
+All app-side Supabase and API access belongs in `src/services/**`.
+
+If a task wants to add a new client, token flow, or request contract, start there.
+
+## Current Hotspot Clusters
+
+### Lifecycle-model and calculation-adjacent UI
+
+- `src/services/lifeCycleModels/**`
+- `src/services/lca/**`
+- `src/components/LcaTaskCenter/**`
+- `src/pages/Processes/Analysis/**`
+
+### Review, team, and system-management flows
+
+- `src/pages/Review/**`
+- `src/pages/ManageSystem/**`
+- nearby services under `src/services/**`
+
+### Static cache-backed resource bundles
+
+- `public/classifications/**`
+- `public/locations/**`
+- `public/lciamethods/**`
+
+## Cross-Repo Boundaries
+
+- `database-engine` owns schema truth and Supabase branch governance
+- `edge-functions` owns Edge runtime behavior
+- `next-docs` owns public docs-site content
+- `calculator` owns solver and compute internals
+- `lca-workspace` owns root delivery completion after a child PR merges
+
+## Common Misreads
+
+- GitHub default branch `main` is not the daily trunk
+- `docker/volumes/functions/**` is a synced mirror, not a primary edit surface
+- app-side data access does not belong outside `src/services/**`
+- a merged child PR does not finish workspace delivery

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -179,7 +179,11 @@
           "kind": "test-gate"
         },
         {
-          "path": ".github/workflows/**",
+          "path": ".github/workflows/ci.yml",
+          "kind": "ci"
+        },
+        {
+          "path": ".github/workflows/build.yml",
           "kind": "ci"
         },
         {
@@ -256,6 +260,44 @@
         }
       ],
       "reason": "Static resource changes can invalidate both the AI routing layer and the detailed cache or usage guidance."
+    },
+    {
+      "id": "next-ai-doc-maintenance-contract",
+      "scope": "repo",
+      "repo": "next",
+      "triggers": [
+        {
+          "path": ".github/workflows/ai-doc-lint.yml",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.mjs",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.test.mjs",
+          "kind": "automation"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/doc-impact.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Repo-local AI doc maintenance automation changes alter the maintenance gate and should refresh the AI contract docs."
     }
   ]
 }

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -1,0 +1,261 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "002be46cbcb8a650c30a0b8962defa50a4c8be93",
+  "rules": [
+    {
+      "id": "next-bootstrap-contract",
+      "scope": "repo",
+      "repo": "next",
+      "triggers": [
+        {
+          "path": "AGENTS.md",
+          "kind": "doc-contract"
+        },
+        {
+          "path": "README.md",
+          "kind": "doc-entry"
+        },
+        {
+          "path": "docs/agents/**",
+          "kind": "deep-doc"
+        },
+        {
+          "path": "ai/**",
+          "kind": "doc-ai-layer"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Entry guidance, repo facts, and routing docs must stay aligned."
+    },
+    {
+      "id": "next-frontend-runtime-contract",
+      "scope": "repo",
+      "repo": "next",
+      "triggers": [
+        {
+          "path": "config/routes.ts",
+          "kind": "route-tree"
+        },
+        {
+          "path": "config/config.ts",
+          "kind": "app-config"
+        },
+        {
+          "path": "src/app.tsx",
+          "kind": "app-runtime"
+        },
+        {
+          "path": "src/pages/**",
+          "kind": "page-ui"
+        },
+        {
+          "path": "src/components/**",
+          "kind": "shared-ui"
+        },
+        {
+          "path": "src/locales/**",
+          "kind": "ui-locale"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "docs/agents/ai-dev-guide.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Frontend runtime changes alter the shipped product surface and should refresh both the AI bootstrap docs and the primary dev guide."
+    },
+    {
+      "id": "next-data-boundary-contract",
+      "scope": "repo",
+      "repo": "next",
+      "triggers": [
+        {
+          "path": "config/supabaseEnv.ts",
+          "kind": "env-selection"
+        },
+        {
+          "path": "src/services/**",
+          "kind": "service-logic"
+        },
+        {
+          "path": "docker/pull-edge-functions.sh",
+          "kind": "sync-helper"
+        },
+        {
+          "path": "docker/scripts/sync-migrations-to-data-sql.sh",
+          "kind": "sync-helper"
+        },
+        {
+          "path": "docker/volumes/functions/**",
+          "kind": "mirrored-runtime"
+        },
+        {
+          "path": "docker/volumes/db/init/**",
+          "kind": "mirrored-runtime"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "docs/agents/supabase-branching.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "App-side service and environment changes alter the frontend data boundary and should refresh both the AI layer and the branching guide."
+    },
+    {
+      "id": "next-testing-and-gate-contract",
+      "scope": "repo",
+      "repo": "next",
+      "triggers": [
+        {
+          "path": "package.json",
+          "kind": "runtime-config"
+        },
+        {
+          "path": ".nvmrc",
+          "kind": "runtime-config"
+        },
+        {
+          "path": "jest.config.cjs",
+          "kind": "test-gate"
+        },
+        {
+          "path": ".husky/pre-push",
+          "kind": "test-gate"
+        },
+        {
+          "path": ".github/workflows/**",
+          "kind": "ci"
+        },
+        {
+          "path": "scripts/test-runner.cjs",
+          "kind": "test-gate"
+        },
+        {
+          "path": "scripts/test-coverage-report.js",
+          "kind": "test-gate"
+        },
+        {
+          "path": "tests/**",
+          "kind": "repo-test"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "docs/agents/ai-testing-guide.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "docs/agents/test_todo_list.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Coverage and protected-branch gate changes alter how future frontend work is validated and should refresh both the AI layer and the testing docs."
+    },
+    {
+      "id": "next-static-resource-contract",
+      "scope": "repo",
+      "repo": "next",
+      "triggers": [
+        {
+          "path": "public/classifications/**",
+          "kind": "static-resource"
+        },
+        {
+          "path": "public/locations/**",
+          "kind": "static-resource"
+        },
+        {
+          "path": "public/lciamethods/**",
+          "kind": "static-resource"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "docs/agents/public-classifications-gz-usage.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Static resource changes can invalidate both the AI routing layer and the detailed cache or usage guidance."
+    }
+  ]
+}

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -184,7 +184,7 @@
       "notes": [
         "Use npm run test:ci -- <jest-args> for focused suites with extra flags.",
         "Use npm run test:coverage and npm run test:coverage:assert-full when validating coverage-sensitive changes.",
-        "AI-doc changes should still run the root warning-only ai-doc-lint."
+        "AI-doc changes should still run the repo-local ai-doc-lint workflow or the equivalent local node command."
       ]
     }
   }

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -1,0 +1,191 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "002be46cbcb8a650c30a0b8962defa50a4c8be93",
+  "repo": {
+    "id": "next",
+    "path": "tiangong-lca-next",
+    "canonicalRepo": "linancn/tiangong-lca-next",
+    "purpose": "Shipped frontend and product UI repository for TianGong LCA.",
+    "entryDoc": "AGENTS.md",
+    "taskRouterDoc": "ai/task-router.md",
+    "validationDoc": "ai/validation.md",
+    "architectureDoc": "ai/architecture.md",
+    "readmeDoc": "README.md",
+    "defaultBranch": "main",
+    "dailyTrunk": "dev",
+    "routinePrBase": "dev",
+    "branchModel": "M2",
+    "promotePath": "dev -> main",
+    "hotfixPath": "branch from main, merge into main, then back-merge main -> dev",
+    "workspaceIntegrationRequired": true,
+    "rootIntegrationRule": "lca-workspace/main should normally bump only commits already promoted onto tiangong-lca-next/main.",
+    "trackedBy": {
+      "workspaceParentIssue": "https://github.com/tiangong-lca/workspace/issues/73",
+      "repoIssue": "https://github.com/linancn/tiangong-lca-next/issues/346"
+    },
+    "runtime": {
+      "packageManager": "npm",
+      "nodeVersion": ">=24",
+      "framework": "React 18 + @umijs/max 4 + Ant Design Pro 5 + TypeScript",
+      "defaultDevCommand": "npm start",
+      "defaultDevAlias": "npm run start:dev",
+      "mainEnvCommand": "npm run start:main",
+      "baselineValidationCommands": [
+        "npm run lint",
+        "npm test",
+        "npm run build"
+      ],
+      "fullGateCommand": "npm run prepush:gate",
+      "deployFacts": [
+        "main pushes deploy the web app build",
+        "v* tags build draft Electron releases"
+      ]
+    },
+    "sourceOfTruth": {
+      "stableManualEditPaths": [
+        {
+          "path": "config/routes.ts",
+          "role": "route tree and route-family entrypoints"
+        },
+        {
+          "path": "config/config.ts",
+          "role": "Umi runtime config"
+        },
+        {
+          "path": "config/supabaseEnv.ts",
+          "role": "frontend env selection for shared dev versus main"
+        },
+        {
+          "path": "src/app.tsx",
+          "role": "app runtime setup, auth redirect, dark mode, and cache monitors"
+        },
+        {
+          "path": "src/pages/**",
+          "role": "feature pages and route-level UI behavior"
+        },
+        {
+          "path": "src/services/**",
+          "role": "app-side Supabase and API access plus service logic"
+        },
+        {
+          "path": "src/components/**",
+          "role": "shared UI components and modal or task-center behavior"
+        },
+        {
+          "path": "src/locales/**",
+          "role": "UI strings"
+        },
+        {
+          "path": "public/**",
+          "role": "static resource bundles consumed by the app"
+        },
+        {
+          "path": "docker/**",
+          "role": "self-hosted mirrors and sync helpers"
+        },
+        {
+          "path": "electron/**",
+          "role": "desktop packaging surface"
+        }
+      ],
+      "nonOwnerBoundaries": [
+        {
+          "repo": "database-engine",
+          "doesNotOwn": [
+            "schema truth",
+            "migrations",
+            "Supabase branch governance"
+          ]
+        },
+        {
+          "repo": "edge-functions",
+          "doesNotOwn": [
+            "Edge runtime behavior",
+            "API orchestration"
+          ]
+        },
+        {
+          "repo": "next-docs",
+          "doesNotOwn": [
+            "public docs-site content"
+          ]
+        },
+        {
+          "repo": "calculator",
+          "doesNotOwn": [
+            "solver runtime and compute internals"
+          ]
+        },
+        {
+          "repo": "lca-workspace",
+          "doesNotOwn": [
+            "root integration state",
+            "submodule pointer updates"
+          ]
+        }
+      ]
+    },
+    "taskHotspots": [
+      {
+        "topic": "route, page, and shared UI behavior",
+        "paths": [
+          "config/routes.ts",
+          "src/app.tsx",
+          "src/pages/**",
+          "src/components/**",
+          "src/locales/**"
+        ]
+      },
+      {
+        "topic": "app-side data boundaries and environment selection",
+        "paths": [
+          "config/supabaseEnv.ts",
+          "src/services/**",
+          "docker/pull-edge-functions.sh",
+          "docker/scripts/sync-migrations-to-data-sql.sh",
+          "docker/volumes/functions/**",
+          "docker/volumes/db/init/**"
+        ]
+      },
+      {
+        "topic": "static resource caches and analysis workflows",
+        "paths": [
+          "public/classifications/**",
+          "public/locations/**",
+          "public/lciamethods/**",
+          "src/services/lifeCycleModels/**",
+          "src/services/lca/**",
+          "src/components/LcaTaskCenter/**",
+          "src/pages/Processes/Analysis/**"
+        ]
+      },
+      {
+        "topic": "test, coverage, and protected-branch gates",
+        "paths": [
+          "package.json",
+          ".nvmrc",
+          "jest.config.cjs",
+          ".husky/pre-push",
+          ".github/workflows/**",
+          "scripts/test-runner.cjs",
+          "scripts/test-coverage-report.js",
+          "tests/**"
+        ]
+      }
+    ],
+    "validation": {
+      "baselineLocalCommands": [
+        "npm run lint",
+        "npm test",
+        "npm run build"
+      ],
+      "fullGateCommand": "npm run prepush:gate",
+      "notes": [
+        "Use npm run test:ci -- <jest-args> for focused suites with extra flags.",
+        "Use npm run test:coverage and npm run test:coverage:assert-full when validating coverage-sensitive changes.",
+        "AI-doc changes should still run the root warning-only ai-doc-lint."
+      ]
+    }
+  }
+}

--- a/ai/task-router.md
+++ b/ai/task-router.md
@@ -1,0 +1,95 @@
+---
+title: next Task Router
+docType: router
+scope: repo
+status: active
+authoritative: false
+owner: next
+language: en
+whenToUse:
+  - when you already know the task belongs in tiangong-lca-next but need the right next file or next doc
+  - when deciding whether a change belongs in routes, pages, services, static resources, deep docs, or another repo
+  - when routing between frontend work and handoffs to database-engine, edge-functions, next-docs, calculator, or lca-workspace
+whenToUpdate:
+  - when new high-frequency UI or service areas appear
+  - when cross-repo boundaries change
+  - when validation routing becomes misleading
+checkPaths:
+  - AGENTS.md
+  - ai/repo.yaml
+  - ai/task-router.md
+  - ai/validation.md
+  - ai/architecture.md
+  - config/**
+  - src/**
+  - public/**
+  - docs/agents/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 002be46cbcb8a650c30a0b8962defa50a4c8be93
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./validation.md
+  - ./architecture.md
+  - ../docs/agents/ai-dev-guide.md
+  - ../docs/agents/ai-testing-guide.md
+  - ../docs/agents/supabase-branching.md
+  - ../docs/agents/util_calculate.md
+---
+
+## Repo Load Order
+
+When working inside `tiangong-lca-next`, load docs in this order:
+
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. this file
+4. `ai/validation.md` or `ai/architecture.md`
+5. the narrow deep doc that matches the task
+
+## High-Frequency Task Routing
+
+| Task intent | First code paths to inspect | Next docs to load | Notes |
+| --- | --- | --- | --- |
+| Change a page, route family, layout behavior, or shared UI flow | `config/routes.ts`, `src/app.tsx`, `src/pages/**`, `src/components/**` | `ai/validation.md`, `ai/architecture.md`, `docs/agents/ai-dev-guide.md` | This is the main shipped product surface. |
+| Change app-side service logic or Supabase/env handling | `config/supabaseEnv.ts`, `src/services/**` | `ai/validation.md`, `ai/architecture.md`, `docs/agents/supabase-branching.md`, `docs/agents/ai-dev-guide.md` | App-side data access belongs only in `src/services/**`; keep the `tg` / `co` / `my` / `te` data-source semantics aligned with the service-first contract. |
+| Change tests, coverage, or protected-branch gates | `tests/**`, `jest.config.cjs`, `.husky/pre-push`, `.github/workflows/**`, `scripts/test-runner.cjs`, `scripts/test-coverage-report.js` | `ai/validation.md`, `docs/agents/ai-testing-guide.md`, `docs/agents/test_todo_list.md` | Coverage remains a hard contract. |
+| Change lifecycle-model or calculation-adjacent frontend behavior | `src/services/lifeCycleModels/**`, nearby pages or components | `ai/validation.md`, `ai/architecture.md`, `docs/agents/util_calculate.md` | Solver truth still belongs outside this repo. |
+| Change LCA task-center, process-analysis, or result-view behavior | `src/services/lca/**`, `src/components/LcaTaskCenter/**`, `src/pages/Processes/Analysis/**` | `ai/validation.md`, `ai/architecture.md`, `docs/agents/ai-dev-guide.md` | Cross-check runtime expectations with `edge-functions` or `calculator` when needed. |
+| Change team, review, or system-management frontend flows | `src/pages/Review/**`, `src/pages/ManageSystem/**`, `src/pages/Teams/**` and nearby services | `ai/validation.md`, `docs/agents/team_management.md`, `docs/agents/data_audit_instruction.md` | These are shipped UI flows, not public docs-site pages. |
+| Change static classifications, locations, or LCIA bundles | `public/classifications/**`, `public/locations/**`, `public/lciamethods/**`, nearby service consumers | `ai/validation.md`, `ai/architecture.md`, `docs/agents/public-classifications-gz-usage.md` | Review both assets and consumers together. |
+| Change public documentation only | `tiangong-lca-next-docs`, not this repo | root `ai/task-router.md` | Product docs-site content lives in `next-docs`. |
+| Change schema, migration, or Supabase branch truth | `database-engine`, not this repo | root `ai/task-router.md`, `database-engine/AGENTS.md` | This repo consumes that truth. |
+| Change Edge Function runtime or API orchestration | `edge-functions`, not this repo | root `ai/task-router.md`, `tiangong-lca-edge-functions/AGENTS.md` | Do not paper over runtime issues only in the frontend. |
+| Decide whether work is delivery-complete after merge | root workspace docs, not repo code paths | root `AGENTS.md`, `_docs/workspace-branch-policy-contract.md` | Root integration remains a separate phase. |
+
+## Wrong Turns To Avoid
+
+### Editing schema or migration truth in the frontend repo
+
+If the task is really about schema, migration, or branch-governance truth, route it to `database-engine`.
+
+### Hand-editing synced edge-function mirrors
+
+Do not hand-edit `docker/volumes/functions/**`. Refresh via `docker/pull-edge-functions.sh`.
+
+### Creating ad-hoc data clients in UI code
+
+App-side Supabase and API access belongs only in `src/services/**`.
+
+## Cross-Repo Handoffs
+
+Use these handoffs when work crosses boundaries:
+
+1. frontend behavior depends on new schema or policy truth
+   - start here for the UI
+   - coordinate with `database-engine`
+2. frontend behavior depends on changed Edge API runtime
+   - start here for the UI
+   - coordinate with `edge-functions`
+3. frontend workflow change needs public docs refresh
+   - update `tiangong-lca-next`
+   - then update `tiangong-lca-next-docs`
+4. merged repo PR still needs to ship through the workspace
+   - return to `lca-workspace`
+   - do the submodule pointer bump there

--- a/ai/task-router.md
+++ b/ai/task-router.md
@@ -61,6 +61,7 @@ When working inside `tiangong-lca-next`, load docs in this order:
 | Change public documentation only | `tiangong-lca-next-docs`, not this repo | root `ai/task-router.md` | Product docs-site content lives in `next-docs`. |
 | Change schema, migration, or Supabase branch truth | `database-engine`, not this repo | root `ai/task-router.md`, `database-engine/AGENTS.md` | This repo consumes that truth. |
 | Change Edge Function runtime or API orchestration | `edge-functions`, not this repo | root `ai/task-router.md`, `tiangong-lca-edge-functions/AGENTS.md` | Do not paper over runtime issues only in the frontend. |
+| Change repo-local AI-doc maintenance only | `AGENTS.md`, `ai/**`, `.github/workflows/ai-doc-lint.yml`, `.github/scripts/ai-doc-lint.*` | `ai/validation.md` when present, otherwise `ai/repo.yaml` | Keep the repo-local maintenance gate aligned with root `ai/ci-lint-spec.md` and `ai/review-matrix.md`. |
 | Decide whether work is delivery-complete after merge | root workspace docs, not repo code paths | root `AGENTS.md`, `_docs/workspace-branch-policy-contract.md` | Root integration remains a separate phase. |
 
 ## Wrong Turns To Avoid

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -1,0 +1,72 @@
+---
+title: next Validation Guide
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: next
+language: en
+whenToUse:
+  - when a tiangong-lca-next change is ready for local validation
+  - when deciding the minimum proof required for page, service, test, or asset changes
+  - when writing PR validation notes for tiangong-lca-next work
+whenToUpdate:
+  - when the repo gains new canonical commands or gate expectations
+  - when change categories require different proof
+  - when coverage or deploy policy changes
+checkPaths:
+  - ai/validation.md
+  - ai/task-router.md
+  - package.json
+  - jest.config.cjs
+  - .husky/pre-push
+  - .github/workflows/**
+  - config/**
+  - src/**
+  - public/**
+  - docker/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 002be46cbcb8a650c30a0b8962defa50a4c8be93
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./task-router.md
+  - ./architecture.md
+  - ../docs/agents/ai-testing-guide.md
+---
+
+## Default Baseline
+
+Unless the change is doc-only AI-contract work, the minimum local baseline is:
+
+```bash
+npm run lint
+npm test
+npm run build
+```
+
+For protected-branch parity, the authoritative full gate is:
+
+```bash
+npm run prepush:gate
+```
+
+## Validation Matrix
+
+| Change type | Minimum local proof | Additional proof when risk is higher | Notes |
+| --- | --- | --- | --- |
+| `config/routes.ts`, `src/app.tsx`, `src/pages/**`, or `src/components/**` | `npm run lint`; focused `npm run test:ci -- <jest-args>`; `npm run build` | run `npm run prepush:gate` before PR or when the change affects shared UX flows broadly | Route and shared UI changes usually affect multiple entrypoints. |
+| `src/services/**` or `config/supabaseEnv.ts` | `npm run lint`; focused `npm run test:ci -- <jest-args>`; `npm run build` | run `npm run prepush:gate` when the change affects shared data access or auth flow | If the issue depends on schema or Edge runtime truth, record the companion repo proof separately. |
+| `public/**` static resource bundles | `npm run lint`; `npm run build` | run focused tests or one nearby feature suite if the asset change affects parsing or cache behavior | Review both assets and consuming services together. |
+| `docker/**` sync helpers or mirrors | `npm run lint`; `npm run build` | run the specific sync helper only when the task explicitly includes it; never hand-edit mirrors | `docker/volumes/functions/**` is a synced mirror, not an edit surface. |
+| tests, coverage, or gate scripts | `npm run lint`; `npm test`; `npm run test:coverage`; `npm run test:coverage:assert-full` | run `npm run prepush:gate` when the protected-branch gate changed directly | Coverage remains `100%` for `src/**/*.ts`. |
+| AI docs only | run the root warning-only `ai-doc-lint` against touched files | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
+
+## Minimum PR Note Quality
+
+A good PR note for this repo should say:
+
+1. which commands ran
+2. which focused suites covered the touched feature area
+3. whether the full protected-branch gate ran or was intentionally deferred
+4. whether any required database-engine or edge-functions proof lives elsewhere

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -60,7 +60,7 @@ npm run prepush:gate
 | `public/**` static resource bundles | `npm run lint`; `npm run build` | run focused tests or one nearby feature suite if the asset change affects parsing or cache behavior | Review both assets and consuming services together. |
 | `docker/**` sync helpers or mirrors | `npm run lint`; `npm run build` | run the specific sync helper only when the task explicitly includes it; never hand-edit mirrors | `docker/volumes/functions/**` is a synced mirror, not an edit surface. |
 | tests, coverage, or gate scripts | `npm run lint`; `npm test`; `npm run test:coverage`; `npm run test:coverage:assert-full` | run `npm run prepush:gate` when the protected-branch gate changed directly | Coverage remains `100%` for `src/**/*.ts`. |
-| AI docs only | run the root warning-only `ai-doc-lint` against touched files | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
+| AI docs only | run repo-local `ai-doc-lint` against touched files or the equivalent local PR check | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
 
 ## Minimum PR Note Quality
 

--- a/docs/agents/ai-testing-guide.md
+++ b/docs/agents/ai-testing-guide.md
@@ -57,7 +57,12 @@ npx jest tests/unit/services/processes/ --watch
 
 # Lint gate
 npm run lint
+
+# Repo-local AI-doc maintenance gate
+node .github/scripts/ai-doc-lint.mjs --mode enforce --files "<comma-separated touched files>"
 ```
+
+GitHub PRs now run the same AI-doc maintenance gate through `.github/workflows/ai-doc-lint.yml`.
 
 ## Coverage Expectations
 

--- a/docs/agents/ai-testing-guide_CN.md
+++ b/docs/agents/ai-testing-guide_CN.md
@@ -57,7 +57,12 @@ npx jest tests/unit/services/processes/ --watch
 
 # 代码门禁
 npm run lint
+
+# 仓库内 AI 文档维护门禁
+node .github/scripts/ai-doc-lint.mjs --mode enforce --files "<逗号分隔的变更文件列表>"
 ```
+
+GitHub PR 也会通过 `.github/workflows/ai-doc-lint.yml` 执行同一条 AI 文档维护门禁。
 
 ## 覆盖率预期
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -40,6 +40,7 @@ Latest verified full run (`npm run test:coverage:report`, followed by `npm run t
 - Any code change is a hard requirement to preserve repo-wide `100%` statements / branches / functions / lines.
 - Local `main` pushes are blocked unless the repo passes `.husky/pre-push`, which runs `npm run prepush:gate`.
 - PRs targeting `dev` or `main` must pass the same full gate in GitHub Actions before merge.
+- Test workflow or backlog doc changes must also pass the repo-local AI-doc maintenance gate in `.github/workflows/ai-doc-lint.yml`; run `node .github/scripts/ai-doc-lint.mjs --mode enforce --files "<comma-separated touched files>"` before push when those docs changed.
 
 ## Integration Expansion Program (Separate from Coverage Queue)
 

--- a/docs/agents/test_todo_list_CN.md
+++ b/docs/agents/test_todo_list_CN.md
@@ -40,6 +40,7 @@
 - 任何代码修改都必须作为硬约束维持全仓 `100%` statements / branches / functions / lines。
 - 本地 `main` push 会被 `.husky/pre-push` 强制门禁；当前门禁命令是 `npm run prepush:gate`。
 - 目标为 `dev` 或 `main` 的 PR，在合并前必须通过 GitHub Actions 中同一条完整门禁。
+- 若测试工作流或 backlog 文档发生变化，还必须通过 `.github/workflows/ai-doc-lint.yml` 中的仓库内 AI 文档维护门禁；提交前可运行 `node .github/scripts/ai-doc-lint.mjs --mode enforce --files "<逗号分隔的变更文件列表>"` 自检。
 
 ## 集成测试扩展计划（独立于覆盖率清零队列）
 

--- a/tests/unit/pages/Review/Components/ReviewProcess.test.tsx
+++ b/tests/unit/pages/Review/Components/ReviewProcess.test.tsx
@@ -721,6 +721,54 @@ describe('ReviewProcessDetail component', () => {
     expect(mergedData.modellingAndValidation.validation.review).toEqual([{ id: 'comment-review' }]);
   });
 
+  it('treats legacy compliance comment arrays with null and primitive entries as meaningful', async () => {
+    mockGetProcessDetail.mockResolvedValueOnce({
+      ...baseProcessDetail,
+      data: {
+        ...baseProcessDetail.data,
+        json: {
+          processDataSet: {
+            modellingAndValidation: {
+              validation: {},
+              complianceDeclarations: {},
+            },
+          },
+        },
+      },
+    });
+    mockGetCommentApi.mockResolvedValueOnce({
+      data: [
+        {
+          json: {
+            modellingAndValidation: {
+              validation: {
+                review: [{ id: 'comment-review' }],
+              },
+              complianceDeclarations: {
+                compliance: [null, 'legacy compliance note'],
+              },
+            },
+          },
+        },
+      ],
+      error: null,
+    });
+    mockGenProcessFromData.mockImplementation((data: any) => data);
+
+    renderComponent({ tabType: 'assigned' });
+
+    fireEvent.click(screen.getAllByRole('button')[0]);
+
+    await waitFor(() => expect(mockGenProcessFromData).toHaveBeenCalled());
+
+    const mergedData = mockGenProcessFromData.mock.calls.at(-1)?.[0];
+    expect(mergedData.modellingAndValidation.complianceDeclarations.compliance).toEqual([
+      null,
+      'legacy compliance note',
+    ]);
+    expect(mergedData.modellingAndValidation.validation.review).toEqual([{ id: 'comment-review' }]);
+  });
+
   it('handles sparse process detail payloads and skips rejected-comment loading for published rows', async () => {
     mockGetProcessDetail.mockResolvedValueOnce({
       data: {


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#346

## Summary
- Add a checked-in AI contract layer with AGENTS.md and repo-local ai/*.md docs.
- Keep frontend service-routing guidance low-token by linking service-first and data-source semantics from the repo AI layer.

## Validation
- npm run lint

## Workspace Integration
- If this doc change must ship through the workspace snapshot, bump the submodule in lca-workspace after merge.