### PR TITLE
feat: unify process LCIA results tabs

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-04-28"
-lastReviewedCommit: "bc446e0fcc3bcdbe022f76f62731247b25d6bdfb"
+lastReviewedCommit: "4aff6766513c9a50312879a34689e13b793086c3"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-04-28
-lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
+lastReviewedCommit: 4aff6766513c9a50312879a34689e13b793086c3
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-04-28
-lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
+lastReviewedCommit: 4aff6766513c9a50312879a34689e13b793086c3
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .github/workflows/**
 lastReviewedAt: 2026-04-28
-lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
+lastReviewedCommit: 4aff6766513c9a50312879a34689e13b793086c3
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-04-28
-lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
+lastReviewedCommit: 4aff6766513c9a50312879a34689e13b793086c3
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-04-28
-lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
+lastReviewedCommit: 4aff6766513c9a50312879a34689e13b793086c3
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-04-28
-lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
+lastReviewedCommit: 4aff6766513c9a50312879a34689e13b793086c3
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-04-28
-lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
+lastReviewedCommit: 4aff6766513c9a50312879a34689e13b793086c3
 ---
 
 # Testing Execution State
@@ -31,9 +31,9 @@ lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
 ## Current Baseline
 
 - latest verified full run: `npm run prepush:gate`
-- suites: `322`
-- tests: `3905`
-- tracked source files: `337`
+- suites: `323`
+- tests: `3907`
+- tracked source files: `338`
 - coverage: `100%` statements, branches, functions, and lines
 
 ## Current State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/helpers/**
   - package.json
 lastReviewedAt: 2026-04-28
-lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
+lastReviewedCommit: 4aff6766513c9a50312879a34689e13b793086c3
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-04-28
-lastReviewedCommit: bc446e0fcc3bcdbe022f76f62731247b25d6bdfb
+lastReviewedCommit: 4aff6766513c9a50312879a34689e13b793086c3
 ---
 
 # Testing Troubleshooting

--- a/src/locales/en-US/pages_process.ts
+++ b/src/locales/en-US/pages_process.ts
@@ -319,7 +319,6 @@ export default {
 
   'pages.process.view.exchanges': 'Inputs and Outputs',
   'pages.process.view.lciaresults': 'LCIA Results',
-  'pages.process.view.lciaresults.calculate': 'Calculate LCIA Results',
   'pages.process.view.lciaresults.shortDescription': 'LCIA',
   'pages.process.view.lciaresults.meanAmount': 'Mean amount',
   'pages.process.view.lciaresults.unit': 'Unit',

--- a/src/locales/zh-CN/pages_process.ts
+++ b/src/locales/zh-CN/pages_process.ts
@@ -401,7 +401,6 @@ export default {
 
   'pages.process.view.exchanges': '输入/输出',
   'pages.process.view.lciaresults': 'LCIA 结果',
-  'pages.process.view.lciaresults.calculate': '计算 LCIA 结果',
   'pages.process.view.lciaresults.shortDescription': 'LCIA',
   'pages.process.view.lciaresults.meanAmount': '平均量',
   'pages.process.view.lciaresults.unit': '单位',

--- a/src/pages/Processes/Components/create.tsx
+++ b/src/pages/Processes/Components/create.tsx
@@ -222,22 +222,6 @@ const ProcessCreate: FC<CreateProps> = ({
     setFromData({ ...fromData, exchanges: { exchange: exchangeDataSource } } as FormProcessWithId);
   }, [exchangeDataSource]);
 
-  const handleLciaResults = (result: LCIAResultTable[]) => {
-    const updatedLciaResults = result.map((item) => ({
-      referenceToLCIAMethodDataSet: item.referenceToLCIAMethodDataSet,
-      meanAmount: String(item.meanAmount ?? ''),
-    }));
-    setFromData(
-      (prev) =>
-        ({
-          ...prev,
-          LCIAResults: {
-            LCIAResult: updatedLciaResults,
-          },
-        }) as FormProcessWithId,
-    );
-  };
-
   return (
     <>
       <Tooltip
@@ -432,7 +416,6 @@ const ProcessCreate: FC<CreateProps> = ({
               onTabChange={(key) => onTabChange(key as TabKeysType)}
               exchangeDataSource={exchangeDataSource}
               lciaResults={jsonToList(fromData?.LCIAResults?.LCIAResult) as LCIAResultTable[]}
-              onLciaResults={handleLciaResults}
             />
           </ProForm>
         </Spin>

--- a/src/pages/Processes/Components/edit.tsx
+++ b/src/pages/Processes/Components/edit.tsx
@@ -1017,22 +1017,6 @@ const ProcessEdit: FC<Props> = ({
     void runCheckData({ silent: true });
   }, [autoCheckRequired, autoCheckTriggered, drawerVisible, fromData, runCheckData, spinning]);
 
-  const handleLciaResults = (result: LCIAResultTable[]) => {
-    const updatedLciaResults = result.map((item) => ({
-      referenceToLCIAMethodDataSet: item.referenceToLCIAMethodDataSet,
-      meanAmount: String(item.meanAmount ?? ''),
-    }));
-    setFromData(
-      (prev) =>
-        ({
-          ...prev,
-          LCIAResults: {
-            LCIAResult: updatedLciaResults,
-          },
-        }) as FormProcessWithDatas,
-    );
-  };
-
   return (
     <>
       {!autoOpen &&
@@ -1229,11 +1213,13 @@ const ProcessEdit: FC<Props> = ({
                 exchangeDataSource={exchangeDataSource}
                 formRef={formRefEdit}
                 lciaResults={jsonToList(fromData?.LCIAResults?.LCIAResult) as LCIAResultTable[]}
+                lciaResultsMode='solver'
                 onData={handletFromData}
                 onExchangeData={handletExchangeData}
                 onExchangeDataCreate={handletExchangeDataCreate}
-                onLciaResults={handleLciaResults}
                 onTabChange={(key) => onTabChange(key as TabKeysType)}
+                processId={id}
+                processVersion={version}
                 sdkValidationDetails={sdkValidationDetails}
                 sdkValidationFocus={sdkValidationFocus}
                 showRules={showRules}

--- a/src/pages/Processes/Components/edit.tsx
+++ b/src/pages/Processes/Components/edit.tsx
@@ -1213,7 +1213,6 @@ const ProcessEdit: FC<Props> = ({
                 exchangeDataSource={exchangeDataSource}
                 formRef={formRefEdit}
                 lciaResults={jsonToList(fromData?.LCIAResults?.LCIAResult) as LCIAResultTable[]}
-                lciaResultsMode='solver'
                 onData={handletFromData}
                 onExchangeData={handletExchangeData}
                 onExchangeDataCreate={handletExchangeDataCreate}

--- a/src/pages/Processes/Components/form.tsx
+++ b/src/pages/Processes/Components/form.tsx
@@ -4,21 +4,18 @@ import LocationTextItemForm from '@/components/LocationTextItem/form';
 import ContactSelectForm from '@/pages/Contacts/Components/select/form';
 import SourceSelectForm from '@/pages/Sources/Components/select/form';
 // import ReferenceUnit from '@/pages/Unitgroups/Components/Unit/reference';
-import AlignedNumber from '@/components/AlignedNumber';
 import RequiredMark from '@/components/RequiredMark';
-import ToolBarButton from '@/components/ToolBarButton';
 import { RefCheckType, useRefCheckContext } from '@/contexts/refCheckContext';
 import { getRules } from '@/pages/Utils';
 import type { ValidationIssueSdkDetail } from '@/pages/Utils/review';
 import { getFlowStateCodeByIdsAndVersions } from '@/services/flows/api';
 import { ListPagination } from '@/services/general/data';
-import { getLangText, getUnitData, jsonToList } from '@/services/general/util';
+import { getUnitData } from '@/services/general/util';
 import { LCIAResultTable } from '@/services/lciaMethods/data';
-import LCIAResultCalculation, { getReferenceQuantityFromMethod } from '@/services/lciaMethods/util';
 import { getProcessExchange } from '@/services/processes/api';
 import { ProcessExchangeData, ProcessExchangeTable } from '@/services/processes/data';
 import { genProcessExchangeTableData } from '@/services/processes/util';
-import { CalculatorOutlined, CloseOutlined } from '@ant-design/icons';
+import { CloseOutlined } from '@ant-design/icons';
 import { ActionType, ProColumns, ProFormInstance, ProTable } from '@ant-design/pro-components';
 import {
   Button,
@@ -31,7 +28,6 @@ import {
   Select,
   Space,
   theme,
-  Tooltip,
 } from 'antd';
 import { useEffect, useRef, useState, type FC } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
@@ -66,11 +62,9 @@ type Props = {
   onExchangeData: (data: ProcessExchangeData[]) => void;
   onExchangeDataCreate: (data: ProcessExchangeData) => void;
   onTabChange: (key: string) => void;
-  onLciaResults?: (result: LCIAResultTable[]) => void;
   exchangeDataSource: ProcessExchangeData[];
   lciaResults: LCIAResultTable[];
   formType?: string;
-  lciaResultsMode?: 'local' | 'solver';
   processId?: string;
   processVersion?: string;
   showRules?: boolean;
@@ -229,10 +223,8 @@ export const ProcessForm: FC<Props> = ({
   onExchangeData,
   onExchangeDataCreate,
   onTabChange,
-  onLciaResults,
   exchangeDataSource,
   formType,
-  lciaResultsMode = 'local',
   processId,
   processVersion,
   showRules = false,
@@ -245,7 +237,6 @@ export const ProcessForm: FC<Props> = ({
   const refCheckContext = useRefCheckContext();
   const actionRefExchangeTableInput = useRef<ActionType>();
   const actionRefExchangeTableOutput = useRef<ActionType>();
-  const actionRefLciaResultTable = useRef<ActionType>();
   const rootSdkFieldMessagesRef = useRef<
     Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
   >(new Map());
@@ -260,12 +251,6 @@ export const ProcessForm: FC<Props> = ({
     useState(false);
   const [intendedApplicationsError, setIntendedApplicationsError] = useState(false);
   const [generalCommentError, setGeneralCommentError] = useState(false);
-
-  const [lciaResultDataSource, setLciaResultDataSource] = useState<LCIAResultTable[]>(
-    jsonToList(lciaResults),
-  );
-  const [lciaResultDataSourceLoading, setLciaResultDataSourceLoading] = useState(false);
-  const shouldUseSolverLciaResults = lciaResultsMode === 'solver' && !!processId;
 
   const { token } = theme.useToken();
 
@@ -739,86 +724,6 @@ export const ProcessForm: FC<Props> = ({
       },
     },
   ];
-  const lciaResultColumns: ProColumns<LCIAResultTable>[] = [
-    {
-      title: <FormattedMessage id='pages.table.title.index' defaultMessage='Index' />,
-      dataIndex: 'index',
-      valueType: 'index',
-      search: false,
-      width: 70,
-    },
-    {
-      title: (
-        <FormattedMessage
-          id='pages.process.view.lciaresults.shortDescription'
-          defaultMessage='LCIA'
-        />
-      ),
-      dataIndex: 'Name',
-      search: false,
-      width: 500,
-      render: (_, row) => {
-        return [
-          <span key={0}>
-            {getLangText(row?.referenceToLCIAMethodDataSet?.['common:shortDescription'], lang)}
-          </span>,
-        ];
-      },
-    },
-
-    {
-      title: (
-        <FormattedMessage
-          id='pages.process.view.lciaresults.meanAmount'
-          defaultMessage='Mean amount'
-        />
-      ),
-      dataIndex: 'meanAmount',
-      search: false,
-      render: (_, row) => {
-        return [<AlignedNumber key={0} value={row.meanAmount} />];
-      },
-    },
-    {
-      title: <FormattedMessage id='pages.process.view.lciaresults.unit' defaultMessage='Unit' />,
-      dataIndex: 'referenceQuantity',
-      search: false,
-      render: (_, row) => {
-        return [<span key={0}>{getLangText(row?.referenceQuantityDesc, lang) || '-'}</span>];
-      },
-    },
-    {
-      title: (
-        <FormattedMessage
-          id='pages.process.view.lciaresults.referenceToLCIAMethodDataSetVersion'
-          defaultMessage='Version'
-        />
-      ),
-      dataIndex: 'Version',
-      search: false,
-      render: (_, row) => {
-        const version = row.referenceToLCIAMethodDataSet?.['@version'] ?? '-';
-        return [
-          <Tooltip key={0} placement='topLeft' title={version}>
-            {version}
-          </Tooltip>,
-        ];
-      },
-    },
-  ];
-  const syncReferenceQuantityToLciaResults = async (lciaResults: LCIAResultTable[] | undefined) => {
-    if (!lciaResults) return;
-    const listLciaResults = jsonToList(lciaResults);
-    await getReferenceQuantityFromMethod(listLciaResults);
-    setLciaResultDataSource(listLciaResults);
-  };
-  const getLCIAResult = async () => {
-    setLciaResultDataSourceLoading(true);
-    const lciaResults = await LCIAResultCalculation(exchangeDataSource);
-    await syncReferenceQuantityToLciaResults(JSON.parse(JSON.stringify(lciaResults)));
-    onLciaResults?.(lciaResults ?? []);
-    setLciaResultDataSourceLoading(false);
-  };
   const tabContent: { [key: string]: JSX.Element } = {
     processInformation: (
       <Space direction='vertical' style={{ width: '100%' }}>
@@ -2757,34 +2662,12 @@ export const ProcessForm: FC<Props> = ({
         />
       </>
     ),
-    lciaResults: shouldUseSolverLciaResults ? (
+    lciaResults: (
       <ProcessLciaResultsPanel
         baseRows={lciaResults}
         lang={lang}
         processId={processId}
         processVersion={processVersion}
-      />
-    ) : (
-      <ProTable<LCIAResultTable, ListPagination>
-        actionRef={actionRefLciaResultTable}
-        rowKey={(record) => record.key}
-        search={false}
-        loading={lciaResultDataSourceLoading}
-        toolBarRender={() => [
-          <ToolBarButton
-            key='calculate'
-            icon={<CalculatorOutlined />}
-            tooltip={
-              <FormattedMessage
-                id='pages.process.view.lciaresults.calculate'
-                defaultMessage='Calculate LCIA Results'
-              />
-            }
-            onClick={getLCIAResult}
-          />,
-        ]}
-        dataSource={lciaResultDataSource}
-        columns={lciaResultColumns}
       />
     ),
     validation: (
@@ -2818,13 +2701,6 @@ export const ProcessForm: FC<Props> = ({
     actionRefExchangeTableInput.current?.reload();
     actionRefExchangeTableOutput.current?.reload();
   }, [exchangeDataSource]);
-
-  useEffect(() => {
-    actionRefLciaResultTable.current?.reload();
-    syncReferenceQuantityToLciaResults(
-      JSON.parse(JSON.stringify(lciaResults)) as LCIAResultTable[],
-    );
-  }, [lciaResults]);
 
   return (
     <Card

--- a/src/pages/Processes/Components/form.tsx
+++ b/src/pages/Processes/Components/form.tsx
@@ -55,6 +55,7 @@ import {
   uncertaintyDistributionTypeOptions,
   workflowAndPublicationStatusOptions,
 } from './optiondata';
+import ProcessLciaResultsPanel from './processLciaResultsPanel';
 import ReveiwItemForm from './Review/form';
 
 type Props = {
@@ -65,10 +66,13 @@ type Props = {
   onExchangeData: (data: ProcessExchangeData[]) => void;
   onExchangeDataCreate: (data: ProcessExchangeData) => void;
   onTabChange: (key: string) => void;
-  onLciaResults: (result: LCIAResultTable[]) => void;
+  onLciaResults?: (result: LCIAResultTable[]) => void;
   exchangeDataSource: ProcessExchangeData[];
   lciaResults: LCIAResultTable[];
   formType?: string;
+  lciaResultsMode?: 'local' | 'solver';
+  processId?: string;
+  processVersion?: string;
   showRules?: boolean;
   actionFrom?: 'modelResult';
   sdkValidationDetails?: ValidationIssueSdkDetail[];
@@ -228,6 +232,9 @@ export const ProcessForm: FC<Props> = ({
   onLciaResults,
   exchangeDataSource,
   formType,
+  lciaResultsMode = 'local',
+  processId,
+  processVersion,
   showRules = false,
   lciaResults,
   actionFrom,
@@ -258,6 +265,7 @@ export const ProcessForm: FC<Props> = ({
     jsonToList(lciaResults),
   );
   const [lciaResultDataSourceLoading, setLciaResultDataSourceLoading] = useState(false);
+  const shouldUseSolverLciaResults = lciaResultsMode === 'solver' && !!processId;
 
   const { token } = theme.useToken();
 
@@ -808,7 +816,7 @@ export const ProcessForm: FC<Props> = ({
     setLciaResultDataSourceLoading(true);
     const lciaResults = await LCIAResultCalculation(exchangeDataSource);
     await syncReferenceQuantityToLciaResults(JSON.parse(JSON.stringify(lciaResults)));
-    onLciaResults(lciaResults ?? []);
+    onLciaResults?.(lciaResults ?? []);
     setLciaResultDataSourceLoading(false);
   };
   const tabContent: { [key: string]: JSX.Element } = {
@@ -2749,7 +2757,14 @@ export const ProcessForm: FC<Props> = ({
         />
       </>
     ),
-    lciaResults: (
+    lciaResults: shouldUseSolverLciaResults ? (
+      <ProcessLciaResultsPanel
+        baseRows={lciaResults}
+        lang={lang}
+        processId={processId}
+        processVersion={processVersion}
+      />
+    ) : (
       <ProTable<LCIAResultTable, ListPagination>
         actionRef={actionRefLciaResultTable}
         rowKey={(record) => record.key}

--- a/src/pages/Processes/Components/lcaAnalysisShared.ts
+++ b/src/pages/Processes/Components/lcaAnalysisShared.ts
@@ -41,6 +41,7 @@ type LcaMethodMeta = {
 
 export type SolverLcaImpactValueRow = {
   impact_id: string;
+  impact_index?: number;
   impact_name: string;
   unit: string;
   value: number;
@@ -207,7 +208,12 @@ export async function getLcaMethodMetaMap(
     return new Map<string, LcaMethodMeta>();
   }
 
-  const files = await getLciaMethodListEntries();
+  let files: LciaMethodListEntry[];
+  try {
+    files = await getLciaMethodListEntries();
+  } catch {
+    return new Map<string, LcaMethodMeta>();
+  }
   const byId = new Map<string, LcaMethodMeta>();
 
   files.forEach((item) => {

--- a/src/pages/Processes/Components/processLciaResultsPanel.tsx
+++ b/src/pages/Processes/Components/processLciaResultsPanel.tsx
@@ -1,0 +1,343 @@
+import AlignedNumber from '@/components/AlignedNumber';
+import { ListPagination } from '@/services/general/data';
+import { getLangText } from '@/services/general/util';
+import { isLcaFunctionInvokeError, queryLcaResults } from '@/services/lca';
+import type { LCIAResultTable } from '@/services/lciaMethods/data';
+import { getReferenceQuantityFromMethod } from '@/services/lciaMethods/util';
+import { ProColumns, ProTable } from '@ant-design/pro-components';
+import { Button, Space, Tooltip, Typography } from 'antd';
+import type { FC } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { FormattedMessage, useLocation } from 'umi';
+import {
+  buildMergedLcaRows,
+  getDefaultLcaDataScopeForPath,
+  getLcaMethodMetaMap,
+  LCA_SCOPE,
+  type LcaAnalysisDataScope,
+  type SolverLcaImpactValueRow,
+} from './lcaAnalysisShared';
+import LcaProfileSummary from './lcaProfileSummary';
+
+type Props = {
+  baseRows: LCIAResultTable[];
+  lang: string;
+  processId?: string;
+  processVersion?: string;
+  lcaDataScope?: Exclude<LcaAnalysisDataScope, 'all_data'>;
+  queryScope?: string;
+  enableSolverRefresh?: boolean;
+};
+
+const ProcessLciaResultsPanel: FC<Props> = ({
+  baseRows,
+  lang,
+  processId,
+  processVersion,
+  lcaDataScope,
+  queryScope = LCA_SCOPE,
+  enableSolverRefresh = true,
+}) => {
+  const location = useLocation();
+  const resolvedDataScope = lcaDataScope ?? getDefaultLcaDataScopeForPath(location.pathname ?? '');
+  const canQuerySolver = enableSolverRefresh && !!processId;
+  const [normalizedBaseRows, setNormalizedBaseRows] = useState<LCIAResultTable[]>([]);
+  const [rows, setRows] = useState<LCIAResultTable[]>([]);
+  const [baseRowsReady, setBaseRowsReady] = useState(false);
+  const [solverLciaLoading, setSolverLciaLoading] = useState(false);
+  const [solverLciaLoaded, setSolverLciaLoaded] = useState(false);
+  const [solverLciaError, setSolverLciaError] = useState<string | null>(null);
+  const [solverLciaMeta, setSolverLciaMeta] = useState<{
+    snapshotId: string;
+    resultId: string;
+    source: string;
+    computedAt: string;
+  } | null>(null);
+  const [solverLciaPendingBuild, setSolverLciaPendingBuild] = useState<{
+    jobId: string;
+    snapshotId: string;
+  } | null>(null);
+
+  const columns = useMemo<ProColumns<LCIAResultTable>[]>(
+    () => [
+      {
+        title: <FormattedMessage id='pages.table.title.index' defaultMessage='Index' />,
+        dataIndex: 'index',
+        valueType: 'index',
+        search: false,
+        width: 70,
+      },
+      {
+        title: (
+          <FormattedMessage
+            id='pages.process.view.lciaresults.shortDescription'
+            defaultMessage='LCIA'
+          />
+        ),
+        dataIndex: 'Name',
+        search: false,
+        width: 500,
+        render: (_, row) => {
+          return [
+            <span key={0}>
+              {getLangText(row?.referenceToLCIAMethodDataSet?.['common:shortDescription'], lang)}
+            </span>,
+          ];
+        },
+      },
+      {
+        title: (
+          <FormattedMessage
+            id='pages.process.view.lciaresults.meanAmount'
+            defaultMessage='Mean amount'
+          />
+        ),
+        dataIndex: 'meanAmount',
+        search: false,
+        render: (_, row) => {
+          return [<AlignedNumber key={0} value={row.meanAmount} />];
+        },
+      },
+      {
+        title: <FormattedMessage id='pages.process.view.lciaresults.unit' defaultMessage='Unit' />,
+        dataIndex: 'referenceQuantity',
+        search: false,
+        render: (_, row) => {
+          return [<span key={0}>{getLangText(row?.referenceQuantityDesc, lang) || '-'}</span>];
+        },
+      },
+      {
+        title: (
+          <FormattedMessage
+            id='pages.process.view.lciaresults.referenceToLCIAMethodDataSetVersion'
+            defaultMessage='Version'
+          />
+        ),
+        dataIndex: 'Version',
+        search: false,
+        render: (_, row) => {
+          const version = row.referenceToLCIAMethodDataSet?.['@version'] ?? '-';
+          return [
+            <Tooltip key={0} placement='topLeft' title={version}>
+              {version}
+            </Tooltip>,
+          ];
+        },
+      },
+    ],
+    [lang],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setBaseRowsReady(false);
+    setSolverLciaLoaded(false);
+    setSolverLciaError(null);
+    setSolverLciaMeta(null);
+    setSolverLciaPendingBuild(null);
+
+    const syncBaseRows = async () => {
+      const sourceRows = JSON.parse(JSON.stringify(baseRows ?? [])) as LCIAResultTable[];
+      try {
+        await getReferenceQuantityFromMethod(sourceRows);
+      } catch {
+        // Keep the tab usable even if method metadata cannot be enriched.
+      }
+
+      if (cancelled) {
+        return;
+      }
+
+      setNormalizedBaseRows(sourceRows);
+      setRows(sourceRows);
+      setBaseRowsReady(true);
+    };
+
+    void syncBaseRows();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [baseRows]);
+
+  const loadSolverLciaResults = useCallback(
+    async (forceReload: boolean) => {
+      if (!canQuerySolver || !baseRowsReady || !processId) {
+        return;
+      }
+      if (solverLciaLoading) {
+        return;
+      }
+      if (solverLciaLoaded && !forceReload) {
+        return;
+      }
+
+      setSolverLciaLoading(true);
+      setSolverLciaError(null);
+      setSolverLciaPendingBuild(null);
+
+      try {
+        const queried = await queryLcaResults({
+          scope: queryScope,
+          ...(resolvedDataScope ? { data_scope: resolvedDataScope } : {}),
+          mode: 'process_all_impacts',
+          process_id: processId,
+          ...(processVersion ? { process_version: processVersion } : {}),
+          allow_fallback: false,
+        });
+        const values = (queried.data as { values?: unknown[] })?.values;
+        const solverRows = (Array.isArray(values) ? values : [])
+          .map((item) => {
+            const row = item as {
+              impact_id?: unknown;
+              impact_index?: unknown;
+              impact_name?: unknown;
+              unit?: unknown;
+              value?: unknown;
+            };
+
+            return {
+              impact_id: String(row.impact_id ?? ''),
+              impact_index: Number(row.impact_index ?? 0),
+              impact_name: String(row.impact_name ?? ''),
+              unit: String(row.unit ?? ''),
+              value: Number(row.value ?? 0),
+            } as SolverLcaImpactValueRow;
+          })
+          .filter((row) => row.impact_id.length > 0)
+          .sort((left, right) => (left.impact_index ?? 0) - (right.impact_index ?? 0));
+        const methodMetaById = await getLcaMethodMetaMap(
+          solverRows.map((solverRow) => solverRow.impact_id),
+        );
+        const mergedRows = buildMergedLcaRows(normalizedBaseRows, solverRows, methodMetaById);
+
+        setRows(mergedRows);
+        setSolverLciaMeta({
+          snapshotId: queried.snapshot_id,
+          resultId: queried.result_id,
+          source: queried.source,
+          computedAt: queried.meta.computed_at,
+        });
+        setSolverLciaPendingBuild(null);
+        setSolverLciaLoaded(true);
+      } catch (error: unknown) {
+        if (isLcaFunctionInvokeError(error) && error.code === 'snapshot_build_queued') {
+          const buildJobId =
+            typeof error.body?.build_job_id === 'string' ? error.body.build_job_id.trim() : '';
+          const buildSnapshotId =
+            typeof error.body?.build_snapshot_id === 'string'
+              ? error.body.build_snapshot_id.trim()
+              : '';
+
+          if (buildJobId && buildSnapshotId) {
+            setSolverLciaPendingBuild({
+              jobId: buildJobId,
+              snapshotId: buildSnapshotId,
+            });
+            setSolverLciaMeta(null);
+            setSolverLciaError(null);
+            setSolverLciaLoaded(true);
+            return;
+          }
+        }
+
+        setSolverLciaPendingBuild(null);
+        setRows(normalizedBaseRows);
+        setSolverLciaMeta(null);
+        setSolverLciaError(error instanceof Error ? error.message : String(error));
+        setSolverLciaLoaded(true);
+      } finally {
+        setSolverLciaLoading(false);
+      }
+    },
+    [
+      baseRowsReady,
+      canQuerySolver,
+      normalizedBaseRows,
+      processId,
+      processVersion,
+      queryScope,
+      resolvedDataScope,
+      solverLciaLoaded,
+      solverLciaLoading,
+    ],
+  );
+
+  useEffect(() => {
+    if (!canQuerySolver || !baseRowsReady) {
+      return;
+    }
+
+    void loadSolverLciaResults(false);
+  }, [baseRowsReady, canQuerySolver, loadSolverLciaResults]);
+
+  useEffect(() => {
+    if (!canQuerySolver || !solverLciaPendingBuild) {
+      return;
+    }
+
+    const timer = globalThis.setTimeout(() => {
+      void loadSolverLciaResults(true);
+    }, 4000);
+
+    return () => {
+      globalThis.clearTimeout(timer);
+    };
+  }, [canQuerySolver, loadSolverLciaResults, solverLciaPendingBuild]);
+
+  return (
+    <Space direction='vertical' size={'middle'} style={{ width: '100%' }}>
+      {canQuerySolver && (
+        <Space size={'middle'} wrap>
+          <Button
+            size='small'
+            loading={solverLciaLoading}
+            onClick={() => {
+              void loadSolverLciaResults(true);
+            }}
+          >
+            <FormattedMessage
+              id='pages.process.view.lciaresults.solver.reload'
+              defaultMessage='Refresh latest calculated results'
+            />
+          </Button>
+          {solverLciaMeta && (
+            <Typography.Text type='secondary'>
+              {`source=${solverLciaMeta.source}, snapshot=${solverLciaMeta.snapshotId}, result=${solverLciaMeta.resultId}, computed_at=${solverLciaMeta.computedAt}`}
+            </Typography.Text>
+          )}
+          {solverLciaPendingBuild && (
+            <Typography.Text type='secondary'>
+              <FormattedMessage
+                id='pages.process.view.lciaresults.solver.snapshotBuilding'
+                defaultMessage='Snapshot is rebuilding (job {jobId}). Retrying automatically...'
+                values={{ jobId: solverLciaPendingBuild.jobId }}
+              />
+            </Typography.Text>
+          )}
+        </Space>
+      )}
+      {solverLciaError && !solverLciaPendingBuild && (
+        <Typography.Text type='danger'>
+          <FormattedMessage
+            id='pages.process.view.lciaresults.solver.error'
+            defaultMessage='Result query failed: {message}'
+            values={{ message: solverLciaError }}
+          />
+        </Typography.Text>
+      )}
+      <LcaProfileSummary rows={rows} lang={lang} loading={solverLciaLoading} />
+      <ProTable<LCIAResultTable, ListPagination>
+        rowKey={(row) => row.referenceToLCIAMethodDataSet?.['@refObjectId'] || row.key}
+        loading={solverLciaLoading}
+        search={false}
+        options={false}
+        dataSource={rows}
+        columns={columns}
+      />
+    </Space>
+  );
+};
+
+export default ProcessLciaResultsPanel;

--- a/src/pages/Processes/Components/processLciaResultsPanel.tsx
+++ b/src/pages/Processes/Components/processLciaResultsPanel.tsx
@@ -206,7 +206,7 @@ const ProcessLciaResultsPanel: FC<Props> = ({
             } as SolverLcaImpactValueRow;
           })
           .filter((row) => row.impact_id.length > 0)
-          .sort((left, right) => (left.impact_index ?? 0) - (right.impact_index ?? 0));
+          .sort((left, right) => Number(left.impact_index) - Number(right.impact_index));
         const methodMetaById = await getLcaMethodMetaMap(
           solverRows.map((solverRow) => solverRow.impact_id),
         );

--- a/src/pages/Processes/Components/view.tsx
+++ b/src/pages/Processes/Components/view.tsx
@@ -4,12 +4,10 @@ import LocationTextItemDescription from '@/components/LocationTextItem/descripti
 import ContactSelectDescription from '@/pages/Contacts/Components/select/description';
 import SourceSelectDescription from '@/pages/Sources/Components/select/description';
 // import ReferenceUnit from '@/pages/Unitgroups/Components/Unit/reference';
-import AlignedNumber from '@/components/AlignedNumber';
 import { getFlowStateCodeByIdsAndVersions } from '@/services/flows/api';
 import { ListPagination } from '@/services/general/data';
-import { getLangJson, getLangText, getUnitData, jsonToList } from '@/services/general/util';
-import { isLcaFunctionInvokeError, queryLcaResults } from '@/services/lca';
-import type { LciaMethodListData, LCIAResultTable } from '@/services/lciaMethods/data';
+import { getUnitData, jsonToList } from '@/services/general/util';
+import type { LCIAResultTable } from '@/services/lciaMethods/data';
 import { getProcessDetail, getProcessExchange } from '@/services/processes/api';
 import {
   FormProcess,
@@ -21,11 +19,6 @@ import { genProcessExchangeTableData, genProcessFromData } from '@/services/proc
 
 import { getClassificationValues } from '@/pages/Utils';
 import { getRejectedComments, mergeCommentsToData } from '@/pages/Utils/review';
-import {
-  cacheAndDecompressMethod,
-  getDecompressedMethod,
-  getReferenceQuantityFromMethod,
-} from '@/services/lciaMethods/util';
 import { CloseOutlined, ProductOutlined, ProfileOutlined } from '@ant-design/icons';
 import { ActionType, ProColumns, ProTable } from '@ant-design/pro-components';
 import {
@@ -42,8 +35,8 @@ import {
 } from 'antd';
 import type { ButtonType } from 'antd/es/button';
 import type { FC, ReactNode } from 'react';
-import { useCallback, useEffect, useState } from 'react';
-import { FormattedMessage, useLocation } from 'umi';
+import { useState } from 'react';
+import { FormattedMessage } from 'umi';
 import ComplianceItemView from './Compliance/view';
 import ProcessExchangeView from './Exchange/view';
 import {
@@ -55,8 +48,10 @@ import {
 import ReviewItemView from './Review/view';
 
 import { getExchangeColumns } from './Exchange/column';
-import { getDefaultLcaDataScopeForPath } from './lcaAnalysisShared';
-import LcaProfileSummary from './lcaProfileSummary';
+import {
+  buildMergedLcaRows as buildMergedLciaRows,
+  getLcaMethodMetaMap,
+} from './lcaAnalysisShared';
 import {
   copyrightOptions,
   LCIMethodApproachOptions,
@@ -64,6 +59,7 @@ import {
   licenseTypeOptions,
   processtypeOfDataSetOptions,
 } from './optiondata';
+import ProcessLciaResultsPanel from './processLciaResultsPanel';
 
 type Props = {
   id: string;
@@ -95,131 +91,6 @@ type ProcessExchangeResponse = {
   page?: number;
   success?: boolean;
   total?: number;
-};
-
-type SolverLciaValueRow = {
-  impact_id: string;
-  impact_index: number;
-  impact_name: string;
-  unit: string;
-  value: number;
-};
-
-type LciaMethodListEntry = {
-  id?: string;
-  version?: string;
-  description?: unknown;
-  referenceQuantity?: {
-    'common:shortDescription'?: unknown;
-  };
-};
-
-type LciaMethodMeta = {
-  description?: unknown;
-  version?: string;
-  referenceQuantityDesc?: unknown;
-};
-
-const LCA_SCOPE = 'dev-v1';
-const UNKNOWN_LCIA_UNIT = 'unknown';
-
-const getLciaMethodMetaMap = async (impactIds: string[]): Promise<Map<string, LciaMethodMeta>> => {
-  const impactIdSet = new Set(impactIds.filter((id) => !!id));
-  if (impactIdSet.size === 0) {
-    return new Map<string, LciaMethodMeta>();
-  }
-
-  let listData = await getDecompressedMethod<LciaMethodListData>('list.json');
-  const needsUpdate = listData && !listData.files?.[0]?.referenceQuantity;
-  if (!listData || needsUpdate) {
-    const cached = await cacheAndDecompressMethod('list.json');
-    if (!cached) {
-      return new Map<string, LciaMethodMeta>();
-    }
-    listData = await getDecompressedMethod<LciaMethodListData>('list.json');
-  }
-
-  const files = Array.isArray(listData?.files) ? (listData.files as LciaMethodListEntry[]) : [];
-  const byId = new Map<string, LciaMethodMeta>();
-  files.forEach((item) => {
-    const methodId = String(item?.id ?? '');
-    if (!methodId || !impactIdSet.has(methodId)) {
-      return;
-    }
-    byId.set(methodId, {
-      description: item?.description,
-      version: item?.version,
-      referenceQuantityDesc: getLangJson(item?.referenceQuantity?.['common:shortDescription']),
-    });
-  });
-  return byId;
-};
-
-const toLangFallback = (text: string) => getLangJson({ '@xml:lang': 'en', '#text': text });
-
-const buildMergedLciaRows = (
-  baseRows: LCIAResultTable[],
-  solverRows: SolverLciaValueRow[],
-  methodMetaById: Map<string, LciaMethodMeta>,
-): LCIAResultTable[] => {
-  const mergedRows = baseRows.map((row) => ({
-    ...row,
-    referenceToLCIAMethodDataSet: { ...row.referenceToLCIAMethodDataSet },
-  }));
-  const indexByMethodId = new Map<string, number>();
-  mergedRows.forEach((row, idx) => {
-    const methodId = String(row?.referenceToLCIAMethodDataSet?.['@refObjectId'] ?? '');
-    if (methodId) {
-      indexByMethodId.set(methodId, idx);
-    }
-  });
-
-  solverRows.forEach((solverRow) => {
-    const methodId = solverRow.impact_id;
-    const methodMeta = methodMetaById.get(methodId);
-    const shortDescription =
-      methodMeta?.description ??
-      toLangFallback(solverRow.impact_name?.trim() || solverRow.impact_id || '-');
-    const unitDesc =
-      methodMeta?.referenceQuantityDesc ??
-      (solverRow.unit?.trim() && solverRow.unit !== UNKNOWN_LCIA_UNIT
-        ? toLangFallback(solverRow.unit)
-        : undefined);
-    const existingIdx = indexByMethodId.get(methodId);
-
-    if (existingIdx !== undefined) {
-      const existing = mergedRows[existingIdx];
-      mergedRows[existingIdx] = {
-        ...existing,
-        meanAmount: solverRow.value,
-        referenceQuantityDesc: existing.referenceQuantityDesc || unitDesc,
-        referenceToLCIAMethodDataSet: {
-          ...existing.referenceToLCIAMethodDataSet,
-          '@version':
-            existing.referenceToLCIAMethodDataSet?.['@version'] || methodMeta?.version || '',
-          'common:shortDescription':
-            existing.referenceToLCIAMethodDataSet?.['common:shortDescription'] ||
-            (shortDescription as any),
-        },
-      };
-      return;
-    }
-
-    mergedRows.push({
-      key: methodId,
-      referenceToLCIAMethodDataSet: {
-        '@refObjectId': methodId,
-        '@type': 'lCIA method data set',
-        '@uri': `../lciamethods/${methodId}.xml`,
-        '@version': methodMeta?.version || '',
-        'common:shortDescription': shortDescription as any,
-      },
-      meanAmount: solverRow.value,
-      referenceQuantityDesc: unitDesc,
-    });
-  });
-
-  return mergedRows;
 };
 
 const toReferenceValue = (reference?: ProcessExchangeData['referenceToFlowDataSet']) => {
@@ -276,8 +147,6 @@ const ProcessView: FC<Props> = ({
   buttonTypeProp = 'default',
   triggerLabel,
 }) => {
-  const location = useLocation();
-  const defaultLcaDataScope = getDefaultLcaDataScopeForPath(location.pathname);
   const [drawerVisible, setDrawerVisible] = useState(false);
   // const [footerButtons, setFooterButtons] = useState<JSX.Element>();
   const [activeTabKey, setActiveTabKey] = useState<string>('processInformation');
@@ -285,21 +154,6 @@ const ProcessView: FC<Props> = ({
   const [spinning, setSpinning] = useState(false);
   const [initData, setInitData] = useState<Partial<ProcessFormWithId>>({});
   const [lciaResultDataSource, setLciaResultDataSource] = useState<LCIAResultTable[]>([]);
-  const [baseLciaResultDataSource, setBaseLciaResultDataSource] = useState<LCIAResultTable[]>([]);
-  const [solverLciaLoading, setSolverLciaLoading] = useState(false);
-  const [solverLciaLoaded, setSolverLciaLoaded] = useState(false);
-  const [solverLciaError, setSolverLciaError] = useState<string | null>(null);
-  const [solverLciaMeta, setSolverLciaMeta] = useState<{
-    snapshotId: string;
-    resultId: string;
-    source: string;
-    computedAt: string;
-  } | null>(null);
-  const [solverLciaPendingBuild, setSolverLciaPendingBuild] = useState<{
-    jobId: string;
-    snapshotId: string;
-  } | null>(null);
-  // const [lciaResultDataSourceLoading, setLciaResultDataSourceLoading] = useState(false);
   const tabList = [
     {
       key: 'processInformation',
@@ -375,190 +229,6 @@ const ProcessView: FC<Props> = ({
       },
     },
   ];
-  const lciaResultColumns: ProColumns<LCIAResultTable>[] = [
-    {
-      title: <FormattedMessage id='pages.table.title.index' defaultMessage='Index' />,
-      dataIndex: 'index',
-      valueType: 'index',
-      search: false,
-      width: 70,
-    },
-    {
-      title: (
-        <FormattedMessage
-          id='pages.process.view.lciaresults.shortDescription'
-          defaultMessage='LCIA'
-        />
-      ),
-      dataIndex: 'Name',
-      search: false,
-      width: 500,
-      render: (_, row) => {
-        return [
-          <span key={0}>
-            {getLangText(row?.referenceToLCIAMethodDataSet?.['common:shortDescription'], lang)}
-          </span>,
-        ];
-      },
-    },
-
-    {
-      title: (
-        <FormattedMessage
-          id='pages.process.view.lciaresults.meanAmount'
-          defaultMessage='Mean amount'
-        />
-      ),
-      dataIndex: 'meanAmount',
-      search: false,
-      render: (_, row) => {
-        return [<AlignedNumber key={0} value={row.meanAmount} />];
-      },
-    },
-    {
-      title: <FormattedMessage id='pages.process.view.lciaresults.unit' defaultMessage='Unit' />,
-      dataIndex: 'referenceQuantity',
-      search: false,
-      render: (_, row) => {
-        return [<span key={0}>{getLangText(row?.referenceQuantityDesc, lang) || '-'}</span>];
-      },
-    },
-    {
-      title: (
-        <FormattedMessage
-          id='pages.process.view.lciaresults.referenceToLCIAMethodDataSetVersion'
-          defaultMessage='Version'
-        />
-      ),
-      dataIndex: 'Version',
-      search: false,
-      render: (_, row) => {
-        return [
-          <Tooltip
-            key={0}
-            placement='topLeft'
-            title={row?.referenceToLCIAMethodDataSet?.['@version']}
-          >
-            {row?.referenceToLCIAMethodDataSet?.['@version']}
-          </Tooltip>,
-        ];
-      },
-    },
-  ];
-  const loadSolverLciaResults = useCallback(
-    async (forceReload: boolean) => {
-      if (solverLciaLoading) {
-        return;
-      }
-      if (solverLciaLoaded && !forceReload) {
-        return;
-      }
-      setSolverLciaLoading(true);
-      setSolverLciaError(null);
-      setSolverLciaPendingBuild(null);
-      try {
-        const queried = await queryLcaResults({
-          scope: LCA_SCOPE,
-          ...(defaultLcaDataScope ? { data_scope: defaultLcaDataScope } : {}),
-          mode: 'process_all_impacts',
-          process_id: id,
-          process_version: version,
-          allow_fallback: false,
-        });
-        const values = (queried.data as { values?: unknown[] })?.values;
-        const rows = (Array.isArray(values) ? values : [])
-          .map((item) => {
-            const row = item as {
-              impact_id?: unknown;
-              impact_index?: unknown;
-              impact_name?: unknown;
-              unit?: unknown;
-              value?: unknown;
-            };
-            return {
-              impact_id: String(row.impact_id ?? ''),
-              impact_index: Number(row.impact_index ?? 0),
-              impact_name: String(row.impact_name ?? ''),
-              unit: String(row.unit ?? ''),
-              value: Number(row.value ?? 0),
-            } as SolverLciaValueRow;
-          })
-          .filter((row) => row.impact_id.length > 0)
-          .sort((a, b) => a.impact_index - b.impact_index);
-        const methodMetaById = await getLciaMethodMetaMap(rows.map((row) => row.impact_id));
-        const mergedRows = buildMergedLciaRows(baseLciaResultDataSource, rows, methodMetaById);
-        setLciaResultDataSource(mergedRows);
-        setSolverLciaMeta({
-          snapshotId: queried.snapshot_id,
-          resultId: queried.result_id,
-          source: queried.source,
-          computedAt: queried.meta.computed_at,
-        });
-        setSolverLciaPendingBuild(null);
-        setSolverLciaLoaded(true);
-      } catch (error: unknown) {
-        if (isLcaFunctionInvokeError(error) && error.code === 'snapshot_build_queued') {
-          const buildJobId =
-            typeof error.body?.build_job_id === 'string' ? error.body.build_job_id.trim() : '';
-          const buildSnapshotId =
-            typeof error.body?.build_snapshot_id === 'string'
-              ? error.body.build_snapshot_id.trim()
-              : '';
-          if (buildJobId && buildSnapshotId) {
-            setSolverLciaPendingBuild({
-              jobId: buildJobId,
-              snapshotId: buildSnapshotId,
-            });
-            setSolverLciaMeta(null);
-            setSolverLciaError(null);
-            setSolverLciaLoaded(true);
-            return;
-          }
-        }
-        setSolverLciaPendingBuild(null);
-        setLciaResultDataSource(baseLciaResultDataSource);
-        setSolverLciaMeta(null);
-        setSolverLciaError(error instanceof Error ? error.message : String(error));
-        setSolverLciaLoaded(true);
-      } finally {
-        setSolverLciaLoading(false);
-      }
-    },
-    [
-      baseLciaResultDataSource,
-      defaultLcaDataScope,
-      id,
-      solverLciaLoaded,
-      solverLciaLoading,
-      version,
-    ],
-  );
-
-  useEffect(() => {
-    if (!drawerVisible || activeTabKey !== 'lciaResults') {
-      return;
-    }
-    void loadSolverLciaResults(false);
-  }, [activeTabKey, drawerVisible, loadSolverLciaResults]);
-
-  useEffect(() => {
-    if (!drawerVisible || activeTabKey !== 'lciaResults' || !solverLciaPendingBuild) {
-      return;
-    }
-    const timer = globalThis.setTimeout(() => {
-      void loadSolverLciaResults(true);
-    }, 4000);
-    return () => {
-      globalThis.clearTimeout(timer);
-    };
-  }, [activeTabKey, drawerVisible, loadSolverLciaResults, solverLciaPendingBuild]);
-
-  // const getLCIAResult = async () => {
-  //   setLciaResultDataSourceLoading(true);
-  //   const lciaResults = await LCIAResultCalculation(exchangeDataSource);
-  //   setLciaResultDataSource(lciaResults ?? []);
-  //   setLciaResultDataSourceLoading(false);
-  // };
 
   const contentList: Record<string, React.ReactNode> = {
     processInformation: (
@@ -1919,54 +1589,12 @@ const ProcessView: FC<Props> = ({
       </>
     ),
     lciaResults: (
-      <Space direction='vertical' size={'middle'} style={{ width: '100%' }}>
-        <Space size={'middle'} wrap>
-          <Button
-            size='small'
-            loading={solverLciaLoading}
-            onClick={() => {
-              void loadSolverLciaResults(true);
-            }}
-          >
-            <FormattedMessage
-              id='pages.process.view.lciaresults.solver.reload'
-              defaultMessage='Refresh latest calculated results'
-            />
-          </Button>
-          {solverLciaMeta && (
-            <Typography.Text type='secondary'>
-              {`source=${solverLciaMeta.source}, snapshot=${solverLciaMeta.snapshotId}, result=${solverLciaMeta.resultId}, computed_at=${solverLciaMeta.computedAt}`}
-            </Typography.Text>
-          )}
-          {solverLciaPendingBuild && (
-            <Typography.Text type='secondary'>
-              <FormattedMessage
-                id='pages.process.view.lciaresults.solver.snapshotBuilding'
-                defaultMessage='Snapshot is rebuilding (job {jobId}). Retrying automatically...'
-                values={{ jobId: solverLciaPendingBuild.jobId }}
-              />
-            </Typography.Text>
-          )}
-        </Space>
-        {solverLciaError && !solverLciaPendingBuild && (
-          <Typography.Text type='danger'>
-            <FormattedMessage
-              id='pages.process.view.lciaresults.solver.error'
-              defaultMessage='Result query failed: {message}'
-              values={{ message: solverLciaError }}
-            />
-          </Typography.Text>
-        )}
-        <LcaProfileSummary rows={lciaResultDataSource} lang={lang} loading={solverLciaLoading} />
-        <ProTable<LCIAResultTable, ListPagination>
-          rowKey={(row) => row.referenceToLCIAMethodDataSet?.['@refObjectId'] || row.key}
-          loading={solverLciaLoading}
-          search={false}
-          options={false}
-          dataSource={lciaResultDataSource}
-          columns={lciaResultColumns}
-        />
-      </Space>
+      <ProcessLciaResultsPanel
+        baseRows={lciaResultDataSource}
+        lang={lang}
+        processId={id}
+        processVersion={version}
+      />
     ),
     validation: (
       <ReviewItemView data={initData?.modellingAndValidation?.validation?.review ?? []} />
@@ -1983,12 +1611,6 @@ const ProcessView: FC<Props> = ({
     setActiveTabKey('processInformation');
     setSpinning(true);
     setLciaResultDataSource([]);
-    setBaseLciaResultDataSource([]);
-    setSolverLciaError(null);
-    setSolverLciaMeta(null);
-    setSolverLciaPendingBuild(null);
-    setSolverLciaLoaded(false);
-    setSolverLciaLoading(false);
     getProcessDetail(id, version).then(async (result: ProcessDetailResponse) => {
       const formData = genProcessFromData(result.data?.json?.processDataSet ?? {});
       if ((result?.data?.stateCode ?? 100) < 100) {
@@ -1998,8 +1620,6 @@ const ProcessView: FC<Props> = ({
       setInitData({ ...formData, id: id });
       setExchangeDataSource([...(formData?.exchanges?.exchange ?? [])]);
       const sourceData = jsonToList(formData?.LCIAResults?.LCIAResult) as LCIAResultTable[];
-      await getReferenceQuantityFromMethod(sourceData);
-      setBaseLciaResultDataSource(sourceData);
       setLciaResultDataSource(sourceData);
       // if (dataSource === 'my') {
       //   setFooterButtons(
@@ -2126,4 +1746,4 @@ const ProcessView: FC<Props> = ({
 
 export default ProcessView;
 
-export { buildMergedLciaRows, getLciaMethodMetaMap, toReferenceValue };
+export { buildMergedLciaRows, getLcaMethodMetaMap as getLciaMethodMetaMap, toReferenceValue };

--- a/tests/unit/pages/Processes/Components/create.test.tsx
+++ b/tests/unit/pages/Processes/Components/create.test.tsx
@@ -545,16 +545,6 @@ describe('ProcessCreate component', () => {
       });
       triggerValuesChange?.({}, {});
       await latestProcessFormProps.onData();
-      latestProcessFormProps.onLciaResults([
-        {
-          referenceToLCIAMethodDataSet: 'lcia-1',
-          meanAmount: 12,
-        },
-        {
-          referenceToLCIAMethodDataSet: 'lcia-2',
-          meanAmount: undefined,
-        },
-      ]);
       latestProcessFormProps.onExchangeData([
         {
           '@dataSetInternalID': '0',
@@ -574,19 +564,8 @@ describe('ProcessCreate component', () => {
     await waitFor(() =>
       expect(mockCreateProcess).toHaveBeenCalledWith(
         'process-1',
-        expect.objectContaining({
-          LCIAResults: {
-            LCIAResult: [
-              {
-                referenceToLCIAMethodDataSet: 'lcia-1',
-                meanAmount: '12',
-              },
-              {
-                referenceToLCIAMethodDataSet: 'lcia-2',
-                meanAmount: '',
-              },
-            ],
-          },
+        expect.not.objectContaining({
+          LCIAResults: expect.anything(),
         }),
       ),
     );

--- a/tests/unit/pages/Processes/Components/edit.test.tsx
+++ b/tests/unit/pages/Processes/Components/edit.test.tsx
@@ -1860,78 +1860,18 @@ describe('ProcessEdit component', () => {
     expect(mockSubmitDatasetReview).not.toHaveBeenCalled();
   });
 
-  it('normalizes LCIA results before saving', async () => {
+  it('passes solver-backed LCIA props to the shared process form', async () => {
     render(<ProcessEdit {...baseProps} />);
 
     fireEvent.click(screen.getByRole('button'));
     await screen.findByRole('dialog', { name: 'Edit process' });
 
-    await act(async () => {
-      latestProcessFormProps.onLciaResults([
-        {
-          referenceToLCIAMethodDataSet: { '@refObjectId': 'lcia-1', '@version': '1.0.0' },
-          meanAmount: 12.5,
-        },
-      ]);
+    expect(latestProcessFormProps).toMatchObject({
+      lciaResultsMode: 'solver',
+      processId: 'process-1',
+      processVersion: '1.0.0',
     });
-    await act(async () => {
-      await proFormApi?.submit();
-    });
-
-    expect(mockUpdateProcess).toHaveBeenCalledWith(
-      'process-1',
-      '1.0.0',
-      expect.objectContaining({
-        LCIAResults: {
-          LCIAResult: [
-            {
-              referenceToLCIAMethodDataSet: {
-                '@refObjectId': 'lcia-1',
-                '@version': '1.0.0',
-              },
-              meanAmount: '12.5',
-            },
-          ],
-        },
-      }),
-    );
-  });
-
-  it('normalizes missing LCIA mean amounts to empty strings before saving', async () => {
-    render(<ProcessEdit {...baseProps} />);
-
-    fireEvent.click(screen.getByRole('button'));
-    await screen.findByRole('dialog', { name: 'Edit process' });
-
-    await act(async () => {
-      latestProcessFormProps.onLciaResults([
-        {
-          referenceToLCIAMethodDataSet: { '@refObjectId': 'lcia-1', '@version': '1.0.0' },
-          meanAmount: undefined,
-        },
-      ]);
-    });
-    await act(async () => {
-      await proFormApi?.submit();
-    });
-
-    expect(mockUpdateProcess).toHaveBeenCalledWith(
-      'process-1',
-      '1.0.0',
-      expect.objectContaining({
-        LCIAResults: {
-          LCIAResult: [
-            {
-              referenceToLCIAMethodDataSet: {
-                '@refObjectId': 'lcia-1',
-                '@version': '1.0.0',
-              },
-              meanAmount: '',
-            },
-          ],
-        },
-      }),
-    );
+    expect(latestProcessFormProps).not.toHaveProperty('onLciaResults');
   });
 
   it('ignores reference updates and saves until the process payload has loaded', async () => {

--- a/tests/unit/pages/Processes/Components/edit.test.tsx
+++ b/tests/unit/pages/Processes/Components/edit.test.tsx
@@ -1860,14 +1860,13 @@ describe('ProcessEdit component', () => {
     expect(mockSubmitDatasetReview).not.toHaveBeenCalled();
   });
 
-  it('passes solver-backed LCIA props to the shared process form', async () => {
+  it('passes process identity for the shared LCIA panel to the process form', async () => {
     render(<ProcessEdit {...baseProps} />);
 
     fireEvent.click(screen.getByRole('button'));
     await screen.findByRole('dialog', { name: 'Edit process' });
 
     expect(latestProcessFormProps).toMatchObject({
-      lciaResultsMode: 'solver',
       processId: 'process-1',
       processVersion: '1.0.0',
     });

--- a/tests/unit/pages/Processes/Components/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/form.test.tsx
@@ -1588,6 +1588,19 @@ describe('ProcessForm component', () => {
     rerender(
       <ProcessForm
         {...defaultProps}
+        activeTabKey='processInformation'
+        showRules
+        sdkValidationDetails={[rootDetail]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Please input reference year')).toHaveLength(1);
+    });
+
+    rerender(
+      <ProcessForm
+        {...defaultProps}
         activeTabKey='exchanges'
         sdkValidationDetails={[exchangeDetail]}
         sdkValidationFocus={exchangeDetail}

--- a/tests/unit/pages/Processes/Components/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/form.test.tsx
@@ -19,6 +19,7 @@ const mockProcessExchangeCreate = jest.fn();
 const mockProcessExchangeEdit = jest.fn();
 const mockProcessExchangeDelete = jest.fn();
 const mockProcessExchangeView = jest.fn();
+const mockProcessLciaResultsPanel = jest.fn();
 const mockSourceSelectForm = jest.fn();
 const mockGetLangText = jest.fn(() => 'text');
 const mockJsonToList = jest.fn((value: any) =>
@@ -142,6 +143,14 @@ jest.mock('@/components/ToolBarButton', () => ({
       {toText(tooltip) || 'button'}
     </button>
   ),
+}));
+
+jest.mock('@/pages/Processes/Components/processLciaResultsPanel', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    mockProcessLciaResultsPanel(props);
+    return <div data-testid='process-lcia-results-panel'>process-lcia-results-panel</div>;
+  },
 }));
 
 jest.mock('@/pages/Flows/Components/select/form', () => ({
@@ -459,6 +468,7 @@ describe('ProcessForm component', () => {
     (globalThis as any).__TEST_PROCESS_FORM_INSTANCE__ = createMockFormInstance();
     defaultProps.formRef = { current: (globalThis as any).__TEST_PROCESS_FORM_INSTANCE__ };
     mockSourceSelectForm.mockClear();
+    mockProcessLciaResultsPanel.mockClear();
     mockGetLangText.mockReset();
     mockGetLangText.mockReturnValue('text');
     mockGetProcessExchange.mockReset();
@@ -1008,6 +1018,34 @@ describe('ProcessForm component', () => {
       expect(onLciaResults).toHaveBeenCalledWith([]);
     });
     expect(mockGetReferenceQuantityFromMethod).not.toHaveBeenCalled();
+  });
+
+  it('renders the shared solver-backed LCIA panel in solver mode', async () => {
+    render(
+      <ProcessForm
+        {...defaultProps}
+        activeTabKey='lciaResults'
+        lciaResultsMode='solver'
+        processId='process-1'
+        processVersion='1.0.0'
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockGetReferenceQuantityFromMethod).toHaveBeenCalled();
+    });
+    expect(screen.getByTestId('process-lcia-results-panel')).toBeInTheDocument();
+    expect(mockProcessLciaResultsPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseRows: [],
+        lang: 'en',
+        processId: 'process-1',
+        processVersion: '1.0.0',
+      }),
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Calculate LCIA Results' }),
+    ).not.toBeInTheDocument();
   });
 
   it('loads input exchanges, resolves units, and injects flow state metadata', async () => {

--- a/tests/unit/pages/Processes/Components/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/form.test.tsx
@@ -39,6 +39,9 @@ const createMockFormInstance = () => {
       fields.forEach((field) => {
         errorStore.set(normalizeFieldName(field.name), [...(field.errors ?? [])]);
       });
+      ((globalThis as any).__TEST_PROCESS_FORM_LISTENERS__ ?? []).forEach((notify: () => void) =>
+        notify(),
+      );
     }),
   };
 };
@@ -70,7 +73,6 @@ jest.mock('umi', () => ({
 
 jest.mock('@ant-design/icons', () => ({
   __esModule: true,
-  CalculatorOutlined: () => <span data-testid='icon-calculator' />,
   CloseOutlined: () => <span data-testid='icon-close' />,
 }));
 
@@ -116,21 +118,6 @@ jest.mock('@/services/general/util', () => ({
   jsonToList: (...args: any[]) => mockJsonToList(...args),
 }));
 
-jest.mock('@/services/lciaMethods/util', () => {
-  const mockLCIAResultCalculation = jest.fn(() => Promise.resolve([{ key: '1', meanAmount: 12 }]));
-  const mockGetReferenceQuantityFromMethod = jest.fn(() => Promise.resolve());
-  return {
-    __esModule: true,
-    default: mockLCIAResultCalculation,
-    LCIAResultCalculation: mockLCIAResultCalculation,
-    getReferenceQuantityFromMethod: mockGetReferenceQuantityFromMethod,
-  };
-});
-
-const { default: mockLCIAResultCalculation } = jest.requireMock('@/services/lciaMethods/util');
-const { getReferenceQuantityFromMethod: mockGetReferenceQuantityFromMethod } = jest.requireMock(
-  '@/services/lciaMethods/util',
-);
 const { getProcessExchange: mockGetProcessExchange } = jest.requireMock('@/services/processes/api');
 const { getFlowStateCodeByIdsAndVersions: mockGetFlowStateCodeByIdsAndVersions } =
   jest.requireMock('@/services/flows/api');
@@ -327,7 +314,27 @@ jest.mock('antd', () => {
   );
 
   const FormComponent = ({ children }: any) => <form>{children}</form>;
-  FormComponent.Item = ({ children, name }: any) => {
+  const FormItem = ({ children, name }: any) => {
+    const [, forceRender] = React.useState(0);
+    const notifyRef = React.useRef<() => void>();
+    const listeners = ((globalThis as any).__TEST_PROCESS_FORM_LISTENERS__ ??= new Set<
+      () => void
+    >());
+
+    if (!notifyRef.current) {
+      notifyRef.current = () => forceRender((renderCount: number) => renderCount + 1);
+    }
+
+    listeners.add(notifyRef.current);
+
+    React.useEffect(() => {
+      return () => {
+        if (notifyRef.current) {
+          listeners.delete(notifyRef.current);
+        }
+      };
+    }, [listeners]);
+
     const activeFormInstance = (globalThis as any).__TEST_PROCESS_FORM_INSTANCE__;
     const rawErrors =
       name && typeof activeFormInstance?.getFieldError === 'function'
@@ -348,6 +355,7 @@ jest.mock('antd', () => {
       </div>
     );
   };
+  FormComponent.Item = FormItem;
   const MockFormList = ({ children, name, initialValue = [], rules = [] }: any) => {
     const initialCount = initialValue.length > 0 ? initialValue.length : 1;
     const [fieldCount, setFieldCount] = React.useState(initialCount);
@@ -443,7 +451,6 @@ const defaultProps = {
   onExchangeData: jest.fn(),
   onExchangeDataCreate: jest.fn(),
   onTabChange: jest.fn(),
-  onLciaResults: jest.fn(),
   exchangeDataSource: [sampleExchange],
   formType: 'create',
   showRules: false,
@@ -465,6 +472,7 @@ describe('ProcessForm component', () => {
     proTableInstances.length = 0;
     Object.keys(formListInstances).forEach((key) => delete formListInstances[key]);
     mockRefCheckContextValue = { refCheckData: [] };
+    (globalThis as any).__TEST_PROCESS_FORM_LISTENERS__ = new Set();
     (globalThis as any).__TEST_PROCESS_FORM_INSTANCE__ = createMockFormInstance();
     defaultProps.formRef = { current: (globalThis as any).__TEST_PROCESS_FORM_INSTANCE__ };
     mockSourceSelectForm.mockClear();
@@ -477,10 +485,6 @@ describe('ProcessForm component', () => {
     mockGetUnitData.mockResolvedValue([]);
     mockGetFlowStateCodeByIdsAndVersions.mockReset();
     mockGetFlowStateCodeByIdsAndVersions.mockResolvedValue({ error: null, data: [] });
-    mockLCIAResultCalculation.mockReset();
-    mockLCIAResultCalculation.mockResolvedValue([{ key: '1', meanAmount: 12 }]);
-    mockGetReferenceQuantityFromMethod.mockReset();
-    mockGetReferenceQuantityFromMethod.mockResolvedValue();
   });
 
   it('marks rows with issues when rules are enabled', async () => {
@@ -918,7 +922,6 @@ describe('ProcessForm component', () => {
     );
 
     await waitFor(() => {
-      expect(mockGetReferenceQuantityFromMethod).toHaveBeenCalled();
       expect(screen.getByText('Enter this in the correct format')).toBeInTheDocument();
       expect(screen.getByTestId('review-form')).toBeInTheDocument();
     });
@@ -976,64 +979,16 @@ describe('ProcessForm component', () => {
     });
   });
 
-  it('calculates LCIA results when toolbar button is clicked', async () => {
-    const onLciaResults = jest.fn();
-    const exchangeData = [{ id: 'exchange-1' }];
-
+  it('renders the shared LCIA panel without exposing local calculation', () => {
     render(
       <ProcessForm
         {...defaultProps}
         activeTabKey='lciaResults'
-        onLciaResults={onLciaResults}
-        exchangeDataSource={exchangeData}
-      />,
-    );
-
-    const calculateButton = screen.getByRole('button', { name: 'Calculate LCIA Results' });
-    fireEvent.click(calculateButton);
-
-    await waitFor(() => {
-      expect(mockLCIAResultCalculation).toHaveBeenCalledWith(exchangeData);
-      expect(onLciaResults).toHaveBeenCalledWith([{ key: '1', meanAmount: 12 }]);
-    });
-  });
-
-  it('returns an empty LCIA payload when calculation resolves to null', async () => {
-    const onLciaResults = jest.fn();
-    mockLCIAResultCalculation.mockResolvedValueOnce(null);
-
-    render(
-      <ProcessForm
-        {...defaultProps}
-        activeTabKey='lciaResults'
-        onLciaResults={onLciaResults}
-        exchangeDataSource={[{ id: 'exchange-2' }]}
-      />,
-    );
-
-    mockGetReferenceQuantityFromMethod.mockClear();
-    fireEvent.click(screen.getByRole('button', { name: 'Calculate LCIA Results' }));
-
-    await waitFor(() => {
-      expect(onLciaResults).toHaveBeenCalledWith([]);
-    });
-    expect(mockGetReferenceQuantityFromMethod).not.toHaveBeenCalled();
-  });
-
-  it('renders the shared solver-backed LCIA panel in solver mode', async () => {
-    render(
-      <ProcessForm
-        {...defaultProps}
-        activeTabKey='lciaResults'
-        lciaResultsMode='solver'
         processId='process-1'
         processVersion='1.0.0'
       />,
     );
 
-    await waitFor(() => {
-      expect(mockGetReferenceQuantityFromMethod).toHaveBeenCalled();
-    });
     expect(screen.getByTestId('process-lcia-results-panel')).toBeInTheDocument();
     expect(mockProcessLciaResultsPanel).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1259,7 +1214,7 @@ describe('ProcessForm component', () => {
     unmount();
   });
 
-  it('syncs reference quantities whenever lciaResults prop changes', async () => {
+  it('passes updated LCIA rows through to the shared panel', () => {
     const initialResults = [
       {
         key: 'lcia-1',
@@ -1273,11 +1228,11 @@ describe('ProcessForm component', () => {
       <ProcessForm {...defaultProps} activeTabKey='lciaResults' lciaResults={initialResults} />,
     );
 
-    await waitFor(() => {
-      expect(mockGetReferenceQuantityFromMethod).toHaveBeenCalledWith([
-        expect.objectContaining({ key: 'lcia-1' }),
-      ]);
-    });
+    expect(mockProcessLciaResultsPanel).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        baseRows: [expect.objectContaining({ key: 'lcia-1' })],
+      }),
+    );
 
     const nextResults = [
       {
@@ -1292,16 +1247,14 @@ describe('ProcessForm component', () => {
       <ProcessForm {...defaultProps} activeTabKey='lciaResults' lciaResults={nextResults} />,
     );
 
-    await waitFor(() => {
-      expect(mockGetReferenceQuantityFromMethod).toHaveBeenCalledWith([
-        expect.objectContaining({ key: 'lcia-2' }),
-      ]);
-    });
-
-    expect(screen.getByTestId('pro-row-lcia-2')).toBeInTheDocument();
+    expect(mockProcessLciaResultsPanel).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        baseRows: [expect.objectContaining({ key: 'lcia-2' })],
+      }),
+    );
   });
 
-  it('falls back to a dash when the LCIA reference quantity label is empty', async () => {
+  it('passes LCIA rows with missing reference quantity labels through to the shared panel', () => {
     mockGetLangText.mockImplementation((value: any) =>
       value === 'missing-quantity' ? '' : 'text',
     );
@@ -1322,11 +1275,11 @@ describe('ProcessForm component', () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId('pro-row-lcia-empty')).toBeInTheDocument();
-    });
-
-    expect(within(screen.getByTestId('pro-row-lcia-empty')).getAllByText('-')).toHaveLength(2);
+    expect(mockProcessLciaResultsPanel).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        baseRows: [expect.objectContaining({ key: 'lcia-empty' })],
+      }),
+    );
   });
 
   it('validates and mutates modelling data-source references through the form list controls', async () => {

--- a/tests/unit/pages/Processes/Components/processLciaResultsPanel.test.tsx
+++ b/tests/unit/pages/Processes/Components/processLciaResultsPanel.test.tsx
@@ -1,0 +1,186 @@
+// @ts-nocheck
+import ProcessLciaResultsPanel from '@/pages/Processes/Components/processLciaResultsPanel';
+import { act, render, screen, waitFor } from '@testing-library/react';
+
+const mockGetDataSource = jest.fn();
+const mockGetLangText = jest.fn();
+const mockGetReferenceQuantityFromMethod = jest.fn();
+const mockQueryLcaResults = jest.fn();
+const mockIsLcaFunctionInvokeError = jest.fn();
+const mockUseLocation = jest.fn();
+
+const toText = (node: any): string => {
+  if (node === null || node === undefined) return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(toText).join('');
+  if (node?.props?.defaultMessage) return node.props.defaultMessage;
+  if (node?.props?.id) return node.props.id;
+  if (node?.props?.children) return toText(node.props.children);
+  return '';
+};
+
+jest.mock('umi', () => ({
+  __esModule: true,
+  FormattedMessage: ({ defaultMessage, id }: any) => defaultMessage ?? id,
+  useLocation: () => mockUseLocation(),
+}));
+
+jest.mock('@/services/general/util', () => ({
+  __esModule: true,
+  getDataSource: (...args: any[]) => mockGetDataSource(...args),
+  getLangJson: (value: any) => value,
+  getLangText: (...args: any[]) => mockGetLangText(...args),
+}));
+
+jest.mock('@/services/lciaMethods/util', () => ({
+  __esModule: true,
+  cacheAndDecompressMethod: jest.fn(),
+  getDecompressedMethod: jest.fn(),
+  getReferenceQuantityFromMethod: (...args: any[]) => mockGetReferenceQuantityFromMethod(...args),
+}));
+
+jest.mock('@/services/lca', () => ({
+  __esModule: true,
+  isLcaFunctionInvokeError: (...args: any[]) => mockIsLcaFunctionInvokeError(...args),
+  queryLcaResults: (...args: any[]) => mockQueryLcaResults(...args),
+}));
+
+jest.mock('@/components/AlignedNumber', () => ({
+  __esModule: true,
+  default: ({ value }: any) => <span data-testid='aligned-number'>{value}</span>,
+}));
+
+jest.mock('@/pages/Processes/Components/lcaProfileSummary', () => ({
+  __esModule: true,
+  default: ({ loading, rows }: any) => (
+    <div data-testid='lca-profile-summary' data-loading={String(loading)}>
+      {rows.length}
+    </div>
+  ),
+}));
+
+jest.mock('@ant-design/pro-components', () => ({
+  __esModule: true,
+  ProTable: ({ columns = [], dataSource = [], rowKey }: any) => {
+    const resolveRowKey = (row: any, index: number) => {
+      if (typeof rowKey === 'function') return rowKey(row);
+      if (typeof rowKey === 'string') return row?.[rowKey];
+      return row.key ?? index;
+    };
+
+    return (
+      <div data-testid='pro-table'>
+        {dataSource.map((row: any, rowIndex: number) => (
+          <div
+            key={resolveRowKey(row, rowIndex)}
+            data-testid={`pro-row-${resolveRowKey(row, rowIndex)}`}
+          >
+            {columns.map((column: any, columnIndex: number) => (
+              <span key={column.dataIndex ?? columnIndex}>
+                {column.render
+                  ? column.render(row[column.dataIndex], row, rowIndex)
+                  : toText(row[column.dataIndex])}
+              </span>
+            ))}
+          </div>
+        ))}
+      </div>
+    );
+  },
+}));
+
+jest.mock('antd', () => {
+  const Button = ({ children, loading, onClick }: any) => (
+    <button type='button' data-loading={String(loading)} onClick={onClick}>
+      {toText(children)}
+    </button>
+  );
+  const Space = ({ children }: any) => <div>{children}</div>;
+  const Tooltip = ({ children }: any) => <>{children}</>;
+  const Typography = {
+    Text: ({ children, type }: any) => (
+      <span data-testid={`typography-${type ?? 'default'}`}>{children}</span>
+    ),
+  };
+
+  return {
+    __esModule: true,
+    Button,
+    Space,
+    Tooltip,
+    Typography,
+  };
+});
+
+describe('ProcessLciaResultsPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetDataSource.mockReturnValue('');
+    mockGetLangText.mockImplementation((value: any) => {
+      if (typeof value === 'string') return value;
+      if (typeof value?.['#text'] === 'string') return value['#text'];
+      return '';
+    });
+    mockGetReferenceQuantityFromMethod.mockResolvedValue(undefined);
+    mockIsLcaFunctionInvokeError.mockReturnValue(false);
+    mockQueryLcaResults.mockResolvedValue({
+      snapshot_id: 'snapshot-1',
+      result_id: 'result-1',
+      source: 'latest_ready',
+      meta: { computed_at: '2026-04-28T00:00:00Z' },
+      data: { values: [] },
+    });
+    mockUseLocation.mockReturnValue({ pathname: '/mydata/processes', search: '' });
+  });
+
+  it('normalizes missing base rows and queries solver without optional version or scope', async () => {
+    mockUseLocation.mockReturnValue({ pathname: undefined, search: '' });
+
+    render(<ProcessLciaResultsPanel baseRows={undefined} lang='en' processId='process-1' />);
+
+    await waitFor(() =>
+      expect(mockQueryLcaResults).toHaveBeenCalledWith({
+        scope: 'dev-v1',
+        mode: 'process_all_impacts',
+        process_id: 'process-1',
+        allow_fallback: false,
+      }),
+    );
+
+    expect(mockGetDataSource).toHaveBeenCalledWith('');
+    expect(screen.getByTestId('pro-table')).toBeInTheDocument();
+  });
+
+  it('skips state updates when base-row enrichment resolves after unmount', async () => {
+    let resolveReferenceQuantity: () => void = () => {};
+    mockGetReferenceQuantityFromMethod.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveReferenceQuantity = resolve;
+        }),
+    );
+
+    const { unmount } = render(
+      <ProcessLciaResultsPanel
+        baseRows={[
+          {
+            key: 'base-row',
+            meanAmount: 3,
+            referenceToLCIAMethodDataSet: { '@refObjectId': 'impact-1' },
+          },
+        ]}
+        enableSolverRefresh={false}
+        lang='en'
+      />,
+    );
+
+    unmount();
+
+    await act(async () => {
+      resolveReferenceQuantity();
+    });
+
+    expect(mockGetReferenceQuantityFromMethod).toHaveBeenCalledTimes(1);
+    expect(mockQueryLcaResults).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#376

## Summary
- Remove the local calculate action from process edit/create/copy LCIA Results tabs.
- Render process-form LCIA results through the same shared summary/table experience used by process view.
- Stop create/copy from writing browser-calculated LCIA results into saved process payloads.

## Key Decisions
- Use `ProcessLciaResultsPanel` for the shared process-form LCIA tab instead of keeping a separate local ProTable/calculation mode.
- Pass stored dataset LCIA rows into the shared panel as fallback data, with solver-backed latest results used when a process identity is available.
- Leave lifecycle-model service calculation behavior unchanged; this change removes process-form UI entrypoints and create/copy writeback only.
- Harden shared method-metadata lookup so missing LCIA method cache data falls back to empty metadata instead of breaking the tab.

## Validation
- npm run test:ci -- tests/unit/pages/Processes/Components/form.test.tsx tests/unit/pages/Processes/Components/create.test.tsx tests/unit/pages/Processes/Components/edit.test.tsx tests/unit/pages/Processes/Components/view.test.tsx tests/unit/pages/Processes/Components/lcaAnalysisShared.test.ts
- npm run lint
- npm run build

## Risks / Rollback
- Low to medium: the LCIA result UI flow is shared by process view and process form tabs, so regressions would affect multiple process surfaces; focused unit coverage was updated for form/create/edit/view paths.

## Follow-ups
- After merge, update the lca-workspace submodule pointer before considering the delivery complete.

## Workspace Integration
- Workspace integration remains pending until lca-workspace bumps tiangong-lca-next to the merged commit.
