### PR TITLE
chore: promote dev to main for issue 385

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-04-29"
-lastReviewedCommit: "6ae7b0addeca213bece99a8127235cdeb2c73b93"
+lastReviewedAt: "2026-05-04"
+lastReviewedCommit: "cba40d2affaa241b27f28f1db5a69674d5ae50b2"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-04-29
-lastReviewedCommit: 6ae7b0addeca213bece99a8127235cdeb2c73b93
+lastReviewedAt: 2026-05-04
+lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-04-29
-lastReviewedCommit: f7bccdded90e0e6e2d937e78782a09b911df5fe2
+lastReviewedAt: 2026-05-04
+lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
 ---
 
 # Development Bootstrap

--- a/docs/agents/contribution-path-analysis-design.md
+++ b/docs/agents/contribution-path-analysis-design.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-04-28
-lastReviewedCommit: 232b36c46bfc7b0d6095af577334ad6efb4e6e61
+lastReviewedAt: 2026-05-04
+lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
 ---
 
 # Contribution Path Analysis Design

--- a/docs/agents/lca-analysis-visualization-plan.md
+++ b/docs/agents/lca-analysis-visualization-plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-04-28
-lastReviewedCommit: 232b36c46bfc7b0d6095af577334ad6efb4e6e61
+lastReviewedAt: 2026-05-04
+lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
 ---
 
 # LCA Analysis And Visualization Plan

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -20,8 +20,8 @@ checkPaths:
   - .husky/pre-push
   - package.json
   - .github/workflows/**
-lastReviewedAt: 2026-04-29
-lastReviewedCommit: 6ae7b0addeca213bece99a8127235cdeb2c73b93
+lastReviewedAt: 2026-05-04
+lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-04-29
-lastReviewedCommit: 6ae7b0addeca213bece99a8127235cdeb2c73b93
+lastReviewedAt: 2026-05-04
+lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-04-29
-lastReviewedCommit: 6ae7b0addeca213bece99a8127235cdeb2c73b93
+lastReviewedAt: 2026-05-04
+lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -19,8 +19,8 @@ checkPaths:
   - config/supabaseEnv.ts
   - src/services/**
   - docker/**
-lastReviewedAt: 2026-04-28
-lastReviewedCommit: 232b36c46bfc7b0d6095af577334ad6efb4e6e61
+lastReviewedAt: 2026-05-04
+lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-04-29
-lastReviewedCommit: 6ae7b0addeca213bece99a8127235cdeb2c73b93
+lastReviewedAt: 2026-05-04
+lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-04-29
-lastReviewedCommit: 6ae7b0addeca213bece99a8127235cdeb2c73b93
+lastReviewedAt: 2026-05-04
+lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/testing-troubleshooting.md
   - tests/helpers/**
   - package.json
-lastReviewedAt: 2026-04-29
-lastReviewedCommit: 6ae7b0addeca213bece99a8127235cdeb2c73b93
+lastReviewedAt: 2026-05-04
+lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-04-29
-lastReviewedCommit: 6ae7b0addeca213bece99a8127235cdeb2c73b93
+lastReviewedAt: 2026-05-04
+lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/util_calculate.md
+++ b/docs/agents/util_calculate.md
@@ -20,8 +20,8 @@ checkPaths:
   - src/services/lca/**
   - src/components/LcaTaskCenter/**
   - src/pages/Processes/Analysis/**
-lastReviewedAt: 2026-04-28
-lastReviewedCommit: 232b36c46bfc7b0d6095af577334ad6efb4e6e61
+lastReviewedAt: 2026-05-04
+lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
 ---
 
 # Lifecycle Model Calculation Reference

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@antv/x6-react-shape": "^3.0.1",
     "@dagrejs/dagre": "^3.0.0",
     "@supabase/supabase-js": "^2.104.0",
-    "@tiangong-lca/tidas-sdk": "^0.1.35",
+    "@tiangong-lca/tidas-sdk": "^0.1.36",
     "antd": "^5.29.1",
     "bignumber.js": "^11.0.0",
     "dayjs": "^1.11.20",

--- a/src/pages/Contacts/Components/form.tsx
+++ b/src/pages/Contacts/Components/form.tsx
@@ -11,6 +11,9 @@ import { ProFormInstance } from '@ant-design/pro-components';
 import { Card, Form, Input, Space, theme } from 'antd';
 import { FC, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
+
+const CONTACT_SCHEMA_PATH_PREFIX = ['contactDataSet'];
+
 type Props = {
   lang: string;
   activeTabKey: string;
@@ -44,6 +47,8 @@ export const ContactForm: FC<Props> = ({
     intl,
     sdkValidationDetails,
     sdkValidationFocus,
+    schemaPathPrefix: CONTACT_SCHEMA_PATH_PREFIX,
+    schemaRoot: schema,
     showRules,
   });
 

--- a/src/pages/Flowproperties/Components/form.tsx
+++ b/src/pages/Flowproperties/Components/form.tsx
@@ -17,6 +17,8 @@ import schema from '../flowproperties_schema.json';
 import { complianceOptions } from './optiondata';
 // import FlowpropertiesSelectForm from './select/form';
 
+const FLOW_PROPERTY_DATASET_SCHEMA_PATH_PREFIX = ['flowPropertyDataSet'];
+
 type Props = {
   lang: string;
   activeTabKey: string;
@@ -50,6 +52,8 @@ export const FlowpropertyForm: FC<Props> = ({
     intl,
     sdkValidationDetails,
     sdkValidationFocus,
+    schemaPathPrefix: FLOW_PROPERTY_DATASET_SCHEMA_PATH_PREFIX,
+    schemaRoot: schema,
     showRules,
   });
 

--- a/src/pages/Flows/Components/Property/edit.tsx
+++ b/src/pages/Flows/Components/Property/edit.tsx
@@ -3,7 +3,10 @@ import LangTextItemForm from '@/components/LangTextItem/form';
 import FlowpropertiesSelectForm from '@/pages/Flowproperties/Components/select/form';
 import { getRules } from '@/pages/Utils';
 import type { ValidationIssueSdkDetail } from '@/pages/Utils/review';
-import { getSdkSuggestedFixMessage } from '@/pages/Utils/validation/messages';
+import {
+  getSdkSuggestedFixMessage,
+  resolveRequiredValidationMessage,
+} from '@/pages/Utils/validation/messages';
 import { FlowPropertyData } from '@/services/flows/data';
 import styles from '@/style/custom.less';
 import { CloseOutlined, FormOutlined } from '@ant-design/icons';
@@ -21,7 +24,7 @@ import {
   Tooltip,
 } from 'antd';
 import type { FC } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 import schema from '../../flows_schema.json';
 import { dataDerivationTypeStatusOptions, uncertaintyDistributionTypeOptions } from '../optiondata';
@@ -30,6 +33,8 @@ type SdkFieldMessageEntry = {
   text: string;
   validationCode?: string;
 };
+
+const FLOW_PROPERTY_SCHEMA_PATH_PREFIX = ['flowDataSet', 'flowProperties', 'flowProperty'];
 
 type Props = {
   id: string;
@@ -72,6 +77,8 @@ const PropertyEdit: FC<Props> = ({
   autoOpen = false,
 }) => {
   const intl = useIntl();
+  const intlRef = useRef(intl);
+  intlRef.current = intl;
   const [drawerVisible, setDrawerVisible] = useState(false);
   const formRefEdit = useRef<ProFormInstance>();
   const [fromData, setFromData] = useState<FlowPropertyData>({});
@@ -81,47 +88,51 @@ const PropertyEdit: FC<Props> = ({
     Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
   >(new Map());
 
-  const sdkFieldMessages = sdkHighlights.reduce<
-    Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
-  >((accumulator, detail) => {
-    const formName =
-      (Array.isArray(detail.formName) && detail.formName.length > 0
-        ? detail.formName
-        : parseSdkFieldPathToFormName(detail.fieldPath)) ??
-      (detail.fieldKey ? [detail.fieldKey] : undefined);
-    const fieldKey = formName ? formName.map(String).join('.') : '';
-    const messageText = getSdkSuggestedFixMessage(intl, detail);
+  const sdkFieldMessages = useMemo(
+    () =>
+      sdkHighlights.reduce<
+        Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
+      >((accumulator, detail) => {
+        const formName =
+          (Array.isArray(detail.formName) && detail.formName.length > 0
+            ? detail.formName
+            : parseSdkFieldPathToFormName(detail.fieldPath)) ??
+          (detail.fieldKey ? [detail.fieldKey] : undefined);
+        const fieldKey = formName ? formName.map(String).join('.') : '';
+        const messageText = getSdkSuggestedFixMessage(intlRef.current, detail);
 
-    if (!formName || !fieldKey || !messageText) {
-      return accumulator;
-    }
+        if (!formName || !fieldKey || !messageText) {
+          return accumulator;
+        }
 
-    const messageEntry: SdkFieldMessageEntry = {
-      text: messageText,
-      validationCode: detail.validationCode,
-    };
-    const currentEntry = accumulator.get(fieldKey);
+        const messageEntry: SdkFieldMessageEntry = {
+          text: messageText,
+          validationCode: detail.validationCode,
+        };
+        const currentEntry = accumulator.get(fieldKey);
 
-    if (currentEntry) {
-      if (
-        !currentEntry.entries.some(
-          (entry) =>
-            entry.text === messageEntry.text &&
-            entry.validationCode === messageEntry.validationCode,
-        )
-      ) {
-        currentEntry.entries.push(messageEntry);
-      }
+        if (currentEntry) {
+          if (
+            !currentEntry.entries.some(
+              (entry) =>
+                entry.text === messageEntry.text &&
+                entry.validationCode === messageEntry.validationCode,
+            )
+          ) {
+            currentEntry.entries.push(messageEntry);
+          }
 
-      return accumulator;
-    }
+          return accumulator;
+        }
 
-    accumulator.set(fieldKey, {
-      entries: [messageEntry],
-      name: formName,
-    });
-    return accumulator;
-  }, new Map());
+        accumulator.set(fieldKey, {
+          entries: [messageEntry],
+          name: formName,
+        });
+        return accumulator;
+      }, new Map()),
+    [sdkHighlights],
+  );
 
   useEffect(() => {
     if (!autoOpen) {
@@ -200,15 +211,30 @@ const PropertyEdit: FC<Props> = ({
       const nextAppliedFieldEntries: SdkFieldMessageEntry[] = [];
 
       (nextEntry?.entries ?? []).forEach((entry) => {
-        if (entry.validationCode === 'required_missing' && retainedErrors.length > 0) {
+        const requiredResolution = resolveRequiredValidationMessage({
+          fieldName,
+          frontendRulesEnabled: showRules,
+          intl: intlRef.current,
+          retainedErrors,
+          schemaPathPrefix: FLOW_PROPERTY_SCHEMA_PATH_PREFIX,
+          schemaRoot: schema,
+          validationCode: entry.validationCode,
+        });
+
+        if (requiredResolution.suppressSdkMessage) {
           return;
         }
 
-        if (!nextErrors.includes(entry.text)) {
-          nextErrors.push(entry.text);
+        const resolvedEntry = {
+          ...entry,
+          text: requiredResolution.replacementMessage ?? entry.text,
+        };
+
+        if (!nextErrors.includes(resolvedEntry.text)) {
+          nextErrors.push(resolvedEntry.text);
         }
 
-        nextAppliedFieldEntries.push(entry);
+        nextAppliedFieldEntries.push(resolvedEntry);
       });
 
       if (nextAppliedFieldEntries.length > 0) {
@@ -238,7 +264,7 @@ const PropertyEdit: FC<Props> = ({
     }
 
     sdkFieldMessagesRef.current = appliedEntries;
-  }, [drawerVisible, sdkFieldMessages]);
+  }, [drawerVisible, showRules, sdkFieldMessages]);
 
   useEffect(() => {
     const highlightedField = sdkHighlights.find(

--- a/src/pages/Flows/Components/form.tsx
+++ b/src/pages/Flows/Components/form.tsx
@@ -22,7 +22,7 @@ import { getLangText, getUnitData } from '@/services/general/util';
 import { ActionType, ProColumns, ProFormInstance, ProTable } from '@ant-design/pro-components';
 import { Card, Divider, Form, Input, Select, Space, theme, Tooltip } from 'antd';
 import type { FC } from 'react';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 import schema from '../flows_schema.json';
 import { complianceOptions, myFlowTypeOptions } from './optiondata';
@@ -32,6 +32,9 @@ import PropertyEdit from './Property/edit';
 import PropertyView from './Property/view';
 // import FlowsSelectForm from './select/form';
 import AlignedNumber from '@/components/AlignedNumber';
+
+const FLOW_SCHEMA_PATH_PREFIX = ['flowDataSet'];
+
 type Props = {
   lang: string;
   activeTabKey: FlowDataSetObjectKeys;
@@ -92,8 +95,9 @@ export const FlowForm: FC<Props> = ({
   const [baseNameError, setBaseNameError] = useState(false);
   const [treatmentStandardsRoutesError, setTreatmentStandardsRoutesError] = useState(false);
   const [mixAndLocationTypesError, setMixAndLocationTypesError] = useState(false);
-  const sdkRootValidationDetails = sdkValidationDetails.filter(
-    (detail) => !getFlowPropertyInternalId(detail),
+  const sdkRootValidationDetails = useMemo(
+    () => sdkValidationDetails.filter((detail) => !getFlowPropertyInternalId(detail)),
+    [sdkValidationDetails],
   );
   const { sdkValidationCountsByTab: rootSdkValidationCountsByTab, sdkValidationSectionMessages } =
     useDatasetSdkValidationFormSupport({
@@ -102,62 +106,75 @@ export const FlowForm: FC<Props> = ({
       intl,
       sdkValidationDetails: sdkRootValidationDetails,
       sdkValidationFocus: getFlowPropertyInternalId(sdkValidationFocus) ? null : sdkValidationFocus,
+      schemaPathPrefix: FLOW_SCHEMA_PATH_PREFIX,
+      schemaRoot: schema,
       showRules,
     });
-  const sdkFlowPropertyRowHighlightsById = sdkValidationDetails.reduce<
-    Record<string, ValidationIssueSdkDetail[]>
-  >((accumulator, detail) => {
-    const flowPropertyInternalId = getFlowPropertyInternalId(detail);
+  const sdkFlowPropertyRowHighlightsById = useMemo(
+    () =>
+      sdkValidationDetails.reduce<Record<string, ValidationIssueSdkDetail[]>>(
+        (accumulator, detail) => {
+          const flowPropertyInternalId = getFlowPropertyInternalId(detail);
 
-    if (!flowPropertyInternalId || isSdkSectionDetail(detail)) {
-      return accumulator;
-    }
+          if (!flowPropertyInternalId || isSdkSectionDetail(detail)) {
+            return accumulator;
+          }
 
-    if (!accumulator[flowPropertyInternalId]) {
-      accumulator[flowPropertyInternalId] = [];
-    }
+          if (!accumulator[flowPropertyInternalId]) {
+            accumulator[flowPropertyInternalId] = [];
+          }
 
-    accumulator[flowPropertyInternalId].push(detail);
-    return accumulator;
-  }, {});
-  const sdkFlowPropertyFieldDetailsById = sdkValidationDetails.reduce<
-    Record<string, ValidationIssueSdkDetail[]>
-  >((accumulator, detail) => {
-    const flowPropertyInternalId = getFlowPropertyInternalId(detail);
+          accumulator[flowPropertyInternalId].push(detail);
+          return accumulator;
+        },
+        {},
+      ),
+    [sdkValidationDetails],
+  );
+  const sdkFlowPropertyFieldDetailsById = useMemo(
+    () =>
+      sdkValidationDetails.reduce<Record<string, ValidationIssueSdkDetail[]>>(
+        (accumulator, detail) => {
+          const flowPropertyInternalId = getFlowPropertyInternalId(detail);
 
-    if (
-      !flowPropertyInternalId ||
-      !isSdkFieldDetail(detail) ||
-      isSdkSectionDetail(detail) ||
-      isSdkHighlightOnlyDetail(detail)
-    ) {
-      return accumulator;
-    }
+          if (
+            !flowPropertyInternalId ||
+            !isSdkFieldDetail(detail) ||
+            isSdkSectionDetail(detail) ||
+            isSdkHighlightOnlyDetail(detail)
+          ) {
+            return accumulator;
+          }
 
-    if (!accumulator[flowPropertyInternalId]) {
-      accumulator[flowPropertyInternalId] = [];
-    }
+          if (!accumulator[flowPropertyInternalId]) {
+            accumulator[flowPropertyInternalId] = [];
+          }
 
-    accumulator[flowPropertyInternalId].push(detail);
-    return accumulator;
-  }, {});
-  const sdkVisibleFlowPropertyRowsByTab = sdkValidationDetails.reduce<Record<string, Set<string>>>(
-    (accumulator, detail) => {
-      const flowPropertyInternalId = getFlowPropertyInternalId(detail);
-      const tabName = detail.tabName;
+          accumulator[flowPropertyInternalId].push(detail);
+          return accumulator;
+        },
+        {},
+      ),
+    [sdkValidationDetails],
+  );
+  const sdkVisibleFlowPropertyRowsByTab = useMemo(
+    () =>
+      sdkValidationDetails.reduce<Record<string, Set<string>>>((accumulator, detail) => {
+        const flowPropertyInternalId = getFlowPropertyInternalId(detail);
+        const tabName = detail.tabName;
 
-      if (!flowPropertyInternalId || !tabName || isSdkSectionDetail(detail)) {
+        if (!flowPropertyInternalId || !tabName || isSdkSectionDetail(detail)) {
+          return accumulator;
+        }
+
+        if (!accumulator[tabName]) {
+          accumulator[tabName] = new Set<string>();
+        }
+
+        accumulator[tabName].add(flowPropertyInternalId);
         return accumulator;
-      }
-
-      if (!accumulator[tabName]) {
-        accumulator[tabName] = new Set<string>();
-      }
-
-      accumulator[tabName].add(flowPropertyInternalId);
-      return accumulator;
-    },
-    {},
+      }, {}),
+    [sdkValidationDetails],
   );
   const sdkValidationCountsByTab: Record<string, number> = {
     ...rootSdkValidationCountsByTab,

--- a/src/pages/LifeCycleModels/Components/form.tsx
+++ b/src/pages/LifeCycleModels/Components/form.tsx
@@ -18,6 +18,8 @@ import { FormattedMessage, useIntl } from 'umi';
 import schema from '../lifecyclemodels.json';
 import { licenseTypeOptions } from './optiondata';
 
+const LIFE_CYCLE_MODEL_SCHEMA_PATH_PREFIX = ['lifeCycleModelDataSet'];
+
 type Props = {
   lang: string;
   activeTabKey: string;
@@ -55,6 +57,8 @@ export const LifeCycleModelForm: FC<Props> = ({
     intl,
     sdkValidationDetails,
     sdkValidationFocus,
+    schemaPathPrefix: LIFE_CYCLE_MODEL_SCHEMA_PATH_PREFIX,
+    schemaRoot: schema,
     showRules,
   });
 

--- a/src/pages/LifeCycleModels/Components/form.tsx
+++ b/src/pages/LifeCycleModels/Components/form.tsx
@@ -842,12 +842,12 @@ export const LifeCycleModelForm: FC<Props> = ({
       activeTabKey={activeTabKey}
       onTabChange={onTabChange}
     >
-      {/* {Object.keys(tabContent).map((key) => (
+      {Object.keys(tabContent).map((key) => (
         <div key={key} style={{ display: key === activeTabKey ? 'block' : 'none' }}>
           {tabContent[key]}
         </div>
-      ))} */}
-      {tabContent[activeTabKey]}
+      ))}
+      {/* {tabContent[activeTabKey]} */}
     </Card>
   );
 };

--- a/src/pages/LifeCycleModels/Components/toolbar/eidtInfo.tsx
+++ b/src/pages/LifeCycleModels/Components/toolbar/eidtInfo.tsx
@@ -226,7 +226,7 @@ const ToolbarEditInfo = forwardRef<ToolbarEditInfoHandle, Props>(
       return () => {
         cancelled = true;
       };
-    }, [activeTabKey, drawerVisible, showRules]);
+    }, [drawerVisible, showRules]);
 
     const handleUpdateRefsVersion = async (newRefs: RefVersionItem[]) => {
       const res = updateRefsData(fromData, newRefs, true);

--- a/src/pages/Processes/Components/Exchange/edit.tsx
+++ b/src/pages/Processes/Components/Exchange/edit.tsx
@@ -24,7 +24,7 @@ import {
   Tooltip,
 } from 'antd';
 import type { FC, ReactNode } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 import schema from '../../processes_schema.json';
 import { getSdkSuggestedFixMessage, resolveRequiredValidationMessage } from '../../sdkValidationUi';
@@ -114,6 +114,8 @@ const ProcessExchangeEdit: FC<Props> = ({
   autoOpen = false,
 }) => {
   const intl = useIntl();
+  const intlRef = useRef(intl);
+  intlRef.current = intl;
   const [drawerVisible, setDrawerVisible] = useState(false);
   const formRefEdit = useRef<ProFormInstance>();
   const [fromData, setFromData] = useState<ProcessExchangeData>({});
@@ -134,45 +136,49 @@ const ProcessExchangeEdit: FC<Props> = ({
     }
   }, [unitConvertVisible]);
 
-  const sdkFieldMessages = sdkHighlights.reduce<
-    Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
-  >((accumulator, detail) => {
-    const formName =
-      (Array.isArray(detail.formName) && detail.formName.length > 0
-        ? detail.formName
-        : parseSdkFieldPathToFormName(detail.fieldPath)) ??
-      (detail.fieldKey ? [detail.fieldKey] : undefined);
-    const fieldKey = formName ? formName.map(String).join('.') : '';
-    const messageText = getSdkSuggestedFixMessage(intl, detail);
+  const sdkFieldMessages = useMemo(
+    () =>
+      sdkHighlights.reduce<
+        Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
+      >((accumulator, detail) => {
+        const formName =
+          (Array.isArray(detail.formName) && detail.formName.length > 0
+            ? detail.formName
+            : parseSdkFieldPathToFormName(detail.fieldPath)) ??
+          (detail.fieldKey ? [detail.fieldKey] : undefined);
+        const fieldKey = formName ? formName.map(String).join('.') : '';
+        const messageText = getSdkSuggestedFixMessage(intlRef.current, detail);
 
-    if (!formName || !fieldKey || !messageText) {
-      return accumulator;
-    }
-    const messageEntry: SdkFieldMessageEntry = {
-      text: messageText,
-      validationCode: detail.validationCode,
-    };
+        if (!formName || !fieldKey || !messageText) {
+          return accumulator;
+        }
+        const messageEntry: SdkFieldMessageEntry = {
+          text: messageText,
+          validationCode: detail.validationCode,
+        };
 
-    const currentEntry = accumulator.get(fieldKey);
-    if (currentEntry) {
-      if (
-        !currentEntry.entries.some(
-          (entry) =>
-            entry.text === messageEntry.text &&
-            entry.validationCode === messageEntry.validationCode,
-        )
-      ) {
-        currentEntry.entries.push(messageEntry);
-      }
-      return accumulator;
-    }
+        const currentEntry = accumulator.get(fieldKey);
+        if (currentEntry) {
+          if (
+            !currentEntry.entries.some(
+              (entry) =>
+                entry.text === messageEntry.text &&
+                entry.validationCode === messageEntry.validationCode,
+            )
+          ) {
+            currentEntry.entries.push(messageEntry);
+          }
+          return accumulator;
+        }
 
-    accumulator.set(fieldKey, {
-      entries: [messageEntry],
-      name: formName,
-    });
-    return accumulator;
-  }, new Map());
+        accumulator.set(fieldKey, {
+          entries: [messageEntry],
+          name: formName,
+        });
+        return accumulator;
+      }, new Map()),
+    [sdkHighlights],
+  );
 
   const renderSdkHighlightedField = (_fieldKey: string, content: ReactNode) => content;
 
@@ -263,7 +269,7 @@ const ProcessExchangeEdit: FC<Props> = ({
           context: 'exchange',
           fieldName,
           frontendRulesEnabled: showRules,
-          intl,
+          intl: intlRef.current,
           retainedErrors,
           schemaRoot: schema,
           validationCode: entry.validationCode,
@@ -312,7 +318,7 @@ const ProcessExchangeEdit: FC<Props> = ({
     }
 
     sdkFieldMessagesRef.current = appliedEntries;
-  }, [drawerVisible, intl, showRules, sdkFieldMessages]);
+  }, [drawerVisible, showRules, sdkFieldMessages]);
 
   useEffect(() => {
     if (!drawerVisible || sdkHighlights.length === 0) {

--- a/src/pages/Processes/Components/edit.tsx
+++ b/src/pages/Processes/Components/edit.tsx
@@ -75,6 +75,35 @@ type RefProblemNode = ProblemNode & {
   versionIsInTg?: boolean;
 };
 
+const collectChangedFieldPaths = (
+  value: unknown,
+  prefix: Array<string | number> = [],
+): Array<Array<string | number>> => {
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return prefix.length > 0 ? [prefix] : [];
+    }
+
+    return value.flatMap((item, index) => collectChangedFieldPaths(item, [...prefix, index]));
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+
+    if (entries.length === 0) {
+      return prefix.length > 0 ? [prefix] : [];
+    }
+
+    return entries.flatMap(([key, childValue]) =>
+      collectChangedFieldPaths(childValue, [...prefix, key]),
+    );
+  }
+
+  return prefix.length > 0 ? [prefix] : [];
+};
+
+const stringifyProcessFieldPath = (path: Array<string | number>) => path.map(String).join('.');
+
 const toReferenceValue = (reference?: ProcessExchangeData['referenceToFlowDataSet']) => {
   return Array.isArray(reference) ? reference[0] : reference;
 };
@@ -154,6 +183,9 @@ const ProcessEdit: FC<Props> = ({
   const [sdkValidationFocus, setSdkValidationFocus] = useState<ValidationIssueSdkDetail | null>(
     null,
   );
+  const [sdkValidationDismissedFieldKeys, setSdkValidationDismissedFieldKeys] = useState<
+    ReadonlySet<string>
+  >(new Set());
   const [pendingTabValidationKey, setPendingTabValidationKey] = useState<TabKeysType | null>(null);
   const [spinning, setSpinning] = useState(false);
   const [showRules, setShowRules] = useState<boolean>(false);
@@ -243,6 +275,37 @@ const ProcessEdit: FC<Props> = ({
   const handleLatestJsonChange = (latestJson: ProcessDetailData['json']) => {
     aiSuggestionDataRef.current = latestJson;
   };
+
+  const dismissChangedSdkValidationFields = useCallback(
+    (changedValues: unknown) => {
+      if (!showRules || sdkValidationDetails.length === 0) {
+        return;
+      }
+
+      const changedFieldKeys = collectChangedFieldPaths(changedValues)
+        .map(stringifyProcessFieldPath)
+        .filter(Boolean);
+
+      if (changedFieldKeys.length === 0) {
+        return;
+      }
+
+      setSdkValidationDismissedFieldKeys((currentKeys) => {
+        let hasNewKey = false;
+        const nextKeys = new Set(currentKeys);
+
+        changedFieldKeys.forEach((fieldKey) => {
+          if (!nextKeys.has(fieldKey)) {
+            nextKeys.add(fieldKey);
+            hasNewKey = true;
+          }
+        });
+
+        return hasNewKey ? nextKeys : currentKeys;
+      });
+    },
+    [sdkValidationDetails.length, showRules],
+  );
 
   const handleAISuggestionClose = () => {
     const dataSet = genProcessFromData(aiSuggestionDataRef.current?.processDataSet ?? {});
@@ -663,6 +726,7 @@ const ProcessEdit: FC<Props> = ({
     const silent = options?.silent ?? false;
     setSpinning(true);
     setShowRules(true);
+    setSdkValidationDismissedFieldKeys(new Set());
     if (processDetail.stateCode >= 20 && processDetail.stateCode < 100 && from === 'checkData') {
       if (!silent) {
         message.error(
@@ -975,6 +1039,7 @@ const ProcessEdit: FC<Props> = ({
       setRefCheckData([]);
       setSdkValidationDetails([]);
       setSdkValidationFocus(null);
+      setSdkValidationDismissedFieldKeys(new Set());
       setPendingTabValidationKey(null);
       setAutoCheckTriggered(false);
       // setUnRuleVerificationData([]);
@@ -1170,7 +1235,8 @@ const ProcessEdit: FC<Props> = ({
             <ProForm
               formRef={formRefEdit}
               initialValues={initData}
-              onValuesChange={async (_, allValues) => {
+              onValuesChange={async (changedValues, allValues) => {
+                dismissChangedSdkValidationFields(changedValues);
                 if (activeTabKey === 'validation') {
                   await setFromData({
                     ...fromData,
@@ -1220,6 +1286,7 @@ const ProcessEdit: FC<Props> = ({
                 processId={id}
                 processVersion={version}
                 sdkValidationDetails={sdkValidationDetails}
+                sdkValidationDismissedFieldKeys={sdkValidationDismissedFieldKeys}
                 sdkValidationFocus={sdkValidationFocus}
                 showRules={showRules}
               />

--- a/src/pages/Processes/Components/form.tsx
+++ b/src/pages/Processes/Components/form.tsx
@@ -70,6 +70,7 @@ type Props = {
   showRules?: boolean;
   actionFrom?: 'modelResult';
   sdkValidationDetails?: ValidationIssueSdkDetail[];
+  sdkValidationDismissedFieldKeys?: ReadonlySet<string>;
   sdkValidationFocus?: ValidationIssueSdkDetail | null;
 };
 
@@ -96,6 +97,8 @@ type SdkFieldMessageEntry = {
   text: string;
   validationCode?: string;
 };
+
+const EMPTY_SDK_DISMISSED_FIELD_KEYS = new Set<string>();
 
 const isSdkFieldDetail = (detail: ValidationIssueSdkDetail) =>
   !detail.presentation || detail.presentation === 'field';
@@ -136,6 +139,43 @@ const stringifySdkFormName = (name?: Array<string | number>) => {
   }
 
   return name.map(String).join('.');
+};
+
+const isDismissedSdkFieldKey = (dismissedFieldKeys: ReadonlySet<string>, fieldKey: string) => {
+  if (!fieldKey || dismissedFieldKeys.size === 0) {
+    return false;
+  }
+
+  return Array.from(dismissedFieldKeys).some((dismissedFieldKey) => {
+    if (
+      dismissedFieldKey === fieldKey ||
+      dismissedFieldKey.startsWith(`${fieldKey}.`) ||
+      fieldKey.startsWith(`${dismissedFieldKey}.`)
+    ) {
+      return true;
+    }
+
+    return false;
+  });
+};
+
+const isDismissedRootSdkFieldDetail = (
+  detail: ValidationIssueSdkDetail,
+  dismissedFieldKeys: ReadonlySet<string>,
+) => {
+  if (
+    detail.exchangeInternalId ||
+    !isSdkFieldDetail(detail) ||
+    isSdkSectionDetail(detail) ||
+    isSdkHighlightOnlyDetail(detail)
+  ) {
+    return false;
+  }
+
+  return isDismissedSdkFieldKey(
+    dismissedFieldKeys,
+    stringifySdkFormName(parseSdkDetailFormName(detail)),
+  );
 };
 
 const PROCESS_VALIDATION_REVIEW_FIELD_PATH = 'modellingAndValidation.validation.review';
@@ -231,6 +271,7 @@ export const ProcessForm: FC<Props> = ({
   lciaResults,
   actionFrom,
   sdkValidationDetails = [],
+  sdkValidationDismissedFieldKeys = EMPTY_SDK_DISMISSED_FIELD_KEYS,
   sdkValidationFocus,
 }) => {
   const intl = useIntl();
@@ -260,46 +301,49 @@ export const ProcessForm: FC<Props> = ({
     (detail: ValidationIssueSdkDetail) => getSdkSuggestedFixMessage(intlRef.current, detail),
     [],
   );
+  const visibleSdkValidationDetails = useMemo(() => {
+    if (sdkValidationDismissedFieldKeys.size === 0) {
+      return sdkValidationDetails;
+    }
 
-  const sdkVisibleSectionAnchorsByTab = sdkValidationDetails.reduce<Record<string, Set<string>>>(
-    (accumulator, detail) => {
-      const tabName = getSdkVisibleTabName(detail);
-      const sectionAnchorPath = getSdkSectionAnchorPath(detail);
+    return sdkValidationDetails.filter(
+      (detail) => !isDismissedRootSdkFieldDetail(detail, sdkValidationDismissedFieldKeys),
+    );
+  }, [sdkValidationDetails, sdkValidationDismissedFieldKeys]);
 
-      if (!tabName || !sectionAnchorPath || !formatSdkDetailMessage(detail)) {
-        return accumulator;
-      }
+  const sdkVisibleSectionAnchorsByTab = visibleSdkValidationDetails.reduce<
+    Record<string, Set<string>>
+  >((accumulator, detail) => {
+    const tabName = getSdkVisibleTabName(detail);
+    const sectionAnchorPath = getSdkSectionAnchorPath(detail);
 
-      getOrCreateTabKeySet(accumulator, tabName).add(sectionAnchorPath);
+    if (!tabName || !sectionAnchorPath || !formatSdkDetailMessage(detail)) {
       return accumulator;
-    },
-    {},
-  );
-  const sdkVisibleRootFieldAnchorsByTab = sdkValidationDetails.reduce<Record<string, Set<string>>>(
-    (accumulator, detail) => {
-      if (
-        detail.exchangeInternalId ||
-        !isSdkFieldDetail(detail) ||
-        getSdkSectionAnchorPath(detail)
-      ) {
-        return accumulator;
-      }
+    }
 
-      const tabName = getSdkVisibleTabName(detail);
-      const formName = parseSdkDetailFormName(detail);
-      const serializedFormName = stringifySdkFormName(formName);
-      const rootFieldAnchorPath = serializedFormName || normalizeSdkFieldPath(detail.fieldPath);
-
-      if (!tabName || !rootFieldAnchorPath || !formatSdkDetailMessage(detail)) {
-        return accumulator;
-      }
-
-      getOrCreateTabKeySet(accumulator, tabName).add(rootFieldAnchorPath);
+    getOrCreateTabKeySet(accumulator, tabName).add(sectionAnchorPath);
+    return accumulator;
+  }, {});
+  const sdkVisibleRootFieldAnchorsByTab = visibleSdkValidationDetails.reduce<
+    Record<string, Set<string>>
+  >((accumulator, detail) => {
+    if (detail.exchangeInternalId || !isSdkFieldDetail(detail) || getSdkSectionAnchorPath(detail)) {
       return accumulator;
-    },
-    {},
-  );
-  const sdkExchangeRowHighlightsByExchangeId = sdkValidationDetails.reduce<
+    }
+
+    const tabName = getSdkVisibleTabName(detail);
+    const formName = parseSdkDetailFormName(detail);
+    const serializedFormName = stringifySdkFormName(formName);
+    const rootFieldAnchorPath = serializedFormName || normalizeSdkFieldPath(detail.fieldPath);
+
+    if (!tabName || !rootFieldAnchorPath || !formatSdkDetailMessage(detail)) {
+      return accumulator;
+    }
+
+    getOrCreateTabKeySet(accumulator, tabName).add(rootFieldAnchorPath);
+    return accumulator;
+  }, {});
+  const sdkExchangeRowHighlightsByExchangeId = visibleSdkValidationDetails.reduce<
     Record<string, ValidationIssueSdkDetail[]>
   >((accumulator, detail) => {
     if (!detail.exchangeInternalId || isSdkSectionDetail(detail)) {
@@ -313,22 +357,21 @@ export const ProcessForm: FC<Props> = ({
     accumulator[detail.exchangeInternalId].push(detail);
     return accumulator;
   }, {});
-  const sdkVisibleExchangeRowsByTab = sdkValidationDetails.reduce<Record<string, Set<string>>>(
-    (accumulator, detail) => {
-      const tabName = getSdkVisibleTabName(detail);
+  const sdkVisibleExchangeRowsByTab = visibleSdkValidationDetails.reduce<
+    Record<string, Set<string>>
+  >((accumulator, detail) => {
+    const tabName = getSdkVisibleTabName(detail);
 
-      if (!tabName || !detail.exchangeInternalId || isSdkSectionDetail(detail)) {
-        return accumulator;
-      }
-
-      getOrCreateTabKeySet(accumulator, tabName).add(detail.exchangeInternalId);
+    if (!tabName || !detail.exchangeInternalId || isSdkSectionDetail(detail)) {
       return accumulator;
-    },
-    {},
-  );
+    }
+
+    getOrCreateTabKeySet(accumulator, tabName).add(detail.exchangeInternalId);
+    return accumulator;
+  }, {});
   const sdkExchangeFieldDetailsByExchangeId = useMemo(
     () =>
-      sdkValidationDetails.reduce<Record<string, ValidationIssueSdkDetail[]>>(
+      visibleSdkValidationDetails.reduce<Record<string, ValidationIssueSdkDetail[]>>(
         (accumulator, detail) => {
           if (
             !detail.exchangeInternalId ||
@@ -348,11 +391,11 @@ export const ProcessForm: FC<Props> = ({
         },
         {},
       ),
-    [sdkValidationDetails],
+    [visibleSdkValidationDetails],
   );
   const sdkRootFieldMessages = useMemo(
     () =>
-      sdkValidationDetails.reduce<
+      visibleSdkValidationDetails.reduce<
         Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
       >((accumulator, detail) => {
         if (detail.exchangeInternalId || !isSdkFieldDetail(detail)) {
@@ -400,9 +443,9 @@ export const ProcessForm: FC<Props> = ({
         });
         return accumulator;
       }, new Map()),
-    [formatSdkDetailMessage, sdkValidationDetails],
+    [formatSdkDetailMessage, visibleSdkValidationDetails],
   );
-  const sdkValidationSectionMessages = sdkValidationDetails.reduce<Record<string, string[]>>(
+  const sdkValidationSectionMessages = visibleSdkValidationDetails.reduce<Record<string, string[]>>(
     (accumulator, detail) => {
       if (detail.exchangeInternalId || isSdkHighlightOnlyDetail(detail)) {
         return accumulator;
@@ -568,7 +611,8 @@ export const ProcessForm: FC<Props> = ({
       !sdkValidationFocus ||
       sdkValidationFocus.exchangeInternalId ||
       !isSdkFieldDetail(sdkValidationFocus) ||
-      sdkValidationFocus.tabName !== activeTabKey
+      sdkValidationFocus.tabName !== activeTabKey ||
+      isDismissedRootSdkFieldDetail(sdkValidationFocus, sdkValidationDismissedFieldKeys)
     ) {
       return;
     }
@@ -587,7 +631,7 @@ export const ProcessForm: FC<Props> = ({
     return () => {
       window.clearTimeout(timer);
     };
-  }, [activeTabKey, formRef, sdkValidationFocus]);
+  }, [activeTabKey, formRef, sdkValidationDismissedFieldKeys, sdkValidationFocus]);
 
   const renderSdkSectionMessages = (fieldPath: string) => {
     const messages = sdkValidationSectionMessages[fieldPath] ?? [];

--- a/src/pages/Processes/Components/form.tsx
+++ b/src/pages/Processes/Components/form.tsx
@@ -29,7 +29,7 @@ import {
   Space,
   theme,
 } from 'antd';
-import { useEffect, useRef, useState, type FC } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type FC } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 import schema from '../processes_schema.json';
 import { getSdkSuggestedFixMessage, resolveRequiredValidationMessage } from '../sdkValidationUi';
@@ -234,6 +234,8 @@ export const ProcessForm: FC<Props> = ({
   sdkValidationFocus,
 }) => {
   const intl = useIntl();
+  const intlRef = useRef(intl);
+  intlRef.current = intl;
   const refCheckContext = useRefCheckContext();
   const actionRefExchangeTableInput = useRef<ActionType>();
   const actionRefExchangeTableOutput = useRef<ActionType>();
@@ -254,8 +256,10 @@ export const ProcessForm: FC<Props> = ({
 
   const { token } = theme.useToken();
 
-  const formatSdkDetailMessage = (detail: ValidationIssueSdkDetail) =>
-    getSdkSuggestedFixMessage(intl, detail);
+  const formatSdkDetailMessage = useCallback(
+    (detail: ValidationIssueSdkDetail) => getSdkSuggestedFixMessage(intlRef.current, detail),
+    [],
+  );
 
   const sdkVisibleSectionAnchorsByTab = sdkValidationDetails.reduce<Record<string, Set<string>>>(
     (accumulator, detail) => {
@@ -322,73 +326,82 @@ export const ProcessForm: FC<Props> = ({
     },
     {},
   );
-  const sdkExchangeFieldDetailsByExchangeId = sdkValidationDetails.reduce<
-    Record<string, ValidationIssueSdkDetail[]>
-  >((accumulator, detail) => {
-    if (
-      !detail.exchangeInternalId ||
-      !isSdkFieldDetail(detail) ||
-      isSdkSectionDetail(detail) ||
-      isSdkHighlightOnlyDetail(detail)
-    ) {
-      return accumulator;
-    }
+  const sdkExchangeFieldDetailsByExchangeId = useMemo(
+    () =>
+      sdkValidationDetails.reduce<Record<string, ValidationIssueSdkDetail[]>>(
+        (accumulator, detail) => {
+          if (
+            !detail.exchangeInternalId ||
+            !isSdkFieldDetail(detail) ||
+            isSdkSectionDetail(detail) ||
+            isSdkHighlightOnlyDetail(detail)
+          ) {
+            return accumulator;
+          }
 
-    if (!accumulator[detail.exchangeInternalId]) {
-      accumulator[detail.exchangeInternalId] = [];
-    }
+          if (!accumulator[detail.exchangeInternalId]) {
+            accumulator[detail.exchangeInternalId] = [];
+          }
 
-    accumulator[detail.exchangeInternalId].push(detail);
-    return accumulator;
-  }, {});
-  const sdkRootFieldMessages = sdkValidationDetails.reduce<
-    Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
-  >((accumulator, detail) => {
-    if (detail.exchangeInternalId || !isSdkFieldDetail(detail)) {
-      return accumulator;
-    }
+          accumulator[detail.exchangeInternalId].push(detail);
+          return accumulator;
+        },
+        {},
+      ),
+    [sdkValidationDetails],
+  );
+  const sdkRootFieldMessages = useMemo(
+    () =>
+      sdkValidationDetails.reduce<
+        Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
+      >((accumulator, detail) => {
+        if (detail.exchangeInternalId || !isSdkFieldDetail(detail)) {
+          return accumulator;
+        }
 
-    const formName = parseSdkDetailFormName(detail);
-    const serializedFormName = stringifySdkFormName(formName);
+        const formName = parseSdkDetailFormName(detail);
+        const serializedFormName = stringifySdkFormName(formName);
 
-    if (
-      !formName ||
-      !serializedFormName ||
-      serializedFormName === 'modellingAndValidation.validation.review' ||
-      serializedFormName === 'modellingAndValidation.complianceDeclarations.compliance'
-    ) {
-      return accumulator;
-    }
+        if (
+          !formName ||
+          !serializedFormName ||
+          serializedFormName === 'modellingAndValidation.validation.review' ||
+          serializedFormName === 'modellingAndValidation.complianceDeclarations.compliance'
+        ) {
+          return accumulator;
+        }
 
-    const formattedMessage = formatSdkDetailMessage(detail);
-    if (!formattedMessage) {
-      return accumulator;
-    }
-    const messageEntry: SdkFieldMessageEntry = {
-      text: formattedMessage,
-      validationCode: detail.validationCode,
-    };
+        const formattedMessage = formatSdkDetailMessage(detail);
+        if (!formattedMessage) {
+          return accumulator;
+        }
+        const messageEntry: SdkFieldMessageEntry = {
+          text: formattedMessage,
+          validationCode: detail.validationCode,
+        };
 
-    const currentEntry = accumulator.get(serializedFormName);
-    if (currentEntry) {
-      if (
-        !currentEntry.entries.some(
-          (entry) =>
-            entry.text === messageEntry.text &&
-            entry.validationCode === messageEntry.validationCode,
-        )
-      ) {
-        currentEntry.entries.push(messageEntry);
-      }
-      return accumulator;
-    }
+        const currentEntry = accumulator.get(serializedFormName);
+        if (currentEntry) {
+          if (
+            !currentEntry.entries.some(
+              (entry) =>
+                entry.text === messageEntry.text &&
+                entry.validationCode === messageEntry.validationCode,
+            )
+          ) {
+            currentEntry.entries.push(messageEntry);
+          }
+          return accumulator;
+        }
 
-    accumulator.set(serializedFormName, {
-      entries: [messageEntry],
-      name: formName,
-    });
-    return accumulator;
-  }, new Map());
+        accumulator.set(serializedFormName, {
+          entries: [messageEntry],
+          name: formName,
+        });
+        return accumulator;
+      }, new Map()),
+    [formatSdkDetailMessage, sdkValidationDetails],
+  );
   const sdkValidationSectionMessages = sdkValidationDetails.reduce<Record<string, string[]>>(
     (accumulator, detail) => {
       if (detail.exchangeInternalId || isSdkHighlightOnlyDetail(detail)) {
@@ -499,7 +512,7 @@ export const ProcessForm: FC<Props> = ({
           context: 'process',
           fieldName,
           frontendRulesEnabled: showRules,
-          intl,
+          intl: intlRef.current,
           retainedErrors,
           schemaRoot: schema,
           validationCode: entry.validationCode,
@@ -548,7 +561,7 @@ export const ProcessForm: FC<Props> = ({
     }
 
     rootSdkFieldMessagesRef.current = appliedEntries;
-  }, [formRef, intl, showRules, sdkRootFieldMessages]);
+  }, [formRef, showRules, sdkRootFieldMessages]);
 
   useEffect(() => {
     if (

--- a/src/pages/Processes/Components/form.tsx
+++ b/src/pages/Processes/Components/form.tsx
@@ -301,7 +301,7 @@ export const ProcessForm: FC<Props> = ({
     (detail: ValidationIssueSdkDetail) => getSdkSuggestedFixMessage(intlRef.current, detail),
     [],
   );
-  const visibleSdkValidationDetails = useMemo(() => {
+  const fieldMessageSdkValidationDetails = useMemo(() => {
     if (sdkValidationDismissedFieldKeys.size === 0) {
       return sdkValidationDetails;
     }
@@ -311,39 +311,45 @@ export const ProcessForm: FC<Props> = ({
     );
   }, [sdkValidationDetails, sdkValidationDismissedFieldKeys]);
 
-  const sdkVisibleSectionAnchorsByTab = visibleSdkValidationDetails.reduce<
-    Record<string, Set<string>>
-  >((accumulator, detail) => {
-    const tabName = getSdkVisibleTabName(detail);
-    const sectionAnchorPath = getSdkSectionAnchorPath(detail);
+  const sdkVisibleSectionAnchorsByTab = sdkValidationDetails.reduce<Record<string, Set<string>>>(
+    (accumulator, detail) => {
+      const tabName = getSdkVisibleTabName(detail);
+      const sectionAnchorPath = getSdkSectionAnchorPath(detail);
 
-    if (!tabName || !sectionAnchorPath || !formatSdkDetailMessage(detail)) {
+      if (!tabName || !sectionAnchorPath || !formatSdkDetailMessage(detail)) {
+        return accumulator;
+      }
+
+      getOrCreateTabKeySet(accumulator, tabName).add(sectionAnchorPath);
       return accumulator;
-    }
+    },
+    {},
+  );
+  const sdkVisibleRootFieldAnchorsByTab = sdkValidationDetails.reduce<Record<string, Set<string>>>(
+    (accumulator, detail) => {
+      if (
+        detail.exchangeInternalId ||
+        !isSdkFieldDetail(detail) ||
+        getSdkSectionAnchorPath(detail)
+      ) {
+        return accumulator;
+      }
 
-    getOrCreateTabKeySet(accumulator, tabName).add(sectionAnchorPath);
-    return accumulator;
-  }, {});
-  const sdkVisibleRootFieldAnchorsByTab = visibleSdkValidationDetails.reduce<
-    Record<string, Set<string>>
-  >((accumulator, detail) => {
-    if (detail.exchangeInternalId || !isSdkFieldDetail(detail) || getSdkSectionAnchorPath(detail)) {
+      const tabName = getSdkVisibleTabName(detail);
+      const formName = parseSdkDetailFormName(detail);
+      const serializedFormName = stringifySdkFormName(formName);
+      const rootFieldAnchorPath = serializedFormName || normalizeSdkFieldPath(detail.fieldPath);
+
+      if (!tabName || !rootFieldAnchorPath || !formatSdkDetailMessage(detail)) {
+        return accumulator;
+      }
+
+      getOrCreateTabKeySet(accumulator, tabName).add(rootFieldAnchorPath);
       return accumulator;
-    }
-
-    const tabName = getSdkVisibleTabName(detail);
-    const formName = parseSdkDetailFormName(detail);
-    const serializedFormName = stringifySdkFormName(formName);
-    const rootFieldAnchorPath = serializedFormName || normalizeSdkFieldPath(detail.fieldPath);
-
-    if (!tabName || !rootFieldAnchorPath || !formatSdkDetailMessage(detail)) {
-      return accumulator;
-    }
-
-    getOrCreateTabKeySet(accumulator, tabName).add(rootFieldAnchorPath);
-    return accumulator;
-  }, {});
-  const sdkExchangeRowHighlightsByExchangeId = visibleSdkValidationDetails.reduce<
+    },
+    {},
+  );
+  const sdkExchangeRowHighlightsByExchangeId = sdkValidationDetails.reduce<
     Record<string, ValidationIssueSdkDetail[]>
   >((accumulator, detail) => {
     if (!detail.exchangeInternalId || isSdkSectionDetail(detail)) {
@@ -357,21 +363,22 @@ export const ProcessForm: FC<Props> = ({
     accumulator[detail.exchangeInternalId].push(detail);
     return accumulator;
   }, {});
-  const sdkVisibleExchangeRowsByTab = visibleSdkValidationDetails.reduce<
-    Record<string, Set<string>>
-  >((accumulator, detail) => {
-    const tabName = getSdkVisibleTabName(detail);
+  const sdkVisibleExchangeRowsByTab = sdkValidationDetails.reduce<Record<string, Set<string>>>(
+    (accumulator, detail) => {
+      const tabName = getSdkVisibleTabName(detail);
 
-    if (!tabName || !detail.exchangeInternalId || isSdkSectionDetail(detail)) {
+      if (!tabName || !detail.exchangeInternalId || isSdkSectionDetail(detail)) {
+        return accumulator;
+      }
+
+      getOrCreateTabKeySet(accumulator, tabName).add(detail.exchangeInternalId);
       return accumulator;
-    }
-
-    getOrCreateTabKeySet(accumulator, tabName).add(detail.exchangeInternalId);
-    return accumulator;
-  }, {});
+    },
+    {},
+  );
   const sdkExchangeFieldDetailsByExchangeId = useMemo(
     () =>
-      visibleSdkValidationDetails.reduce<Record<string, ValidationIssueSdkDetail[]>>(
+      sdkValidationDetails.reduce<Record<string, ValidationIssueSdkDetail[]>>(
         (accumulator, detail) => {
           if (
             !detail.exchangeInternalId ||
@@ -391,11 +398,11 @@ export const ProcessForm: FC<Props> = ({
         },
         {},
       ),
-    [visibleSdkValidationDetails],
+    [sdkValidationDetails],
   );
   const sdkRootFieldMessages = useMemo(
     () =>
-      visibleSdkValidationDetails.reduce<
+      fieldMessageSdkValidationDetails.reduce<
         Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
       >((accumulator, detail) => {
         if (detail.exchangeInternalId || !isSdkFieldDetail(detail)) {
@@ -443,58 +450,57 @@ export const ProcessForm: FC<Props> = ({
         });
         return accumulator;
       }, new Map()),
-    [formatSdkDetailMessage, visibleSdkValidationDetails],
+    [fieldMessageSdkValidationDetails, formatSdkDetailMessage],
   );
-  const sdkValidationSectionMessages = visibleSdkValidationDetails.reduce<Record<string, string[]>>(
-    (accumulator, detail) => {
-      if (detail.exchangeInternalId || isSdkHighlightOnlyDetail(detail)) {
-        return accumulator;
-      }
+  const sdkValidationSectionMessages = fieldMessageSdkValidationDetails.reduce<
+    Record<string, string[]>
+  >((accumulator, detail) => {
+    if (detail.exchangeInternalId || isSdkHighlightOnlyDetail(detail)) {
+      return accumulator;
+    }
 
-      if (isSdkSectionDetail(detail)) {
-        const formattedMessage = formatSdkDetailMessage(detail);
-        if (!formattedMessage) {
-          return accumulator;
-        }
-
-        if (!accumulator[detail.fieldPath]) {
-          accumulator[detail.fieldPath] = [];
-        }
-
-        if (!accumulator[detail.fieldPath].includes(formattedMessage)) {
-          accumulator[detail.fieldPath].push(formattedMessage);
-        }
-
-        return accumulator;
-      }
-
-      const formName = parseSdkDetailFormName(detail);
-      const serializedFormName = stringifySdkFormName(formName);
-
-      if (
-        serializedFormName !== 'modellingAndValidation.validation.review' &&
-        serializedFormName !== 'modellingAndValidation.complianceDeclarations.compliance'
-      ) {
-        return accumulator;
-      }
-
+    if (isSdkSectionDetail(detail)) {
       const formattedMessage = formatSdkDetailMessage(detail);
       if (!formattedMessage) {
         return accumulator;
       }
 
-      if (!accumulator[serializedFormName]) {
-        accumulator[serializedFormName] = [];
+      if (!accumulator[detail.fieldPath]) {
+        accumulator[detail.fieldPath] = [];
       }
 
-      if (!accumulator[serializedFormName].includes(formattedMessage)) {
-        accumulator[serializedFormName].push(formattedMessage);
+      if (!accumulator[detail.fieldPath].includes(formattedMessage)) {
+        accumulator[detail.fieldPath].push(formattedMessage);
       }
 
       return accumulator;
-    },
-    {},
-  );
+    }
+
+    const formName = parseSdkDetailFormName(detail);
+    const serializedFormName = stringifySdkFormName(formName);
+
+    if (
+      serializedFormName !== 'modellingAndValidation.validation.review' &&
+      serializedFormName !== 'modellingAndValidation.complianceDeclarations.compliance'
+    ) {
+      return accumulator;
+    }
+
+    const formattedMessage = formatSdkDetailMessage(detail);
+    if (!formattedMessage) {
+      return accumulator;
+    }
+
+    if (!accumulator[serializedFormName]) {
+      accumulator[serializedFormName] = [];
+    }
+
+    if (!accumulator[serializedFormName].includes(formattedMessage)) {
+      accumulator[serializedFormName].push(formattedMessage);
+    }
+
+    return accumulator;
+  }, {});
   const sdkValidationCountsByTab = [
     ...new Set([
       ...Object.keys(sdkVisibleSectionAnchorsByTab),

--- a/src/pages/Sources/Components/form.tsx
+++ b/src/pages/Sources/Components/form.tsx
@@ -18,6 +18,8 @@ import { FormattedMessage, useIntl } from 'umi';
 import schema from '../sources_schema.json';
 import { publicationTypeOptions } from './optiondata';
 
+const SOURCE_SCHEMA_PATH_PREFIX = ['sourceDataSet'];
+
 type Props = {
   lang: string;
   activeTabKey: string;
@@ -60,6 +62,8 @@ export const SourceForm: FC<Props> = ({
     intl,
     sdkValidationDetails,
     sdkValidationFocus,
+    schemaPathPrefix: SOURCE_SCHEMA_PATH_PREFIX,
+    schemaRoot: schema,
     showRules,
   });
   const handlePreview = async (file: UploadFile) => {

--- a/src/pages/Unitgroups/Components/Unit/edit.tsx
+++ b/src/pages/Unitgroups/Components/Unit/edit.tsx
@@ -8,7 +8,7 @@ import { CloseOutlined, FormOutlined } from '@ant-design/icons';
 import { ActionType, ProForm, ProFormInstance } from '@ant-design/pro-components';
 import { Button, Card, Drawer, Form, Input, Space, Switch, Tooltip } from 'antd';
 import type { FC } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 
 type SdkFieldMessageEntry = {
@@ -53,6 +53,8 @@ const UnitEdit: FC<Props> = ({
   autoOpen = false,
 }) => {
   const intl = useIntl();
+  const intlRef = useRef(intl);
+  intlRef.current = intl;
   const [drawerVisible, setDrawerVisible] = useState(false);
   const [fromData, setFromData] = useState<UnitDraft>({});
   const [initData, setInitData] = useState<UnitDraft>({});
@@ -62,47 +64,51 @@ const UnitEdit: FC<Props> = ({
     Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
   >(new Map());
 
-  const sdkFieldMessages = sdkHighlights.reduce<
-    Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
-  >((accumulator, detail) => {
-    const formName =
-      (Array.isArray(detail.formName) && detail.formName.length > 0
-        ? detail.formName
-        : parseSdkFieldPathToFormName(detail.fieldPath)) ??
-      (detail.fieldKey ? [detail.fieldKey] : undefined);
-    const fieldKey = formName ? formName.map(String).join('.') : '';
-    const messageText = getSdkSuggestedFixMessage(intl, detail);
+  const sdkFieldMessages = useMemo(
+    () =>
+      sdkHighlights.reduce<
+        Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
+      >((accumulator, detail) => {
+        const formName =
+          (Array.isArray(detail.formName) && detail.formName.length > 0
+            ? detail.formName
+            : parseSdkFieldPathToFormName(detail.fieldPath)) ??
+          (detail.fieldKey ? [detail.fieldKey] : undefined);
+        const fieldKey = formName ? formName.map(String).join('.') : '';
+        const messageText = getSdkSuggestedFixMessage(intlRef.current, detail);
 
-    if (!formName || !fieldKey || !messageText) {
-      return accumulator;
-    }
+        if (!formName || !fieldKey || !messageText) {
+          return accumulator;
+        }
 
-    const messageEntry: SdkFieldMessageEntry = {
-      text: messageText,
-      validationCode: detail.validationCode,
-    };
-    const currentEntry = accumulator.get(fieldKey);
+        const messageEntry: SdkFieldMessageEntry = {
+          text: messageText,
+          validationCode: detail.validationCode,
+        };
+        const currentEntry = accumulator.get(fieldKey);
 
-    if (currentEntry) {
-      if (
-        !currentEntry.entries.some(
-          (entry) =>
-            entry.text === messageEntry.text &&
-            entry.validationCode === messageEntry.validationCode,
-        )
-      ) {
-        currentEntry.entries.push(messageEntry);
-      }
+        if (currentEntry) {
+          if (
+            !currentEntry.entries.some(
+              (entry) =>
+                entry.text === messageEntry.text &&
+                entry.validationCode === messageEntry.validationCode,
+            )
+          ) {
+            currentEntry.entries.push(messageEntry);
+          }
 
-      return accumulator;
-    }
+          return accumulator;
+        }
 
-    accumulator.set(fieldKey, {
-      entries: [messageEntry],
-      name: formName,
-    });
-    return accumulator;
-  }, new Map());
+        accumulator.set(fieldKey, {
+          entries: [messageEntry],
+          name: formName,
+        });
+        return accumulator;
+      }, new Map()),
+    [sdkHighlights],
+  );
 
   useEffect(() => {
     if (!autoOpen) {

--- a/src/pages/Unitgroups/Components/form.tsx
+++ b/src/pages/Unitgroups/Components/form.tsx
@@ -14,7 +14,7 @@ import { UnitDraft, UnitItem, UnitTable } from '@/services/unitgroups/data';
 import { genUnitTableData } from '@/services/unitgroups/util';
 import { ActionType, ProColumns, ProFormInstance, ProTable } from '@ant-design/pro-components';
 import { Card, Form, Input, Select, Space, theme } from 'antd';
-import { FC, useRef, useState } from 'react';
+import { FC, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 import schema from '../unitgroups_schema.json';
 import UnitCreate from './Unit/create';
@@ -24,6 +24,8 @@ import UnitView from './Unit/view';
 import { complianceOptions } from './optiondata';
 // import UnitGroupSelectFrom from './select/form';
 import { toSuperscript } from '@/components/AlignedNumber';
+
+const UNIT_GROUP_SCHEMA_PATH_PREFIX = ['unitGroupDataSet'];
 
 type Props = {
   lang: string;
@@ -71,8 +73,9 @@ export const UnitGroupForm: FC<Props> = ({
   const intl = useIntl();
   const actionRefUnitTable = useRef<ActionType>();
   const [showNameError, setShowNameError] = useState(false);
-  const sdkRootValidationDetails = sdkValidationDetails.filter(
-    (detail) => !getUnitInternalId(detail),
+  const sdkRootValidationDetails = useMemo(
+    () => sdkValidationDetails.filter((detail) => !getUnitInternalId(detail)),
+    [sdkValidationDetails],
   );
   const { sdkValidationCountsByTab: rootSdkValidationCountsByTab, sdkValidationSectionMessages } =
     useDatasetSdkValidationFormSupport({
@@ -81,62 +84,75 @@ export const UnitGroupForm: FC<Props> = ({
       intl,
       sdkValidationDetails: sdkRootValidationDetails,
       sdkValidationFocus: getUnitInternalId(sdkValidationFocus) ? null : sdkValidationFocus,
+      schemaPathPrefix: UNIT_GROUP_SCHEMA_PATH_PREFIX,
+      schemaRoot: schema,
       showRules,
     });
-  const sdkUnitRowHighlightsById = sdkValidationDetails.reduce<
-    Record<string, ValidationIssueSdkDetail[]>
-  >((accumulator, detail) => {
-    const unitInternalId = getUnitInternalId(detail);
+  const sdkUnitRowHighlightsById = useMemo(
+    () =>
+      sdkValidationDetails.reduce<Record<string, ValidationIssueSdkDetail[]>>(
+        (accumulator, detail) => {
+          const unitInternalId = getUnitInternalId(detail);
 
-    if (!unitInternalId || isSdkSectionDetail(detail)) {
-      return accumulator;
-    }
+          if (!unitInternalId || isSdkSectionDetail(detail)) {
+            return accumulator;
+          }
 
-    if (!accumulator[unitInternalId]) {
-      accumulator[unitInternalId] = [];
-    }
+          if (!accumulator[unitInternalId]) {
+            accumulator[unitInternalId] = [];
+          }
 
-    accumulator[unitInternalId].push(detail);
-    return accumulator;
-  }, {});
-  const sdkUnitFieldDetailsById = sdkValidationDetails.reduce<
-    Record<string, ValidationIssueSdkDetail[]>
-  >((accumulator, detail) => {
-    const unitInternalId = getUnitInternalId(detail);
+          accumulator[unitInternalId].push(detail);
+          return accumulator;
+        },
+        {},
+      ),
+    [sdkValidationDetails],
+  );
+  const sdkUnitFieldDetailsById = useMemo(
+    () =>
+      sdkValidationDetails.reduce<Record<string, ValidationIssueSdkDetail[]>>(
+        (accumulator, detail) => {
+          const unitInternalId = getUnitInternalId(detail);
 
-    if (
-      !unitInternalId ||
-      !isSdkFieldDetail(detail) ||
-      isSdkSectionDetail(detail) ||
-      isSdkHighlightOnlyDetail(detail)
-    ) {
-      return accumulator;
-    }
+          if (
+            !unitInternalId ||
+            !isSdkFieldDetail(detail) ||
+            isSdkSectionDetail(detail) ||
+            isSdkHighlightOnlyDetail(detail)
+          ) {
+            return accumulator;
+          }
 
-    if (!accumulator[unitInternalId]) {
-      accumulator[unitInternalId] = [];
-    }
+          if (!accumulator[unitInternalId]) {
+            accumulator[unitInternalId] = [];
+          }
 
-    accumulator[unitInternalId].push(detail);
-    return accumulator;
-  }, {});
-  const sdkVisibleUnitRowsByTab = sdkValidationDetails.reduce<Record<string, Set<string>>>(
-    (accumulator, detail) => {
-      const unitInternalId = getUnitInternalId(detail);
-      const tabName = detail.tabName;
+          accumulator[unitInternalId].push(detail);
+          return accumulator;
+        },
+        {},
+      ),
+    [sdkValidationDetails],
+  );
+  const sdkVisibleUnitRowsByTab = useMemo(
+    () =>
+      sdkValidationDetails.reduce<Record<string, Set<string>>>((accumulator, detail) => {
+        const unitInternalId = getUnitInternalId(detail);
+        const tabName = detail.tabName;
 
-      if (!unitInternalId || !tabName || isSdkSectionDetail(detail)) {
+        if (!unitInternalId || !tabName || isSdkSectionDetail(detail)) {
+          return accumulator;
+        }
+
+        if (!accumulator[tabName]) {
+          accumulator[tabName] = new Set<string>();
+        }
+
+        accumulator[tabName].add(unitInternalId);
         return accumulator;
-      }
-
-      if (!accumulator[tabName]) {
-        accumulator[tabName] = new Set<string>();
-      }
-
-      accumulator[tabName].add(unitInternalId);
-      return accumulator;
-    },
-    {},
+      }, {}),
+    [sdkValidationDetails],
   );
   const sdkValidationCountsByTab: Record<string, number> = {
     ...rootSdkValidationCountsByTab,

--- a/src/pages/Utils/validation/formSupport.ts
+++ b/src/pages/Utils/validation/formSupport.ts
@@ -1,7 +1,11 @@
 import type { ValidationIssueSdkDetail } from '@/pages/Utils/review';
 import type { ProFormInstance } from '@ant-design/pro-components';
 import { useEffect, useMemo, useRef } from 'react';
-import { getSdkSuggestedFixMessage } from './messages';
+import {
+  getSdkSuggestedFixMessage,
+  resolveRequiredValidationMessage,
+  type SdkFieldFormName,
+} from './messages';
 
 type IntlShapeLike = {
   formatMessage: (
@@ -26,8 +30,13 @@ type UseDatasetSdkValidationFormSupportOptions = {
   intl: IntlShapeLike;
   sdkValidationDetails?: ValidationIssueSdkDetail[];
   sdkValidationFocus?: ValidationIssueSdkDetail | null;
+  schemaPathPrefix?: Array<string | number>;
+  schemaRoot?: unknown;
   showRules?: boolean;
+  usesLocalRequiredValidationUi?: (fieldName?: SdkFieldFormName) => boolean;
 };
+
+const EMPTY_SCHEMA_PATH_PREFIX: Array<string | number> = [];
 
 const waitForNextValidationTurn = async () => {
   await new Promise<void>((resolve) => {
@@ -136,8 +145,13 @@ export const useDatasetSdkValidationFormSupport = ({
   intl,
   sdkValidationDetails = [],
   sdkValidationFocus,
+  schemaPathPrefix = EMPTY_SCHEMA_PATH_PREFIX,
+  schemaRoot,
   showRules = false,
+  usesLocalRequiredValidationUi,
 }: UseDatasetSdkValidationFormSupportOptions) => {
+  const intlRef = useRef(intl);
+  intlRef.current = intl;
   const rootSdkFieldMessagesRef = useRef<
     Map<string, { entries: SdkFieldMessageEntry[]; name: Array<string | number> }>
   >(new Map());
@@ -159,7 +173,7 @@ export const useDatasetSdkValidationFormSupport = ({
         return accumulator;
       }
 
-      const messageText = getSdkSuggestedFixMessage(intl, detail);
+      const messageText = getSdkSuggestedFixMessage(intlRef.current, detail);
 
       if (!messageText) {
         return accumulator;
@@ -175,7 +189,7 @@ export const useDatasetSdkValidationFormSupport = ({
 
       return accumulator;
     }, {});
-  }, [intl, sdkValidationDetails]);
+  }, [sdkValidationDetails]);
 
   const sdkRootFieldMessages = useMemo(() => {
     return sdkValidationDetails.reduce<
@@ -187,7 +201,7 @@ export const useDatasetSdkValidationFormSupport = ({
 
       const formName = parseSdkDetailFormName(detail);
       const serializedFormName = stringifySdkFormName(formName);
-      const messageText = getSdkSuggestedFixMessage(intl, detail);
+      const messageText = getSdkSuggestedFixMessage(intlRef.current, detail);
 
       if (!formName || !serializedFormName || !messageText) {
         return accumulator;
@@ -219,7 +233,7 @@ export const useDatasetSdkValidationFormSupport = ({
 
       return accumulator;
     }, new Map());
-  }, [intl, sdkValidationDetails]);
+  }, [sdkValidationDetails]);
 
   useEffect(() => {
     const formInstance = formRef.current;
@@ -263,15 +277,31 @@ export const useDatasetSdkValidationFormSupport = ({
       const nextAppliedFieldEntries: SdkFieldMessageEntry[] = [];
 
       (nextEntry?.entries ?? []).forEach((entry) => {
-        if (entry.validationCode === 'required_missing' && retainedErrors.length > 0) {
+        const requiredResolution = resolveRequiredValidationMessage({
+          fieldName,
+          frontendRulesEnabled: showRules,
+          intl: intlRef.current,
+          retainedErrors,
+          schemaPathPrefix,
+          schemaRoot,
+          usesLocalRequiredValidationUi,
+          validationCode: entry.validationCode,
+        });
+
+        if (requiredResolution.suppressSdkMessage) {
           return;
         }
 
-        if (!nextErrors.includes(entry.text)) {
-          nextErrors.push(entry.text);
+        const resolvedEntry = {
+          ...entry,
+          text: requiredResolution.replacementMessage ?? entry.text,
+        };
+
+        if (!nextErrors.includes(resolvedEntry.text)) {
+          nextErrors.push(resolvedEntry.text);
         }
 
-        nextAppliedFieldEntries.push(entry);
+        nextAppliedFieldEntries.push(resolvedEntry);
       });
 
       if (nextAppliedFieldEntries.length > 0) {
@@ -301,7 +331,14 @@ export const useDatasetSdkValidationFormSupport = ({
     }
 
     rootSdkFieldMessagesRef.current = appliedEntries;
-  }, [formRef, showRules, sdkRootFieldMessages]);
+  }, [
+    formRef,
+    schemaPathPrefix,
+    schemaRoot,
+    showRules,
+    sdkRootFieldMessages,
+    usesLocalRequiredValidationUi,
+  ]);
 
   useEffect(() => {
     if (

--- a/src/pages/Utils/validation/messages.ts
+++ b/src/pages/Utils/validation/messages.ts
@@ -18,8 +18,24 @@ type SdkValidationDetailMessageLike = {
   validationParams?: Record<string, string | number | boolean | null | undefined>;
 };
 
+type SchemaRuleLike = {
+  defaultMessage?: string;
+  message?: unknown;
+  messageKey?: string;
+  required?: boolean;
+};
+
+type RequiredValidationMessageResolution = {
+  replacementMessage?: string;
+  suppressSdkMessage: boolean;
+};
+
 const SDK_MESSAGE_TRAILING_PUNCTUATION_PATTERN = /[。．.!！?？,，;；:：]+$/u;
 const PROCESS_REFERENCE_YEAR_FIELD_PATH = 'processInformation.time.common:referenceYear';
+const DEFAULT_REQUIRED_MESSAGE = {
+  defaultMessage: 'Please complete this field',
+  id: 'validator.lang.required',
+};
 
 export const normalizeValidationMessageText = (message?: string) =>
   (message ?? '').trim().replace(SDK_MESSAGE_TRAILING_PUNCTUATION_PATTERN, '').trim();
@@ -61,6 +77,184 @@ const getSdkFieldSpecificSuggestedFixMessage = (
   }
 
   return undefined;
+};
+
+const isRequiredRule = (rule: unknown): rule is SchemaRuleLike =>
+  typeof rule === 'object' &&
+  rule !== null &&
+  'required' in rule &&
+  Boolean((rule as { required?: boolean }).required);
+
+export const getSchemaNodeAtPath = (schemaRoot: unknown, path: Array<string | number>) => {
+  let current: any = schemaRoot;
+
+  for (const segment of path) {
+    if (Array.isArray(current)) {
+      current = current[typeof segment === 'number' ? segment : 0];
+
+      if (typeof segment === 'number') {
+        continue;
+      }
+    }
+
+    if (!current || typeof current !== 'object') {
+      return undefined;
+    }
+
+    current = current[segment as keyof typeof current];
+  }
+
+  return current;
+};
+
+const isIndexedLangTextLeafFormName = (fieldName: SdkFieldFormName) => {
+  if (fieldName.length < 2) {
+    return false;
+  }
+
+  const lastSegment = fieldName[fieldName.length - 1];
+  const previousSegment = fieldName[fieldName.length - 2];
+
+  return (
+    (lastSegment === '#text' || lastSegment === '@xml:lang') && typeof previousSegment === 'number'
+  );
+};
+
+const getRequiredRuleCandidatePaths = (
+  fieldName: SdkFieldFormName,
+  schemaPathPrefix: Array<string | number>,
+) => {
+  const paths = [[...schemaPathPrefix, ...fieldName]];
+
+  if (isIndexedLangTextLeafFormName(fieldName)) {
+    paths.unshift([...schemaPathPrefix, ...fieldName.slice(0, -2)]);
+  }
+
+  return paths;
+};
+
+export const getSchemaRequiredRule = ({
+  fieldName,
+  schemaPathPrefix = [],
+  schemaRoot,
+}: {
+  fieldName?: SdkFieldFormName;
+  schemaPathPrefix?: Array<string | number>;
+  schemaRoot?: unknown;
+}) => {
+  if (!schemaRoot || !fieldName || fieldName.length === 0) {
+    return undefined;
+  }
+
+  for (const schemaPath of getRequiredRuleCandidatePaths(fieldName, schemaPathPrefix)) {
+    const schemaNode = getSchemaNodeAtPath(schemaRoot, schemaPath);
+    const schemaRules = (schemaNode as { rules?: unknown[] } | undefined)?.rules;
+    const rules = Array.isArray(schemaRules) ? schemaRules : [];
+    const requiredRule = rules.find(isRequiredRule);
+
+    if (requiredRule) {
+      return requiredRule;
+    }
+  }
+
+  return undefined;
+};
+
+export const formatRequiredRuleMessage = (intl: IntlShapeLike, rule?: SchemaRuleLike) => {
+  if (!rule) {
+    return normalizeValidationMessageText(intl.formatMessage(DEFAULT_REQUIRED_MESSAGE));
+  }
+
+  if (typeof rule.message === 'string') {
+    return normalizeValidationMessageText(rule.message);
+  }
+
+  if (rule.message && typeof rule.message === 'object' && 'props' in (rule.message as object)) {
+    const props = (rule.message as { props?: Record<string, unknown> }).props ?? {};
+    const id = typeof props.id === 'string' ? props.id : DEFAULT_REQUIRED_MESSAGE.id;
+    const defaultMessage =
+      typeof props.defaultMessage === 'string'
+        ? props.defaultMessage
+        : DEFAULT_REQUIRED_MESSAGE.defaultMessage;
+
+    return normalizeValidationMessageText(
+      intl.formatMessage(
+        {
+          id,
+          defaultMessage,
+        },
+        props.values as Record<string, string | number | undefined> | undefined,
+      ),
+    );
+  }
+
+  return normalizeValidationMessageText(
+    intl.formatMessage({
+      id: rule.messageKey ?? DEFAULT_REQUIRED_MESSAGE.id,
+      defaultMessage: rule.defaultMessage ?? DEFAULT_REQUIRED_MESSAGE.defaultMessage,
+    }),
+  );
+};
+
+export const resolveRequiredValidationMessage = ({
+  fieldName,
+  frontendRulesEnabled = true,
+  intl,
+  retainedErrors,
+  schemaPathPrefix = [],
+  schemaRoot,
+  usesLocalRequiredValidationUi,
+  validationCode,
+}: {
+  fieldName?: SdkFieldFormName;
+  frontendRulesEnabled?: boolean;
+  intl: IntlShapeLike;
+  retainedErrors: string[];
+  schemaPathPrefix?: Array<string | number>;
+  schemaRoot?: unknown;
+  usesLocalRequiredValidationUi?: (fieldName?: SdkFieldFormName) => boolean;
+  validationCode?: string;
+}): RequiredValidationMessageResolution => {
+  if (validationCode !== 'required_missing') {
+    return {
+      suppressSdkMessage: false,
+    };
+  }
+
+  if (retainedErrors.length > 0) {
+    return {
+      suppressSdkMessage: true,
+    };
+  }
+
+  if (!frontendRulesEnabled) {
+    return {
+      suppressSdkMessage: false,
+    };
+  }
+
+  if (usesLocalRequiredValidationUi?.(fieldName)) {
+    return {
+      suppressSdkMessage: true,
+    };
+  }
+
+  const requiredRule = getSchemaRequiredRule({
+    fieldName,
+    schemaPathPrefix,
+    schemaRoot,
+  });
+
+  if (!requiredRule) {
+    return {
+      suppressSdkMessage: false,
+    };
+  }
+
+  return {
+    replacementMessage: formatRequiredRuleMessage(intl, requiredRule),
+    suppressSdkMessage: false,
+  };
 };
 
 export const getSdkSuggestedFixMessage = (

--- a/src/services/contacts/data.ts
+++ b/src/services/contacts/data.ts
@@ -49,5 +49,5 @@ export type ContactDataSetObjectKeys = Exclude<
       ? K
       : never;
   }[keyof Contact['contactDataSet']],
-  undefined
+  undefined | 'common:other'
 >;

--- a/src/services/flowproperties/data.ts
+++ b/src/services/flowproperties/data.ts
@@ -56,7 +56,7 @@ export type FlowPropertyDataSetObjectKeys = Exclude<
       ? K
       : never;
   }[keyof FlowProperty['flowPropertyDataSet']],
-  undefined
+  undefined | 'common:other'
 >;
 
 export type FormFlowProperty = Pick<

--- a/src/services/flows/data.ts
+++ b/src/services/flows/data.ts
@@ -89,7 +89,7 @@ export type FlowDataSetObjectKeys = Exclude<
   {
     [K in keyof Flow['flowDataSet']]: Flow['flowDataSet'][K] extends object | undefined ? K : never;
   }[keyof Flow['flowDataSet']],
-  undefined
+  undefined | 'common:other'
 >;
 
 export type FormFlow = Pick<Flow['flowDataSet'], FlowDataSetObjectKeys>;

--- a/src/services/lifeCycleModels/data.ts
+++ b/src/services/lifeCycleModels/data.ts
@@ -43,7 +43,7 @@ export type LifeCycleModelDataSetObjectKeys = Exclude<
       ? K
       : never;
   }[keyof LifeCycleModel['lifeCycleModelDataSet']],
-  undefined
+  undefined | 'common:other'
 >;
 
 export type FormLifeCycleModel = Pick<

--- a/src/services/processes/data.ts
+++ b/src/services/processes/data.ts
@@ -1,5 +1,5 @@
 import type { LangTextValue, ReferenceItem } from '@/services/general/data';
-import type { Process } from '@tiangong-lca/tidas-sdk/types';
+import type { CommonOther, Process } from '@tiangong-lca/tidas-sdk/types';
 
 export type ProcessTable = {
   key: string;
@@ -54,7 +54,7 @@ export type ProcessExchangeData = {
   dataDerivationTypeStatus?: string;
   referencesToDataSource?: {
     referenceToDataSource?: ReferenceItem | ReferenceItem[];
-    'common:other'?: string;
+    'common:other'?: string | CommonOther;
   };
   generalComment?: LangTextValue;
   quantitativeReference?: boolean;
@@ -173,7 +173,7 @@ export type ProcessDataSetObjectKeys = Exclude<
       ? K
       : never;
   }[keyof Process['processDataSet']],
-  undefined
+  undefined | 'common:other'
 >;
 
 export type FormProcess = Pick<Process['processDataSet'], ProcessDataSetObjectKeys>;

--- a/src/services/sources/data.ts
+++ b/src/services/sources/data.ts
@@ -43,7 +43,7 @@ export type SourceDataSetObjectKeys = Exclude<
       ? K
       : never;
   }[keyof Source['sourceDataSet']],
-  undefined
+  undefined | 'common:other'
 >;
 
 export type FormSource = Pick<Source['sourceDataSet'], SourceDataSetObjectKeys>;

--- a/src/services/unitgroups/data.ts
+++ b/src/services/unitgroups/data.ts
@@ -50,7 +50,7 @@ export type UnitGroupDataSetObjectKeys = Exclude<
       ? K
       : never;
   }[keyof UnitGroup['unitGroupDataSet']],
-  undefined
+  undefined | 'common:other'
 >;
 
 export type FormUnitGroup = Pick<UnitGroup['unitGroupDataSet'], UnitGroupDataSetObjectKeys>;

--- a/tests/unit/pages/Flows/Components/Property/edit.test.tsx
+++ b/tests/unit/pages/Flows/Components/Property/edit.test.tsx
@@ -555,4 +555,50 @@ describe('FlowPropertyEdit', () => {
     expect(lastFormApi.setFields).not.toHaveBeenCalled();
     expect(lastFormApi.getFieldError(['meanValue'])).toEqual(['Local mean value error']);
   });
+
+  it('uses the flow-property frontend required copy for sdk required_missing highlights', async () => {
+    const actionRef = { current: { reload: jest.fn() } };
+    const sdkHighlights = [
+      {
+        fieldPath: 'flowProperty[#prop-1].meanValue',
+        key: 'flow-property-required-highlight',
+        reasonMessage: 'Validation failed',
+        suggestedFix: 'Fill in the required value for this field.',
+        tabName: 'flowProperties',
+        validationCode: 'required_missing',
+      },
+    ] as any;
+    renderWithProviders(
+      <PropertyEdit
+        id='1'
+        data={[{ '@dataSetInternalID': '1', meanValue: '10' }] as any}
+        lang='en'
+        buttonType='text'
+        actionRef={actionRef as any}
+        setViewDrawerVisible={jest.fn()}
+        onData={jest.fn()}
+        autoOpen
+        showRules
+        sdkHighlights={sdkHighlights}
+      />,
+    );
+
+    await screen.findByRole('dialog', { name: /edit flow property/i });
+    await waitFor(() => expect(lastFormApi).not.toBeNull());
+    expect(lastFormApi.setFields).toHaveBeenCalledWith([
+      {
+        errors: ['Please input mean value (of flow property)'],
+        name: ['meanValue'],
+      },
+    ]);
+
+    lastFormApi.setFields([{ errors: [], name: ['meanValue'] }]);
+    lastFormApi.setFields.mockClear();
+
+    await act(async () => {
+      lastFormApi.setFieldsValue({ meanValue: '42' });
+    });
+
+    expect(lastFormApi.setFields).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/pages/LifeCycleModels/Components/form.test.tsx
+++ b/tests/unit/pages/LifeCycleModels/Components/form.test.tsx
@@ -202,19 +202,25 @@ describe('LifeCycleModelForm', () => {
     };
   });
 
+  const getSourceSelects = () => screen.getAllByTestId('source-select');
+
+  const getSourceSelectByLabel = (label: string) =>
+    getSourceSelects().find((sourceSelect) =>
+      sourceSelect.textContent?.includes(`"label":"${label}"`),
+    );
+
   it('renders the information tab and wires classification/source helpers', async () => {
     renderWithProviders(
       <LifeCycleModelForm {...baseProps} activeTabKey='lifeCycleModelInformation' />,
     );
 
     expect(screen.getByTestId('level-text-form')).toHaveTextContent('"dataType":"LifeCycleModel"');
-    expect(screen.getAllByTestId('source-select')).toHaveLength(2);
-    expect(screen.getAllByTestId('source-select')[0]).toHaveTextContent(
+    expect(getSourceSelectByLabel('Data set report, background info')).toHaveTextContent(
       '"label":"Data set report, background info"',
     );
-    expect(screen.getAllByTestId('source-select')[1]).toHaveTextContent(
-      '"label":"Life cycle model diagramm(s) or screenshot(s)"',
-    );
+    expect(
+      getSourceSelectByLabel('Life cycle model diagramm(s) or screenshot(s)'),
+    ).toHaveTextContent('"label":"Life cycle model diagramm(s) or screenshot(s)"');
 
     await userEvent.click(screen.getByTestId('level-text-form'));
     expect(baseProps.onData).toHaveBeenCalledTimes(1);
@@ -231,7 +237,7 @@ describe('LifeCycleModelForm', () => {
     );
 
     expect(screen.getAllByRole('textbox')[1]).toBeDisabled();
-    expect(screen.getByTestId('source-select')).toHaveTextContent(
+    expect(getSourceSelectByLabel('Data set format(s)')).toHaveTextContent(
       '"defaultSourceName":"ILCD format"',
     );
     expect(screen.getAllByTestId('contact-select')[0]).toHaveTextContent(
@@ -249,7 +255,11 @@ describe('LifeCycleModelForm', () => {
     );
 
     expect(screen.getAllByRole('textbox')[1]).not.toBeDisabled();
-    expect(screen.getByTestId('source-select')).not.toHaveTextContent('ILCD format');
+    expect(
+      getSourceSelects().every(
+        (sourceSelect) => !sourceSelect.textContent?.includes('ILCD format'),
+      ),
+    ).toBe(true);
   });
 
   it('renders validation and compliance child forms with lifecycle paths', () => {

--- a/tests/unit/pages/LifeCycleModels/Components/toolbar/eidtInfo.test.tsx
+++ b/tests/unit/pages/LifeCycleModels/Components/toolbar/eidtInfo.test.tsx
@@ -1013,7 +1013,7 @@ describe('ToolbarEditInfo', () => {
     );
   });
 
-  it('revalidates metadata fields after opening the base info drawer for sdk errors', async () => {
+  it('revalidates metadata fields after opening the base info drawer for sdk errors without revalidating on tab switch', async () => {
     const ref = React.createRef<any>();
     mockGetLifeCycleModelDetail.mockResolvedValue(createModelDetail());
     mockGetProcessDetail.mockResolvedValue({});
@@ -1045,6 +1045,10 @@ describe('ToolbarEditInfo', () => {
       expect(screen.getByRole('dialog', { name: 'Model base infomation' })).toBeInTheDocument(),
     );
     await waitFor(() => expect(mockValidateVisibleFormFields).toHaveBeenCalledTimes(2));
+
+    await userEvent.click(screen.getByRole('button', { name: 'switch-validation' }));
+    await waitFor(() => expect(screen.getByTestId('active-tab')).toHaveTextContent('validation'));
+    expect(mockValidateVisibleFormFields).toHaveBeenCalledTimes(2);
   });
 
   it('uses structuredClone while falling back to raw sdk validation payloads and empty model nodes', async () => {

--- a/tests/unit/pages/Processes/Components/Exchange/edit.test.tsx
+++ b/tests/unit/pages/Processes/Components/Exchange/edit.test.tsx
@@ -759,6 +759,39 @@ describe('ProcessExchangeEdit', () => {
     expect(setFieldsSpy).not.toHaveBeenCalled();
   });
 
+  it('skips sdk field updates when rerendered highlights keep the same field errors', async () => {
+    const highlight = {
+      key: 'sdk-stable-mean-amount',
+      fieldKey: 'meanAmount',
+      fieldLabel: 'Mean amount',
+      fieldPath: 'exchange[#0].meanAmount',
+      formName: ['meanAmount'],
+      suggestedFix: 'Stable sdk warning',
+      validationCode: 'invalid_type',
+    };
+    const { rerender } = render(
+      <ProcessExchangeEdit {...defaultProps} autoOpen sdkHighlights={[highlight]} />,
+    );
+
+    await waitFor(() => {
+      expect(mockProFormApi?.getFieldError(['meanAmount'])).toEqual(['Stable sdk warning']);
+    });
+
+    const setFieldsSpy = jest.spyOn(mockProFormApi, 'setFields');
+    setFieldsSpy.mockClear();
+
+    rerender(
+      <ProcessExchangeEdit
+        {...defaultProps}
+        autoOpen
+        sdkHighlights={[{ ...highlight, fieldLabel: 'Mean amount' }]}
+      />,
+    );
+
+    await act(async () => {});
+    expect(setFieldsSpy).not.toHaveBeenCalled();
+  });
+
   it('suppresses local required sdk copy for exchange selectors', async () => {
     render(
       <ProcessExchangeEdit

--- a/tests/unit/pages/Processes/Components/edit.test.tsx
+++ b/tests/unit/pages/Processes/Components/edit.test.tsx
@@ -1558,6 +1558,66 @@ describe('ProcessEdit component', () => {
     );
   });
 
+  it('dismisses changed sdk field messages for the current process validation run', async () => {
+    mockGenProcessJsonOrdered.mockImplementation((_id, processDetail) => ({
+      processDataSet: processDetail,
+    }));
+    mockValidateDatasetWithSdk
+      .mockReturnValueOnce({
+        success: false,
+        issues: [
+          {
+            code: 'required_missing',
+            message: 'Required value is missing.',
+            path: ['processDataSet', 'processInformation', 'time', 'common:referenceYear'],
+          },
+        ],
+      })
+      .mockReturnValueOnce({ success: true, issues: [] });
+
+    render(<ProcessEdit {...baseProps} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    await screen.findByRole('dialog', { name: 'Edit process' });
+    fireEvent.click(screen.getByRole('button', { name: 'Data Check' }));
+
+    await waitFor(() => {
+      expect(latestProcessFormProps.sdkValidationDetails.length).toBeGreaterThan(0);
+    });
+    expect(latestProcessFormProps.sdkValidationDismissedFieldKeys.size).toBe(0);
+
+    await act(async () => {
+      await triggerValuesChange?.(
+        {
+          processInformation: {
+            time: {
+              'common:referenceYear': 2026,
+            },
+          },
+        },
+        {
+          processInformation: {
+            time: {
+              'common:referenceYear': 2026,
+            },
+          },
+        },
+      );
+    });
+
+    await waitFor(() => {
+      expect(Array.from(latestProcessFormProps.sdkValidationDismissedFieldKeys)).toContain(
+        'processInformation.time.common:referenceYear',
+      );
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Data Check' }));
+
+    await waitFor(() => {
+      expect(latestProcessFormProps.sdkValidationDismissedFieldKeys.size).toBe(0);
+    });
+  });
+
   it('shows a validation error when exchanges do not contain exactly one quantitative reference', async () => {
     mockUpdateProcess.mockResolvedValue({
       data: [

--- a/tests/unit/pages/Processes/Components/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/form.test.tsx
@@ -298,7 +298,7 @@ jest.mock('antd', () => {
     <div data-testid='card' data-active-key={activeTabKey}>
       {tabList.map((item: any) => (
         <button type='button' key={item.key} onClick={() => onTabChange?.(item.key)}>
-          {toText(item.tab)}
+          {item.tab}
         </button>
       ))}
       <div>{children}</div>
@@ -422,7 +422,7 @@ jest.mock('antd', () => {
     theme: {
       defaultAlgorithm: {},
       darkAlgorithm: {},
-      useToken: () => ({ token: {} }),
+      useToken: () => ({ token: { colorError: 'red', fontWeightStrong: 600 } }),
     },
   };
 });
@@ -912,6 +912,9 @@ describe('ProcessForm component', () => {
     await waitFor(() => {
       expect(screen.queryByText('Please input reference year')).not.toBeInTheDocument();
     });
+    expect(
+      screen.getByRole('button', { name: 'Process information' }).querySelector('span'),
+    ).toHaveStyle({ color: 'red' });
     expect(defaultProps.formRef.current.setFields).toHaveBeenCalledWith([
       {
         errors: [],

--- a/tests/unit/pages/Processes/Components/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/form.test.tsx
@@ -923,6 +923,75 @@ describe('ProcessForm component', () => {
     ]);
   });
 
+  it('matches dismissed sdk fields by parent and child paths while keeping unrelated details', async () => {
+    const sdkValidationDetail = {
+      key: 'sdk-root-reference-year-required',
+      tabName: 'processInformation',
+      fieldKey: 'common:referenceYear',
+      fieldLabel: 'Reference year',
+      fieldPath: 'processInformation.time.common:referenceYear',
+      formName: ['processInformation', 'time', 'common:referenceYear'],
+      reasonMessage: 'Required value is missing.',
+      suggestedFix: 'Fill in the required value for this field.',
+      validationCode: 'required_missing',
+    };
+    const exchangeValidationDetail = {
+      exchangeInternalId: 'row-0',
+      key: 'sdk-exchange-mean-amount',
+      tabName: 'exchanges',
+      fieldKey: 'meanAmount',
+      fieldLabel: 'Mean amount',
+      fieldPath: 'exchanges.exchange.meanAmount',
+      formName: ['exchanges', 'exchange', 0, 'meanAmount'],
+      suggestedFix: 'Fill in the exchange amount.',
+      validationCode: 'required_missing',
+    };
+
+    const { rerender } = render(
+      <ProcessForm
+        {...defaultProps}
+        activeTabKey='processInformation'
+        showRules
+        sdkValidationDetails={[sdkValidationDetail]}
+        sdkValidationDismissedFieldKeys={new Set(['processInformation.time'])}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Please input reference year')).not.toBeInTheDocument();
+    });
+
+    rerender(
+      <ProcessForm
+        {...defaultProps}
+        activeTabKey='processInformation'
+        showRules
+        sdkValidationDetails={[sdkValidationDetail]}
+        sdkValidationDismissedFieldKeys={
+          new Set(['processInformation.time.common:referenceYear.detail'])
+        }
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Please input reference year')).not.toBeInTheDocument();
+    });
+
+    rerender(
+      <ProcessForm
+        {...defaultProps}
+        activeTabKey='processInformation'
+        showRules
+        sdkValidationDetails={[sdkValidationDetail, exchangeValidationDetail]}
+        sdkValidationDismissedFieldKeys={new Set(['administrativeInformation.unrelated'])}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Please input reference year')).toBeInTheDocument();
+    });
+  });
+
   it('uses the year validation copy for reference year range sdk issues', async () => {
     render(
       <ProcessForm

--- a/tests/unit/pages/Processes/Components/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/form.test.tsx
@@ -870,6 +870,56 @@ describe('ProcessForm component', () => {
     expect(screen.queryByText('Fill in this field')).not.toBeInTheDocument();
   });
 
+  it('clears dismissed root sdk messages instead of replaying them on rerender', async () => {
+    const fieldName = ['processInformation', 'time', 'common:referenceYear'];
+    const sdkValidationDetail = {
+      key: 'sdk-root-reference-year-required',
+      tabName: 'processInformation',
+      fieldKey: 'common:referenceYear',
+      fieldLabel: 'Reference year',
+      fieldPath: 'processInformation.time.common:referenceYear',
+      formName: fieldName,
+      reasonMessage: 'Required value is missing.',
+      suggestedFix: 'Fill in the required value for this field.',
+      validationCode: 'required_missing',
+    };
+
+    const { rerender } = render(
+      <ProcessForm
+        {...defaultProps}
+        activeTabKey='processInformation'
+        showRules
+        sdkValidationDetails={[sdkValidationDetail]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Please input reference year')).toBeInTheDocument();
+    });
+
+    defaultProps.formRef.current.setFields.mockClear();
+
+    rerender(
+      <ProcessForm
+        {...defaultProps}
+        activeTabKey='processInformation'
+        showRules
+        sdkValidationDetails={[sdkValidationDetail]}
+        sdkValidationDismissedFieldKeys={new Set(['processInformation.time.common:referenceYear'])}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Please input reference year')).not.toBeInTheDocument();
+    });
+    expect(defaultProps.formRef.current.setFields).toHaveBeenCalledWith([
+      {
+        errors: [],
+        name: fieldName,
+      },
+    ]);
+  });
+
   it('uses the year validation copy for reference year range sdk issues', async () => {
     render(
       <ProcessForm

--- a/tests/unit/pages/Utils/formSupport.test.tsx
+++ b/tests/unit/pages/Utils/formSupport.test.tsx
@@ -294,6 +294,55 @@ describe('useDatasetSdkValidationFormSupport', () => {
     ).toEqual(['Name is required']);
   });
 
+  it('uses frontend required rule messages instead of sdk required_missing copy', () => {
+    const { formRef, setFields } = createFormRef();
+    const schema = {
+      flowDataSet: {
+        modellingAndValidation: {
+          LCIMethod: {
+            typeOfDataSet: {
+              rules: [
+                {
+                  defaultMessage: 'Please input type of flow',
+                  messageKey: 'pages.flow.validator.typeOfDataSet.required',
+                  required: true,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    renderHook(() =>
+      useDatasetSdkValidationFormSupport({
+        activeTabKey: 'flowInformation',
+        formRef,
+        intl,
+        schemaPathPrefix: ['flowDataSet'],
+        schemaRoot: schema,
+        sdkValidationDetails: [
+          createSdkDetail({
+            fieldPath: 'modellingAndValidation.LCIMethod.typeOfDataSet',
+            formName: ['modellingAndValidation', 'LCIMethod', 'typeOfDataSet'],
+            key: 'flow-type-required',
+            suggestedFix: 'Fill in the required value for this field.',
+            tabName: 'flowInformation',
+            validationCode: 'required_missing',
+          }),
+        ],
+        showRules: true,
+      }),
+    );
+
+    expect(setFields).toHaveBeenCalledWith([
+      {
+        errors: ['Please input type of flow'],
+        name: ['modellingAndValidation', 'LCIMethod', 'typeOfDataSet'],
+      },
+    ]);
+  });
+
   it('clears stale sdk errors while preserving non-sdk errors on rerender', () => {
     const { formRef, errorMap, setFields } = createFormRef({
       'sourceInformation.dataSetInformation.common:shortName.0.#text': ['Existing local error'],

--- a/tests/unit/pages/Utils/messages.test.ts
+++ b/tests/unit/pages/Utils/messages.test.ts
@@ -1,6 +1,9 @@
 import {
+  formatRequiredRuleMessage,
+  getSchemaRequiredRule,
   getSdkSuggestedFixMessage,
   normalizeValidationMessageText,
+  resolveRequiredValidationMessage,
 } from '@/pages/Utils/validation/messages';
 
 const intl = {
@@ -88,5 +91,102 @@ describe('validation message helpers', () => {
 
     expect(getSdkSuggestedFixMessage(intl, { suggestedFix: undefined })).toBe('');
     expect(getSdkSuggestedFixMessage(intl)).toBe('');
+  });
+
+  it('resolves sdk required_missing to frontend required copy when schema rules exist', () => {
+    const schema = {
+      flowDataSet: {
+        modellingAndValidation: {
+          LCIMethod: {
+            typeOfDataSet: {
+              rules: [
+                {
+                  defaultMessage: 'Please input type of flow',
+                  messageKey: 'pages.flow.validator.typeOfDataSet.required',
+                  required: true,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      resolveRequiredValidationMessage({
+        fieldName: ['modellingAndValidation', 'LCIMethod', 'typeOfDataSet'],
+        frontendRulesEnabled: true,
+        intl,
+        retainedErrors: [],
+        schemaPathPrefix: ['flowDataSet'],
+        schemaRoot: schema,
+        validationCode: 'required_missing',
+      }),
+    ).toEqual({
+      replacementMessage: 'Please input type of flow',
+      suppressSdkMessage: false,
+    });
+  });
+
+  it('finds lang-text required rules on the frontend group field', () => {
+    const schema = {
+      contactDataSet: {
+        contactInformation: {
+          dataSetInformation: {
+            'common:shortName': {
+              rules: [
+                {
+                  defaultMessage: 'Please input contact short name',
+                  messageKey: 'pages.contact.validator.shortName.required',
+                  required: true,
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      getSchemaRequiredRule({
+        fieldName: ['contactInformation', 'dataSetInformation', 'common:shortName', 0, '#text'],
+        schemaPathPrefix: ['contactDataSet'],
+        schemaRoot: schema,
+      }),
+    ).toMatchObject({
+      defaultMessage: 'Please input contact short name',
+    });
+  });
+
+  it('suppresses sdk required_missing when local frontend errors already exist', () => {
+    expect(
+      resolveRequiredValidationMessage({
+        fieldName: ['meanValue'],
+        frontendRulesEnabled: true,
+        intl,
+        retainedErrors: ['Please input mean value'],
+        validationCode: 'required_missing',
+      }),
+    ).toEqual({
+      suppressSdkMessage: true,
+    });
+  });
+
+  it('keeps sdk fallback when no frontend required rule is available', () => {
+    expect(
+      resolveRequiredValidationMessage({
+        fieldName: ['optionalComment'],
+        frontendRulesEnabled: true,
+        intl,
+        retainedErrors: [],
+        schemaPathPrefix: ['flowDataSet'],
+        schemaRoot: { flowDataSet: { optionalComment: {} } },
+        validationCode: 'required_missing',
+      }),
+    ).toEqual({
+      suppressSdkMessage: false,
+    });
+
+    expect(formatRequiredRuleMessage(intl)).toBe('Please complete this field');
   });
 });

--- a/tests/unit/pages/Utils/messages.test.ts
+++ b/tests/unit/pages/Utils/messages.test.ts
@@ -1,5 +1,6 @@
 import {
   formatRequiredRuleMessage,
+  getSchemaNodeAtPath,
   getSchemaRequiredRule,
   getSdkSuggestedFixMessage,
   normalizeValidationMessageText,
@@ -89,6 +90,13 @@ describe('validation message helpers', () => {
       }),
     ).toBe('Keep the non-year fallback');
 
+    expect(
+      getSdkSuggestedFixMessage(intl, {
+        validationCode: 'custom',
+        suggestedFix: undefined,
+      }),
+    ).toBe('Resolve  custom issues');
+
     expect(getSdkSuggestedFixMessage(intl, { suggestedFix: undefined })).toBe('');
     expect(getSdkSuggestedFixMessage(intl)).toBe('');
   });
@@ -158,6 +166,41 @@ describe('validation message helpers', () => {
     });
   });
 
+  it('walks array-backed schema nodes and safely stops on invalid paths', () => {
+    const schema = {
+      processDataSet: {
+        exchanges: {
+          exchange: [
+            {
+              meanAmount: {
+                rules: [{ message: 'Please input mean amount', required: true }],
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    expect(
+      getSchemaNodeAtPath(schema, ['processDataSet', 'exchanges', 'exchange', 0, 'meanAmount']),
+    ).toEqual({
+      rules: [{ message: 'Please input mean amount', required: true }],
+    });
+    expect(
+      getSchemaNodeAtPath(schema, ['processDataSet', 'exchanges', 'exchange', 'meanAmount']),
+    ).toEqual({
+      rules: [{ message: 'Please input mean amount', required: true }],
+    });
+    expect(getSchemaNodeAtPath({ value: null }, ['value', 'nested'])).toBeUndefined();
+
+    expect(
+      getSchemaRequiredRule({
+        fieldName: undefined,
+        schemaRoot: schema,
+      }),
+    ).toBeUndefined();
+  });
+
   it('suppresses sdk required_missing when local frontend errors already exist', () => {
     expect(
       resolveRequiredValidationMessage({
@@ -188,5 +231,102 @@ describe('validation message helpers', () => {
     });
 
     expect(formatRequiredRuleMessage(intl)).toBe('Please complete this field');
+  });
+
+  it('formats direct and element-style frontend required messages', () => {
+    expect(
+      formatRequiredRuleMessage(intl, {
+        message: 'Please input direct message.',
+        required: true,
+      }),
+    ).toBe('Please input direct message');
+
+    expect(
+      formatRequiredRuleMessage(intl, {
+        message: {
+          props: {
+            defaultMessage: 'Please input {field}.',
+            id: 'validator.customRequired',
+            values: { field: 'owner' },
+          },
+        },
+        required: true,
+      }),
+    ).toBe('Please input owner');
+
+    expect(
+      formatRequiredRuleMessage(intl, {
+        message: {
+          props: undefined,
+        },
+        required: true,
+      }),
+    ).toBe('Please complete this field');
+
+    expect(
+      formatRequiredRuleMessage(intl, {
+        message: {
+          props: {
+            defaultMessage: undefined,
+            id: undefined,
+          },
+        },
+        required: true,
+      }),
+    ).toBe('Please complete this field');
+
+    expect(
+      formatRequiredRuleMessage(intl, {
+        defaultMessage: 'Please input default-only message.',
+        required: true,
+      }),
+    ).toBe('Please input default-only message');
+
+    expect(
+      formatRequiredRuleMessage(intl, {
+        messageKey: 'validator.unknownRequired',
+        required: true,
+      }),
+    ).toBe('Please complete this field');
+  });
+
+  it('suppresses required_missing when the field uses local required validation UI', () => {
+    expect(
+      resolveRequiredValidationMessage({
+        fieldName: ['administrativeInformation', 'publicationAndOwnership', 'common:copyright'],
+        frontendRulesEnabled: true,
+        intl,
+        retainedErrors: [],
+        usesLocalRequiredValidationUi: () => true,
+        validationCode: 'required_missing',
+      }),
+    ).toEqual({
+      suppressSdkMessage: true,
+    });
+  });
+
+  it('keeps sdk messages for non-required validations and when frontend rules are disabled', () => {
+    expect(
+      resolveRequiredValidationMessage({
+        fieldName: ['someField'],
+        intl,
+        retainedErrors: [],
+        validationCode: 'invalid_type',
+      }),
+    ).toEqual({
+      suppressSdkMessage: false,
+    });
+
+    expect(
+      resolveRequiredValidationMessage({
+        fieldName: ['someField'],
+        frontendRulesEnabled: false,
+        intl,
+        retainedErrors: [],
+        validationCode: 'required_missing',
+      }),
+    ).toEqual({
+      suppressSdkMessage: false,
+    });
   });
 });


### PR DESCRIPTION
## Promotion Contract

- base branch: `main`
- source branch: `ForeverYoung5:dev`, fast-forward synced from `linancn:dev` at `42d94f4d`
- validated environment before promotion: `dev` via PR #387 CI; promote PR CI will re-run protected full gate
- back-merge required after merge: No, this is the standard `dev -> main` promotion path
- root workspace integration expected: Yes, after merge update the `lca-workspace` submodule pointer to the promoted `tiangong-lca-next/main` commit

- [x] this PR promotes `dev` into `main`
- [x] integrated behavior was verified in `dev` before promotion
- [x] if the PR includes a direct `main` hotfix path, the required `main -> dev` back-merge plan is documented

## Linked Issue

Closes #385

## Promotion Facts

Promotes the merged `dev` changes from PR #387 into `main`, including the data-validation message handling fix for SDK `required_missing`, process/lifecycle model validation rerender behavior, SDK `0.1.36` compatibility, and docpact review evidence.

## Validation Facts

- PR #387 `Full Gate`: passed
- PR #387 `ai-doc-lint`: passed
- Local pre-promotion proof from #387 branch: `npm run prepush:gate` passed; `docpact lint --root . --base origin/dev --head HEAD` passed
- This promote PR is expected to run the protected `Full Gate` again against `main`

## Integration And Follow-Up

After this PR merges, update the root `lca-workspace` submodule pointer to the promoted `tiangong-lca-next/main` commit before treating workspace delivery as complete.