### PR TITLE
fix: normalize review process instances

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-04"
-lastReviewedCommit: "cba40d2affaa241b27f28f1db5a69674d5ae50b2"
+lastReviewedAt: "2026-05-06"
+lastReviewedCommit: "0340a89c1079470aa2cbade3feb6a73ba3bba9a3"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -20,8 +20,8 @@ checkPaths:
   - .husky/pre-push
   - package.json
   - .github/workflows/**
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -19,8 +19,8 @@ checkPaths:
   - config/supabaseEnv.ts
   - src/services/**
   - docker/**
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/testing-troubleshooting.md
   - tests/helpers/**
   - package.json
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 ---
 
 # Testing Troubleshooting

--- a/src/services/reviews/api.ts
+++ b/src/services/reviews/api.ts
@@ -6,7 +6,7 @@ import {
 import { getLifeCyclesByIdAndVersion } from '@/services/lifeCycleModels/api';
 import { supabase } from '@/services/supabase';
 import { getUserId } from '@/services/users/api';
-import { getLangText } from '../general/util';
+import { getLangText, jsonToList } from '../general/util';
 import { getProcessDetailByIdAndVersion } from '../processes/api';
 import { genProcessName } from '../processes/util';
 import { isCurrentAssignedReviewerCommentState } from './util';
@@ -552,7 +552,8 @@ export async function getLifeCycleModelSubTableDataBatch(
     const processInstances =
       json?.lifeCycleModelDataSet?.lifeCycleModelInformation?.technology?.processes
         ?.processInstance ?? [];
-    processInstances.forEach((instance: any) => {
+
+    jsonToList(processInstances).forEach((instance: any) => {
       const refObjectId = instance?.referenceToProcess?.['@refObjectId'];
       const refVersion = instance?.referenceToProcess?.['@version'];
       if (refObjectId && refVersion) {

--- a/tests/unit/services/reviews/api.test.ts
+++ b/tests/unit/services/reviews/api.test.ts
@@ -73,6 +73,10 @@ jest.mock('@/services/general/util', () => {
   return {
     __esModule: true,
     getLangText: (...args: any[]) => mockGetLangText.apply(null, args),
+    jsonToList: (json: any) => {
+      if (!json) return [];
+      return Array.isArray(json) ? json : [json];
+    },
   };
 });
 


### PR DESCRIPTION
## Branch Contract

- base branch: `dev`
- validated environment: local Node `v24.13.0`; local build
- back-merge required after merge: No
- root workspace integration expected: Yes, if this frontend fix must ship through the workspace after merge/promote

- [x] this PR targets `dev`
- [x] final branch is based on `origin/dev`; the original local uncommitted fix was preserved while switching from `main`

## Linked Issue

No linked issue was provided in the handoff, so no `Closes #...` reference is available.

## Change Facts

- Normalize lifecycle model `processInstance` data with `jsonToList` before iterating so singleton JSON process refs are handled.
- Update the reviews service unit-test mock for `jsonToList` to keep the focused service suite aligned with `src/services/general/util`.
- Record docpact review evidence for the governed data-boundary, testing, and bootstrap docs required by `ai-doc-lint`; no governed doc body rules changed.

## Validation Facts

- `npm run lint` passes.
- `npm run build` passes.
- `npm run test:ci -- tests/unit/services/reviews/api.test.ts` passes: 55 tests.
- `~/.cargo/bin/docpact validate-config --root . --strict --format json` passes.
- `~/.cargo/bin/docpact lint --root . --base 42d94f4d9421362926882b722670ebc7e2bd6eb2 --head 46519e52a1579316a67ba7ef9a63dea42a004fe4 --mode enforce --format json --output .docpact/runs/pr389-final-ai-doc-lint.json` passes.
- GitHub `ai-doc-lint` check passes on head `46519e52a1579316a67ba7ef9a63dea42a004fe4`.
- `npm run prepush:gate` not run locally; fork pre-push hook skipped it on this feature branch and PR gates should enforce protected-branch parity.
- Required proof in another repo: No.

## Risks And Follow-Up

- Low-risk service-layer normalization; no schema, Edge Function, or root pointer update included.
- Root workspace integration may be needed after merge/promote according to workspace policy.