### PR TITLE
fix(validation): prefer frontend required messages

### DIFF
--- a/src/pages/Contacts/Components/form.tsx
+++ b/src/pages/Contacts/Components/form.tsx
@@ -11,6 +11,9 @@ import { ProFormInstance } from '@ant-design/pro-components';
 import { Card, Form, Input, Space, theme } from 'antd';
 import { FC, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
+
+const CONTACT_SCHEMA_PATH_PREFIX = ['contactDataSet'];
+
 type Props = {
   lang: string;
   activeTabKey: string;
@@ -44,6 +47,8 @@ export const ContactForm: FC<Props> = ({
     intl,
     sdkValidationDetails,
     sdkValidationFocus,
+    schemaPathPrefix: CONTACT_SCHEMA_PATH_PREFIX,
+    schemaRoot: schema,
     showRules,
   });
 

--- a/src/pages/Flowproperties/Components/form.tsx
+++ b/src/pages/Flowproperties/Components/form.tsx
@@ -17,6 +17,8 @@ import schema from '../flowproperties_schema.json';
 import { complianceOptions } from './optiondata';
 // import FlowpropertiesSelectForm from './select/form';
 
+const FLOW_PROPERTY_DATASET_SCHEMA_PATH_PREFIX = ['flowPropertyDataSet'];
+
 type Props = {
   lang: string;
   activeTabKey: string;
@@ -50,6 +52,8 @@ export const FlowpropertyForm: FC<Props> = ({
     intl,
     sdkValidationDetails,
     sdkValidationFocus,
+    schemaPathPrefix: FLOW_PROPERTY_DATASET_SCHEMA_PATH_PREFIX,
+    schemaRoot: schema,
     showRules,
   });
 

--- a/src/pages/Flows/Components/Property/edit.tsx
+++ b/src/pages/Flows/Components/Property/edit.tsx
@@ -3,7 +3,10 @@ import LangTextItemForm from '@/components/LangTextItem/form';
 import FlowpropertiesSelectForm from '@/pages/Flowproperties/Components/select/form';
 import { getRules } from '@/pages/Utils';
 import type { ValidationIssueSdkDetail } from '@/pages/Utils/review';
-import { getSdkSuggestedFixMessage } from '@/pages/Utils/validation/messages';
+import {
+  getSdkSuggestedFixMessage,
+  resolveRequiredValidationMessage,
+} from '@/pages/Utils/validation/messages';
 import { FlowPropertyData } from '@/services/flows/data';
 import styles from '@/style/custom.less';
 import { CloseOutlined, FormOutlined } from '@ant-design/icons';
@@ -21,7 +24,7 @@ import {
   Tooltip,
 } from 'antd';
 import type { FC } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 import schema from '../../flows_schema.json';
 import { dataDerivationTypeStatusOptions, uncertaintyDistributionTypeOptions } from '../optiondata';
@@ -30,6 +33,8 @@ type SdkFieldMessageEntry = {
   text: string;
   validationCode?: string;
 };
+
+const FLOW_PROPERTY_SCHEMA_PATH_PREFIX = ['flowDataSet', 'flowProperties', 'flowProperty'];
 
 type Props = {
   id: string;
@@ -72,6 +77,8 @@ const PropertyEdit: FC<Props> = ({
   autoOpen = false,
 }) => {
   const intl = useIntl();
+  const intlRef = useRef(intl);
+  intlRef.current = intl;
   const [drawerVisible, setDrawerVisible] = useState(false);
   const formRefEdit = useRef<ProFormInstance>();
   const [fromData, setFromData] = useState<FlowPropertyData>({});
@@ -81,47 +88,51 @@ const PropertyEdit: FC<Props> = ({
     Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
   >(new Map());
 
-  const sdkFieldMessages = sdkHighlights.reduce<
-    Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
-  >((accumulator, detail) => {
-    const formName =
-      (Array.isArray(detail.formName) && detail.formName.length > 0
-        ? detail.formName
-        : parseSdkFieldPathToFormName(detail.fieldPath)) ??
-      (detail.fieldKey ? [detail.fieldKey] : undefined);
-    const fieldKey = formName ? formName.map(String).join('.') : '';
-    const messageText = getSdkSuggestedFixMessage(intl, detail);
+  const sdkFieldMessages = useMemo(
+    () =>
+      sdkHighlights.reduce<
+        Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
+      >((accumulator, detail) => {
+        const formName =
+          (Array.isArray(detail.formName) && detail.formName.length > 0
+            ? detail.formName
+            : parseSdkFieldPathToFormName(detail.fieldPath)) ??
+          (detail.fieldKey ? [detail.fieldKey] : undefined);
+        const fieldKey = formName ? formName.map(String).join('.') : '';
+        const messageText = getSdkSuggestedFixMessage(intlRef.current, detail);
 
-    if (!formName || !fieldKey || !messageText) {
-      return accumulator;
-    }
+        if (!formName || !fieldKey || !messageText) {
+          return accumulator;
+        }
 
-    const messageEntry: SdkFieldMessageEntry = {
-      text: messageText,
-      validationCode: detail.validationCode,
-    };
-    const currentEntry = accumulator.get(fieldKey);
+        const messageEntry: SdkFieldMessageEntry = {
+          text: messageText,
+          validationCode: detail.validationCode,
+        };
+        const currentEntry = accumulator.get(fieldKey);
 
-    if (currentEntry) {
-      if (
-        !currentEntry.entries.some(
-          (entry) =>
-            entry.text === messageEntry.text &&
-            entry.validationCode === messageEntry.validationCode,
-        )
-      ) {
-        currentEntry.entries.push(messageEntry);
-      }
+        if (currentEntry) {
+          if (
+            !currentEntry.entries.some(
+              (entry) =>
+                entry.text === messageEntry.text &&
+                entry.validationCode === messageEntry.validationCode,
+            )
+          ) {
+            currentEntry.entries.push(messageEntry);
+          }
 
-      return accumulator;
-    }
+          return accumulator;
+        }
 
-    accumulator.set(fieldKey, {
-      entries: [messageEntry],
-      name: formName,
-    });
-    return accumulator;
-  }, new Map());
+        accumulator.set(fieldKey, {
+          entries: [messageEntry],
+          name: formName,
+        });
+        return accumulator;
+      }, new Map()),
+    [sdkHighlights],
+  );
 
   useEffect(() => {
     if (!autoOpen) {
@@ -200,15 +211,30 @@ const PropertyEdit: FC<Props> = ({
       const nextAppliedFieldEntries: SdkFieldMessageEntry[] = [];
 
       (nextEntry?.entries ?? []).forEach((entry) => {
-        if (entry.validationCode === 'required_missing' && retainedErrors.length > 0) {
+        const requiredResolution = resolveRequiredValidationMessage({
+          fieldName,
+          frontendRulesEnabled: showRules,
+          intl: intlRef.current,
+          retainedErrors,
+          schemaPathPrefix: FLOW_PROPERTY_SCHEMA_PATH_PREFIX,
+          schemaRoot: schema,
+          validationCode: entry.validationCode,
+        });
+
+        if (requiredResolution.suppressSdkMessage) {
           return;
         }
 
-        if (!nextErrors.includes(entry.text)) {
-          nextErrors.push(entry.text);
+        const resolvedEntry = {
+          ...entry,
+          text: requiredResolution.replacementMessage ?? entry.text,
+        };
+
+        if (!nextErrors.includes(resolvedEntry.text)) {
+          nextErrors.push(resolvedEntry.text);
         }
 
-        nextAppliedFieldEntries.push(entry);
+        nextAppliedFieldEntries.push(resolvedEntry);
       });
 
       if (nextAppliedFieldEntries.length > 0) {
@@ -238,7 +264,7 @@ const PropertyEdit: FC<Props> = ({
     }
 
     sdkFieldMessagesRef.current = appliedEntries;
-  }, [drawerVisible, sdkFieldMessages]);
+  }, [drawerVisible, showRules, sdkFieldMessages]);
 
   useEffect(() => {
     const highlightedField = sdkHighlights.find(

--- a/src/pages/Flows/Components/form.tsx
+++ b/src/pages/Flows/Components/form.tsx
@@ -22,7 +22,7 @@ import { getLangText, getUnitData } from '@/services/general/util';
 import { ActionType, ProColumns, ProFormInstance, ProTable } from '@ant-design/pro-components';
 import { Card, Divider, Form, Input, Select, Space, theme, Tooltip } from 'antd';
 import type { FC } from 'react';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 import schema from '../flows_schema.json';
 import { complianceOptions, myFlowTypeOptions } from './optiondata';
@@ -32,6 +32,9 @@ import PropertyEdit from './Property/edit';
 import PropertyView from './Property/view';
 // import FlowsSelectForm from './select/form';
 import AlignedNumber from '@/components/AlignedNumber';
+
+const FLOW_SCHEMA_PATH_PREFIX = ['flowDataSet'];
+
 type Props = {
   lang: string;
   activeTabKey: FlowDataSetObjectKeys;
@@ -92,8 +95,9 @@ export const FlowForm: FC<Props> = ({
   const [baseNameError, setBaseNameError] = useState(false);
   const [treatmentStandardsRoutesError, setTreatmentStandardsRoutesError] = useState(false);
   const [mixAndLocationTypesError, setMixAndLocationTypesError] = useState(false);
-  const sdkRootValidationDetails = sdkValidationDetails.filter(
-    (detail) => !getFlowPropertyInternalId(detail),
+  const sdkRootValidationDetails = useMemo(
+    () => sdkValidationDetails.filter((detail) => !getFlowPropertyInternalId(detail)),
+    [sdkValidationDetails],
   );
   const { sdkValidationCountsByTab: rootSdkValidationCountsByTab, sdkValidationSectionMessages } =
     useDatasetSdkValidationFormSupport({
@@ -102,62 +106,75 @@ export const FlowForm: FC<Props> = ({
       intl,
       sdkValidationDetails: sdkRootValidationDetails,
       sdkValidationFocus: getFlowPropertyInternalId(sdkValidationFocus) ? null : sdkValidationFocus,
+      schemaPathPrefix: FLOW_SCHEMA_PATH_PREFIX,
+      schemaRoot: schema,
       showRules,
     });
-  const sdkFlowPropertyRowHighlightsById = sdkValidationDetails.reduce<
-    Record<string, ValidationIssueSdkDetail[]>
-  >((accumulator, detail) => {
-    const flowPropertyInternalId = getFlowPropertyInternalId(detail);
+  const sdkFlowPropertyRowHighlightsById = useMemo(
+    () =>
+      sdkValidationDetails.reduce<Record<string, ValidationIssueSdkDetail[]>>(
+        (accumulator, detail) => {
+          const flowPropertyInternalId = getFlowPropertyInternalId(detail);
 
-    if (!flowPropertyInternalId || isSdkSectionDetail(detail)) {
-      return accumulator;
-    }
+          if (!flowPropertyInternalId || isSdkSectionDetail(detail)) {
+            return accumulator;
+          }
 
-    if (!accumulator[flowPropertyInternalId]) {
-      accumulator[flowPropertyInternalId] = [];
-    }
+          if (!accumulator[flowPropertyInternalId]) {
+            accumulator[flowPropertyInternalId] = [];
+          }
 
-    accumulator[flowPropertyInternalId].push(detail);
-    return accumulator;
-  }, {});
-  const sdkFlowPropertyFieldDetailsById = sdkValidationDetails.reduce<
-    Record<string, ValidationIssueSdkDetail[]>
-  >((accumulator, detail) => {
-    const flowPropertyInternalId = getFlowPropertyInternalId(detail);
+          accumulator[flowPropertyInternalId].push(detail);
+          return accumulator;
+        },
+        {},
+      ),
+    [sdkValidationDetails],
+  );
+  const sdkFlowPropertyFieldDetailsById = useMemo(
+    () =>
+      sdkValidationDetails.reduce<Record<string, ValidationIssueSdkDetail[]>>(
+        (accumulator, detail) => {
+          const flowPropertyInternalId = getFlowPropertyInternalId(detail);
 
-    if (
-      !flowPropertyInternalId ||
-      !isSdkFieldDetail(detail) ||
-      isSdkSectionDetail(detail) ||
-      isSdkHighlightOnlyDetail(detail)
-    ) {
-      return accumulator;
-    }
+          if (
+            !flowPropertyInternalId ||
+            !isSdkFieldDetail(detail) ||
+            isSdkSectionDetail(detail) ||
+            isSdkHighlightOnlyDetail(detail)
+          ) {
+            return accumulator;
+          }
 
-    if (!accumulator[flowPropertyInternalId]) {
-      accumulator[flowPropertyInternalId] = [];
-    }
+          if (!accumulator[flowPropertyInternalId]) {
+            accumulator[flowPropertyInternalId] = [];
+          }
 
-    accumulator[flowPropertyInternalId].push(detail);
-    return accumulator;
-  }, {});
-  const sdkVisibleFlowPropertyRowsByTab = sdkValidationDetails.reduce<Record<string, Set<string>>>(
-    (accumulator, detail) => {
-      const flowPropertyInternalId = getFlowPropertyInternalId(detail);
-      const tabName = detail.tabName;
+          accumulator[flowPropertyInternalId].push(detail);
+          return accumulator;
+        },
+        {},
+      ),
+    [sdkValidationDetails],
+  );
+  const sdkVisibleFlowPropertyRowsByTab = useMemo(
+    () =>
+      sdkValidationDetails.reduce<Record<string, Set<string>>>((accumulator, detail) => {
+        const flowPropertyInternalId = getFlowPropertyInternalId(detail);
+        const tabName = detail.tabName;
 
-      if (!flowPropertyInternalId || !tabName || isSdkSectionDetail(detail)) {
+        if (!flowPropertyInternalId || !tabName || isSdkSectionDetail(detail)) {
+          return accumulator;
+        }
+
+        if (!accumulator[tabName]) {
+          accumulator[tabName] = new Set<string>();
+        }
+
+        accumulator[tabName].add(flowPropertyInternalId);
         return accumulator;
-      }
-
-      if (!accumulator[tabName]) {
-        accumulator[tabName] = new Set<string>();
-      }
-
-      accumulator[tabName].add(flowPropertyInternalId);
-      return accumulator;
-    },
-    {},
+      }, {}),
+    [sdkValidationDetails],
   );
   const sdkValidationCountsByTab: Record<string, number> = {
     ...rootSdkValidationCountsByTab,

--- a/src/pages/LifeCycleModels/Components/form.tsx
+++ b/src/pages/LifeCycleModels/Components/form.tsx
@@ -18,6 +18,8 @@ import { FormattedMessage, useIntl } from 'umi';
 import schema from '../lifecyclemodels.json';
 import { licenseTypeOptions } from './optiondata';
 
+const LIFE_CYCLE_MODEL_SCHEMA_PATH_PREFIX = ['lifeCycleModelDataSet'];
+
 type Props = {
   lang: string;
   activeTabKey: string;
@@ -55,6 +57,8 @@ export const LifeCycleModelForm: FC<Props> = ({
     intl,
     sdkValidationDetails,
     sdkValidationFocus,
+    schemaPathPrefix: LIFE_CYCLE_MODEL_SCHEMA_PATH_PREFIX,
+    schemaRoot: schema,
     showRules,
   });
 

--- a/src/pages/Processes/Components/Exchange/edit.tsx
+++ b/src/pages/Processes/Components/Exchange/edit.tsx
@@ -24,7 +24,7 @@ import {
   Tooltip,
 } from 'antd';
 import type { FC, ReactNode } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 import schema from '../../processes_schema.json';
 import { getSdkSuggestedFixMessage, resolveRequiredValidationMessage } from '../../sdkValidationUi';
@@ -114,6 +114,8 @@ const ProcessExchangeEdit: FC<Props> = ({
   autoOpen = false,
 }) => {
   const intl = useIntl();
+  const intlRef = useRef(intl);
+  intlRef.current = intl;
   const [drawerVisible, setDrawerVisible] = useState(false);
   const formRefEdit = useRef<ProFormInstance>();
   const [fromData, setFromData] = useState<ProcessExchangeData>({});
@@ -134,45 +136,49 @@ const ProcessExchangeEdit: FC<Props> = ({
     }
   }, [unitConvertVisible]);
 
-  const sdkFieldMessages = sdkHighlights.reduce<
-    Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
-  >((accumulator, detail) => {
-    const formName =
-      (Array.isArray(detail.formName) && detail.formName.length > 0
-        ? detail.formName
-        : parseSdkFieldPathToFormName(detail.fieldPath)) ??
-      (detail.fieldKey ? [detail.fieldKey] : undefined);
-    const fieldKey = formName ? formName.map(String).join('.') : '';
-    const messageText = getSdkSuggestedFixMessage(intl, detail);
+  const sdkFieldMessages = useMemo(
+    () =>
+      sdkHighlights.reduce<
+        Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
+      >((accumulator, detail) => {
+        const formName =
+          (Array.isArray(detail.formName) && detail.formName.length > 0
+            ? detail.formName
+            : parseSdkFieldPathToFormName(detail.fieldPath)) ??
+          (detail.fieldKey ? [detail.fieldKey] : undefined);
+        const fieldKey = formName ? formName.map(String).join('.') : '';
+        const messageText = getSdkSuggestedFixMessage(intlRef.current, detail);
 
-    if (!formName || !fieldKey || !messageText) {
-      return accumulator;
-    }
-    const messageEntry: SdkFieldMessageEntry = {
-      text: messageText,
-      validationCode: detail.validationCode,
-    };
+        if (!formName || !fieldKey || !messageText) {
+          return accumulator;
+        }
+        const messageEntry: SdkFieldMessageEntry = {
+          text: messageText,
+          validationCode: detail.validationCode,
+        };
 
-    const currentEntry = accumulator.get(fieldKey);
-    if (currentEntry) {
-      if (
-        !currentEntry.entries.some(
-          (entry) =>
-            entry.text === messageEntry.text &&
-            entry.validationCode === messageEntry.validationCode,
-        )
-      ) {
-        currentEntry.entries.push(messageEntry);
-      }
-      return accumulator;
-    }
+        const currentEntry = accumulator.get(fieldKey);
+        if (currentEntry) {
+          if (
+            !currentEntry.entries.some(
+              (entry) =>
+                entry.text === messageEntry.text &&
+                entry.validationCode === messageEntry.validationCode,
+            )
+          ) {
+            currentEntry.entries.push(messageEntry);
+          }
+          return accumulator;
+        }
 
-    accumulator.set(fieldKey, {
-      entries: [messageEntry],
-      name: formName,
-    });
-    return accumulator;
-  }, new Map());
+        accumulator.set(fieldKey, {
+          entries: [messageEntry],
+          name: formName,
+        });
+        return accumulator;
+      }, new Map()),
+    [sdkHighlights],
+  );
 
   const renderSdkHighlightedField = (_fieldKey: string, content: ReactNode) => content;
 
@@ -263,7 +269,7 @@ const ProcessExchangeEdit: FC<Props> = ({
           context: 'exchange',
           fieldName,
           frontendRulesEnabled: showRules,
-          intl,
+          intl: intlRef.current,
           retainedErrors,
           schemaRoot: schema,
           validationCode: entry.validationCode,
@@ -312,7 +318,7 @@ const ProcessExchangeEdit: FC<Props> = ({
     }
 
     sdkFieldMessagesRef.current = appliedEntries;
-  }, [drawerVisible, intl, showRules, sdkFieldMessages]);
+  }, [drawerVisible, showRules, sdkFieldMessages]);
 
   useEffect(() => {
     if (!drawerVisible || sdkHighlights.length === 0) {

--- a/src/pages/Processes/Components/form.tsx
+++ b/src/pages/Processes/Components/form.tsx
@@ -29,7 +29,7 @@ import {
   Space,
   theme,
 } from 'antd';
-import { useEffect, useRef, useState, type FC } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type FC } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 import schema from '../processes_schema.json';
 import { getSdkSuggestedFixMessage, resolveRequiredValidationMessage } from '../sdkValidationUi';
@@ -234,6 +234,8 @@ export const ProcessForm: FC<Props> = ({
   sdkValidationFocus,
 }) => {
   const intl = useIntl();
+  const intlRef = useRef(intl);
+  intlRef.current = intl;
   const refCheckContext = useRefCheckContext();
   const actionRefExchangeTableInput = useRef<ActionType>();
   const actionRefExchangeTableOutput = useRef<ActionType>();
@@ -254,8 +256,10 @@ export const ProcessForm: FC<Props> = ({
 
   const { token } = theme.useToken();
 
-  const formatSdkDetailMessage = (detail: ValidationIssueSdkDetail) =>
-    getSdkSuggestedFixMessage(intl, detail);
+  const formatSdkDetailMessage = useCallback(
+    (detail: ValidationIssueSdkDetail) => getSdkSuggestedFixMessage(intlRef.current, detail),
+    [],
+  );
 
   const sdkVisibleSectionAnchorsByTab = sdkValidationDetails.reduce<Record<string, Set<string>>>(
     (accumulator, detail) => {
@@ -322,73 +326,82 @@ export const ProcessForm: FC<Props> = ({
     },
     {},
   );
-  const sdkExchangeFieldDetailsByExchangeId = sdkValidationDetails.reduce<
-    Record<string, ValidationIssueSdkDetail[]>
-  >((accumulator, detail) => {
-    if (
-      !detail.exchangeInternalId ||
-      !isSdkFieldDetail(detail) ||
-      isSdkSectionDetail(detail) ||
-      isSdkHighlightOnlyDetail(detail)
-    ) {
-      return accumulator;
-    }
+  const sdkExchangeFieldDetailsByExchangeId = useMemo(
+    () =>
+      sdkValidationDetails.reduce<Record<string, ValidationIssueSdkDetail[]>>(
+        (accumulator, detail) => {
+          if (
+            !detail.exchangeInternalId ||
+            !isSdkFieldDetail(detail) ||
+            isSdkSectionDetail(detail) ||
+            isSdkHighlightOnlyDetail(detail)
+          ) {
+            return accumulator;
+          }
 
-    if (!accumulator[detail.exchangeInternalId]) {
-      accumulator[detail.exchangeInternalId] = [];
-    }
+          if (!accumulator[detail.exchangeInternalId]) {
+            accumulator[detail.exchangeInternalId] = [];
+          }
 
-    accumulator[detail.exchangeInternalId].push(detail);
-    return accumulator;
-  }, {});
-  const sdkRootFieldMessages = sdkValidationDetails.reduce<
-    Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
-  >((accumulator, detail) => {
-    if (detail.exchangeInternalId || !isSdkFieldDetail(detail)) {
-      return accumulator;
-    }
+          accumulator[detail.exchangeInternalId].push(detail);
+          return accumulator;
+        },
+        {},
+      ),
+    [sdkValidationDetails],
+  );
+  const sdkRootFieldMessages = useMemo(
+    () =>
+      sdkValidationDetails.reduce<
+        Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
+      >((accumulator, detail) => {
+        if (detail.exchangeInternalId || !isSdkFieldDetail(detail)) {
+          return accumulator;
+        }
 
-    const formName = parseSdkDetailFormName(detail);
-    const serializedFormName = stringifySdkFormName(formName);
+        const formName = parseSdkDetailFormName(detail);
+        const serializedFormName = stringifySdkFormName(formName);
 
-    if (
-      !formName ||
-      !serializedFormName ||
-      serializedFormName === 'modellingAndValidation.validation.review' ||
-      serializedFormName === 'modellingAndValidation.complianceDeclarations.compliance'
-    ) {
-      return accumulator;
-    }
+        if (
+          !formName ||
+          !serializedFormName ||
+          serializedFormName === 'modellingAndValidation.validation.review' ||
+          serializedFormName === 'modellingAndValidation.complianceDeclarations.compliance'
+        ) {
+          return accumulator;
+        }
 
-    const formattedMessage = formatSdkDetailMessage(detail);
-    if (!formattedMessage) {
-      return accumulator;
-    }
-    const messageEntry: SdkFieldMessageEntry = {
-      text: formattedMessage,
-      validationCode: detail.validationCode,
-    };
+        const formattedMessage = formatSdkDetailMessage(detail);
+        if (!formattedMessage) {
+          return accumulator;
+        }
+        const messageEntry: SdkFieldMessageEntry = {
+          text: formattedMessage,
+          validationCode: detail.validationCode,
+        };
 
-    const currentEntry = accumulator.get(serializedFormName);
-    if (currentEntry) {
-      if (
-        !currentEntry.entries.some(
-          (entry) =>
-            entry.text === messageEntry.text &&
-            entry.validationCode === messageEntry.validationCode,
-        )
-      ) {
-        currentEntry.entries.push(messageEntry);
-      }
-      return accumulator;
-    }
+        const currentEntry = accumulator.get(serializedFormName);
+        if (currentEntry) {
+          if (
+            !currentEntry.entries.some(
+              (entry) =>
+                entry.text === messageEntry.text &&
+                entry.validationCode === messageEntry.validationCode,
+            )
+          ) {
+            currentEntry.entries.push(messageEntry);
+          }
+          return accumulator;
+        }
 
-    accumulator.set(serializedFormName, {
-      entries: [messageEntry],
-      name: formName,
-    });
-    return accumulator;
-  }, new Map());
+        accumulator.set(serializedFormName, {
+          entries: [messageEntry],
+          name: formName,
+        });
+        return accumulator;
+      }, new Map()),
+    [formatSdkDetailMessage, sdkValidationDetails],
+  );
   const sdkValidationSectionMessages = sdkValidationDetails.reduce<Record<string, string[]>>(
     (accumulator, detail) => {
       if (detail.exchangeInternalId || isSdkHighlightOnlyDetail(detail)) {
@@ -499,7 +512,7 @@ export const ProcessForm: FC<Props> = ({
           context: 'process',
           fieldName,
           frontendRulesEnabled: showRules,
-          intl,
+          intl: intlRef.current,
           retainedErrors,
           schemaRoot: schema,
           validationCode: entry.validationCode,
@@ -548,7 +561,7 @@ export const ProcessForm: FC<Props> = ({
     }
 
     rootSdkFieldMessagesRef.current = appliedEntries;
-  }, [formRef, intl, showRules, sdkRootFieldMessages]);
+  }, [formRef, showRules, sdkRootFieldMessages]);
 
   useEffect(() => {
     if (

--- a/src/pages/Sources/Components/form.tsx
+++ b/src/pages/Sources/Components/form.tsx
@@ -18,6 +18,8 @@ import { FormattedMessage, useIntl } from 'umi';
 import schema from '../sources_schema.json';
 import { publicationTypeOptions } from './optiondata';
 
+const SOURCE_SCHEMA_PATH_PREFIX = ['sourceDataSet'];
+
 type Props = {
   lang: string;
   activeTabKey: string;
@@ -60,6 +62,8 @@ export const SourceForm: FC<Props> = ({
     intl,
     sdkValidationDetails,
     sdkValidationFocus,
+    schemaPathPrefix: SOURCE_SCHEMA_PATH_PREFIX,
+    schemaRoot: schema,
     showRules,
   });
   const handlePreview = async (file: UploadFile) => {

--- a/src/pages/Unitgroups/Components/Unit/edit.tsx
+++ b/src/pages/Unitgroups/Components/Unit/edit.tsx
@@ -8,7 +8,7 @@ import { CloseOutlined, FormOutlined } from '@ant-design/icons';
 import { ActionType, ProForm, ProFormInstance } from '@ant-design/pro-components';
 import { Button, Card, Drawer, Form, Input, Space, Switch, Tooltip } from 'antd';
 import type { FC } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 
 type SdkFieldMessageEntry = {
@@ -53,6 +53,8 @@ const UnitEdit: FC<Props> = ({
   autoOpen = false,
 }) => {
   const intl = useIntl();
+  const intlRef = useRef(intl);
+  intlRef.current = intl;
   const [drawerVisible, setDrawerVisible] = useState(false);
   const [fromData, setFromData] = useState<UnitDraft>({});
   const [initData, setInitData] = useState<UnitDraft>({});
@@ -62,47 +64,51 @@ const UnitEdit: FC<Props> = ({
     Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
   >(new Map());
 
-  const sdkFieldMessages = sdkHighlights.reduce<
-    Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
-  >((accumulator, detail) => {
-    const formName =
-      (Array.isArray(detail.formName) && detail.formName.length > 0
-        ? detail.formName
-        : parseSdkFieldPathToFormName(detail.fieldPath)) ??
-      (detail.fieldKey ? [detail.fieldKey] : undefined);
-    const fieldKey = formName ? formName.map(String).join('.') : '';
-    const messageText = getSdkSuggestedFixMessage(intl, detail);
+  const sdkFieldMessages = useMemo(
+    () =>
+      sdkHighlights.reduce<
+        Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
+      >((accumulator, detail) => {
+        const formName =
+          (Array.isArray(detail.formName) && detail.formName.length > 0
+            ? detail.formName
+            : parseSdkFieldPathToFormName(detail.fieldPath)) ??
+          (detail.fieldKey ? [detail.fieldKey] : undefined);
+        const fieldKey = formName ? formName.map(String).join('.') : '';
+        const messageText = getSdkSuggestedFixMessage(intlRef.current, detail);
 
-    if (!formName || !fieldKey || !messageText) {
-      return accumulator;
-    }
+        if (!formName || !fieldKey || !messageText) {
+          return accumulator;
+        }
 
-    const messageEntry: SdkFieldMessageEntry = {
-      text: messageText,
-      validationCode: detail.validationCode,
-    };
-    const currentEntry = accumulator.get(fieldKey);
+        const messageEntry: SdkFieldMessageEntry = {
+          text: messageText,
+          validationCode: detail.validationCode,
+        };
+        const currentEntry = accumulator.get(fieldKey);
 
-    if (currentEntry) {
-      if (
-        !currentEntry.entries.some(
-          (entry) =>
-            entry.text === messageEntry.text &&
-            entry.validationCode === messageEntry.validationCode,
-        )
-      ) {
-        currentEntry.entries.push(messageEntry);
-      }
+        if (currentEntry) {
+          if (
+            !currentEntry.entries.some(
+              (entry) =>
+                entry.text === messageEntry.text &&
+                entry.validationCode === messageEntry.validationCode,
+            )
+          ) {
+            currentEntry.entries.push(messageEntry);
+          }
 
-      return accumulator;
-    }
+          return accumulator;
+        }
 
-    accumulator.set(fieldKey, {
-      entries: [messageEntry],
-      name: formName,
-    });
-    return accumulator;
-  }, new Map());
+        accumulator.set(fieldKey, {
+          entries: [messageEntry],
+          name: formName,
+        });
+        return accumulator;
+      }, new Map()),
+    [sdkHighlights],
+  );
 
   useEffect(() => {
     if (!autoOpen) {

--- a/src/pages/Unitgroups/Components/form.tsx
+++ b/src/pages/Unitgroups/Components/form.tsx
@@ -14,7 +14,7 @@ import { UnitDraft, UnitItem, UnitTable } from '@/services/unitgroups/data';
 import { genUnitTableData } from '@/services/unitgroups/util';
 import { ActionType, ProColumns, ProFormInstance, ProTable } from '@ant-design/pro-components';
 import { Card, Form, Input, Select, Space, theme } from 'antd';
-import { FC, useRef, useState } from 'react';
+import { FC, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 import schema from '../unitgroups_schema.json';
 import UnitCreate from './Unit/create';
@@ -24,6 +24,8 @@ import UnitView from './Unit/view';
 import { complianceOptions } from './optiondata';
 // import UnitGroupSelectFrom from './select/form';
 import { toSuperscript } from '@/components/AlignedNumber';
+
+const UNIT_GROUP_SCHEMA_PATH_PREFIX = ['unitGroupDataSet'];
 
 type Props = {
   lang: string;
@@ -71,8 +73,9 @@ export const UnitGroupForm: FC<Props> = ({
   const intl = useIntl();
   const actionRefUnitTable = useRef<ActionType>();
   const [showNameError, setShowNameError] = useState(false);
-  const sdkRootValidationDetails = sdkValidationDetails.filter(
-    (detail) => !getUnitInternalId(detail),
+  const sdkRootValidationDetails = useMemo(
+    () => sdkValidationDetails.filter((detail) => !getUnitInternalId(detail)),
+    [sdkValidationDetails],
   );
   const { sdkValidationCountsByTab: rootSdkValidationCountsByTab, sdkValidationSectionMessages } =
     useDatasetSdkValidationFormSupport({
@@ -81,62 +84,75 @@ export const UnitGroupForm: FC<Props> = ({
       intl,
       sdkValidationDetails: sdkRootValidationDetails,
       sdkValidationFocus: getUnitInternalId(sdkValidationFocus) ? null : sdkValidationFocus,
+      schemaPathPrefix: UNIT_GROUP_SCHEMA_PATH_PREFIX,
+      schemaRoot: schema,
       showRules,
     });
-  const sdkUnitRowHighlightsById = sdkValidationDetails.reduce<
-    Record<string, ValidationIssueSdkDetail[]>
-  >((accumulator, detail) => {
-    const unitInternalId = getUnitInternalId(detail);
+  const sdkUnitRowHighlightsById = useMemo(
+    () =>
+      sdkValidationDetails.reduce<Record<string, ValidationIssueSdkDetail[]>>(
+        (accumulator, detail) => {
+          const unitInternalId = getUnitInternalId(detail);
 
-    if (!unitInternalId || isSdkSectionDetail(detail)) {
-      return accumulator;
-    }
+          if (!unitInternalId || isSdkSectionDetail(detail)) {
+            return accumulator;
+          }
 
-    if (!accumulator[unitInternalId]) {
-      accumulator[unitInternalId] = [];
-    }
+          if (!accumulator[unitInternalId]) {
+            accumulator[unitInternalId] = [];
+          }
 
-    accumulator[unitInternalId].push(detail);
-    return accumulator;
-  }, {});
-  const sdkUnitFieldDetailsById = sdkValidationDetails.reduce<
-    Record<string, ValidationIssueSdkDetail[]>
-  >((accumulator, detail) => {
-    const unitInternalId = getUnitInternalId(detail);
+          accumulator[unitInternalId].push(detail);
+          return accumulator;
+        },
+        {},
+      ),
+    [sdkValidationDetails],
+  );
+  const sdkUnitFieldDetailsById = useMemo(
+    () =>
+      sdkValidationDetails.reduce<Record<string, ValidationIssueSdkDetail[]>>(
+        (accumulator, detail) => {
+          const unitInternalId = getUnitInternalId(detail);
 
-    if (
-      !unitInternalId ||
-      !isSdkFieldDetail(detail) ||
-      isSdkSectionDetail(detail) ||
-      isSdkHighlightOnlyDetail(detail)
-    ) {
-      return accumulator;
-    }
+          if (
+            !unitInternalId ||
+            !isSdkFieldDetail(detail) ||
+            isSdkSectionDetail(detail) ||
+            isSdkHighlightOnlyDetail(detail)
+          ) {
+            return accumulator;
+          }
 
-    if (!accumulator[unitInternalId]) {
-      accumulator[unitInternalId] = [];
-    }
+          if (!accumulator[unitInternalId]) {
+            accumulator[unitInternalId] = [];
+          }
 
-    accumulator[unitInternalId].push(detail);
-    return accumulator;
-  }, {});
-  const sdkVisibleUnitRowsByTab = sdkValidationDetails.reduce<Record<string, Set<string>>>(
-    (accumulator, detail) => {
-      const unitInternalId = getUnitInternalId(detail);
-      const tabName = detail.tabName;
+          accumulator[unitInternalId].push(detail);
+          return accumulator;
+        },
+        {},
+      ),
+    [sdkValidationDetails],
+  );
+  const sdkVisibleUnitRowsByTab = useMemo(
+    () =>
+      sdkValidationDetails.reduce<Record<string, Set<string>>>((accumulator, detail) => {
+        const unitInternalId = getUnitInternalId(detail);
+        const tabName = detail.tabName;
 
-      if (!unitInternalId || !tabName || isSdkSectionDetail(detail)) {
+        if (!unitInternalId || !tabName || isSdkSectionDetail(detail)) {
+          return accumulator;
+        }
+
+        if (!accumulator[tabName]) {
+          accumulator[tabName] = new Set<string>();
+        }
+
+        accumulator[tabName].add(unitInternalId);
         return accumulator;
-      }
-
-      if (!accumulator[tabName]) {
-        accumulator[tabName] = new Set<string>();
-      }
-
-      accumulator[tabName].add(unitInternalId);
-      return accumulator;
-    },
-    {},
+      }, {}),
+    [sdkValidationDetails],
   );
   const sdkValidationCountsByTab: Record<string, number> = {
     ...rootSdkValidationCountsByTab,

--- a/src/pages/Utils/validation/formSupport.ts
+++ b/src/pages/Utils/validation/formSupport.ts
@@ -1,7 +1,11 @@
 import type { ValidationIssueSdkDetail } from '@/pages/Utils/review';
 import type { ProFormInstance } from '@ant-design/pro-components';
 import { useEffect, useMemo, useRef } from 'react';
-import { getSdkSuggestedFixMessage } from './messages';
+import {
+  getSdkSuggestedFixMessage,
+  resolveRequiredValidationMessage,
+  type SdkFieldFormName,
+} from './messages';
 
 type IntlShapeLike = {
   formatMessage: (
@@ -26,8 +30,13 @@ type UseDatasetSdkValidationFormSupportOptions = {
   intl: IntlShapeLike;
   sdkValidationDetails?: ValidationIssueSdkDetail[];
   sdkValidationFocus?: ValidationIssueSdkDetail | null;
+  schemaPathPrefix?: Array<string | number>;
+  schemaRoot?: unknown;
   showRules?: boolean;
+  usesLocalRequiredValidationUi?: (fieldName?: SdkFieldFormName) => boolean;
 };
+
+const EMPTY_SCHEMA_PATH_PREFIX: Array<string | number> = [];
 
 const waitForNextValidationTurn = async () => {
   await new Promise<void>((resolve) => {
@@ -136,8 +145,13 @@ export const useDatasetSdkValidationFormSupport = ({
   intl,
   sdkValidationDetails = [],
   sdkValidationFocus,
+  schemaPathPrefix = EMPTY_SCHEMA_PATH_PREFIX,
+  schemaRoot,
   showRules = false,
+  usesLocalRequiredValidationUi,
 }: UseDatasetSdkValidationFormSupportOptions) => {
+  const intlRef = useRef(intl);
+  intlRef.current = intl;
   const rootSdkFieldMessagesRef = useRef<
     Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
   >(new Map());
@@ -159,7 +173,7 @@ export const useDatasetSdkValidationFormSupport = ({
         return accumulator;
       }
 
-      const messageText = getSdkSuggestedFixMessage(intl, detail);
+      const messageText = getSdkSuggestedFixMessage(intlRef.current, detail);
 
       if (!messageText) {
         return accumulator;
@@ -175,7 +189,7 @@ export const useDatasetSdkValidationFormSupport = ({
 
       return accumulator;
     }, {});
-  }, [intl, sdkValidationDetails]);
+  }, [sdkValidationDetails]);
 
   const sdkRootFieldMessages = useMemo(() => {
     return sdkValidationDetails.reduce<
@@ -187,7 +201,7 @@ export const useDatasetSdkValidationFormSupport = ({
 
       const formName = parseSdkDetailFormName(detail);
       const serializedFormName = stringifySdkFormName(formName);
-      const messageText = getSdkSuggestedFixMessage(intl, detail);
+      const messageText = getSdkSuggestedFixMessage(intlRef.current, detail);
 
       if (!formName || !serializedFormName || !messageText) {
         return accumulator;
@@ -219,7 +233,7 @@ export const useDatasetSdkValidationFormSupport = ({
 
       return accumulator;
     }, new Map());
-  }, [intl, sdkValidationDetails]);
+  }, [sdkValidationDetails]);
 
   useEffect(() => {
     const formInstance = formRef.current;
@@ -263,15 +277,31 @@ export const useDatasetSdkValidationFormSupport = ({
       const nextAppliedFieldEntries: SdkFieldMessageEntry[] = [];
 
       (nextEntry?.entries ?? []).forEach((entry) => {
-        if (entry.validationCode === 'required_missing' && retainedErrors.length > 0) {
+        const requiredResolution = resolveRequiredValidationMessage({
+          fieldName,
+          frontendRulesEnabled: showRules,
+          intl: intlRef.current,
+          retainedErrors,
+          schemaPathPrefix,
+          schemaRoot,
+          usesLocalRequiredValidationUi,
+          validationCode: entry.validationCode,
+        });
+
+        if (requiredResolution.suppressSdkMessage) {
           return;
         }
 
-        if (!nextErrors.includes(entry.text)) {
-          nextErrors.push(entry.text);
+        const resolvedEntry = {
+          ...entry,
+          text: requiredResolution.replacementMessage ?? entry.text,
+        };
+
+        if (!nextErrors.includes(resolvedEntry.text)) {
+          nextErrors.push(resolvedEntry.text);
         }
 
-        nextAppliedFieldEntries.push(entry);
+        nextAppliedFieldEntries.push(resolvedEntry);
       });
 
       if (nextAppliedFieldEntries.length > 0) {
@@ -301,7 +331,14 @@ export const useDatasetSdkValidationFormSupport = ({
     }
 
     rootSdkFieldMessagesRef.current = appliedEntries;
-  }, [formRef, showRules, sdkRootFieldMessages]);
+  }, [
+    formRef,
+    schemaPathPrefix,
+    schemaRoot,
+    showRules,
+    sdkRootFieldMessages,
+    usesLocalRequiredValidationUi,
+  ]);
 
   useEffect(() => {
     if (

--- a/src/pages/Utils/validation/messages.ts
+++ b/src/pages/Utils/validation/messages.ts
@@ -18,8 +18,24 @@ type SdkValidationDetailMessageLike = {
   validationParams?: Record<string, string | number | boolean | null | undefined>;
 };
 
+type SchemaRuleLike = {
+  defaultMessage?: string;
+  message?: unknown;
+  messageKey?: string;
+  required?: boolean;
+};
+
+type RequiredValidationMessageResolution = {
+  replacementMessage?: string;
+  suppressSdkMessage: boolean;
+};
+
 const SDK_MESSAGE_TRAILING_PUNCTUATION_PATTERN = /[。．.!！?？,，;；:：]+$/u;
 const PROCESS_REFERENCE_YEAR_FIELD_PATH = 'processInformation.time.common:referenceYear';
+const DEFAULT_REQUIRED_MESSAGE = {
+  defaultMessage: 'Please complete this field',
+  id: 'validator.lang.required',
+};
 
 export const normalizeValidationMessageText = (message?: string) =>
   (message ?? '').trim().replace(SDK_MESSAGE_TRAILING_PUNCTUATION_PATTERN, '').trim();
@@ -61,6 +77,184 @@ const getSdkFieldSpecificSuggestedFixMessage = (
   }
 
   return undefined;
+};
+
+const isRequiredRule = (rule: unknown): rule is SchemaRuleLike =>
+  typeof rule === 'object' &&
+  rule !== null &&
+  'required' in rule &&
+  Boolean((rule as { required?: boolean }).required);
+
+export const getSchemaNodeAtPath = (schemaRoot: unknown, path: Array<string | number>) => {
+  let current: any = schemaRoot;
+
+  for (const segment of path) {
+    if (Array.isArray(current)) {
+      current = current[typeof segment === 'number' ? segment : 0];
+
+      if (typeof segment === 'number') {
+        continue;
+      }
+    }
+
+    if (!current || typeof current !== 'object') {
+      return undefined;
+    }
+
+    current = current[segment as keyof typeof current];
+  }
+
+  return current;
+};
+
+const isIndexedLangTextLeafFormName = (fieldName: SdkFieldFormName) => {
+  if (fieldName.length < 2) {
+    return false;
+  }
+
+  const lastSegment = fieldName[fieldName.length - 1];
+  const previousSegment = fieldName[fieldName.length - 2];
+
+  return (
+    (lastSegment === '#text' || lastSegment === '@xml:lang') && typeof previousSegment === 'number'
+  );
+};
+
+const getRequiredRuleCandidatePaths = (
+  fieldName: SdkFieldFormName,
+  schemaPathPrefix: Array<string | number>,
+) => {
+  const paths = [[...schemaPathPrefix, ...fieldName]];
+
+  if (isIndexedLangTextLeafFormName(fieldName)) {
+    paths.unshift([...schemaPathPrefix, ...fieldName.slice(0, -2)]);
+  }
+
+  return paths;
+};
+
+export const getSchemaRequiredRule = ({
+  fieldName,
+  schemaPathPrefix = [],
+  schemaRoot,
+}: {
+  fieldName?: SdkFieldFormName;
+  schemaPathPrefix?: Array<string | number>;
+  schemaRoot?: unknown;
+}) => {
+  if (!schemaRoot || !fieldName || fieldName.length === 0) {
+    return undefined;
+  }
+
+  for (const schemaPath of getRequiredRuleCandidatePaths(fieldName, schemaPathPrefix)) {
+    const schemaNode = getSchemaNodeAtPath(schemaRoot, schemaPath);
+    const schemaRules = (schemaNode as { rules?: unknown[] } | undefined)?.rules;
+    const rules = Array.isArray(schemaRules) ? schemaRules : [];
+    const requiredRule = rules.find(isRequiredRule);
+
+    if (requiredRule) {
+      return requiredRule;
+    }
+  }
+
+  return undefined;
+};
+
+export const formatRequiredRuleMessage = (intl: IntlShapeLike, rule?: SchemaRuleLike) => {
+  if (!rule) {
+    return normalizeValidationMessageText(intl.formatMessage(DEFAULT_REQUIRED_MESSAGE));
+  }
+
+  if (typeof rule.message === 'string') {
+    return normalizeValidationMessageText(rule.message);
+  }
+
+  if (rule.message && typeof rule.message === 'object' && 'props' in (rule.message as object)) {
+    const props = (rule.message as { props?: Record<string, unknown> }).props ?? {};
+    const id = typeof props.id === 'string' ? props.id : DEFAULT_REQUIRED_MESSAGE.id;
+    const defaultMessage =
+      typeof props.defaultMessage === 'string'
+        ? props.defaultMessage
+        : DEFAULT_REQUIRED_MESSAGE.defaultMessage;
+
+    return normalizeValidationMessageText(
+      intl.formatMessage(
+        {
+          id,
+          defaultMessage,
+        },
+        props.values as Record<string, string | number | undefined> | undefined,
+      ),
+    );
+  }
+
+  return normalizeValidationMessageText(
+    intl.formatMessage({
+      id: rule.messageKey ?? DEFAULT_REQUIRED_MESSAGE.id,
+      defaultMessage: rule.defaultMessage ?? DEFAULT_REQUIRED_MESSAGE.defaultMessage,
+    }),
+  );
+};
+
+export const resolveRequiredValidationMessage = ({
+  fieldName,
+  frontendRulesEnabled = true,
+  intl,
+  retainedErrors,
+  schemaPathPrefix = [],
+  schemaRoot,
+  usesLocalRequiredValidationUi,
+  validationCode,
+}: {
+  fieldName?: SdkFieldFormName;
+  frontendRulesEnabled?: boolean;
+  intl: IntlShapeLike;
+  retainedErrors: string[];
+  schemaPathPrefix?: Array<string | number>;
+  schemaRoot?: unknown;
+  usesLocalRequiredValidationUi?: (fieldName?: SdkFieldFormName) => boolean;
+  validationCode?: string;
+}): RequiredValidationMessageResolution => {
+  if (validationCode !== 'required_missing') {
+    return {
+      suppressSdkMessage: false,
+    };
+  }
+
+  if (retainedErrors.length > 0) {
+    return {
+      suppressSdkMessage: true,
+    };
+  }
+
+  if (!frontendRulesEnabled) {
+    return {
+      suppressSdkMessage: false,
+    };
+  }
+
+  if (usesLocalRequiredValidationUi?.(fieldName)) {
+    return {
+      suppressSdkMessage: true,
+    };
+  }
+
+  const requiredRule = getSchemaRequiredRule({
+    fieldName,
+    schemaPathPrefix,
+    schemaRoot,
+  });
+
+  if (!requiredRule) {
+    return {
+      suppressSdkMessage: false,
+    };
+  }
+
+  return {
+    replacementMessage: formatRequiredRuleMessage(intl, requiredRule),
+    suppressSdkMessage: false,
+  };
 };
 
 export const getSdkSuggestedFixMessage = (

--- a/tests/unit/pages/Flows/Components/Property/edit.test.tsx
+++ b/tests/unit/pages/Flows/Components/Property/edit.test.tsx
@@ -555,4 +555,50 @@ describe('FlowPropertyEdit', () => {
     expect(lastFormApi.setFields).not.toHaveBeenCalled();
     expect(lastFormApi.getFieldError(['meanValue'])).toEqual(['Local mean value error']);
   });
+
+  it('uses the flow-property frontend required copy for sdk required_missing highlights', async () => {
+    const actionRef = { current: { reload: jest.fn() } };
+    const sdkHighlights = [
+      {
+        fieldPath: 'flowProperty[#prop-1].meanValue',
+        key: 'flow-property-required-highlight',
+        reasonMessage: 'Validation failed',
+        suggestedFix: 'Fill in the required value for this field.',
+        tabName: 'flowProperties',
+        validationCode: 'required_missing',
+      },
+    ] as any;
+    renderWithProviders(
+      <PropertyEdit
+        id='1'
+        data={[{ '@dataSetInternalID': '1', meanValue: '10' }] as any}
+        lang='en'
+        buttonType='text'
+        actionRef={actionRef as any}
+        setViewDrawerVisible={jest.fn()}
+        onData={jest.fn()}
+        autoOpen
+        showRules
+        sdkHighlights={sdkHighlights}
+      />,
+    );
+
+    await screen.findByRole('dialog', { name: /edit flow property/i });
+    await waitFor(() => expect(lastFormApi).not.toBeNull());
+    expect(lastFormApi.setFields).toHaveBeenCalledWith([
+      {
+        errors: ['Please input mean value (of flow property)'],
+        name: ['meanValue'],
+      },
+    ]);
+
+    lastFormApi.setFields([{ errors: [], name: ['meanValue'] }]);
+    lastFormApi.setFields.mockClear();
+
+    await act(async () => {
+      lastFormApi.setFieldsValue({ meanValue: '42' });
+    });
+
+    expect(lastFormApi.setFields).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/pages/Utils/formSupport.test.tsx
+++ b/tests/unit/pages/Utils/formSupport.test.tsx
@@ -294,6 +294,55 @@ describe('useDatasetSdkValidationFormSupport', () => {
     ).toEqual(['Name is required']);
   });
 
+  it('uses frontend required rule messages instead of sdk required_missing copy', () => {
+    const { formRef, setFields } = createFormRef();
+    const schema = {
+      flowDataSet: {
+        modellingAndValidation: {
+          LCIMethod: {
+            typeOfDataSet: {
+              rules: [
+                {
+                  defaultMessage: 'Please input type of flow',
+                  messageKey: 'pages.flow.validator.typeOfDataSet.required',
+                  required: true,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    renderHook(() =>
+      useDatasetSdkValidationFormSupport({
+        activeTabKey: 'flowInformation',
+        formRef,
+        intl,
+        schemaPathPrefix: ['flowDataSet'],
+        schemaRoot: schema,
+        sdkValidationDetails: [
+          createSdkDetail({
+            fieldPath: 'modellingAndValidation.LCIMethod.typeOfDataSet',
+            formName: ['modellingAndValidation', 'LCIMethod', 'typeOfDataSet'],
+            key: 'flow-type-required',
+            suggestedFix: 'Fill in the required value for this field.',
+            tabName: 'flowInformation',
+            validationCode: 'required_missing',
+          }),
+        ],
+        showRules: true,
+      }),
+    );
+
+    expect(setFields).toHaveBeenCalledWith([
+      {
+        errors: ['Please input type of flow'],
+        name: ['modellingAndValidation', 'LCIMethod', 'typeOfDataSet'],
+      },
+    ]);
+  });
+
   it('clears stale sdk errors while preserving non-sdk errors on rerender', () => {
     const { formRef, errorMap, setFields } = createFormRef({
       'sourceInformation.dataSetInformation.common:shortName.0.#text': ['Existing local error'],

--- a/tests/unit/pages/Utils/messages.test.ts
+++ b/tests/unit/pages/Utils/messages.test.ts
@@ -1,6 +1,9 @@
 import {
+  formatRequiredRuleMessage,
+  getSchemaRequiredRule,
   getSdkSuggestedFixMessage,
   normalizeValidationMessageText,
+  resolveRequiredValidationMessage,
 } from '@/pages/Utils/validation/messages';
 
 const intl = {
@@ -88,5 +91,102 @@ describe('validation message helpers', () => {
 
     expect(getSdkSuggestedFixMessage(intl, { suggestedFix: undefined })).toBe('');
     expect(getSdkSuggestedFixMessage(intl)).toBe('');
+  });
+
+  it('resolves sdk required_missing to frontend required copy when schema rules exist', () => {
+    const schema = {
+      flowDataSet: {
+        modellingAndValidation: {
+          LCIMethod: {
+            typeOfDataSet: {
+              rules: [
+                {
+                  defaultMessage: 'Please input type of flow',
+                  messageKey: 'pages.flow.validator.typeOfDataSet.required',
+                  required: true,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      resolveRequiredValidationMessage({
+        fieldName: ['modellingAndValidation', 'LCIMethod', 'typeOfDataSet'],
+        frontendRulesEnabled: true,
+        intl,
+        retainedErrors: [],
+        schemaPathPrefix: ['flowDataSet'],
+        schemaRoot: schema,
+        validationCode: 'required_missing',
+      }),
+    ).toEqual({
+      replacementMessage: 'Please input type of flow',
+      suppressSdkMessage: false,
+    });
+  });
+
+  it('finds lang-text required rules on the frontend group field', () => {
+    const schema = {
+      contactDataSet: {
+        contactInformation: {
+          dataSetInformation: {
+            'common:shortName': {
+              rules: [
+                {
+                  defaultMessage: 'Please input contact short name',
+                  messageKey: 'pages.contact.validator.shortName.required',
+                  required: true,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      getSchemaRequiredRule({
+        fieldName: ['contactInformation', 'dataSetInformation', 'common:shortName', 0, '#text'],
+        schemaPathPrefix: ['contactDataSet'],
+        schemaRoot: schema,
+      }),
+    ).toMatchObject({
+      defaultMessage: 'Please input contact short name',
+    });
+  });
+
+  it('suppresses sdk required_missing when local frontend errors already exist', () => {
+    expect(
+      resolveRequiredValidationMessage({
+        fieldName: ['meanValue'],
+        frontendRulesEnabled: true,
+        intl,
+        retainedErrors: ['Please input mean value'],
+        validationCode: 'required_missing',
+      }),
+    ).toEqual({
+      suppressSdkMessage: true,
+    });
+  });
+
+  it('keeps sdk fallback when no frontend required rule is available', () => {
+    expect(
+      resolveRequiredValidationMessage({
+        fieldName: ['optionalComment'],
+        frontendRulesEnabled: true,
+        intl,
+        retainedErrors: [],
+        schemaPathPrefix: ['flowDataSet'],
+        schemaRoot: { flowDataSet: { optionalComment: {} } },
+        validationCode: 'required_missing',
+      }),
+    ).toEqual({
+      suppressSdkMessage: false,
+    });
+
+    expect(formatRequiredRuleMessage(intl)).toBe('Please complete this field');
   });
 });


### PR DESCRIPTION
## Summary

- Prefer frontend required rule messages over SDK `required_missing` copy when schema rules exist.
- Suppress duplicate SDK required messages when local required UI/errors already cover the field.
- Memoize SDK validation message mapping for lazy-rendered tab/edit drawer paths.

Refs #385

## Tests

`npm run jest -- tests/unit/pages/Utils/messages.test.ts tests/unit/pages/Utils/formSupport.test.tsx tests/unit/pages/Flows/Components/Property/edit.test.tsx --runInBand`