### PR TITLE
fix: improve responsive data table layouts

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-04-29"
-lastReviewedCommit: "b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38"
+lastReviewedCommit: "6ae7b0addeca213bece99a8127235cdeb2c73b93"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
+lastReviewedCommit: 6ae7b0addeca213bece99a8127235cdeb2c73b93
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
+lastReviewedCommit: f7bccdded90e0e6e2d937e78782a09b911df5fe2
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .github/workflows/**
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
+lastReviewedCommit: 6ae7b0addeca213bece99a8127235cdeb2c73b93
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: bad2cb204202598df3df5418386fefe7cd1c3212
+lastReviewedCommit: 6ae7b0addeca213bece99a8127235cdeb2c73b93
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
+lastReviewedCommit: 6ae7b0addeca213bece99a8127235cdeb2c73b93
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
+lastReviewedCommit: 6ae7b0addeca213bece99a8127235cdeb2c73b93
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
+lastReviewedCommit: 6ae7b0addeca213bece99a8127235cdeb2c73b93
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/helpers/**
   - package.json
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
+lastReviewedCommit: 6ae7b0addeca213bece99a8127235cdeb2c73b93
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-04-29
-lastReviewedCommit: b2cc7ceb7d97e81a6d9bb89d22c6b709ab853f38
+lastReviewedCommit: 6ae7b0addeca213bece99a8127235cdeb2c73b93
 ---
 
 # Testing Troubleshooting

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -123,15 +123,7 @@ export const layout: RunTimeLayoutConfig = ({ initialState, setInitialState }) =
       render: () => {
         return (
           <AvatarDropdown>
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                height: '48px',
-                padding: '0 12px',
-                cursor: 'pointer',
-              }}
-            >
+            <div className='tg-global-header-avatar-trigger'>
               <AvatarName />
             </div>
           </AvatarDropdown>

--- a/src/components/HeaderDropdown/index.tsx
+++ b/src/components/HeaderDropdown/index.tsx
@@ -1,4 +1,4 @@
-import { Dropdown, theme } from 'antd';
+import { Dropdown } from 'antd';
 import type { DropDownProps } from 'antd/es/dropdown';
 import React from 'react';
 
@@ -7,12 +7,21 @@ export type HeaderDropdownProps = {
   placement?: 'bottomLeft' | 'bottomRight' | 'topLeft' | 'topCenter' | 'topRight' | 'bottomCenter';
 } & Omit<DropDownProps, 'overlay'>;
 
-const HeaderDropdown: React.FC<HeaderDropdownProps> = ({ overlayClassName: cls, ...restProps }) => {
-  const { token } = theme.useToken();
+const HeaderDropdown: React.FC<HeaderDropdownProps> = ({
+  overlayClassName: cls,
+  overlayStyle,
+  placement = 'bottomRight',
+  ...restProps
+}) => {
   return (
     <Dropdown
       overlayClassName={cls}
-      overlayStyle={{ width: window.innerWidth <= token.screenXS ? '100%' : undefined }}
+      overlayStyle={{
+        minWidth: 168,
+        maxWidth: 'calc(100vw - 24px)',
+        ...overlayStyle,
+      }}
+      placement={placement}
       {...restProps}
     />
   );

--- a/src/components/ResponsiveDataList/index.less
+++ b/src/components/ResponsiveDataList/index.less
@@ -1,0 +1,127 @@
+.responsive-data-list-table {
+  .responsive-data-list-cell-text {
+    display: block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .responsive-data-list-actions {
+    display: inline-flex;
+    max-width: 100%;
+    align-items: center;
+    justify-content: flex-end;
+    white-space: nowrap;
+  }
+
+  .responsive-data-list-more-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .responsive-data-list-toolbar-more-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .responsive-data-list-action-column {
+    white-space: nowrap;
+  }
+}
+
+@media (max-width: 768px) {
+  .responsive-data-list-search-card {
+    margin-bottom: 16px;
+
+    .responsive-data-list-search-primary {
+      min-width: 0;
+      margin-right: 0 !important;
+    }
+
+    .responsive-data-list-search-extra {
+      display: flex;
+      align-items: center;
+      white-space: nowrap;
+    }
+  }
+
+  .responsive-data-list-table {
+    max-width: 100%;
+    overflow: hidden;
+
+    .ant-pro-card,
+    .ant-pro-card-body,
+    .ant-table-wrapper {
+      max-width: 100%;
+      min-width: 0;
+    }
+
+    .ant-pro-table-list-toolbar-container {
+      align-items: flex-start;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .ant-pro-table-list-toolbar-left {
+      min-width: 0;
+      width: 100%;
+      flex: 0 0 auto;
+      margin-block-end: 0;
+    }
+
+    .ant-pro-table-list-toolbar-title {
+      white-space: normal;
+    }
+
+    .ant-pro-table-list-toolbar-setting-items {
+      min-width: 0;
+      flex-wrap: nowrap;
+      gap: 8px;
+    }
+
+    .ant-pro-table-list-toolbar-right {
+      min-width: 0;
+      width: 100%;
+      flex: 0 0 auto;
+      flex-wrap: nowrap;
+      justify-content: flex-end;
+      overflow-x: auto;
+      overflow-y: hidden;
+      padding-bottom: 2px;
+
+      > * {
+        flex: 0 0 auto;
+      }
+    }
+
+    .ant-table-thead > tr > th,
+    .ant-table-tbody > tr > td {
+      white-space: normal;
+    }
+
+    .responsive-data-list-action-column {
+      white-space: nowrap;
+    }
+
+    .ant-table-cell {
+      padding: 10px 8px;
+    }
+  }
+}
+
+@media (max-width: 575px) {
+  .responsive-data-list-search-card {
+    .responsive-data-list-search-primary {
+      flex: 1 1 100% !important;
+      margin-bottom: 8px;
+    }
+
+    .responsive-data-list-search-extra {
+      flex: 1 1 100% !important;
+      width: 100%;
+    }
+  }
+}

--- a/src/components/ResponsiveDataList/index.tsx
+++ b/src/components/ResponsiveDataList/index.tsx
@@ -1,0 +1,166 @@
+import type { ProColumns } from '@ant-design/pro-components';
+import { TableDropdown } from '@ant-design/pro-components';
+import { Grid, Space, Tooltip, theme } from 'antd';
+import type { ReactNode } from 'react';
+import { Children } from 'react';
+
+import './index.less';
+
+export const DATA_LIST_ACTION_SPACE_CLASS_NAME = 'responsive-data-list-actions';
+
+export const DATA_LIST_COLUMN_RESPONSIVE = {
+  tablet: ['md'] as ProColumns<any>['responsive'],
+  desktop: ['lg'] as ProColumns<any>['responsive'],
+  wide: ['xl'] as ProColumns<any>['responsive'],
+};
+
+export const responsiveDataListTableProps = {
+  className: 'responsive-data-list-table',
+  scroll: { x: 'max-content' },
+  tableLayout: 'fixed' as const,
+};
+
+export const responsiveSearchCardClassName = 'responsive-data-list-search-card';
+
+export const responsiveSearchRowProps = {
+  align: 'middle' as const,
+};
+
+export const responsiveSearchPrimaryColProps = {
+  className: 'responsive-data-list-search-primary',
+  flex: 'auto',
+  style: { marginRight: '10px' },
+};
+
+export const responsiveSearchExtraColProps = {
+  className: 'responsive-data-list-search-extra',
+  flex: '100px',
+};
+
+export function dataListIndexColumn<T>(): Partial<ProColumns<T>> {
+  return {
+    align: 'center',
+    search: false,
+    width: 72,
+  };
+}
+
+export function dataListTextColumn<T>(
+  width: number,
+  responsive?: ProColumns<T>['responsive'],
+): Partial<ProColumns<T>> {
+  return {
+    ellipsis: true,
+    responsive,
+    width,
+  };
+}
+
+export function dataListActionColumn<T>(width = 184): Partial<ProColumns<T>> {
+  return {
+    align: 'center',
+    className: 'responsive-data-list-action-column',
+    fixed: 'right',
+    search: false,
+    width,
+  };
+}
+
+export type DataListActionMenu = {
+  key: string;
+  name: ReactNode;
+};
+
+export function useResponsiveDataListMobile() {
+  const useBreakpoint = Grid?.useBreakpoint ?? (() => ({}));
+  const screens = useBreakpoint();
+  return screens.md === false;
+}
+
+export function ResponsiveDataListActions({
+  isMobile,
+  children,
+  moreMenus = [],
+}: {
+  isMobile: boolean;
+  children: ReactNode;
+  moreMenus?: DataListActionMenu[];
+}) {
+  const { token } = theme.useToken();
+  const actions = Children.toArray(children).filter(Boolean);
+  const dropdownStyle = { color: token.colorPrimary };
+
+  if (isMobile) {
+    return (
+      <TableDropdown
+        className='responsive-data-list-more-action'
+        style={dropdownStyle}
+        menus={[
+          ...actions.map((name, index) => ({
+            key: `action-${index}`,
+            name,
+          })),
+          ...moreMenus,
+        ]}
+      />
+    );
+  }
+
+  return (
+    <Space className={DATA_LIST_ACTION_SPACE_CLASS_NAME} size='small'>
+      {actions}
+      {moreMenus.length > 0 && <TableDropdown style={dropdownStyle} menus={moreMenus} />}
+    </Space>
+  );
+}
+
+export function ResponsiveDataListToolbarMore({ children }: { children: ReactNode }) {
+  const { token } = theme.useToken();
+  const actions = Children.toArray(children).filter(Boolean);
+  const dropdownStyle = { color: token.colorPrimary };
+
+  if (actions.length === 0) {
+    return null;
+  }
+
+  return (
+    <span className='ant-pro-table-list-toolbar-setting-item responsive-data-list-toolbar-more-action'>
+      <TableDropdown
+        className='responsive-data-list-more-action'
+        style={dropdownStyle}
+        menus={actions.map((name, index) => ({
+          key: `toolbar-action-${index}`,
+          name,
+        }))}
+      />
+    </span>
+  );
+}
+
+const normalizeTextValue = (value: ReactNode) => {
+  if (value === undefined || value === null || value === '' || value === 'undefined') {
+    return '-';
+  }
+  return value;
+};
+
+export function dataListText(value: ReactNode, tooltip?: ReactNode) {
+  const content = normalizeTextValue(value);
+  const textTitle =
+    typeof content === 'string' || typeof content === 'number' ? String(content) : undefined;
+  const textNode = (
+    <span className='responsive-data-list-cell-text' title={textTitle}>
+      {content}
+    </span>
+  );
+
+  if (tooltip === undefined || tooltip === null || tooltip === '') {
+    return textNode;
+  }
+
+  return (
+    <Tooltip placement='topLeft' title={tooltip}>
+      {textNode}
+    </Tooltip>
+  );
+}

--- a/src/components/RightContent/AvatarDropdown.tsx
+++ b/src/components/RightContent/AvatarDropdown.tsx
@@ -27,19 +27,18 @@ export const AvatarName = () => {
   const { initialState } = useModel('@@initialState');
   const { currentUser } = initialState || {};
   const { token } = theme.useToken();
+  const displayName = currentUser?.name ?? '';
   return (
     <span
+      className='tg-global-header-avatar-name'
       style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        height: '100%',
-        lineHeight: 'inherit',
-        gap: '8px',
         color: token.colorText,
       }}
     >
       <UserOutlined />
-      {currentUser?.name}
+      <span className='tg-global-header-avatar-name-text' title={displayName}>
+        {displayName}
+      </span>
     </span>
   );
 };
@@ -266,6 +265,7 @@ export const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({ children }) =
   return (
     <>
       <HeaderDropdown
+        overlayClassName='tg-global-header-avatar-dropdown'
         menu={{
           selectedKeys: [],
           onClick: onMenuClick,

--- a/src/components/TableFilter/index.tsx
+++ b/src/components/TableFilter/index.tsx
@@ -1,4 +1,5 @@
 import { Select } from 'antd';
+import type { CSSProperties } from 'react';
 import { useIntl } from 'umi';
 
 type TableFilterValue = string | number;
@@ -13,15 +14,17 @@ const TABLE_FILTER_OPTIONS: { value: TableFilterValue; messageId: string }[] = [
 const TableFilter = ({
   onChange,
   disabled = false,
+  width = 140,
 }: {
   onChange: (value: TableFilterValue) => void;
   disabled?: boolean;
+  width?: CSSProperties['width'];
 }) => {
   const intl = useIntl();
 
   return (
     <div>
-      <Select disabled={disabled} defaultValue={'all'} style={{ width: 140 }} onChange={onChange}>
+      <Select disabled={disabled} defaultValue={'all'} style={{ width }} onChange={onChange}>
         {TABLE_FILTER_OPTIONS.map((option) => {
           const label = intl.formatMessage({ id: option.messageId });
 

--- a/src/global.less
+++ b/src/global.less
@@ -137,3 +137,146 @@ ol {
     }
   }
 }
+
+.ant-pro-top-nav-header {
+  .ant-pro-top-nav-header-main,
+  .ant-pro-top-nav-header-main-left,
+  .ant-pro-top-nav-header-logo,
+  .ant-pro-top-nav-header-logo > *:first-child,
+  .ant-pro-top-nav-header-menu {
+    min-width: 0;
+  }
+
+  .ant-pro-top-nav-header-main-left {
+    flex: 0 1 auto;
+  }
+
+  .ant-pro-top-nav-header-logo > *:first-child > h1 {
+    max-width: 220px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+}
+
+.ant-pro-global-header-right-content {
+  min-width: 0 !important;
+}
+
+.ant-pro-global-header-header-actions {
+  min-width: 0;
+}
+
+.ant-pro-global-header-header-actions-avatar {
+  min-width: 0;
+  flex: 0 1 auto;
+}
+
+.tg-global-header-avatar-dropdown {
+  max-width: calc(100vw - 24px);
+
+  .ant-dropdown-menu {
+    width: max-content;
+    min-width: 168px;
+    max-width: 220px;
+  }
+
+  .ant-dropdown-menu-title-content {
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+}
+
+.tg-global-header-avatar-trigger {
+  display: flex;
+  align-items: center;
+  height: 48px;
+  min-width: 0;
+  max-width: 160px;
+  padding: 0 12px;
+  overflow: hidden;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.tg-global-header-avatar-name {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  max-width: 100%;
+  height: 100%;
+  gap: 8px;
+  line-height: inherit;
+  white-space: nowrap;
+
+  .anticon {
+    flex: 0 0 auto;
+  }
+}
+
+.tg-global-header-avatar-name-text {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+@media (max-width: 768px) {
+  .ant-pro-top-nav-header {
+    .ant-pro-top-nav-header-main {
+      padding-inline-start: 8px;
+    }
+
+    .ant-pro-top-nav-header-main-left {
+      max-width: 38vw;
+      margin-inline-end: 8px;
+    }
+
+    .ant-pro-top-nav-header-logo > *:first-child > h1 {
+      max-width: calc(38vw - 46px);
+    }
+
+    .ant-pro-top-nav-header-menu {
+      padding-inline: 2px;
+    }
+  }
+
+  .ant-pro-global-header-header-actions-item {
+    padding-inline: 0;
+
+    > * {
+      padding-inline: 4px;
+    }
+  }
+
+  .ant-pro-global-header-header-actions-avatar {
+    padding-inline: 4px;
+  }
+
+  .tg-global-header-avatar-trigger {
+    max-width: 104px;
+    padding: 0 6px;
+  }
+
+  .tg-global-header-avatar-name {
+    gap: 4px;
+  }
+}
+
+@media (max-width: 430px) {
+  .ant-pro-top-nav-header {
+    .ant-pro-top-nav-header-main-left {
+      max-width: 96px;
+    }
+
+    .ant-pro-top-nav-header-logo > *:first-child > h1 {
+      max-width: 54px;
+    }
+  }
+
+  .tg-global-header-avatar-trigger {
+    max-width: 72px;
+  }
+}

--- a/src/pages/Contacts/index.tsx
+++ b/src/pages/Contacts/index.tsx
@@ -6,6 +6,20 @@ import {
 } from '@/components/ContributeData/utils';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
+import {
+  DATA_LIST_COLUMN_RESPONSIVE,
+  ResponsiveDataListActions,
+  dataListActionColumn,
+  dataListIndexColumn,
+  dataListText,
+  dataListTextColumn,
+  responsiveDataListTableProps,
+  responsiveSearchCardClassName,
+  responsiveSearchExtraColProps,
+  responsiveSearchPrimaryColProps,
+  responsiveSearchRowProps,
+  useResponsiveDataListMobile,
+} from '@/components/ResponsiveDataList';
 import TableFilter from '@/components/TableFilter';
 import {
   contact_hybrid_search,
@@ -18,14 +32,8 @@ import { ListPagination } from '@/services/general/data';
 import { getDataSource, getLang, getLangText, isDataUnderReview } from '@/services/general/util';
 import { getTeamById } from '@/services/teams/api';
 import { TeamTable } from '@/services/teams/data';
-import {
-  ActionType,
-  PageContainer,
-  ProColumns,
-  ProTable,
-  TableDropdown,
-} from '@ant-design/pro-components';
-import { Card, Checkbox, Col, Input, Row, Space, Tooltip, message, theme } from 'antd';
+import { ActionType, PageContainer, ProColumns, ProTable } from '@ant-design/pro-components';
+import { Card, Checkbox, Col, Input, Row, Space, message } from 'antd';
 import { SearchProps } from 'antd/es/input/Search';
 import type { FC } from 'react';
 import { useEffect, useRef, useState } from 'react';
@@ -45,7 +53,7 @@ const TableList: FC = () => {
   const [editDrawerVisible, setEditDrawerVisible] = useState<boolean>(false);
   const [editId, setEditId] = useState<string>('');
   const [editVersion, setEditVersion] = useState<string>('');
-  const { token } = theme.useToken();
+  const isMobileDataList = useResponsiveDataListMobile();
   const location = useLocation();
   const dataSource = getDataSource(location.pathname);
 
@@ -88,23 +96,21 @@ const TableList: FC = () => {
 
   const contactColumns: ProColumns<ContactTable>[] = [
     {
+      ...dataListIndexColumn<ContactTable>(),
       title: <FormattedMessage id='pages.table.title.index' defaultMessage='Index' />,
       dataIndex: 'index',
       valueType: 'index',
-      search: false,
     },
     {
+      ...dataListTextColumn<ContactTable>(280),
       title: <FormattedMessage id='pages.table.title.name' defaultMessage='Name' />,
       dataIndex: 'shortName',
       sorter: false,
       search: false,
-      render: (_, row) => [
-        <Tooltip key={0} placement='topLeft' title={row.name}>
-          {row.shortName}
-        </Tooltip>,
-      ],
+      render: (_, row) => dataListText(row.shortName, row.name),
     },
     {
+      ...dataListTextColumn<ContactTable>(260, DATA_LIST_COLUMN_RESPONSIVE.desktop),
       title: (
         <FormattedMessage id='pages.table.title.classification' defaultMessage='Classification' />
       ),
@@ -112,20 +118,18 @@ const TableList: FC = () => {
       sorter: false,
       search: false,
       render: (_, row) => {
-        return (
-          <div>
-            {row.classification && row.classification !== 'undefined' ? row.classification : '-'}
-          </div>
-        );
+        return dataListText(row.classification);
       },
     },
     {
+      ...dataListTextColumn<ContactTable>(220, DATA_LIST_COLUMN_RESPONSIVE.desktop),
       title: <FormattedMessage id='pages.contact.email' defaultMessage='E-mail' />,
       dataIndex: 'email',
       sorter: false,
       search: false,
     },
     {
+      ...dataListTextColumn<ContactTable>(132),
       title: <FormattedMessage id='pages.table.title.version' defaultMessage='Version' />,
       dataIndex: 'version',
       sorter: false,
@@ -165,6 +169,7 @@ const TableList: FC = () => {
       },
     },
     {
+      ...dataListTextColumn<ContactTable>(180, DATA_LIST_COLUMN_RESPONSIVE.wide),
       title: <FormattedMessage id='pages.table.title.updatedAt' defaultMessage='Updated at' />,
       dataIndex: 'modifiedAt',
       valueType: 'dateTime',
@@ -172,14 +177,66 @@ const TableList: FC = () => {
       search: false,
     },
     {
+      ...dataListActionColumn<ContactTable>(
+        isMobileDataList ? 72 : dataSource === 'my' ? 184 : 152,
+      ),
       title: <FormattedMessage id='pages.table.title.option' defaultMessage='Option' />,
       dataIndex: 'option',
-      search: false,
       render: (_, row) => {
         const actionDisabled = isDataUnderReview(row.stateCode);
         if (dataSource === 'my') {
           return [
-            <Space size={'small'} key={0}>
+            <ResponsiveDataListActions
+              key={0}
+              isMobile={isMobileDataList}
+              moreMenus={[
+                {
+                  key: 'export',
+                  name: <ExportData tableName='contacts' id={row.id} version={row.version} />,
+                },
+                {
+                  key: 'copy',
+                  name: (
+                    <ContactCreate
+                      actionType='copy'
+                      id={row.id}
+                      version={row.version}
+                      lang={lang}
+                      actionRef={actionRef}
+                    />
+                  ),
+                },
+                {
+                  key: 'contribute',
+                  name: (
+                    <ContributeData
+                      onOk={async () => {
+                        const contributeResult = await contributeSource(
+                          'contacts',
+                          row.id,
+                          row.version,
+                        );
+                        const contributeError = extractContributeDataError(contributeResult);
+
+                        if (contributeError) {
+                          message.error(getContributeDataErrorMessage(intl, contributeError));
+                          console.log(contributeError);
+                        } else {
+                          message.success(
+                            intl.formatMessage({
+                              id: 'component.contributeData.success',
+                              defaultMessage: 'Contribute successfully',
+                            }),
+                          );
+                          actionRef.current?.reload();
+                        }
+                      }}
+                      disabled={!!row.teamId}
+                    />
+                  ),
+                },
+              ]}
+            >
               <ContactView
                 id={row.id}
                 version={row.version}
@@ -205,63 +262,11 @@ const TableList: FC = () => {
                 actionRef={actionRef}
                 setViewDrawerVisible={() => {}}
               />
-              <TableDropdown
-                style={{
-                  color: token.colorPrimary,
-                }}
-                menus={[
-                  {
-                    key: 'export',
-                    name: <ExportData tableName='contacts' id={row.id} version={row.version} />,
-                  },
-                  {
-                    key: 'copy',
-                    name: (
-                      <ContactCreate
-                        actionType='copy'
-                        id={row.id}
-                        version={row.version}
-                        lang={lang}
-                        actionRef={actionRef}
-                      />
-                    ),
-                  },
-                  {
-                    key: 'contribute',
-                    name: (
-                      <ContributeData
-                        onOk={async () => {
-                          const contributeResult = await contributeSource(
-                            'contacts',
-                            row.id,
-                            row.version,
-                          );
-                          const contributeError = extractContributeDataError(contributeResult);
-
-                          if (contributeError) {
-                            message.error(getContributeDataErrorMessage(intl, contributeError));
-                            console.log(contributeError);
-                          } else {
-                            message.success(
-                              intl.formatMessage({
-                                id: 'component.contributeData.success',
-                                defaultMessage: 'Contribute successfully',
-                              }),
-                            );
-                            actionRef.current?.reload();
-                          }
-                        }}
-                        disabled={!!row.teamId}
-                      />
-                    ),
-                  },
-                ]}
-              />
-            </Space>,
+            </ResponsiveDataListActions>,
           ];
         }
         return [
-          <Space size={'small'} key={0}>
+          <ResponsiveDataListActions key={0} isMobile={isMobileDataList}>
             <ContactView
               id={row.id}
               version={row.version}
@@ -277,7 +282,7 @@ const TableList: FC = () => {
               actionRef={actionRef}
             />
             <ExportData tableName='contacts' id={row.id} version={row.version} />
-          </Space>,
+          </ResponsiveDataListActions>,
         ];
       },
     },
@@ -306,9 +311,9 @@ const TableList: FC = () => {
         breadcrumb: {},
       }}
     >
-      <Card>
-        <Row align={'middle'}>
-          <Col flex='auto' style={{ marginRight: '10px' }}>
+      <Card className={responsiveSearchCardClassName}>
+        <Row {...responsiveSearchRowProps}>
+          <Col {...responsiveSearchPrimaryColProps}>
             <Search
               size={'large'}
               placeholder={
@@ -320,7 +325,7 @@ const TableList: FC = () => {
               enterButton
             />
           </Col>
-          <Col style={{ display: 'none' }} flex='100px'>
+          <Col {...responsiveSearchExtraColProps} style={{ display: 'none' }}>
             <Checkbox
               onChange={(e) => {
                 setOpenAI(e.target.checked);
@@ -332,6 +337,7 @@ const TableList: FC = () => {
         </Row>
       </Card>
       <ProTable<ContactTable, ListPagination>
+        {...responsiveDataListTableProps}
         rowKey={(record) => `${record.id}-${record.version}`}
         headerTitle={
           <>
@@ -341,21 +347,25 @@ const TableList: FC = () => {
         }
         actionRef={actionRef}
         search={false}
-        options={{ fullScreen: true }}
+        options={isMobileDataList ? false : { fullScreen: true }}
         pagination={{
           showSizeChanger: false,
           pageSize: 10,
         }}
         toolBarRender={() => {
           if (dataSource === 'my') {
-            return [
+            const filters = [
               <TableFilter
                 key={2}
+                width={isMobileDataList ? 120 : 140}
                 onChange={(val) => {
                   stateCodeRef.current = val;
                   actionRef.current?.reload();
                 }}
               />,
+            ];
+            return [
+              ...filters,
               <ContactCreate
                 importData={importData}
                 onClose={() => setImportData(null)}

--- a/src/pages/Flowproperties/index.tsx
+++ b/src/pages/Flowproperties/index.tsx
@@ -14,13 +14,7 @@ import {
   isDataUnderReview,
 } from '@/services/general/util';
 import { TeamTable } from '@/services/teams/data';
-import {
-  ActionType,
-  PageContainer,
-  ProColumns,
-  ProTable,
-  TableDropdown,
-} from '@ant-design/pro-components';
+import { ActionType, PageContainer, ProColumns, ProTable } from '@ant-design/pro-components';
 import { Card, Checkbox, Col, Input, Row, Space, Tooltip, message } from 'antd';
 import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl, useLocation } from 'umi';
@@ -38,8 +32,21 @@ import type { FC } from 'react';
 import { toSuperscript } from '@/components/AlignedNumber';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
+import {
+  DATA_LIST_COLUMN_RESPONSIVE,
+  ResponsiveDataListActions,
+  dataListActionColumn,
+  dataListIndexColumn,
+  dataListText,
+  dataListTextColumn,
+  responsiveDataListTableProps,
+  responsiveSearchCardClassName,
+  responsiveSearchExtraColProps,
+  responsiveSearchPrimaryColProps,
+  responsiveSearchRowProps,
+  useResponsiveDataListMobile,
+} from '@/components/ResponsiveDataList';
 import TableFilter from '@/components/TableFilter';
-import { theme } from 'antd';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
 import FlowpropertiesCreate from './Components/create';
 import FlowpropertiesDelete from './Components/delete';
@@ -57,7 +64,7 @@ const TableList: FC = () => {
   const [editDrawerVisible, setEditDrawerVisible] = useState<boolean>(false);
   const [editId, setEditId] = useState<string>('');
   const [editVersion, setEditVersion] = useState<string>('');
-  const { token } = theme.useToken();
+  const isMobileDataList = useResponsiveDataListMobile();
   const location = useLocation();
   const dataSource = getDataSource(location.pathname);
 
@@ -113,22 +120,20 @@ const TableList: FC = () => {
   }, [dataSource, id, version]);
   const flowpropertiesColumns: ProColumns<FlowpropertyTable>[] = [
     {
+      ...dataListIndexColumn<FlowpropertyTable>(),
       title: <FormattedMessage id='pages.table.title.index' defaultMessage='Index' />,
       dataIndex: 'index',
       valueType: 'index',
-      search: false,
     },
     {
+      ...dataListTextColumn<FlowpropertyTable>(300),
       title: <FormattedMessage id='pages.table.title.name' defaultMessage='Name' />,
       dataIndex: 'name',
       sorter: false,
-      render: (_, row) => [
-        <Tooltip key={0} placement='topLeft' title={row.generalComment}>
-          {row.name}
-        </Tooltip>,
-      ],
+      render: (_, row) => dataListText(row.name, row.generalComment),
     },
     {
+      ...dataListTextColumn<FlowpropertyTable>(260, DATA_LIST_COLUMN_RESPONSIVE.desktop),
       title: (
         <FormattedMessage id='pages.table.title.classification' defaultMessage='Classification' />
       ),
@@ -136,14 +141,11 @@ const TableList: FC = () => {
       sorter: false,
       search: false,
       render: (_, row) => {
-        return (
-          <div>
-            {row.classification && row.classification !== 'undefined' ? row.classification : '-'}
-          </div>
-        );
+        return dataListText(row.classification);
       },
     },
     {
+      ...dataListTextColumn<FlowpropertyTable>(260, DATA_LIST_COLUMN_RESPONSIVE.desktop),
       title: (
         <FormattedMessage
           id='pages.flowproperty.referenceToReferenceUnitGroup'
@@ -155,7 +157,7 @@ const TableList: FC = () => {
       search: false,
       render: (_, row) => {
         return [
-          <span key={0}>
+          <span className='responsive-data-list-cell-text' key={0}>
             {getLangText(row.refUnitRes?.name, lang)} (
             <Tooltip
               placement='topLeft'
@@ -165,17 +167,11 @@ const TableList: FC = () => {
             </Tooltip>
             )
           </span>,
-          // <ReferenceUnit
-          //   key={1}
-          //   id={row.refUnitGroupId}
-          //   version={row.version}
-          //   idType={'unitgroup'}
-          //   lang={lang}
-          // />,
         ];
       },
     },
     {
+      ...dataListTextColumn<FlowpropertyTable>(132),
       title: <FormattedMessage id='pages.table.title.version' defaultMessage='Version' />,
       dataIndex: 'version',
       sorter: false,
@@ -216,6 +212,7 @@ const TableList: FC = () => {
       },
     },
     {
+      ...dataListTextColumn<FlowpropertyTable>(180, DATA_LIST_COLUMN_RESPONSIVE.wide),
       title: <FormattedMessage id='pages.table.title.updatedAt' defaultMessage='Updated at' />,
       dataIndex: 'modifiedAt',
       valueType: 'dateTime',
@@ -223,14 +220,66 @@ const TableList: FC = () => {
       search: false,
     },
     {
+      ...dataListActionColumn<FlowpropertyTable>(
+        isMobileDataList ? 72 : dataSource === 'my' ? 184 : 152,
+      ),
       title: <FormattedMessage id='pages.table.title.option' defaultMessage='Option' />,
       dataIndex: 'option',
-      search: false,
       render: (_, row) => {
         const actionDisabled = isDataUnderReview(row.stateCode);
         if (dataSource === 'my') {
           return [
-            <Space size={'small'} key={0}>
+            <ResponsiveDataListActions
+              key={0}
+              isMobile={isMobileDataList}
+              moreMenus={[
+                {
+                  key: 'export',
+                  name: <ExportData tableName='flowproperties' id={row.id} version={row.version} />,
+                },
+                {
+                  key: 'copy',
+                  name: (
+                    <FlowpropertiesCreate
+                      actionType='copy'
+                      id={row.id}
+                      version={row.version}
+                      actionRef={actionRef}
+                      lang={lang}
+                    />
+                  ),
+                },
+                {
+                  key: 'contribute',
+                  name: (
+                    <ContributeData
+                      onOk={async () => {
+                        const contributeResult = await contributeSource(
+                          'flowproperties',
+                          row.id,
+                          row.version,
+                        );
+                        const contributeError = extractContributeDataError(contributeResult);
+
+                        if (contributeError) {
+                          message.error(getContributeDataErrorMessage(intl, contributeError));
+                          console.log(contributeError);
+                        } else {
+                          message.success(
+                            intl.formatMessage({
+                              id: 'component.contributeData.success',
+                              defaultMessage: 'Contribute successfully',
+                            }),
+                          );
+                          actionRef.current?.reload();
+                        }
+                      }}
+                      disabled={!!row.teamId}
+                    />
+                  ),
+                },
+              ]}
+            >
               <FlowpropertyView
                 actionRef={actionRef}
                 lang={lang}
@@ -254,65 +303,11 @@ const TableList: FC = () => {
                 actionRef={actionRef}
                 setViewDrawerVisible={() => {}}
               />
-              <TableDropdown
-                style={{
-                  color: token.colorPrimary,
-                }}
-                menus={[
-                  {
-                    key: 'export',
-                    name: (
-                      <ExportData tableName='flowproperties' id={row.id} version={row.version} />
-                    ),
-                  },
-                  {
-                    key: 'copy',
-                    name: (
-                      <FlowpropertiesCreate
-                        actionType='copy'
-                        id={row.id}
-                        version={row.version}
-                        actionRef={actionRef}
-                        lang={lang}
-                      />
-                    ),
-                  },
-                  {
-                    key: 'contribute',
-                    name: (
-                      <ContributeData
-                        onOk={async () => {
-                          const contributeResult = await contributeSource(
-                            'flowproperties',
-                            row.id,
-                            row.version,
-                          );
-                          const contributeError = extractContributeDataError(contributeResult);
-
-                          if (contributeError) {
-                            message.error(getContributeDataErrorMessage(intl, contributeError));
-                            console.log(contributeError);
-                          } else {
-                            message.success(
-                              intl.formatMessage({
-                                id: 'component.contributeData.success',
-                                defaultMessage: 'Contribute successfully',
-                              }),
-                            );
-                            actionRef.current?.reload();
-                          }
-                        }}
-                        disabled={!!row.teamId}
-                      />
-                    ),
-                  },
-                ]}
-              />
-            </Space>,
+            </ResponsiveDataListActions>,
           ];
         }
         return [
-          <Space size={'small'} key={0}>
+          <ResponsiveDataListActions key={0} isMobile={isMobileDataList}>
             <FlowpropertyView
               actionRef={actionRef}
               lang={lang}
@@ -328,7 +323,7 @@ const TableList: FC = () => {
               lang={lang}
             />
             <ExportData tableName='flowproperties' id={row.id} version={row.version} />
-          </Space>,
+          </ResponsiveDataListActions>,
         ];
       },
     },
@@ -356,9 +351,9 @@ const TableList: FC = () => {
         breadcrumb: {},
       }}
     >
-      <Card>
-        <Row align={'middle'}>
-          <Col flex='auto' style={{ marginRight: '10px' }}>
+      <Card className={responsiveSearchCardClassName}>
+        <Row {...responsiveSearchRowProps}>
+          <Col {...responsiveSearchPrimaryColProps}>
             <Search
               size={'large'}
               placeholder={
@@ -370,7 +365,7 @@ const TableList: FC = () => {
               enterButton
             />
           </Col>
-          <Col style={{ display: 'none' }} flex='100px'>
+          <Col {...responsiveSearchExtraColProps} style={{ display: 'none' }}>
             <Checkbox
               onChange={(e) => {
                 setOpenAI(e.target.checked);
@@ -382,6 +377,7 @@ const TableList: FC = () => {
         </Row>
       </Card>
       <ProTable<FlowpropertyTable, ListPagination>
+        {...responsiveDataListTableProps}
         rowKey={(record) => `${record.id}-${record.version}`}
         headerTitle={
           <>
@@ -391,22 +387,26 @@ const TableList: FC = () => {
         }
         actionRef={actionRef}
         search={false}
-        options={{ fullScreen: true }}
+        options={isMobileDataList ? false : { fullScreen: true }}
         pagination={{
           showSizeChanger: false,
           pageSize: 10,
         }}
         toolBarRender={() => {
           if (dataSource === 'my') {
-            return [
+            const filters = [
               <TableFilter
                 key={2}
+                width={isMobileDataList ? 120 : 140}
                 onChange={(val) => {
                   stateCodeRef.current = val;
                   setStateCode(val);
                   actionRef.current?.reload();
                 }}
               />,
+            ];
+            return [
+              ...filters,
               <FlowpropertiesCreate
                 importData={importData}
                 onClose={() => setImportData(null)}

--- a/src/pages/Flows/index.tsx
+++ b/src/pages/Flows/index.tsx
@@ -3,7 +3,7 @@ import {
   getFlowTableAll,
   getFlowTablePgroongaSearch,
 } from '@/services/flows/api';
-import { Card, Checkbox, Col, Input, Row, Space, Tooltip, message } from 'antd';
+import { Card, Checkbox, Col, Input, Row, Space, message } from 'antd';
 import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl, useLocation } from 'umi';
 
@@ -15,6 +15,20 @@ import {
 } from '@/components/ContributeData/utils';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
+import {
+  DATA_LIST_COLUMN_RESPONSIVE,
+  ResponsiveDataListActions,
+  dataListActionColumn,
+  dataListIndexColumn,
+  dataListText,
+  dataListTextColumn,
+  responsiveDataListTableProps,
+  responsiveSearchCardClassName,
+  responsiveSearchExtraColProps,
+  responsiveSearchPrimaryColProps,
+  responsiveSearchRowProps,
+  useResponsiveDataListMobile,
+} from '@/components/ResponsiveDataList';
 import TableFilter from '@/components/TableFilter';
 import { getCachedFlowCategorizationAll } from '@/services/classifications/cache';
 import { FlowImportData, FlowTable } from '@/services/flows/data';
@@ -23,14 +37,7 @@ import { ListPagination } from '@/services/general/data';
 import { getDataSource, getLang, getLangText, isDataUnderReview } from '@/services/general/util';
 import { getTeamById } from '@/services/teams/api';
 import { TeamTable } from '@/services/teams/data';
-import {
-  ActionType,
-  PageContainer,
-  ProColumns,
-  ProTable,
-  TableDropdown,
-} from '@ant-design/pro-components';
-import { theme } from 'antd';
+import { ActionType, PageContainer, ProColumns, ProTable } from '@ant-design/pro-components';
 import { SearchProps } from 'antd/es/input/Search';
 import type { SortOrder } from 'antd/lib/table/interface';
 import type { FC, ReactNode } from 'react';
@@ -58,7 +65,7 @@ const TableList: FC = () => {
   const [classificationFilterOptions, setClassificationFilterOptions] = useState<
     Array<{ text: ReactNode; value: string }>
   >([]);
-  const { token } = theme.useToken();
+  const isMobileDataList = useResponsiveDataListMobile();
   const location = useLocation();
   const dataSource = getDataSource(location.pathname);
   const [, setStateCode] = useState<string | number>('all');
@@ -125,25 +132,23 @@ const TableList: FC = () => {
   }, [dataSource, id, version]);
   const flowsColumns: ProColumns<FlowTable>[] = [
     {
+      ...dataListIndexColumn<FlowTable>(),
       title: <FormattedMessage id='pages.table.title.index' defaultMessage='Index' />,
       dataIndex: 'index',
       valueType: 'index',
-      search: false,
     },
     {
+      ...dataListTextColumn<FlowTable>(300),
       title: <FormattedMessage id='pages.table.title.name' defaultMessage='Name' />,
       dataIndex: 'name',
       sorter: true,
       search: false,
       render: (_, row) => {
-        return [
-          <Tooltip key={0} placement='topLeft' title={row.synonyms}>
-            {row.name}
-          </Tooltip>,
-        ];
+        return dataListText(row.name, row.synonyms);
       },
     },
     {
+      ...dataListTextColumn<FlowTable>(160, DATA_LIST_COLUMN_RESPONSIVE.desktop),
       title: <FormattedMessage id='pages.flow.flowType' defaultMessage='Flow type' />,
       dataIndex: 'flowType',
       sorter: false,
@@ -152,12 +157,13 @@ const TableList: FC = () => {
       render: (_, row) => {
         const flowType = flowTypeOptions.find((i) => i.value === row.flowType);
         if (flowType) {
-          return flowType.label;
+          return dataListText(flowType.label);
         }
-        return row.flowType;
+        return dataListText(row.flowType);
       },
     },
     {
+      ...dataListTextColumn<FlowTable>(260, DATA_LIST_COLUMN_RESPONSIVE.wide),
       title: (
         <FormattedMessage id='pages.table.title.classification' defaultMessage='Classification' />
       ),
@@ -166,19 +172,19 @@ const TableList: FC = () => {
       filters: classificationFilterOptions.length > 0 ? classificationFilterOptions : undefined,
       filterMultiple: true,
       render: (_, row) => {
-        return row?.classification && row?.classification !== 'undefined'
-          ? row.classification
-          : '-';
+        return dataListText(row.classification);
       },
     },
 
     {
+      ...dataListTextColumn<FlowTable>(132, DATA_LIST_COLUMN_RESPONSIVE.wide),
       title: <FormattedMessage id='pages.flow.CASNumber' defaultMessage='CAS Number' />,
       dataIndex: 'CASNumber',
       sorter: false,
       search: false,
     },
     {
+      ...dataListTextColumn<FlowTable>(168, DATA_LIST_COLUMN_RESPONSIVE.wide),
       title: (
         <FormattedMessage id='pages.flow.locationOfSupply' defaultMessage='Location of supply' />
       ),
@@ -187,6 +193,7 @@ const TableList: FC = () => {
       search: false,
     },
     {
+      ...dataListTextColumn<FlowTable>(132),
       title: <FormattedMessage id='pages.table.title.version' defaultMessage='Version' />,
       dataIndex: 'version',
       sorter: false,
@@ -229,6 +236,7 @@ const TableList: FC = () => {
       },
     },
     {
+      ...dataListTextColumn<FlowTable>(180, DATA_LIST_COLUMN_RESPONSIVE.wide),
       title: <FormattedMessage id='pages.table.title.updatedAt' defaultMessage='Updated at' />,
       dataIndex: 'modifiedAt',
       valueType: 'dateTime',
@@ -236,14 +244,64 @@ const TableList: FC = () => {
       search: false,
     },
     {
+      ...dataListActionColumn<FlowTable>(isMobileDataList ? 72 : dataSource === 'my' ? 184 : 152),
       title: <FormattedMessage id='pages.table.title.option' defaultMessage='Option' />,
       dataIndex: 'option',
-      search: false,
       render: (_, row) => {
         const actionDisabled = isDataUnderReview(row.stateCode);
         if (dataSource === 'my') {
           return [
-            <Space size={'small'} key={0}>
+            <ResponsiveDataListActions
+              key={0}
+              isMobile={isMobileDataList}
+              moreMenus={[
+                {
+                  key: 'export',
+                  name: <ExportData tableName='flows' id={row.id} version={row.version} />,
+                },
+                {
+                  key: 'copy',
+                  name: (
+                    <FlowsCreate
+                      actionType='copy'
+                      id={row.id}
+                      version={row.version}
+                      lang={lang}
+                      actionRef={actionRef}
+                    />
+                  ),
+                },
+                {
+                  key: 'contribute',
+                  name: (
+                    <ContributeData
+                      onOk={async () => {
+                        const contributeResult = await contributeSource(
+                          'flows',
+                          row.id,
+                          row.version,
+                        );
+                        const contributeError = extractContributeDataError(contributeResult);
+
+                        if (contributeError) {
+                          message.error(getContributeDataErrorMessage(intl, contributeError));
+                          console.log(contributeError);
+                        } else {
+                          message.success(
+                            intl.formatMessage({
+                              id: 'component.contributeData.success',
+                              defaultMessage: 'Contribute successfully',
+                            }),
+                          );
+                          actionRef.current?.reload();
+                        }
+                      }}
+                      disabled={!!row.teamId}
+                    />
+                  ),
+                },
+              ]}
+            >
               <FlowsView
                 // actionRef={actionRef}
                 buttonType={'icon'}
@@ -267,63 +325,11 @@ const TableList: FC = () => {
                 actionRef={actionRef}
                 setViewDrawerVisible={() => {}}
               />
-              <TableDropdown
-                style={{
-                  color: token.colorPrimary,
-                }}
-                menus={[
-                  {
-                    key: 'export',
-                    name: <ExportData tableName='flows' id={row.id} version={row.version} />,
-                  },
-                  {
-                    key: 'copy',
-                    name: (
-                      <FlowsCreate
-                        actionType='copy'
-                        id={row.id}
-                        version={row.version}
-                        lang={lang}
-                        actionRef={actionRef}
-                      />
-                    ),
-                  },
-                  {
-                    key: 'contribute',
-                    name: (
-                      <ContributeData
-                        onOk={async () => {
-                          const contributeResult = await contributeSource(
-                            'flows',
-                            row.id,
-                            row.version,
-                          );
-                          const contributeError = extractContributeDataError(contributeResult);
-
-                          if (contributeError) {
-                            message.error(getContributeDataErrorMessage(intl, contributeError));
-                            console.log(contributeError);
-                          } else {
-                            message.success(
-                              intl.formatMessage({
-                                id: 'component.contributeData.success',
-                                defaultMessage: 'Contribute successfully',
-                              }),
-                            );
-                            actionRef.current?.reload();
-                          }
-                        }}
-                        disabled={!!row.teamId}
-                      />
-                    ),
-                  },
-                ]}
-              />
-            </Space>,
+            </ResponsiveDataListActions>,
           ];
         }
         return [
-          <Space size={'small'} key={0}>
+          <ResponsiveDataListActions key={0} isMobile={isMobileDataList}>
             <FlowsView
               // actionRef={actionRef}
               buttonType={'icon'}
@@ -339,7 +345,7 @@ const TableList: FC = () => {
               actionRef={actionRef}
             />
             <ExportData tableName='flows' id={row.id} version={row.version} />
-          </Space>,
+          </ResponsiveDataListActions>,
         ];
       },
     },
@@ -404,9 +410,9 @@ const TableList: FC = () => {
         breadcrumb: {},
       }}
     >
-      <Card>
-        <Row align={'middle'}>
-          <Col flex='auto' style={{ marginRight: '10px' }}>
+      <Card className={responsiveSearchCardClassName}>
+        <Row {...responsiveSearchRowProps}>
+          <Col {...responsiveSearchPrimaryColProps}>
             <Search
               size={'large'}
               placeholder={
@@ -418,7 +424,7 @@ const TableList: FC = () => {
               enterButton
             />
           </Col>
-          <Col flex='100px'>
+          <Col {...responsiveSearchExtraColProps}>
             <Checkbox
               onChange={(e) => {
                 setOpenAI(e.target.checked);
@@ -430,6 +436,7 @@ const TableList: FC = () => {
         </Row>
       </Card>
       <ProTable<FlowTable, ListPagination>
+        {...responsiveDataListTableProps}
         rowKey={(record) => `${record.id}-${record.version}`}
         headerTitle={
           <>
@@ -439,22 +446,26 @@ const TableList: FC = () => {
         }
         actionRef={actionRef}
         search={false}
-        options={{ fullScreen: true }}
+        options={isMobileDataList ? false : { fullScreen: true }}
         pagination={{
           showSizeChanger: false,
           pageSize: 10,
         }}
         toolBarRender={() => {
           if (dataSource === 'my') {
-            return [
+            const filters = [
               <TableFilter
                 key={2}
+                width={isMobileDataList ? 120 : 140}
                 onChange={(val) => {
                   stateCodeRef.current = val;
                   setStateCode(val);
                   actionRef.current?.reload();
                 }}
               />,
+            ];
+            return [
+              ...filters,
               <FlowsCreate
                 importData={importData}
                 onClose={() => setImportData(null)}

--- a/src/pages/LifeCycleModels/index.tsx
+++ b/src/pages/LifeCycleModels/index.tsx
@@ -6,6 +6,20 @@ import {
 } from '@/components/ContributeData/utils';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
+import {
+  DATA_LIST_COLUMN_RESPONSIVE,
+  ResponsiveDataListActions,
+  dataListActionColumn,
+  dataListIndexColumn,
+  dataListText,
+  dataListTextColumn,
+  responsiveDataListTableProps,
+  responsiveSearchCardClassName,
+  responsiveSearchExtraColProps,
+  responsiveSearchPrimaryColProps,
+  responsiveSearchRowProps,
+  useResponsiveDataListMobile,
+} from '@/components/ResponsiveDataList';
 import TableFilter from '@/components/TableFilter';
 import { attachStateCodesToRows } from '@/services/general/api';
 import { ListPagination } from '@/services/general/data';
@@ -22,14 +36,8 @@ import type {
 } from '@/services/lifeCycleModels/data';
 import { getTeamById } from '@/services/teams/api';
 import type { TeamTable } from '@/services/teams/data';
-import {
-  ActionType,
-  PageContainer,
-  ProColumns,
-  ProTable,
-  TableDropdown,
-} from '@ant-design/pro-components';
-import { Card, Checkbox, Col, Input, Row, Space, Tooltip, message, theme } from 'antd';
+import { ActionType, PageContainer, ProColumns, ProTable } from '@ant-design/pro-components';
+import { Card, Checkbox, Col, Input, Row, Space, message } from 'antd';
 import { SearchProps } from 'antd/es/input/Search';
 import type { FC } from 'react';
 import { useEffect, useRef, useState } from 'react';
@@ -51,7 +59,7 @@ const TableList: FC = () => {
   const [viewDrawerVisible, setViewDrawerVisible] = useState<boolean>(false);
   const [editId, setEditId] = useState<string>('');
   const [editVersion, setEditVersion] = useState<string>('');
-  const { token } = theme.useToken();
+  const isMobileDataList = useResponsiveDataListMobile();
   const location = useLocation();
   const dataSource = getDataSource(location.pathname);
 
@@ -107,25 +115,23 @@ const TableList: FC = () => {
   };
   const processColumns: ProColumns<LifeCycleModelTable>[] = [
     {
+      ...dataListIndexColumn<LifeCycleModelTable>(),
       title: <FormattedMessage id='pages.table.title.index' defaultMessage='Index' />,
       dataIndex: 'index',
       valueType: 'index',
-      search: false,
     },
     {
+      ...dataListTextColumn<LifeCycleModelTable>(320),
       title: <FormattedMessage id='pages.table.title.name' defaultMessage='Name' />,
       dataIndex: 'name',
       sorter: true,
       search: false,
       render: (_, row) => {
-        return [
-          <Tooltip key={0} placement='topLeft' title={row.generalComment}>
-            {row.name}
-          </Tooltip>,
-        ];
+        return dataListText(row.name, row.generalComment);
       },
     },
     {
+      ...dataListTextColumn<LifeCycleModelTable>(260, DATA_LIST_COLUMN_RESPONSIVE.desktop),
       title: (
         <FormattedMessage id='pages.table.title.classification' defaultMessage='Classification' />
       ),
@@ -133,14 +139,11 @@ const TableList: FC = () => {
       sorter: true,
       search: false,
       render: (_, row) => {
-        return (
-          <div>
-            {row.classification && row.classification !== 'undefined' ? row.classification : '-'}
-          </div>
-        );
+        return dataListText(row.classification);
       },
     },
     {
+      ...dataListTextColumn<LifeCycleModelTable>(132),
       title: <FormattedMessage id='pages.table.title.version' defaultMessage='Version' />,
       dataIndex: 'version',
       sorter: false,
@@ -180,6 +183,7 @@ const TableList: FC = () => {
       },
     },
     {
+      ...dataListTextColumn<LifeCycleModelTable>(180, DATA_LIST_COLUMN_RESPONSIVE.wide),
       title: <FormattedMessage id='pages.table.title.updatedAt' defaultMessage='Updated at' />,
       dataIndex: 'modifiedAt',
       valueType: 'dateTime',
@@ -187,14 +191,68 @@ const TableList: FC = () => {
       search: false,
     },
     {
+      ...dataListActionColumn<LifeCycleModelTable>(
+        isMobileDataList ? 72 : dataSource === 'my' ? 184 : 152,
+      ),
       title: <FormattedMessage id='pages.table.title.option' defaultMessage='Option' />,
       dataIndex: 'option',
-      search: false,
       render: (_, row) => {
         const actionDisabled = isDataUnderReview(row.stateCode);
         if (dataSource === 'my') {
           return [
-            <Space size={'small'} key={0}>
+            <ResponsiveDataListActions
+              key={0}
+              isMobile={isMobileDataList}
+              moreMenus={[
+                {
+                  key: 'export',
+                  name: (
+                    <ExportData tableName='lifecyclemodels' id={row.id} version={row.version} />
+                  ),
+                },
+                {
+                  key: 'copy',
+                  name: (
+                    <LifeCycleModelCreate
+                      actionType='copy'
+                      id={row.id}
+                      version={row.version}
+                      lang={lang}
+                      actionRef={actionRef}
+                      buttonType={'icon'}
+                    />
+                  ),
+                },
+                {
+                  key: 'contribute',
+                  name: (
+                    <ContributeData
+                      onOk={async () => {
+                        const contributeResult = await contributeLifeCycleModel(
+                          row.id,
+                          row.version,
+                        );
+                        const contributeError = extractContributeDataError(contributeResult);
+
+                        if (contributeError) {
+                          message.error(getContributeDataErrorMessage(intl, contributeError));
+                          console.log(contributeError);
+                        } else {
+                          message.success(
+                            intl.formatMessage({
+                              id: 'component.contributeData.success',
+                              defaultMessage: 'Contribute successfully',
+                            }),
+                          );
+                          actionRef.current?.reload();
+                        }
+                      }}
+                      disabled={!!row.teamId}
+                    />
+                  ),
+                },
+              ]}
+            >
               <LifeCycleModelView
                 id={row.id}
                 version={row.version}
@@ -218,65 +276,11 @@ const TableList: FC = () => {
                 actionRef={actionRef}
                 setViewDrawerVisible={() => {}}
               />
-              <TableDropdown
-                style={{
-                  color: token.colorPrimary,
-                }}
-                menus={[
-                  {
-                    key: 'export',
-                    name: (
-                      <ExportData tableName='lifecyclemodels' id={row.id} version={row.version} />
-                    ),
-                  },
-                  {
-                    key: 'copy',
-                    name: (
-                      <LifeCycleModelCreate
-                        actionType='copy'
-                        id={row.id}
-                        version={row.version}
-                        lang={lang}
-                        actionRef={actionRef}
-                        buttonType={'icon'}
-                      />
-                    ),
-                  },
-                  {
-                    key: 'contribute',
-                    name: (
-                      <ContributeData
-                        onOk={async () => {
-                          const contributeResult = await contributeLifeCycleModel(
-                            row.id,
-                            row.version,
-                          );
-                          const contributeError = extractContributeDataError(contributeResult);
-
-                          if (contributeError) {
-                            message.error(getContributeDataErrorMessage(intl, contributeError));
-                            console.log(contributeError);
-                          } else {
-                            message.success(
-                              intl.formatMessage({
-                                id: 'component.contributeData.success',
-                                defaultMessage: 'Contribute successfully',
-                              }),
-                            );
-                            actionRef.current?.reload();
-                          }
-                        }}
-                        disabled={!!row.teamId}
-                      />
-                    ),
-                  },
-                ]}
-              />
-            </Space>,
+            </ResponsiveDataListActions>,
           ];
         }
         return [
-          <Space size={'small'} key={0}>
+          <ResponsiveDataListActions key={0} isMobile={isMobileDataList}>
             <LifeCycleModelView id={row.id} version={row.version} lang={lang} buttonType={'icon'} />
             <LifeCycleModelCreate
               actionType='copy'
@@ -287,7 +291,7 @@ const TableList: FC = () => {
               buttonType={'icon'}
             />
             <ExportData tableName='lifecyclemodels' id={row.id} version={row.version} />
-          </Space>,
+          </ResponsiveDataListActions>,
         ];
       },
     },
@@ -318,9 +322,9 @@ const TableList: FC = () => {
         breadcrumb: {},
       }}
     >
-      <Card>
-        <Row align={'middle'}>
-          <Col flex='auto' style={{ marginRight: '10px' }}>
+      <Card className={responsiveSearchCardClassName}>
+        <Row {...responsiveSearchRowProps}>
+          <Col {...responsiveSearchPrimaryColProps}>
             <Search
               size={'large'}
               placeholder={
@@ -332,7 +336,7 @@ const TableList: FC = () => {
               enterButton
             />
           </Col>
-          <Col flex='100px'>
+          <Col {...responsiveSearchExtraColProps}>
             <Checkbox
               onChange={(e) => {
                 setOpenAI(e.target.checked);
@@ -344,6 +348,7 @@ const TableList: FC = () => {
         </Row>
       </Card>
       <ProTable<LifeCycleModelTable, ListPagination>
+        {...responsiveDataListTableProps}
         rowKey={(record) => `${record.id}-${record.version}`}
         headerTitle={
           <>
@@ -353,22 +358,26 @@ const TableList: FC = () => {
         }
         actionRef={actionRef}
         search={false}
-        options={{ fullScreen: true }}
+        options={isMobileDataList ? false : { fullScreen: true }}
         pagination={{
           showSizeChanger: false,
           pageSize: 10,
         }}
         toolBarRender={() => {
           if (dataSource === 'my') {
-            return [
+            const filters = [
               <TableFilter
                 key={2}
+                width={isMobileDataList ? 120 : 140}
                 onChange={(val) => {
                   stateCodeRef.current = val;
                   setStateCode(val);
                   actionRef.current?.reload();
                 }}
               />,
+            ];
+            return [
+              ...filters,
               <LifeCycleModelCreate
                 importData={importData}
                 onClose={() => setImportData(null)}

--- a/src/pages/Processes/index.tsx
+++ b/src/pages/Processes/index.tsx
@@ -110,7 +110,7 @@ const TableList: FC = () => {
   const keyWordRef = useRef('');
   const stateCodeRef = useRef<string | number>('all');
   const typeOfDataSetRef = useRef<string>('all');
-  const typeOfDataSetFilter = (width = 160) => {
+  const typeOfDataSetFilter = (width: number) => {
     const onChange = (value: string) => {
       typeOfDataSetRef.current = value;
       setTypeOfDataSet(value);

--- a/src/pages/Processes/index.tsx
+++ b/src/pages/Processes/index.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/services/processes/api';
 import { BarChartOutlined } from '@ant-design/icons';
 
-import { Card, Checkbox, Col, Input, message, Row, Select, Space, Tooltip } from 'antd';
+import { Card, Checkbox, Col, Input, message, Row, Select, Space } from 'antd';
 import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, history, useIntl, useLocation } from 'umi';
 
@@ -19,6 +19,21 @@ import {
 } from '@/components/ContributeData/utils';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
+import {
+  DATA_LIST_COLUMN_RESPONSIVE,
+  dataListActionColumn,
+  dataListIndexColumn,
+  dataListText,
+  dataListTextColumn,
+  ResponsiveDataListActions,
+  responsiveDataListTableProps,
+  ResponsiveDataListToolbarMore,
+  responsiveSearchCardClassName,
+  responsiveSearchExtraColProps,
+  responsiveSearchPrimaryColProps,
+  responsiveSearchRowProps,
+  useResponsiveDataListMobile,
+} from '@/components/ResponsiveDataList';
 import TableFilter from '@/components/TableFilter';
 import ToolBarButton from '@/components/ToolBarButton';
 import LifeCycleModelCreate from '@/pages/LifeCycleModels/Components/create';
@@ -30,14 +45,7 @@ import { getDataSource, getLang, getLangText, isDataUnderReview } from '@/servic
 import { ProcessImportData, ProcessTable } from '@/services/processes/data';
 import { getTeamById } from '@/services/teams/api';
 import type { TeamTable } from '@/services/teams/data';
-import {
-  ActionType,
-  PageContainer,
-  ProColumns,
-  ProTable,
-  TableDropdown,
-} from '@ant-design/pro-components';
-import { theme } from 'antd';
+import { ActionType, PageContainer, ProColumns, ProTable } from '@ant-design/pro-components';
 import { SearchProps } from 'antd/es/input/Search';
 import type { SortOrder } from 'antd/es/table/interface';
 import type { FC, ReactElement } from 'react';
@@ -68,7 +76,7 @@ const TableList: FC = () => {
   const [viewDrawerVisible, setViewDrawerVisible] = useState<boolean>(false);
   const [editId, setEditId] = useState<string>('');
   const [editVersion, setEditVersion] = useState<string>('');
-  const { token } = theme.useToken();
+  const isMobileDataList = useResponsiveDataListMobile();
   const location = useLocation();
   const dataSource = getDataSource(location.pathname);
 
@@ -102,14 +110,14 @@ const TableList: FC = () => {
   const keyWordRef = useRef('');
   const stateCodeRef = useRef<string | number>('all');
   const typeOfDataSetRef = useRef<string>('all');
-  const typeOfDataSetFilter = () => {
+  const typeOfDataSetFilter = (width = 160) => {
     const onChange = (value: string) => {
       typeOfDataSetRef.current = value;
       setTypeOfDataSet(value);
       actionRef.current?.reloadAndRest?.();
     };
     return (
-      <Select defaultValue={'all'} style={{ width: 160 }} onChange={onChange}>
+      <Select defaultValue={'all'} style={{ width }} onChange={onChange}>
         <Select.Option value={'all'}>
           <FormattedMessage id='pages.table.filter.all.datasetType' />
         </Select.Option>
@@ -123,25 +131,23 @@ const TableList: FC = () => {
   };
   const processColumns: ProColumns<ProcessTable>[] = [
     {
+      ...dataListIndexColumn<ProcessTable>(),
       title: <FormattedMessage id='pages.table.title.index' defaultMessage='Index' />,
       dataIndex: 'index',
       valueType: 'index',
-      search: false,
     },
     {
+      ...dataListTextColumn<ProcessTable>(300),
       title: <FormattedMessage id='pages.table.title.name' defaultMessage='Name' />,
       dataIndex: 'name',
       sorter: true,
       search: false,
       render: (_, row) => {
-        return [
-          <Tooltip key={0} placement='topLeft' title={row.generalComment}>
-            {row.name}
-          </Tooltip>,
-        ];
+        return dataListText(row.name, row.generalComment);
       },
     },
     {
+      ...dataListTextColumn<ProcessTable>(260, DATA_LIST_COLUMN_RESPONSIVE.wide),
       title: (
         <FormattedMessage id='pages.table.title.classification' defaultMessage='Classification' />
       ),
@@ -149,14 +155,11 @@ const TableList: FC = () => {
       sorter: true,
       search: false,
       render: (_, row) => {
-        return (
-          <div>
-            {row.classification && row.classification !== 'undefined' ? row.classification : '-'}
-          </div>
-        );
+        return dataListText(row.classification);
       },
     },
     {
+      ...dataListTextColumn<ProcessTable>(180, DATA_LIST_COLUMN_RESPONSIVE.desktop),
       title: (
         <FormattedMessage
           id='pages.process.view.modellingAndValidation.typeOfDataSet'
@@ -167,22 +170,25 @@ const TableList: FC = () => {
       sorter: false,
       search: false,
       render: (_, row) => {
-        return getProcesstypeOfDataSetOptions(row.typeOfDataSet);
+        return dataListText(getProcesstypeOfDataSetOptions(row.typeOfDataSet));
       },
     },
     {
+      ...dataListTextColumn<ProcessTable>(132, DATA_LIST_COLUMN_RESPONSIVE.wide),
       title: <FormattedMessage id='pages.process.referenceYear' defaultMessage='Reference year' />,
       dataIndex: 'referenceYear',
       sorter: false,
       search: false,
     },
     {
+      ...dataListTextColumn<ProcessTable>(132, DATA_LIST_COLUMN_RESPONSIVE.desktop),
       title: <FormattedMessage id='pages.process.location' defaultMessage='Location' />,
       dataIndex: 'location',
       sorter: false,
       search: false,
     },
     {
+      ...dataListTextColumn<ProcessTable>(132),
       title: <FormattedMessage id='pages.table.title.version' defaultMessage='Version' />,
       dataIndex: 'version',
       sorter: false,
@@ -224,6 +230,7 @@ const TableList: FC = () => {
       },
     },
     {
+      ...dataListTextColumn<ProcessTable>(180, DATA_LIST_COLUMN_RESPONSIVE.wide),
       title: <FormattedMessage id='pages.table.title.updatedAt' defaultMessage='Updated at' />,
       dataIndex: 'modifiedAt',
       valueType: 'dateTime',
@@ -231,14 +238,81 @@ const TableList: FC = () => {
       search: false,
     },
     {
+      ...dataListActionColumn<ProcessTable>(
+        isMobileDataList ? 72 : dataSource === 'my' ? 204 : 168,
+      ),
       title: <FormattedMessage id='pages.table.title.option' defaultMessage='Option' />,
       dataIndex: 'option',
-      search: false,
       render: (_, row) => {
         const actionDisabled = isDataUnderReview(row.stateCode);
         if (dataSource === 'my') {
           return [
-            <Space size={'small'} key={0}>
+            <ResponsiveDataListActions
+              key={0}
+              isMobile={isMobileDataList}
+              moreMenus={[
+                {
+                  key: 'logs',
+                  name: <ReviewDetail processId={row.id} processVersion={row.version} />,
+                },
+                {
+                  key: 'export',
+                  name: <ExportData tableName='processes' id={row.id} version={row.version} />,
+                },
+                {
+                  key: 'copy',
+                  name: (
+                    <>
+                      {row.modelId ? (
+                        <LifeCycleModelCreate
+                          actionType='copy'
+                          id={row.modelId}
+                          version={row.version}
+                          lang={lang}
+                          actionRef={actionRef}
+                          buttonType={'icon'}
+                        />
+                      ) : (
+                        <ProcessCreate
+                          actionType='copy'
+                          id={row.id}
+                          version={row.version}
+                          lang={lang}
+                          actionRef={actionRef}
+                        />
+                      )}
+                    </>
+                  ),
+                },
+                {
+                  key: 'contribute',
+                  name: (
+                    <ContributeData
+                      onOk={async () => {
+                        const contributeResult = row.modelId
+                          ? await contributeLifeCycleModel(row.modelId, row.version)
+                          : await contributeProcess(row.id, row.version);
+                        const contributeError = extractContributeDataError(contributeResult);
+
+                        if (contributeError) {
+                          message.error(getContributeDataErrorMessage(intl, contributeError));
+                          console.log(contributeError);
+                        } else {
+                          message.success(
+                            intl.formatMessage({
+                              id: 'component.contributeData.success',
+                              defaultMessage: 'Contribute successfully',
+                            }),
+                          );
+                        }
+                        actionRef.current?.reload();
+                      }}
+                      disabled={!!row.teamId}
+                    />
+                  ),
+                },
+              ]}
+            >
               <ProcessView
                 id={row.id}
                 version={row.version}
@@ -285,79 +359,33 @@ const TableList: FC = () => {
                 actionRef={actionRef}
                 setViewDrawerVisible={() => {}}
               />
-              <TableDropdown
-                style={{
-                  color: token.colorPrimary,
-                }}
-                menus={[
-                  {
-                    key: 'logs',
-                    name: <ReviewDetail processId={row.id} processVersion={row.version} />,
-                  },
-                  {
-                    key: 'export',
-                    name: <ExportData tableName='processes' id={row.id} version={row.version} />,
-                  },
-                  {
-                    key: 'copy',
-                    name: (
-                      <>
-                        {row.modelId ? (
-                          <LifeCycleModelCreate
-                            actionType='copy'
-                            id={row.modelId}
-                            version={row.version}
-                            lang={lang}
-                            actionRef={actionRef}
-                            buttonType={'icon'}
-                          />
-                        ) : (
-                          <ProcessCreate
-                            actionType='copy'
-                            id={row.id}
-                            version={row.version}
-                            lang={lang}
-                            actionRef={actionRef}
-                          />
-                        )}
-                      </>
-                    ),
-                  },
-                  {
-                    key: 'contribute',
-                    name: (
-                      <ContributeData
-                        onOk={async () => {
-                          const contributeResult = row.modelId
-                            ? await contributeLifeCycleModel(row.modelId, row.version)
-                            : await contributeProcess(row.id, row.version);
-                          const contributeError = extractContributeDataError(contributeResult);
-
-                          if (contributeError) {
-                            message.error(getContributeDataErrorMessage(intl, contributeError));
-                            console.log(contributeError);
-                          } else {
-                            message.success(
-                              intl.formatMessage({
-                                id: 'component.contributeData.success',
-                                defaultMessage: 'Contribute successfully',
-                              }),
-                            );
-                          }
-                          actionRef.current?.reload();
-                        }}
-                        disabled={!!row.teamId}
-                      />
-                    ),
-                  },
-                ]}
-              />
-            </Space>,
+            </ResponsiveDataListActions>,
           ];
         }
         if (dataSource === 'tg') {
           return [
-            <Space size={'small'} key={0}>
+            <ResponsiveDataListActions
+              key={0}
+              isMobile={isMobileDataList}
+              moreMenus={[
+                {
+                  key: 'copy',
+                  name: (
+                    <ProcessCreate
+                      actionType='copy'
+                      id={row.id}
+                      version={row.version}
+                      lang={lang}
+                      actionRef={actionRef}
+                    />
+                  ),
+                },
+                {
+                  key: 'export',
+                  name: <ExportData tableName='processes' id={row.id} version={row.version} />,
+                },
+              ]}
+            >
               <ProcessView
                 id={row.id}
                 version={row.version}
@@ -376,35 +404,11 @@ const TableList: FC = () => {
                 actionRef={actionRef}
               />
               <ReviewDetail processId={row.id} processVersion={row.version} />
-
-              <TableDropdown
-                style={{
-                  color: token.colorPrimary,
-                }}
-                menus={[
-                  {
-                    key: 'copy',
-                    name: (
-                      <ProcessCreate
-                        actionType='copy'
-                        id={row.id}
-                        version={row.version}
-                        lang={lang}
-                        actionRef={actionRef}
-                      />
-                    ),
-                  },
-                  {
-                    key: 'export',
-                    name: <ExportData tableName='processes' id={row.id} version={row.version} />,
-                  },
-                ]}
-              />
-            </Space>,
+            </ResponsiveDataListActions>,
           ];
         }
         return [
-          <Space size={'small'} key={0}>
+          <ResponsiveDataListActions key={0} isMobile={isMobileDataList}>
             <ProcessView
               id={row.id}
               version={row.version}
@@ -430,7 +434,7 @@ const TableList: FC = () => {
               actionRef={actionRef}
             />
             <ExportData tableName='processes' id={row.id} version={row.version} />
-          </Space>,
+          </ResponsiveDataListActions>,
         ];
       },
     },
@@ -489,9 +493,9 @@ const TableList: FC = () => {
         breadcrumb: {},
       }}
     >
-      <Card>
-        <Row align={'middle'}>
-          <Col flex='auto' style={{ marginRight: '10px' }}>
+      <Card className={responsiveSearchCardClassName}>
+        <Row {...responsiveSearchRowProps}>
+          <Col {...responsiveSearchPrimaryColProps}>
             <Search
               size={'large'}
               placeholder={
@@ -503,7 +507,7 @@ const TableList: FC = () => {
               enterButton
             />
           </Col>
-          <Col flex='100px'>
+          <Col {...responsiveSearchExtraColProps}>
             <Checkbox
               onChange={(e) => {
                 setOpenAI(e.target.checked);
@@ -515,6 +519,7 @@ const TableList: FC = () => {
         </Row>
       </Card>
       <ProTable<ProcessTable, ListPagination>
+        {...responsiveDataListTableProps}
         rowKey={(record) => `${record.id}-${record.version}`}
         headerTitle={
           <>
@@ -524,64 +529,100 @@ const TableList: FC = () => {
         }
         actionRef={actionRef}
         search={false}
-        options={{ fullScreen: true }}
-        optionsRender={(_, defaultOptions) => {
-          const settings = (defaultOptions ?? []) as ReactElement[];
-          if (dataSource !== 'my') {
-            return settings;
-          }
-          const calcOption = <LcaSolveToolbar key='lca-calc-option' />;
-          const analysisPageOption = (
-            <ToolBarButton
-              key='lca-analysis-page-option'
-              icon={<BarChartOutlined />}
-              tooltip={intl.formatMessage({
-                id: 'pages.process.lca.page.title',
-                defaultMessage: 'LCA Analysis',
-              })}
-              onClick={() => {
-                history.push('/mydata/processes/analysis');
-              }}
-            />
-          );
-          const reloadIndex = settings.findIndex((item) => item.key === 'reload');
-          if (reloadIndex < 0) {
-            return [...settings, calcOption, analysisPageOption];
-          }
-          return [
-            ...settings.slice(0, reloadIndex + 1),
-            calcOption,
-            analysisPageOption,
-            ...settings.slice(reloadIndex + 1),
-          ];
-        }}
+        options={isMobileDataList ? false : { fullScreen: true }}
+        optionsRender={
+          isMobileDataList
+            ? undefined
+            : (_, defaultOptions) => {
+                const settings = (defaultOptions ?? []) as ReactElement[];
+                if (dataSource !== 'my') {
+                  return settings;
+                }
+                const calcOption = <LcaSolveToolbar key='lca-calc-option' />;
+                const analysisPageOption = (
+                  <ToolBarButton
+                    key='lca-analysis-page-option'
+                    icon={<BarChartOutlined />}
+                    tooltip={intl.formatMessage({
+                      id: 'pages.process.lca.page.title',
+                      defaultMessage: 'LCA Analysis',
+                    })}
+                    onClick={() => {
+                      history.push('/mydata/processes/analysis');
+                    }}
+                  />
+                );
+                const reloadIndex = settings.findIndex((item) => item.key === 'reload');
+                if (reloadIndex < 0) {
+                  return [...settings, calcOption, analysisPageOption];
+                }
+                return [
+                  ...settings.slice(0, reloadIndex + 1),
+                  calcOption,
+                  analysisPageOption,
+                  ...settings.slice(reloadIndex + 1),
+                ];
+              }
+        }
         pagination={{
           showSizeChanger: false,
           pageSize: 10,
         }}
         toolBarRender={() => {
           if (dataSource === 'my') {
-            return [
-              <span key={3}>{typeOfDataSetFilter()}</span>,
+            const filters = [
+              <span key={3}>{typeOfDataSetFilter(isMobileDataList ? 120 : 160)}</span>,
               <TableFilter
                 key={2}
+                width={isMobileDataList ? 112 : 140}
                 onChange={(val) => {
                   stateCodeRef.current = val;
                   setStateCode(val);
                   actionRef.current?.reload();
                 }}
               />,
-              <ProcessCreate
-                importData={importData}
-                onClose={() => setImportData(null)}
-                key={0}
-                lang={lang}
-                actionRef={actionRef}
-              />,
-              <ImportData onJsonData={handleImportData} key={1} />,
             ];
+            const mobileActions = isMobileDataList
+              ? [
+                  <ResponsiveDataListToolbarMore key='process-mobile-toolbar-more'>
+                    <ProcessCreate
+                      importData={importData}
+                      onClose={() => setImportData(null)}
+                      key='process-create-option'
+                      lang={lang}
+                      actionRef={actionRef}
+                    />
+                    <LcaSolveToolbar key='lca-calc-option' />
+                    <ToolBarButton
+                      key='lca-analysis-page-option'
+                      icon={<BarChartOutlined />}
+                      tooltip={intl.formatMessage({
+                        id: 'pages.process.lca.page.title',
+                        defaultMessage: 'LCA Analysis',
+                      })}
+                      onClick={() => {
+                        history.push('/mydata/processes/analysis');
+                      }}
+                    />
+                    <ImportData onJsonData={handleImportData} key='process-import-option' />
+                  </ResponsiveDataListToolbarMore>,
+                ]
+              : [];
+            const desktopActions = isMobileDataList
+              ? []
+              : [
+                  <ProcessCreate
+                    importData={importData}
+                    onClose={() => setImportData(null)}
+                    key={0}
+                    lang={lang}
+                    actionRef={actionRef}
+                  />,
+                  <ImportData onJsonData={handleImportData} key={1} />,
+                ];
+            return [...filters, ...mobileActions, ...desktopActions];
           }
-          return [<span key={0}>{typeOfDataSetFilter()}</span>];
+          return [<span key={0}>{typeOfDataSetFilter(isMobileDataList ? 120 : 160)}</span>];
         }}
         request={async (
           params: {

--- a/src/pages/Sources/index.tsx
+++ b/src/pages/Sources/index.tsx
@@ -4,7 +4,7 @@ import {
   getSourceTablePgroongaSearch,
   source_hybrid_search,
 } from '@/services/sources/api';
-import { Card, Checkbox, Col, Input, Row, Space, Tooltip, message } from 'antd';
+import { Card, Checkbox, Col, Input, Row, Space, message } from 'antd';
 import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl, useLocation } from 'umi';
 import { getPublicationTypeLabel } from './Components/optiondata';
@@ -17,20 +17,27 @@ import {
 } from '@/components/ContributeData/utils';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
+import {
+  DATA_LIST_COLUMN_RESPONSIVE,
+  ResponsiveDataListActions,
+  dataListActionColumn,
+  dataListIndexColumn,
+  dataListText,
+  dataListTextColumn,
+  responsiveDataListTableProps,
+  responsiveSearchCardClassName,
+  responsiveSearchExtraColProps,
+  responsiveSearchPrimaryColProps,
+  responsiveSearchRowProps,
+  useResponsiveDataListMobile,
+} from '@/components/ResponsiveDataList';
 import TableFilter from '@/components/TableFilter';
 import { ListPagination } from '@/services/general/data';
 import { getDataSource, getLang, getLangText, isDataUnderReview } from '@/services/general/util';
 import { SourceImportData, SourceTable } from '@/services/sources/data';
 import { getTeamById } from '@/services/teams/api';
 import { TeamTable } from '@/services/teams/data';
-import {
-  ActionType,
-  PageContainer,
-  ProColumns,
-  ProTable,
-  TableDropdown,
-} from '@ant-design/pro-components';
-import { theme } from 'antd';
+import { ActionType, PageContainer, ProColumns, ProTable } from '@ant-design/pro-components';
 import { SearchProps } from 'antd/es/input/Search';
 import type { FC } from 'react';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
@@ -47,7 +54,7 @@ const TableList: FC = () => {
   const [editDrawerVisible, setEditDrawerVisible] = useState<boolean>(false);
   const [editId, setEditId] = useState<string>('');
   const [editVersion, setEditVersion] = useState<string>('');
-  const { token } = theme.useToken();
+  const isMobileDataList = useResponsiveDataListMobile();
   const location = useLocation();
   const dataSource = getDataSource(location.pathname);
 
@@ -89,23 +96,21 @@ const TableList: FC = () => {
   }, [dataSource, id, version]);
   const sourceColumns: ProColumns<SourceTable>[] = [
     {
+      ...dataListIndexColumn<SourceTable>(),
       title: <FormattedMessage id='pages.table.title.index' defaultMessage='Index' />,
       dataIndex: 'index',
       valueType: 'index',
-      search: false,
     },
     {
+      ...dataListTextColumn<SourceTable>(300),
       title: <FormattedMessage id='pages.table.title.name' defaultMessage='Name' />,
       dataIndex: 'shortName',
       sorter: false,
       search: false,
-      render: (_, row) => [
-        <Tooltip key={0} placement='topLeft' title={row.shortName}>
-          {row.shortName}
-        </Tooltip>,
-      ],
+      render: (_, row) => dataListText(row.shortName),
     },
     {
+      ...dataListTextColumn<SourceTable>(260, DATA_LIST_COLUMN_RESPONSIVE.desktop),
       title: (
         <FormattedMessage id='pages.table.title.classification' defaultMessage='Classification' />
       ),
@@ -113,14 +118,11 @@ const TableList: FC = () => {
       sorter: false,
       search: false,
       render: (_, row) => {
-        return (
-          <div>
-            {row.classification && row.classification !== 'undefined' ? row.classification : '-'}
-          </div>
-        );
+        return dataListText(row.classification);
       },
     },
     {
+      ...dataListTextColumn<SourceTable>(180, DATA_LIST_COLUMN_RESPONSIVE.desktop),
       title: (
         <FormattedMessage id='pages.source.publicationType' defaultMessage='Publication type' />
       ),
@@ -128,10 +130,11 @@ const TableList: FC = () => {
       sorter: false,
       search: false,
       render: (_, row) => {
-        return <span>{getPublicationTypeLabel(row.publicationType)}</span>;
+        return dataListText(getPublicationTypeLabel(row.publicationType));
       },
     },
     {
+      ...dataListTextColumn<SourceTable>(132),
       title: <FormattedMessage id='pages.table.title.version' defaultMessage='Version' />,
       dataIndex: 'version',
       sorter: false,
@@ -171,6 +174,7 @@ const TableList: FC = () => {
       },
     },
     {
+      ...dataListTextColumn<SourceTable>(180, DATA_LIST_COLUMN_RESPONSIVE.wide),
       title: <FormattedMessage id='pages.table.title.updatedAt' defaultMessage='Updated at' />,
       dataIndex: 'modifiedAt',
       valueType: 'dateTime',
@@ -178,14 +182,64 @@ const TableList: FC = () => {
       search: false,
     },
     {
+      ...dataListActionColumn<SourceTable>(isMobileDataList ? 72 : dataSource === 'my' ? 184 : 152),
       title: <FormattedMessage id='pages.table.title.option' defaultMessage='Option' />,
       dataIndex: 'option',
-      search: false,
       render: (_, row) => {
         const actionDisabled = isDataUnderReview(row.stateCode);
         if (dataSource === 'my') {
           return [
-            <Space size={'small'} key={0}>
+            <ResponsiveDataListActions
+              key={0}
+              isMobile={isMobileDataList}
+              moreMenus={[
+                {
+                  key: 'export',
+                  name: <ExportData tableName='sources' id={row.id} version={row.version} />,
+                },
+                {
+                  key: 'copy',
+                  name: (
+                    <SourceCreate
+                      actionType='copy'
+                      id={row.id}
+                      version={row.version}
+                      lang={lang}
+                      actionRef={actionRef}
+                    />
+                  ),
+                },
+                {
+                  key: 'contribute',
+                  name: (
+                    <ContributeData
+                      onOk={async () => {
+                        const contributeResult = await contributeSource(
+                          'sources',
+                          row.id,
+                          row.version,
+                        );
+                        const contributeError = extractContributeDataError(contributeResult);
+
+                        if (contributeError) {
+                          message.error(getContributeDataErrorMessage(intl, contributeError));
+                          console.log(contributeError);
+                        } else {
+                          message.success(
+                            intl.formatMessage({
+                              id: 'component.contributeData.success',
+                              defaultMessage: 'Contribute successfully',
+                            }),
+                          );
+                          actionRef.current?.reload();
+                        }
+                      }}
+                      disabled={!!row.teamId}
+                    />
+                  ),
+                },
+              ]}
+            >
               <SourceView
                 actionRef={actionRef}
                 lang={lang}
@@ -210,63 +264,11 @@ const TableList: FC = () => {
                 actionRef={actionRef}
                 setViewDrawerVisible={() => {}}
               />
-              <TableDropdown
-                style={{
-                  color: token.colorPrimary,
-                }}
-                menus={[
-                  {
-                    key: 'export',
-                    name: <ExportData tableName='sources' id={row.id} version={row.version} />,
-                  },
-                  {
-                    key: 'copy',
-                    name: (
-                      <SourceCreate
-                        actionType='copy'
-                        id={row.id}
-                        version={row.version}
-                        lang={lang}
-                        actionRef={actionRef}
-                      />
-                    ),
-                  },
-                  {
-                    key: 'contribute',
-                    name: (
-                      <ContributeData
-                        onOk={async () => {
-                          const contributeResult = await contributeSource(
-                            'sources',
-                            row.id,
-                            row.version,
-                          );
-                          const contributeError = extractContributeDataError(contributeResult);
-
-                          if (contributeError) {
-                            message.error(getContributeDataErrorMessage(intl, contributeError));
-                            console.log(contributeError);
-                          } else {
-                            message.success(
-                              intl.formatMessage({
-                                id: 'component.contributeData.success',
-                                defaultMessage: 'Contribute successfully',
-                              }),
-                            );
-                            actionRef.current?.reload();
-                          }
-                        }}
-                        disabled={!!row.teamId}
-                      />
-                    ),
-                  },
-                ]}
-              />
-            </Space>,
+            </ResponsiveDataListActions>,
           ];
         }
         return [
-          <Space size={'small'} key={0}>
+          <ResponsiveDataListActions key={0} isMobile={isMobileDataList}>
             <SourceView
               actionRef={actionRef}
               lang={lang}
@@ -282,7 +284,7 @@ const TableList: FC = () => {
               actionRef={actionRef}
             />
             <ExportData tableName='sources' id={row.id} version={row.version} />
-          </Space>,
+          </ResponsiveDataListActions>,
         ];
       },
     },
@@ -307,9 +309,9 @@ const TableList: FC = () => {
         breadcrumb: {},
       }}
     >
-      <Card>
-        <Row align={'middle'}>
-          <Col flex='auto' style={{ marginRight: '10px' }}>
+      <Card className={responsiveSearchCardClassName}>
+        <Row {...responsiveSearchRowProps}>
+          <Col {...responsiveSearchPrimaryColProps}>
             <Search
               size={'large'}
               placeholder={
@@ -321,7 +323,7 @@ const TableList: FC = () => {
               enterButton
             />
           </Col>
-          <Col style={{ display: 'none' }} flex='100px'>
+          <Col {...responsiveSearchExtraColProps} style={{ display: 'none' }}>
             <Checkbox
               onChange={(e) => {
                 setOpenAI(e.target.checked);
@@ -333,6 +335,7 @@ const TableList: FC = () => {
         </Row>
       </Card>
       <ProTable<SourceTable, ListPagination>
+        {...responsiveDataListTableProps}
         rowKey={(record) => `${record.id}-${record.version}`}
         headerTitle={
           <>
@@ -342,21 +345,25 @@ const TableList: FC = () => {
         }
         actionRef={actionRef}
         search={false}
-        options={{ fullScreen: true }}
+        options={isMobileDataList ? false : { fullScreen: true }}
         pagination={{
           showSizeChanger: false,
           pageSize: 10,
         }}
         toolBarRender={() => {
           if (dataSource === 'my') {
-            return [
+            const filters = [
               <TableFilter
                 key={2}
+                width={isMobileDataList ? 120 : 140}
                 onChange={(val) => {
                   stateCodeRef.current = val;
                   actionRef.current?.reload();
                 }}
               />,
+            ];
+            return [
+              ...filters,
               <SourceCreate
                 importData={importData}
                 onClose={() => setImportData(null)}

--- a/src/pages/Unitgroups/index.tsx
+++ b/src/pages/Unitgroups/index.tsx
@@ -7,6 +7,20 @@ import {
 } from '@/components/ContributeData/utils';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
+import {
+  DATA_LIST_COLUMN_RESPONSIVE,
+  ResponsiveDataListActions,
+  dataListActionColumn,
+  dataListIndexColumn,
+  dataListText,
+  dataListTextColumn,
+  responsiveDataListTableProps,
+  responsiveSearchCardClassName,
+  responsiveSearchExtraColProps,
+  responsiveSearchPrimaryColProps,
+  responsiveSearchRowProps,
+  useResponsiveDataListMobile,
+} from '@/components/ResponsiveDataList';
 import TableFilter from '@/components/TableFilter';
 import { attachStateCodesToRows, contributeSource } from '@/services/general/api';
 import { ListPagination } from '@/services/general/data';
@@ -20,14 +34,8 @@ import {
   unitgroup_hybrid_search,
 } from '@/services/unitgroups/api';
 import { UnitGroupImportItem, UnitGroupTable } from '@/services/unitgroups/data';
-import {
-  ActionType,
-  PageContainer,
-  ProColumns,
-  ProTable,
-  TableDropdown,
-} from '@ant-design/pro-components';
-import { Card, Checkbox, Col, Input, Row, Space, Tooltip, message, theme } from 'antd';
+import { ActionType, PageContainer, ProColumns, ProTable } from '@ant-design/pro-components';
+import { Card, Checkbox, Col, Input, Row, Space, message, theme } from 'antd';
 import { SearchProps } from 'antd/es/input/Search';
 import type { FC } from 'react';
 import { useEffect, useRef, useState } from 'react';
@@ -51,6 +59,7 @@ const TableList: FC = () => {
   const [editId, setEditId] = useState<string>('');
   const [editVersion, setEditVersion] = useState<string>('');
   const { token } = theme.useToken();
+  const isMobileDataList = useResponsiveDataListMobile();
   const location = useLocation();
   const dataSource = getDataSource(location.pathname);
 
@@ -92,20 +101,23 @@ const TableList: FC = () => {
   }, [dataSource, id, version]);
   const unitGroupColumns: ProColumns<UnitGroupTable>[] = [
     {
+      ...dataListIndexColumn<UnitGroupTable>(),
       title: (
         <FormattedMessage id='pages.table.title.index' defaultMessage='Index'></FormattedMessage>
       ),
       valueType: 'index',
-      search: false,
     },
     {
+      ...dataListTextColumn<UnitGroupTable>(300),
       title: (
         <FormattedMessage id='pages.table.title.name' defaultMessage='Name'></FormattedMessage>
       ),
       dataIndex: 'name',
       sorter: false,
+      render: (_, row) => dataListText(row.name),
     },
     {
+      ...dataListTextColumn<UnitGroupTable>(180, DATA_LIST_COLUMN_RESPONSIVE.desktop),
       title: (
         <FormattedMessage
           id='pages.unitgroup.unit.quantitativeReference'
@@ -116,14 +128,11 @@ const TableList: FC = () => {
       sorter: false,
       search: false,
       render: (_, row) => {
-        return [
-          <Tooltip key={0} placement='topLeft' title={row.refUnitGeneralComment}>
-            {toSuperscript(row.refUnitName)}
-          </Tooltip>,
-        ];
+        return dataListText(toSuperscript(row.refUnitName), row.refUnitGeneralComment);
       },
     },
     {
+      ...dataListTextColumn<UnitGroupTable>(260, DATA_LIST_COLUMN_RESPONSIVE.desktop),
       title: (
         <FormattedMessage
           id='pages.table.title.classification'
@@ -134,14 +143,11 @@ const TableList: FC = () => {
       sorter: false,
       search: false,
       render: (_, row) => {
-        return (
-          <div>
-            {row.classification && row.classification !== 'undefined' ? row.classification : '-'}
-          </div>
-        );
+        return dataListText(row.classification);
       },
     },
     {
+      ...dataListTextColumn<UnitGroupTable>(132),
       title: <FormattedMessage id='pages.table.title.version' defaultMessage='Version' />,
       dataIndex: 'version',
       sorter: false,
@@ -183,6 +189,7 @@ const TableList: FC = () => {
       },
     },
     {
+      ...dataListTextColumn<UnitGroupTable>(180, DATA_LIST_COLUMN_RESPONSIVE.wide),
       title: (
         <FormattedMessage
           id='pages.table.title.updatedAt'
@@ -195,16 +202,69 @@ const TableList: FC = () => {
       search: false,
     },
     {
+      ...dataListActionColumn<UnitGroupTable>(
+        isMobileDataList ? 72 : dataSource === 'my' ? 184 : 152,
+      ),
       title: (
         <FormattedMessage id='pages.table.title.option' defaultMessage='Option'></FormattedMessage>
       ),
       dataIndex: 'option',
-      search: false,
       render: (_, row) => {
         const actionDisabled = isDataUnderReview(row.stateCode);
         if (dataSource === 'my') {
           return [
-            <Space size={'small'} key={0}>
+            <ResponsiveDataListActions
+              key={0}
+              isMobile={isMobileDataList}
+              moreMenus={[
+                {
+                  key: 'export',
+                  name: <ExportData tableName='unitgroups' id={row.id} version={row.version} />,
+                },
+                {
+                  key: 'copy',
+                  name: (
+                    <UnitGroupCreate
+                      disabled={!isSystemAdmin}
+                      actionType='copy'
+                      id={row.id}
+                      version={row.version}
+                      lang={lang}
+                      actionRef={actionRef}
+                    ></UnitGroupCreate>
+                  ),
+                },
+                {
+                  key: 'contribute',
+                  name: (
+                    <ContributeData
+                      onOk={async () => {
+                        const contributeResult = await contributeSource(
+                          'unitgroups',
+                          row.id,
+                          row.version,
+                        );
+                        const contributeError = extractContributeDataError(contributeResult);
+
+                        if (contributeError) {
+                          message.error(getContributeDataErrorMessage(intl, contributeError));
+                          console.log(contributeError);
+                        } else {
+                          message.success(
+                            intl.formatMessage({
+                              id: 'component.contributeData.success',
+                              defaultMessage: 'Contribute successfully',
+                            }),
+                          );
+                          actionRef.current?.reload();
+                        }
+                      }}
+                      disabled={!!row.teamId}
+                    />
+                  ),
+                },
+              ]}
+            >
               <UnitGroupView
                 actionRef={actionRef}
                 lang={lang}
@@ -229,64 +289,11 @@ const TableList: FC = () => {
                 actionRef={actionRef}
                 setViewDrawerVisible={() => {}}
               ></UnitGroupDelete>
-              <TableDropdown
-                style={{
-                  color: token.colorPrimary,
-                }}
-                menus={[
-                  {
-                    key: 'export',
-                    name: <ExportData tableName='unitgroups' id={row.id} version={row.version} />,
-                  },
-                  {
-                    key: 'copy',
-                    name: (
-                      <UnitGroupCreate
-                        disabled={!isSystemAdmin}
-                        actionType='copy'
-                        id={row.id}
-                        version={row.version}
-                        lang={lang}
-                        actionRef={actionRef}
-                      ></UnitGroupCreate>
-                    ),
-                  },
-                  {
-                    key: 'contribute',
-                    name: (
-                      <ContributeData
-                        onOk={async () => {
-                          const contributeResult = await contributeSource(
-                            'unitgroups',
-                            row.id,
-                            row.version,
-                          );
-                          const contributeError = extractContributeDataError(contributeResult);
-
-                          if (contributeError) {
-                            message.error(getContributeDataErrorMessage(intl, contributeError));
-                            console.log(contributeError);
-                          } else {
-                            message.success(
-                              intl.formatMessage({
-                                id: 'component.contributeData.success',
-                                defaultMessage: 'Contribute successfully',
-                              }),
-                            );
-                            actionRef.current?.reload();
-                          }
-                        }}
-                        disabled={!!row.teamId}
-                      />
-                    ),
-                  },
-                ]}
-              />
-            </Space>,
+            </ResponsiveDataListActions>,
           ];
         }
         return [
-          <Space size={'small'} key={0}>
+          <ResponsiveDataListActions key={0} isMobile={isMobileDataList}>
             <UnitGroupView
               actionRef={actionRef}
               lang={lang}
@@ -303,7 +310,7 @@ const TableList: FC = () => {
               actionRef={actionRef}
             ></UnitGroupCreate>
             <ExportData tableName='unitgroups' id={row.id} version={row.version} />
-          </Space>,
+          </ResponsiveDataListActions>,
         ];
       },
     },
@@ -337,9 +344,9 @@ const TableList: FC = () => {
         breadcrumb: {},
       }}
     >
-      <Card>
-        <Row align={'middle'}>
-          <Col flex='auto' style={{ marginRight: '10px' }}>
+      <Card className={responsiveSearchCardClassName}>
+        <Row {...responsiveSearchRowProps}>
+          <Col {...responsiveSearchPrimaryColProps}>
             <Search
               disabled={dataSource === 'my' && !isSystemAdmin}
               size={'large'}
@@ -352,7 +359,7 @@ const TableList: FC = () => {
               enterButton
             />
           </Col>
-          <Col style={{ display: 'none' }} flex='100px'>
+          <Col {...responsiveSearchExtraColProps} style={{ display: 'none' }}>
             <Checkbox
               onChange={(e) => {
                 setOpenAI(e.target.checked);
@@ -364,6 +371,7 @@ const TableList: FC = () => {
         </Row>
       </Card>
       <ProTable<UnitGroupTable, ListPagination>
+        {...responsiveDataListTableProps}
         rowKey={(record) => `${record.id}-${record.version}`}
         headerTitle={
           <>
@@ -381,23 +389,27 @@ const TableList: FC = () => {
         }
         actionRef={actionRef}
         search={false}
-        options={{ fullScreen: true }}
+        options={isMobileDataList ? false : { fullScreen: true }}
         pagination={{
           showSizeChanger: false,
           pageSize: 10,
         }}
         toolBarRender={() => {
           if (dataSource === 'my') {
-            return [
+            const filters = [
               <TableFilter
                 disabled={!isSystemAdmin}
                 key={2}
+                width={isMobileDataList ? 120 : 140}
                 onChange={(val) => {
                   stateCodeRef.current = val;
                   setStateCode(val);
                   actionRef.current?.reload();
                 }}
               />,
+            ];
+            return [
+              ...filters,
               <UnitGroupCreate
                 disabled={!isSystemAdmin}
                 importData={importData}

--- a/tests/unit/components/HeaderDropdown.test.tsx
+++ b/tests/unit/components/HeaderDropdown.test.tsx
@@ -62,7 +62,7 @@ describe('HeaderDropdown', () => {
     expect(props.placement).toBe('bottomLeft');
   });
 
-  it('uses full-width overlay style on narrow screens', () => {
+  it('constrains overlay width to the viewport', () => {
     const originalWidth = window.innerWidth;
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,
@@ -77,7 +77,10 @@ describe('HeaderDropdown', () => {
     );
 
     const props = mockDropdown.mock.calls[0][0];
-    expect(props.overlayStyle).toEqual({ width: '100%' });
+    expect(props.overlayStyle).toEqual({
+      minWidth: 168,
+      maxWidth: 'calc(100vw - 24px)',
+    });
 
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,

--- a/tests/unit/components/ResponsiveDataList.test.tsx
+++ b/tests/unit/components/ResponsiveDataList.test.tsx
@@ -1,0 +1,237 @@
+import {
+  DATA_LIST_ACTION_SPACE_CLASS_NAME,
+  DATA_LIST_COLUMN_RESPONSIVE,
+  ResponsiveDataListActions,
+  ResponsiveDataListToolbarMore,
+  dataListActionColumn,
+  dataListIndexColumn,
+  dataListText,
+  dataListTextColumn,
+  responsiveDataListTableProps,
+  responsiveSearchCardClassName,
+  responsiveSearchExtraColProps,
+  responsiveSearchPrimaryColProps,
+  responsiveSearchRowProps,
+  useResponsiveDataListMobile,
+} from '@/components/ResponsiveDataList';
+import { render, screen } from '@testing-library/react';
+import { Grid } from 'antd';
+
+let mockBreakpointScreens: Record<string, boolean | undefined> = {};
+const mockUseBreakpoint = jest.fn(() => mockBreakpointScreens);
+
+jest.mock('antd', () => ({
+  Grid: {
+    useBreakpoint: () => mockUseBreakpoint(),
+  },
+  Space: ({ children, className, size }: any) => (
+    <div className={className} data-size={size} data-testid='action-space'>
+      {children}
+    </div>
+  ),
+  Tooltip: ({ children, placement, title }: any) => (
+    <span data-placement={placement} data-testid='tooltip' data-title={String(title)}>
+      {children}
+    </span>
+  ),
+  theme: {
+    useToken: () => ({ token: { colorPrimary: 'rgb(22, 119, 255)' } }),
+  },
+}));
+
+jest.mock('@ant-design/pro-components', () => ({
+  TableDropdown: ({ className, menus = [], style }: any) => (
+    <div className={className} data-testid='table-dropdown' style={style}>
+      {menus.map((menu: any) => (
+        <div data-menu-key={menu.key} key={menu.key}>
+          {menu.name}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+describe('ResponsiveDataList helpers', () => {
+  beforeEach(() => {
+    mockBreakpointScreens = {};
+    mockUseBreakpoint.mockClear();
+  });
+
+  it('provides shared responsive table and search props', () => {
+    expect(DATA_LIST_COLUMN_RESPONSIVE).toEqual({
+      desktop: ['lg'],
+      tablet: ['md'],
+      wide: ['xl'],
+    });
+    expect(responsiveDataListTableProps).toEqual({
+      className: 'responsive-data-list-table',
+      scroll: { x: 'max-content' },
+      tableLayout: 'fixed',
+    });
+    expect(responsiveSearchCardClassName).toBe('responsive-data-list-search-card');
+    expect(responsiveSearchRowProps).toEqual({ align: 'middle' });
+    expect(responsiveSearchPrimaryColProps).toEqual({
+      className: 'responsive-data-list-search-primary',
+      flex: 'auto',
+      style: { marginRight: '10px' },
+    });
+    expect(responsiveSearchExtraColProps).toEqual({
+      className: 'responsive-data-list-search-extra',
+      flex: '100px',
+    });
+  });
+
+  it('builds standard table column props', () => {
+    expect(dataListIndexColumn()).toEqual({
+      align: 'center',
+      search: false,
+      width: 72,
+    });
+    expect(dataListTextColumn(240, DATA_LIST_COLUMN_RESPONSIVE.desktop)).toEqual({
+      ellipsis: true,
+      responsive: ['lg'],
+      width: 240,
+    });
+    expect(dataListActionColumn()).toEqual({
+      align: 'center',
+      className: 'responsive-data-list-action-column',
+      fixed: 'right',
+      search: false,
+      width: 184,
+    });
+    expect(dataListActionColumn(224)).toEqual({
+      align: 'center',
+      className: 'responsive-data-list-action-column',
+      fixed: 'right',
+      search: false,
+      width: 224,
+    });
+  });
+
+  it('detects mobile data-list breakpoints defensively', () => {
+    mockBreakpointScreens = { md: false };
+    expect(useResponsiveDataListMobile()).toBe(true);
+    expect(mockUseBreakpoint).toHaveBeenCalledTimes(1);
+
+    mockBreakpointScreens = { md: true };
+    expect(useResponsiveDataListMobile()).toBe(false);
+
+    mockBreakpointScreens = {};
+    expect(useResponsiveDataListMobile()).toBe(false);
+
+    const originalUseBreakpoint = Grid.useBreakpoint;
+    delete (Grid as any).useBreakpoint;
+    expect(useResponsiveDataListMobile()).toBe(false);
+    Grid.useBreakpoint = originalUseBreakpoint;
+  });
+
+  it('renders row actions inline on desktop', () => {
+    render(
+      <ResponsiveDataListActions
+        isMobile={false}
+        moreMenus={[{ key: 'archive', name: <span>Archive</span> }]}
+      >
+        <button type='button'>Edit</button>
+        {false}
+        <button type='button'>View</button>
+      </ResponsiveDataListActions>,
+    );
+
+    expect(screen.getByTestId('action-space')).toHaveClass(DATA_LIST_ACTION_SPACE_CLASS_NAME);
+    expect(screen.getByTestId('action-space')).toHaveAttribute('data-size', 'small');
+    expect(screen.getByText('Edit')).toBeInTheDocument();
+    expect(screen.getByText('View')).toBeInTheDocument();
+    expect(screen.getByText('Archive')).toBeInTheDocument();
+    expect(screen.getByTestId('table-dropdown')).toHaveStyle({ color: 'rgb(22, 119, 255)' });
+  });
+
+  it('omits the desktop more menu when there are no additional actions', () => {
+    render(
+      <ResponsiveDataListActions isMobile={false}>
+        <button type='button'>Only action</button>
+      </ResponsiveDataListActions>,
+    );
+
+    expect(screen.getByText('Only action')).toBeInTheDocument();
+    expect(screen.queryByTestId('table-dropdown')).not.toBeInTheDocument();
+  });
+
+  it('collapses row actions into one dropdown on mobile', () => {
+    render(
+      <ResponsiveDataListActions
+        isMobile
+        moreMenus={[{ key: 'delete', name: <span>Delete</span> }]}
+      >
+        <button type='button'>Edit</button>
+        <button type='button'>View</button>
+      </ResponsiveDataListActions>,
+    );
+
+    expect(screen.queryByTestId('action-space')).not.toBeInTheDocument();
+    expect(screen.getByTestId('table-dropdown')).toHaveClass('responsive-data-list-more-action');
+    expect(screen.getByText('Edit')).toBeInTheDocument();
+    expect(screen.getByText('View')).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+  });
+
+  it('returns no toolbar dropdown when there are no toolbar actions', () => {
+    const { container } = render(
+      <ResponsiveDataListToolbarMore>{null}</ResponsiveDataListToolbarMore>,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders toolbar actions in a dropdown', () => {
+    const { container } = render(
+      <ResponsiveDataListToolbarMore>
+        <button type='button'>Import</button>
+        {undefined}
+        <button type='button'>Calculate</button>
+      </ResponsiveDataListToolbarMore>,
+    );
+
+    expect(container.querySelector('.ant-pro-table-list-toolbar-setting-item')).toHaveClass(
+      'responsive-data-list-toolbar-more-action',
+    );
+    expect(screen.getByTestId('table-dropdown')).toHaveClass('responsive-data-list-more-action');
+    expect(screen.getByText('Import')).toBeInTheDocument();
+    expect(screen.getByText('Calculate')).toBeInTheDocument();
+  });
+
+  it('normalizes empty display text and keeps primitive titles', () => {
+    const { rerender } = render(<>{dataListText(undefined)}</>);
+    expect(screen.getByText('-')).toHaveAttribute('title', '-');
+
+    rerender(<>{dataListText(null)}</>);
+    expect(screen.getByText('-')).toHaveAttribute('title', '-');
+
+    rerender(<>{dataListText('')}</>);
+    expect(screen.getByText('-')).toHaveAttribute('title', '-');
+
+    rerender(<>{dataListText('undefined')}</>);
+    expect(screen.getByText('-')).toHaveAttribute('title', '-');
+
+    rerender(<>{dataListText('Process name')}</>);
+    expect(screen.getByText('Process name')).toHaveAttribute('title', 'Process name');
+
+    rerender(<>{dataListText(42)}</>);
+    expect(screen.getByText('42')).toHaveAttribute('title', '42');
+
+    rerender(<>{dataListText(<strong>Rich node</strong>)}</>);
+    expect(screen.getByText('Rich node').closest('span')).not.toHaveAttribute('title');
+  });
+
+  it('wraps display text with a tooltip only when tooltip content is present', () => {
+    const { rerender } = render(<>{dataListText('Flow', null)}</>);
+    expect(screen.queryByTestId('tooltip')).not.toBeInTheDocument();
+
+    rerender(<>{dataListText('Flow', '')}</>);
+    expect(screen.queryByTestId('tooltip')).not.toBeInTheDocument();
+
+    rerender(<>{dataListText('Flow', 'Full flow name')}</>);
+    expect(screen.getByTestId('tooltip')).toHaveAttribute('data-placement', 'topLeft');
+    expect(screen.getByTestId('tooltip')).toHaveAttribute('data-title', 'Full flow name');
+    expect(screen.getByText('Flow')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/pages/Contacts/index.test.tsx
+++ b/tests/unit/pages/Contacts/index.test.tsx
@@ -18,6 +18,7 @@ let mockLocation = {
   pathname: '/mydata/contacts',
   search: '?tid=team-1',
 };
+let mockBreakpointScreens: Record<string, boolean | undefined> = {};
 
 const mockContributeSource = jest.fn();
 const mockGetContactTableAll = jest.fn();
@@ -225,6 +226,9 @@ jest.mock('antd', () => {
     Checkbox,
     Col,
     ConfigProvider,
+    Grid: {
+      useBreakpoint: () => mockBreakpointScreens,
+    },
     Input,
     Row,
     Space,
@@ -316,6 +320,7 @@ describe('ContactsPage', () => {
       pathname: '/mydata/contacts',
       search: '?tid=team-1',
     };
+    mockBreakpointScreens = {};
     mockGetDataSource.mockReturnValue('my');
     mockGetLang.mockReturnValue('en');
     mockGetLangText.mockImplementation((value: any) => value?.[0]?.['#text'] ?? 'Team title');
@@ -351,6 +356,17 @@ describe('ContactsPage', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /close-contact-edit/i }));
     await userEvent.click(screen.getByRole('button', { name: /close-contact-delete/i }));
+  });
+
+  it('uses compact mobile controls for my data rows', async () => {
+    mockBreakpointScreens = { md: false };
+
+    renderWithProviders(<ContactsPage />);
+
+    await waitFor(() => expect(mockGetContactTableAll).toHaveBeenCalled());
+    expect(await screen.findByTestId('contact-view')).toHaveTextContent('view:contact-1');
+    expect(screen.getByRole('button', { name: /table-filter/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /import-data/i })).toBeInTheDocument();
   });
 
   it('supports pgroonga search, AI search, and contribute flows', async () => {

--- a/tests/unit/pages/Flowproperties/index.test.tsx
+++ b/tests/unit/pages/Flowproperties/index.test.tsx
@@ -17,6 +17,7 @@ let mockLocation = {
   pathname: '/mydata/flowproperties',
   search: '?tid=team-1',
 };
+let mockBreakpointScreens: Record<string, boolean | undefined> = {};
 
 const mockContributeSource = jest.fn();
 const mockGetFlowpropertyTableAll = jest.fn();
@@ -233,6 +234,9 @@ jest.mock('antd', () => {
     Checkbox,
     Col,
     ConfigProvider,
+    Grid: {
+      useBreakpoint: () => mockBreakpointScreens,
+    },
     Input,
     Row,
     Space,
@@ -325,6 +329,7 @@ describe('FlowpropertiesPage', () => {
       pathname: '/mydata/flowproperties',
       search: '?tid=team-1',
     };
+    mockBreakpointScreens = {};
     mockGetDataSource.mockReturnValue('my');
     mockGetTeamById.mockResolvedValue({
       data: [{ json: { title: [{ '@xml:lang': 'en', '#text': 'Flowproperty Team' }] } }],
@@ -397,6 +402,17 @@ describe('FlowpropertiesPage', () => {
         .some((node) => node.textContent?.includes('"importCount":0')),
     ).toBe(true);
     await userEvent.click(screen.getByTestId('flowproperty-delete'));
+  });
+
+  it('uses compact mobile controls for my data rows', async () => {
+    mockBreakpointScreens = { md: false };
+
+    renderWithProviders(<FlowpropertiesPage />);
+
+    await waitFor(() => expect(mockGetFlowpropertyTableAll).toHaveBeenCalled());
+    expect(screen.getByTestId('flowproperty-view')).toHaveTextContent('fp-1:01.00.000');
+    expect(screen.getByRole('button', { name: /table-filter/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /import-data/i })).toBeInTheDocument();
   });
 
   it('reloads the table with the selected state filter', async () => {

--- a/tests/unit/pages/Flows/index.test.tsx
+++ b/tests/unit/pages/Flows/index.test.tsx
@@ -17,6 +17,7 @@ let mockLocation = {
   pathname: '/mydata/flows',
   search: '?tid=team-1',
 };
+let mockBreakpointScreens: Record<string, boolean | undefined> = {};
 
 const mockContributeSource = jest.fn();
 const mockGetFlowTableAll = jest.fn();
@@ -251,6 +252,9 @@ jest.mock('antd', () => {
     Checkbox,
     Col,
     ConfigProvider,
+    Grid: {
+      useBreakpoint: () => mockBreakpointScreens,
+    },
     Input,
     Row,
     Space,
@@ -392,6 +396,7 @@ describe('FlowsPage', () => {
       pathname: '/mydata/flows',
       search: '?tid=team-1',
     };
+    mockBreakpointScreens = {};
     mockGetDataSource.mockReturnValue('my');
     mockGetTeamById.mockResolvedValue({
       data: [{ json: { title: [{ '@xml:lang': 'en', '#text': 'Flow Team' }] } }],
@@ -455,6 +460,17 @@ describe('FlowsPage', () => {
 
     await user.click(screen.getByRole('button', { name: /close-flow-create-create/i }));
     expect(screen.getByTestId('flow-create-create')).toHaveTextContent('"importCount":0');
+  });
+
+  it('uses compact mobile controls for my data rows', async () => {
+    mockBreakpointScreens = { md: false };
+
+    renderWithProviders(<FlowsPage />);
+
+    await waitFor(() => expect(mockGetFlowTableAll).toHaveBeenCalled());
+    expect(await screen.findByText('Flow One')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /table-filter/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /import-data/i })).toBeInTheDocument();
   });
 
   it('reloads the table with the selected state filter and uses search placeholders for both modes', async () => {

--- a/tests/unit/pages/LifeCycleModels/index.test.tsx
+++ b/tests/unit/pages/LifeCycleModels/index.test.tsx
@@ -18,6 +18,7 @@ let mockLocation = {
   pathname: '/mydata/lifecyclemodels',
   search: '?tid=team-1',
 };
+let mockBreakpointScreens: Record<string, boolean | undefined> = {};
 
 const mockGetDataSource = jest.fn(() => 'my');
 const mockGetLang = jest.fn(() => 'en');
@@ -256,6 +257,9 @@ jest.mock('antd', () => {
     Checkbox,
     Col,
     ConfigProvider,
+    Grid: {
+      useBreakpoint: () => mockBreakpointScreens,
+    },
     Input,
     Row,
     Space,
@@ -376,6 +380,7 @@ describe('LifeCycleModelsPage', () => {
       pathname: '/mydata/lifecyclemodels',
       search: '?tid=team-1',
     };
+    mockBreakpointScreens = {};
     mockGetDataSource.mockReturnValue('my');
     mockGetLang.mockReturnValue('en');
     mockGetLangText.mockImplementation((value: any) => value?.[0]?.['#text'] ?? 'Team title');
@@ -453,6 +458,17 @@ describe('LifeCycleModelsPage', () => {
 
     await user.click(screen.getByRole('button', { name: /close-lifecycle-create-create/i }));
     expect(screen.getByTestId('lifecycle-create-create')).toHaveTextContent('"importCount":0');
+  });
+
+  it('uses compact mobile controls for my data rows', async () => {
+    mockBreakpointScreens = { md: false };
+
+    renderWithProviders(<LifeCycleModelsPage />);
+
+    await waitFor(() => expect(mockGetLifeCycleModelTableAll).toHaveBeenCalled());
+    expect(screen.getByText('Lifecycle model 1')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /table-filter/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /import-data/i })).toBeInTheDocument();
   });
 
   it('uses current state filters for pgroonga search, sort conversion, and AI search', async () => {

--- a/tests/unit/pages/Processes/index.test.tsx
+++ b/tests/unit/pages/Processes/index.test.tsx
@@ -17,6 +17,7 @@ let mockLocation = {
   pathname: '/mydata/processes',
   search: '?tid=team-1',
 };
+let mockBreakpointScreens: Record<string, boolean | undefined> = {};
 
 const mockGetProcessTableAll = jest.fn();
 const mockGetProcessTablePgroongaSearch = jest.fn();
@@ -286,6 +287,9 @@ jest.mock('antd', () => {
     Checkbox,
     Col,
     ConfigProvider,
+    Grid: {
+      useBreakpoint: () => mockBreakpointScreens,
+    },
     Input,
     Select,
     Row,
@@ -403,6 +407,7 @@ describe('ProcessesPage', () => {
       pathname: '/mydata/processes',
       search: '?tid=team-1',
     };
+    mockBreakpointScreens = {};
     mockGetDataSource.mockReturnValue('my');
     mockContributeProcess.mockResolvedValue({ error: null });
     mockContributeLifeCycleModel.mockResolvedValue({ error: null });
@@ -470,6 +475,29 @@ describe('ProcessesPage', () => {
       .find((node) => node.textContent?.includes('"actionType":"create"'));
     expect(createAction).toHaveTextContent('"importCount":1');
 
+    await userEvent.click(
+      within(createAction!).getByRole('button', { name: /process-create-close/i }),
+    );
+    await waitFor(() => expect(createAction).toHaveTextContent('"importCount":0'));
+  });
+
+  it('uses compact mobile controls for my data rows', async () => {
+    const { history } = jest.requireMock('umi');
+    mockBreakpointScreens = { md: false };
+
+    renderWithProviders(<ProcessesPage />);
+
+    await waitFor(() => expect(mockGetProcessTableAll).toHaveBeenCalled());
+    expect(screen.getByRole('button', { name: /dataset-filter/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /table-filter/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /import-data/i })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'LCA Analysis' }));
+    expect(history.push).toHaveBeenCalledWith('/mydata/processes/analysis');
+
+    const createAction = screen
+      .getAllByTestId('process-create')
+      .find((node) => node.textContent?.includes('"actionType":"create"'));
     await userEvent.click(
       within(createAction!).getByRole('button', { name: /process-create-close/i }),
     );
@@ -908,6 +936,18 @@ describe('ProcessesPage', () => {
         .getAllByTestId('process-create')
         .some((node) => node.textContent?.includes('"actionType":"copy"')),
     ).toBe(true);
+  });
+
+  it('uses compact mobile controls for non-my process data', async () => {
+    mockBreakpointScreens = { md: false };
+    mockGetDataSource.mockReturnValue('tg');
+
+    renderWithProviders(<ProcessesPage />);
+
+    await waitFor(() => expect(mockGetProcessTableAll).toHaveBeenCalled());
+    expect(screen.getByRole('button', { name: /dataset-filter/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /table-filter/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /import-data/i })).not.toBeInTheDocument();
   });
 
   it('falls back to empty tid and null team when the route has no team query or team data payload', async () => {

--- a/tests/unit/pages/Sources/index.test.tsx
+++ b/tests/unit/pages/Sources/index.test.tsx
@@ -18,6 +18,7 @@ let mockLocation = {
   pathname: '/mydata/sources',
   search: '?tid=team-1',
 };
+let mockBreakpointScreens: Record<string, boolean | undefined> = {};
 
 const mockContributeSource = jest.fn();
 const mockGetSourceTableAll = jest.fn();
@@ -229,6 +230,9 @@ jest.mock('antd', () => {
     Checkbox,
     Col,
     ConfigProvider,
+    Grid: {
+      useBreakpoint: () => mockBreakpointScreens,
+    },
     Input,
     Row,
     Space,
@@ -320,6 +324,7 @@ describe('SourcesPage', () => {
       pathname: '/mydata/sources',
       search: '?tid=team-1',
     };
+    mockBreakpointScreens = {};
     mockGetDataSource.mockReturnValue('my');
     mockGetLang.mockReturnValue('en');
     mockGetLangText.mockImplementation((value: any) => value?.[0]?.['#text'] ?? 'Team title');
@@ -355,6 +360,17 @@ describe('SourcesPage', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /close-source-edit/i }));
     await userEvent.click(screen.getByRole('button', { name: /close-source-delete/i }));
+  });
+
+  it('uses compact mobile controls for my data rows', async () => {
+    mockBreakpointScreens = { md: false };
+
+    renderWithProviders(<SourcesPage />);
+
+    await waitFor(() => expect(mockGetSourceTableAll).toHaveBeenCalled());
+    expect(await screen.findByTestId('source-view')).toHaveTextContent('view:source-1');
+    expect(screen.getByRole('button', { name: /table-filter/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /import-data/i })).toBeInTheDocument();
   });
 
   it('supports pgroonga search, AI search, and contribute flows', async () => {

--- a/tests/unit/pages/Unitgroups/index.test.tsx
+++ b/tests/unit/pages/Unitgroups/index.test.tsx
@@ -18,6 +18,7 @@ let mockLocation = {
   pathname: '/mydata/unitgroups',
   search: '?tid=team-1',
 };
+let mockBreakpointScreens: Record<string, boolean | undefined> = {};
 let mockUnitGroupCreateCalls: any[] = [];
 let mockUnitGroupEditCalls: any[] = [];
 let mockUnitGroupDeleteCalls: any[] = [];
@@ -234,6 +235,9 @@ jest.mock('antd', () => {
     Checkbox,
     Col,
     ConfigProvider,
+    Grid: {
+      useBreakpoint: () => mockBreakpointScreens,
+    },
     Input,
     Row,
     Space,
@@ -331,6 +335,7 @@ describe('UnitgroupsPage', () => {
       pathname: '/mydata/unitgroups',
       search: '?tid=team-1',
     };
+    mockBreakpointScreens = {};
     mockGetDataSource.mockReturnValue('my');
     mockGetLang.mockReturnValue('en');
     mockGetLangText.mockImplementation((value: any) => value?.[0]?.['#text'] ?? 'Team title');
@@ -481,6 +486,22 @@ describe('UnitgroupsPage', () => {
     const { message } = jest.requireMock('antd');
     expect(message.success).toHaveBeenCalledWith('Contribute successfully');
     expect(latestReloadMock).toHaveBeenCalled();
+  });
+
+  it('uses compact mobile controls for admin my data rows', async () => {
+    mockBreakpointScreens = { md: false };
+    mockGetRoleByUserId.mockResolvedValue([
+      {
+        team_id: '00000000-0000-0000-0000-000000000000',
+        role: 'admin',
+      },
+    ]);
+
+    renderWithProviders(<UnitgroupsPage />);
+
+    await waitFor(() => expect(mockGetUnitGroupTableAll).toHaveBeenCalled());
+    expect(screen.getByRole('button', { name: /table-filter/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /import-data/i })).toBeInTheDocument();
   });
 
   it('logs contribute errors without showing success when the contribute action fails', async () => {

--- a/tests/unit/pages/User/Login/password_forgot.test.tsx
+++ b/tests/unit/pages/User/Login/password_forgot.test.tsx
@@ -232,13 +232,23 @@ describe('PasswordForgot page (src/pages/User/Login/password_forgot.tsx)', () =>
 
     fireEvent.click(screen.getByTestId('submit'));
 
-    await waitFor(() => {
-      expect(mockNotification.error).toHaveBeenCalledWith({
-        message: 'The email was not sent successfully, please try again!',
-        description: 'Error: boom',
-        placement: 'top',
-      });
-    });
+    await waitFor(
+      () => {
+        expect(mockForgotPasswordSendEmail).toHaveBeenCalledWith({ email: 'user@test.com' });
+      },
+      { timeout: 5000 },
+    );
+
+    await waitFor(
+      () => {
+        expect(mockNotification.error).toHaveBeenCalledWith({
+          message: 'The email was not sent successfully, please try again!',
+          description: 'Error: boom',
+          placement: 'top',
+        });
+      },
+      { timeout: 5000 },
+    );
   });
 
   it('falls back to empty init data and supports dark mode toggle from localStorage', async () => {


### PR DESCRIPTION
## Branch Contract

- base branch: `dev`
- validated environment: local checkout rebased on latest `origin/dev`
- back-merge required after merge: No
- root workspace integration expected: Yes, after this frontend change is merged/promoted according to workspace submodule policy

- [x] this PR targets `dev`
- [x] if the work started from `main`, this PR documents why it is a hotfix or production-only exception

## Linked Issue

Closes #370

## Change Facts

- Adds shared responsive data-list helpers for table column sizing, mobile action menus, mobile search/toolbars, and row action collapse.
- Applies the responsive list treatment to Contacts, Flowproperties, Flows, LifeCycleModels, Processes, Sources, and Unitgroups.
- Fixes narrow-screen app shell/header behavior so long titles and account dropdowns do not overflow.
- Keeps desktop ProTable toolbar layout intact while narrowing/mobile-collapsing controls only at small breakpoints.
- On mobile Processes, moves create, calculate, analysis, and import into the same `TableDropdown`-style more menu.

## Validation Facts

- `npx prettier -c src/components/ResponsiveDataList/index.tsx src/components/ResponsiveDataList/index.less src/pages/Processes/index.tsx`
- `npm run tsc`
- `npm run lint:js`
- `npm run build`
- `npm run lint`
- `npm test`
- Targeted regression check: `npm run test:ci -- tests/unit/components/HeaderDropdown.test.tsx tests/unit/pages/LifeCycleModels/index.test.tsx tests/unit/pages/autoOpenEditDrawer.test.tsx tests/unit/pages/underReviewListEdit.test.tsx`

Notes:
- `npm test` passed 309 unit suites / 3851 tests and 14 integration suites / 66 tests.
- `npm run build` passed; Umi still reports the existing bundle-size warning.
- Local authenticated mobile screenshot verification was blocked by login redirect state, so this PR relies on code-level responsive behavior plus local compile/test validation.
- `npm run prepush:gate` was not run locally; PR CI remains the protected gate.

## Risks And Follow-Up

- The shared responsive list helper is intentionally scoped to current data-list pages, but it touches several page entrypoints; review should spot-check both desktop and narrow widths.
- After merge and any required promote, root workspace submodule integration remains a separate delivery step.
