### PR TITLE
chore: promote notification CI fix to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-04-29"
-lastReviewedCommit: "bad2cb204202598df3df5418386fefe7cd1c3212"
+lastReviewedCommit: "b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: bad2cb204202598df3df5418386fefe7cd1c3212
+lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: bad2cb204202598df3df5418386fefe7cd1c3212
+lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .github/workflows/**
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: bad2cb204202598df3df5418386fefe7cd1c3212
+lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: bad2cb204202598df3df5418386fefe7cd1c3212
+lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: bad2cb204202598df3df5418386fefe7cd1c3212
+lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: bad2cb204202598df3df5418386fefe7cd1c3212
+lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/helpers/**
   - package.json
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: bad2cb204202598df3df5418386fefe7cd1c3212
+lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: bad2cb204202598df3df5418386fefe7cd1c3212
+lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
 ---
 
 # Testing Troubleshooting

--- a/tests/unit/pages/Processes/Components/view.test.tsx
+++ b/tests/unit/pages/Processes/Components/view.test.tsx
@@ -464,7 +464,7 @@ describe('ProcessView component', () => {
     fireEvent.click(lciaTab);
 
     await waitFor(() => {
-      expect(screen.getByTestId('card')).toHaveAttribute('data-active-key', 'lciaResults');
+      expect(screen.getAllByTestId('card')[0]).toHaveAttribute('data-active-key', 'lciaResults');
     });
 
     await waitFor(() => {


### PR DESCRIPTION
## Promotion Contract

- base branch: `main`
- source branch: `dev` content via fork branch `ForeverYoung5:codex/promote-dev-to-main-issue-72-ci-fix`
- validated environment before promotion: `dev` PR checks for #381 (`ai-doc-lint`, `Full Gate`) plus local promotion diff checks
- back-merge required after merge: `No` (normal `dev -> main` promotion)
- root workspace integration expected: `Yes` after the promoted `tiangong-lca-next/main` SHA is available for `lca-workspace` submodule integration

- [x] this PR promotes `dev` into `main`
- [x] integrated behavior was verified in `dev` before promotion
- [x] if the PR includes a direct `main` hotfix path, the required `main -> dev` back-merge plan is documented

## Linked Issue

Refs tiangong-lca/workspace#72
Refs #381
Refs #380

This PR intentionally does not close the workspace issue because root submodule integration remains pending after the frontend promotion merges.

## Promotion Facts

Promotes the dev-first follow-up fix for the main `lint-and-test` failure seen after #380.

Included source PR:

- #381 `test: fix process view card selector`

The promoted change disambiguates the mocked Ant Design Card selector in the `ProcessView` tab-switch test and records the required docpact review evidence for the testing/gate governed docs.

## Validation Facts

Source PR #381 is merged to `dev` with checks passing:

- `ai-doc-lint`
- `Full Gate`

Local promotion checks before opening this PR:

- `git diff --check origin/main...HEAD`
- merge-tree conflict preview for `origin/main` + latest `origin/dev` showed no conflict markers

No additional code changes are introduced in this promotion PR beyond promoting the current `dev` content.

## Integration And Follow-Up

After this promotion merges and `main` checks pass, update the root `lca-workspace` submodule pointer in workspace PR #82 from the failed main SHA (`59c1ebf`) to the green promoted `tiangong-lca-next/main` SHA.
