### PR TITLE
docs: finish next docpact pilot cleanup after validation audit

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -119,7 +119,9 @@ routing:
     service-env:
       paths:
         - config/supabaseEnv.ts
-        - src/services/**
+        - src/services/auth/**
+        - src/services/general/api.ts
+        - src/services/supabase/**
         - docker/**
     testing-gates:
       paths:

--- a/.github/PULL_REQUEST_TEMPLATE/feature-to-dev.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature-to-dev.md
@@ -1,3 +1,25 @@
+---
+title: next Feature To Dev PR Template
+docType: template
+scope: repo
+status: active
+authoritative: false
+owner: next
+language: en
+whenToUse:
+  - when opening a routine feature or fix PR into dev
+  - when checking the expected validation and handoff note shape for dev-bound work
+whenToUpdate:
+  - when branch handoff expectations for dev-bound PRs change
+  - when the validation note shape for routine repo delivery changes
+checkPaths:
+  - .github/PULL_REQUEST_TEMPLATE/feature-to-dev.md
+  - AGENTS.md
+  - docs/agents/repo-validation.md
+lastReviewedAt: 2026-04-23
+lastReviewedCommit: eb445ef00ab1d07b76a46d471e54377801117ee7
+---
+
 ## Branch Contract
 
 - base branch: `dev`

--- a/.github/PULL_REQUEST_TEMPLATE/promote-dev-to-main.md
+++ b/.github/PULL_REQUEST_TEMPLATE/promote-dev-to-main.md
@@ -1,3 +1,25 @@
+---
+title: next Promote Dev To Main PR Template
+docType: template
+scope: repo
+status: active
+authoritative: false
+owner: next
+language: en
+whenToUse:
+  - when opening a promotion PR from dev into main
+  - when checking the expected validation and follow-up note shape for a promote PR
+whenToUpdate:
+  - when promotion handoff expectations change
+  - when validation or back-merge note shape for promote PRs changes
+checkPaths:
+  - .github/PULL_REQUEST_TEMPLATE/promote-dev-to-main.md
+  - AGENTS.md
+  - docs/agents/repo-validation.md
+lastReviewedAt: 2026-04-23
+lastReviewedCommit: eb445ef00ab1d07b76a46d471e54377801117ee7
+---
+
 ## Promotion Contract
 
 - base branch: `main`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-04-23
-lastReviewedCommit: f3256848c44466801a61316127c6fe19368f63ef
+lastReviewedCommit: eb445ef00ab1d07b76a46d471e54377801117ee7
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-04-23
-lastReviewedCommit: f3256848c44466801a61316127c6fe19368f63ef
+lastReviewedCommit: eb445ef00ab1d07b76a46d471e54377801117ee7
 ---
 
 # Development Bootstrap

--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
+---
+title: TianGong LCA Data Platform Landing
+docType: landing
+scope: repo
+status: active
+authoritative: false
+owner: next
+language: en
+whenToUse:
+  - when you need the public-facing repo landing summary
+  - when checking whether the high-level product overview still matches the current repo contract
+whenToUpdate:
+  - when the public repo landing summary changes
+  - when linked docs-site entrypoints or deployment references change
+checkPaths:
+  - README.md
+  - README_CN.md
+  - AGENTS.md
+lastReviewedAt: 2026-04-23
+lastReviewedCommit: eb445ef00ab1d07b76a46d471e54377801117ee7
+---
+
 # TianGong LCA Data Platform
 
 [English](https://github.com/linancn/tiangong-lca-next/blob/main/README.md) | [中文](https://github.com/linancn/tiangong-lca-next/blob/main/README_CN.md)

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,3 +1,25 @@
+---
+title: TianGong LCA Data Platform Landing (Chinese)
+docType: landing
+scope: repo
+status: active
+authoritative: false
+owner: next
+language: zh-CN
+whenToUse:
+  - when you need the Chinese public-facing repo landing summary
+  - when checking whether the high-level product overview still matches the current repo contract
+whenToUpdate:
+  - when the Chinese repo landing summary changes
+  - when linked docs-site entrypoints or deployment references change
+checkPaths:
+  - README.md
+  - README_CN.md
+  - AGENTS.md
+lastReviewedAt: 2026-04-23
+lastReviewedCommit: eb445ef00ab1d07b76a46d471e54377801117ee7
+---
+
 # 天工LCA数据平台
 
 [English](https://github.com/linancn/tiangong-lca-next/blob/main/README.md) | [中文](https://github.com/linancn/tiangong-lca-next/blob/main/README_CN.md)

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .github/workflows/**
 lastReviewedAt: 2026-04-23
-lastReviewedCommit: f3256848c44466801a61316127c6fe19368f63ef
+lastReviewedCommit: eb445ef00ab1d07b76a46d471e54377801117ee7
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -46,7 +46,7 @@ This repo is a Umi-based React SPA with service-first data access, cache-backed 
 | `src/pages/**` | route-level product pages |
 | `src/components/**` | shared UI and reusable flows |
 | `src/services/**` | app-side Supabase/API access and service logic |
-| `src/locales/**` | UI strings |
+| `src/locales/**` | UI strings; keep `src/locales/en-US.ts` and `src/locales/zh-CN.ts` aligned when shared user-facing copy changes |
 | `src/global.less`, `src/style/**`, `src/manifest.json`, `src/service-worker.js`, `src/utils/appUrl.ts`, `src/utils/ruleVerification.ts`, `src/typings.d.ts` | browser shell support, global styling, and support utilities |
 | `public/**` | static resource bundles consumed by the app |
 | `icons/**` | packaged app icons and release assets |
@@ -63,6 +63,7 @@ Rules:
 
 - route and page components orchestrate
 - service modules own app-side data access
+- UI copy changes must update both `src/locales/en-US.ts` and `src/locales/zh-CN.ts` when the same user-facing text ships in both languages
 - static bundles are read through consuming services, not directly by pages
 - cache monitors live near runtime setup, not inside feature pages
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-04-23
-lastReviewedCommit: f3256848c44466801a61316127c6fe19368f63ef
+lastReviewedCommit: eb445ef00ab1d07b76a46d471e54377801117ee7
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-04-23
-lastReviewedCommit: b3a3fa77c43ef16d97959690a536805b4b379fb6
+lastReviewedCommit: eb445ef00ab1d07b76a46d471e54377801117ee7
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-04-23
-lastReviewedCommit: f3256848c44466801a61316127c6fe19368f63ef
+lastReviewedCommit: eb445ef00ab1d07b76a46d471e54377801117ee7
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -78,15 +78,15 @@ Special cases:
 2. keep providers minimal but sufficient
 3. assert the contract the parent relies on
 
-## Command Patterns
+## Focused Command Shapes
 
-| Task | Command |
+Canonical baseline and proof ownership stays with `DEV.md` and `docs/agents/repo-validation.md`. Use this file only for focused command shapes that support the test pattern you already chose.
+
+| Need | Command shape |
 | --- | --- |
-| full gate | `npm test` |
 | focused unit or component run | `npm run test:ci -- tests/unit/<scope>/ --runInBand --testTimeout=10000 --no-coverage` |
 | focused integration run | `npm run test:ci -- tests/integration/<feature>/ --runInBand --testTimeout=20000 --no-coverage` |
 | open-handle debug | `npm run test:ci -- <file> --runInBand --detectOpenHandles --no-coverage` |
-| lint gate | `npm run lint` |
 
 ## Skip And TODO Policy
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,16 +28,15 @@ lastReviewedCommit: b3a3fa77c43ef16d97959690a536805b4b379fb6
 
 > Purpose: shortest recovery path when tests fail, hang, timeout, or reopen coverage gaps.
 
-## Command Shortlist
+## Focused Recovery Commands
 
-| Task | Command |
+Canonical baseline and proof ownership stays with `DEV.md` and `docs/agents/repo-validation.md`. Use this shortlist only for the narrow recovery command that matches the failure mode.
+
+| Need | Command shape |
 | --- | --- |
-| full gate | `npm test` |
 | focused integration | `npm run test:ci -- tests/integration/<feature>/ --runInBand --testTimeout=20000 --no-coverage` |
 | focused unit or component | `npm run test:ci -- tests/unit/<scope>/ --runInBand --testTimeout=10000 --no-coverage` |
 | detect open handles | `npm run test:ci -- <file> --runInBand --detectOpenHandles --no-coverage` |
-| full coverage | `npm run test:coverage` |
-| lint | `npm run lint` |
 
 ## Failure Diagnosis
 
@@ -62,11 +61,11 @@ lastReviewedCommit: b3a3fa77c43ef16d97959690a536805b4b379fb6
 2. prefer a real test for the missing branch
 3. if the branch is dead, remove it without changing behavior
 4. rerun focused proof
-5. rerun coverage proof only after the gap is actually closed
+5. rerun the coverage proof defined in `docs/agents/repo-validation.md` only after the gap is actually closed
 
 ## Final Verification
 
 - rerun the narrow failing scope
 - rerun neighboring suites if shared behavior changed
-- run `npm run lint`
+- rerun the baseline proof from `docs/agents/repo-validation.md` when the failure affected shipped behavior or repo gates
 - update the owning testing docs only if workflow or state changed


### PR DESCRIPTION
Closes #360

## Summary
- add valid review metadata to the governed README and PR template docs so freshness no longer reports invalid review references
- tighten the service-env routing alias to env/client/boundary surfaces instead of the full src/services tree
- restore the locale-sync invariant to repo-architecture and trim duplicate command ownership from testing reference docs

## Key Decisions
- use docpact review marks for unchanged owner docs that required review evidence, instead of adding filler prose edits just to satisfy review_or_update rules

## Validation
- docpact validate-config --root . --strict
- docpact freshness --root . --format json (invalid_review_reference_count=0)
- docpact route --root . --intent service-env --format text
- docpact lint --root . --base eb445ef00ab1d07b76a46d471e54377801117ee7 --head HEAD --mode enforce --format text

## Risks / Rollback
- doc-only and config-only governance cleanup; no shipped product code paths changed

## Follow-ups
- use this narrower service-env alias and metadata pattern when migrating the next full-profile repo