### PR TITLE
test: fix process view card selector

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-04-29"
-lastReviewedCommit: "bad2cb204202598df3df5418386fefe7cd1c3212"
+lastReviewedCommit: "b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: bad2cb204202598df3df5418386fefe7cd1c3212
+lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: bad2cb204202598df3df5418386fefe7cd1c3212
+lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .github/workflows/**
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: bad2cb204202598df3df5418386fefe7cd1c3212
+lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: bad2cb204202598df3df5418386fefe7cd1c3212
+lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: bad2cb204202598df3df5418386fefe7cd1c3212
+lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: bad2cb204202598df3df5418386fefe7cd1c3212
+lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/helpers/**
   - package.json
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: bad2cb204202598df3df5418386fefe7cd1c3212
+lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: bad2cb204202598df3df5418386fefe7cd1c3212
+lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
 ---
 
 # Testing Troubleshooting

--- a/tests/unit/pages/Processes/Components/view.test.tsx
+++ b/tests/unit/pages/Processes/Components/view.test.tsx
@@ -464,7 +464,7 @@ describe('ProcessView component', () => {
     fireEvent.click(lciaTab);
 
     await waitFor(() => {
-      expect(screen.getByTestId('card')).toHaveAttribute('data-active-key', 'lciaResults');
+      expect(screen.getAllByTestId('card')[0]).toHaveAttribute('data-active-key', 'lciaResults');
     });
 
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- Disambiguate the mocked Ant Design Card assertion in `ProcessView` tab-switch test.
- Fixes the selector ambiguity that caused `lint-and-test` to fail after the dev -> main promote.
- Record docpact review evidence for the governed testing/gate docs required by `next-testing-and-gate-contract`.

## Validation
- `npm run test:ci -- tests/unit/pages/Processes/Components/view.test.tsx --runInBand`
- `npx eslint --cache --ext .js,.jsx,.ts,.tsx --format=stylish tests/unit/pages/Processes/Components/view.test.tsx`
- `docpact lint --root . --base 32aff37eef2d514be2b55c4b66e4c90f2a585b8a --head HEAD --mode enforce`

## Tracking
- Refs tiangong-lca/workspace#72
- Follow-up for failed main workflow run 25091685817 / job 73518931843.

## Notes
- Base branch is `dev` per request. After this lands and passes, the fix still needs to reach `main` before the workspace pointer is updated to a green promoted commit.