### PR TITLE
fix: scope flow validation modal issue copy

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-04-28"
-lastReviewedCommit: "232b36c46bfc7b0d6095af577334ad6efb4e6e61"
+lastReviewedCommit: "bc446e0fcc3bcdbe022f76f62731247b25d6bdfb"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-04-28
-lastReviewedCommit: 232b36c46bfc7b0d6095af577334ad6efb4e6e61
+lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-04-28
-lastReviewedCommit: 810e80463fd0fc5fc970e1e677e9b9eaeeef87a2
+lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .github/workflows/**
 lastReviewedAt: 2026-04-28
-lastReviewedCommit: 232b36c46bfc7b0d6095af577334ad6efb4e6e61
+lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-04-28
-lastReviewedCommit: 232b36c46bfc7b0d6095af577334ad6efb4e6e61
+lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-04-28
-lastReviewedCommit: 232b36c46bfc7b0d6095af577334ad6efb4e6e61
+lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-04-28
-lastReviewedCommit: 232b36c46bfc7b0d6095af577334ad6efb4e6e61
+lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-04-28
-lastReviewedCommit: 232b36c46bfc7b0d6095af577334ad6efb4e6e61
+lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/helpers/**
   - package.json
 lastReviewedAt: 2026-04-28
-lastReviewedCommit: 232b36c46bfc7b0d6095af577334ad6efb4e6e61
+lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-04-28
-lastReviewedCommit: 232b36c46bfc7b0d6095af577334ad6efb4e6e61
+lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
 ---
 
 # Testing Troubleshooting

--- a/src/components/ValidationIssueModal/index.tsx
+++ b/src/components/ValidationIssueModal/index.tsx
@@ -160,6 +160,7 @@ const getValidationIssueListSeparator = (intl: IntlShapeLike) =>
   });
 
 const MULTIPLICATION_FACTOR_FIELD_TOKEN = '@multiplicationFactor';
+const PROCESS_INSTANCE_FIELD_PATH_PREFIX = 'processInstance[#';
 
 /* istanbul ignore next -- process-instance detail text fallbacks are UI-only formatting branches */
 const getSdkDetailFieldToken = (detail?: ValidationIssueSdkDetail) => {
@@ -183,6 +184,12 @@ const isMultiplicationFactorMissingDetail = (detail?: ValidationIssueSdkDetail) 
   detail?.presentation === 'highlight-only' &&
   detail.validationCode === 'required_missing' &&
   getSdkDetailFieldToken(detail) === MULTIPLICATION_FACTOR_FIELD_TOKEN;
+
+const isLifecycleModelProcessInstanceDetail = (detail?: ValidationIssueSdkDetail) =>
+  detail?.presentation === 'highlight-only' &&
+  (detail.fieldPath?.startsWith(PROCESS_INSTANCE_FIELD_PATH_PREFIX) ||
+    !!detail.processInstanceInternalId?.trim() ||
+    !!detail.processInstanceLabel?.trim());
 
 const getSdkInvalidIsolatedNodeHintText = (
   intl: IntlShapeLike,
@@ -256,8 +263,12 @@ const getSdkInvalidProcessInstanceDetailActionItems = (
   intl: IntlShapeLike,
   issue: ValidationIssue,
 ) => {
+  if (issue.ref['@type'] !== 'lifeCycleModel data set') {
+    return [];
+  }
+
   const interactiveDetails = getValidationIssueInteractiveDetails(issue).filter(
-    (detail) => detail.presentation === 'highlight-only' && !!detail.fieldPath,
+    (detail) => isLifecycleModelProcessInstanceDetail(detail) && !!detail.fieldPath,
   );
   const multiplicationFactorDetails = interactiveDetails.filter(
     isMultiplicationFactorMissingDetail,

--- a/tests/unit/components/ValidationIssueModal.test.tsx
+++ b/tests/unit/components/ValidationIssueModal.test.tsx
@@ -703,6 +703,67 @@ describe('ValidationIssueModal', () => {
     });
   });
 
+  it('does not render process-instance detail copy for flow-property highlight issues', async () => {
+    const onNavigate = jest.fn();
+    let modalHandle: { destroy: () => void } | null = null;
+
+    await act(async () => {
+      modalHandle = showValidationIssueModal({
+        intl,
+        issues: [
+          {
+            code: 'sdkInvalid',
+            link: 'http://localhost:8000/mydata/flows?id=flow-1&version=01.00.000',
+            ref: {
+              '@refObjectId': 'flow-1',
+              '@type': 'flow data set',
+              '@version': '01.00.000',
+            },
+            sdkDetails: [
+              {
+                key: 'sdk-flow-property-quantitative-reference-1',
+                fieldLabel: 'Quantitative reference',
+                fieldPath: 'flowProperty[#prop-1].quantitativeReference',
+                presentation: 'highlight-only',
+                reasonMessage: 'Only one quantitative reference is allowed',
+                suggestedFix: '以下数据必须有且仅有一条数据作为基准',
+                tabName: 'flowProperties',
+                validationCode: 'quantitative_reference_count_invalid',
+              },
+            ],
+            tabNames: ['flowProperties'],
+          },
+        ],
+        onNavigate,
+        title: '数据校验问题',
+      }) as { destroy: () => void };
+    });
+
+    const tabButton = screen.getByRole('button', { name: 'flowProperties' });
+    expect(tabButton).toBeInTheDocument();
+    expect(screen.queryByText(/未知过程/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/quantitativeReference/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/以下数据必须有且仅有一条数据作为基准/)).not.toBeInTheDocument();
+
+    fireEvent.click(tabButton);
+
+    expect(onNavigate).toHaveBeenCalledWith({
+      detail: expect.objectContaining({
+        key: 'sdk-flow-property-quantitative-reference-1',
+        tabName: 'flowProperties',
+      }),
+      tabName: 'flowProperties',
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    await act(async () => {
+      modalHandle?.destroy();
+    });
+  });
+
   it('aggregates multiplication-factor lifecycle model sdk issues into one isolated-node hint', async () => {
     const onNavigate = jest.fn();
     let modalHandle: { destroy: () => void } | null = null;


### PR DESCRIPTION
Closes #372

## Summary
- Prevent flow-property quantitative-reference highlight issues from rendering lifecycle-model-only process-instance copy in the validation modal.
- Keep the existing lifecycle-model process-instance guidance for real processInstance sdk details.

## Key Decisions
- Scope the extra detail-action rendering by dataset type and processInstance path metadata instead of treating every highlight-only sdk detail as a lifecycle-model node issue.
- Cover the regression at the modal layer so future flow sdk detail additions cannot leak model-specific copy back into flow validation dialogs.

## Validation
- npm run lint
- npx jest tests/unit/components/ValidationIssueModal.test.tsx tests/unit/pages/Flows/Components/edit.test.tsx --runInBand --testTimeout=20000
- npm run build

## Risks / Rollback
- Low risk: only narrows supplemental validation-modal copy for non-lifecycle datasets; tab navigation and lifecycle-model detail rendering remain covered by tests.

## Workspace Integration
- After merge to dev, the usual workspace/root integration flow still applies before delivery is fully complete.