### PR TITLE
chore: promote dev to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-04"
-lastReviewedCommit: "cba40d2affaa241b27f28f1db5a69674d5ae50b2"
+lastReviewedAt: "2026-05-06"
+lastReviewedCommit: "0340a89c1079470aa2cbade3feb6a73ba3bba9a3"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -20,8 +20,8 @@ checkPaths:
   - .husky/pre-push
   - package.json
   - .github/workflows/**
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -19,8 +19,8 @@ checkPaths:
   - config/supabaseEnv.ts
   - src/services/**
   - docker/**
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/testing-troubleshooting.md
   - tests/helpers/**
   - package.json
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-05-04
-lastReviewedCommit: cba40d2affaa241b27f28f1db5a69674d5ae50b2
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
 ---
 
 # Testing Troubleshooting

--- a/src/services/reviews/api.ts
+++ b/src/services/reviews/api.ts
@@ -6,7 +6,7 @@ import {
 import { getLifeCyclesByIdAndVersion } from '@/services/lifeCycleModels/api';
 import { supabase } from '@/services/supabase';
 import { getUserId } from '@/services/users/api';
-import { getLangText } from '../general/util';
+import { getLangText, jsonToList } from '../general/util';
 import { getProcessDetailByIdAndVersion } from '../processes/api';
 import { genProcessName } from '../processes/util';
 import { isCurrentAssignedReviewerCommentState } from './util';
@@ -552,7 +552,8 @@ export async function getLifeCycleModelSubTableDataBatch(
     const processInstances =
       json?.lifeCycleModelDataSet?.lifeCycleModelInformation?.technology?.processes
         ?.processInstance ?? [];
-    processInstances.forEach((instance: any) => {
+
+    jsonToList(processInstances).forEach((instance: any) => {
       const refObjectId = instance?.referenceToProcess?.['@refObjectId'];
       const refVersion = instance?.referenceToProcess?.['@version'];
       if (refObjectId && refVersion) {

--- a/tests/unit/services/reviews/api.test.ts
+++ b/tests/unit/services/reviews/api.test.ts
@@ -73,6 +73,10 @@ jest.mock('@/services/general/util', () => {
   return {
     __esModule: true,
     getLangText: (...args: any[]) => mockGetLangText.apply(null, args),
+    jsonToList: (json: any) => {
+      if (!json) return [];
+      return Array.isArray(json) ? json : [json];
+    },
   };
 });
 


### PR DESCRIPTION
## Promotion Contract

- base branch: `main`
- source branch: `dev` via `ForeverYoung5:dev`, synced to `linancn:dev` at `078a3cb530d7fab806a49a51ba0205d64479cee3`
- validated environment before promotion: dev-bound PR CI and local Node `v24.13.0` validation from #389
- back-merge required after merge: No
- root workspace integration expected: Yes, update the `lca-workspace` submodule pointer after this promotion is merged if the release should ship through the workspace

- [x] this PR promotes `dev` into `main`
- [x] integrated behavior was verified in `dev` before promotion via #389 checks
- [x] this PR does not include a direct `main` hotfix path

## Linked Issue

No linked issue was provided for this promotion PR.

## Promotion Facts

- Promotes merged dev PR #389: `fix: normalize review process instances`.
- `dev` currently differs from `main` by the #389 merge and its two non-merge commits:
  - `0340a89c` `fix: normalize review process instances`
  - `46519e52` `docs: record review evidence for reviews fix`

## Validation Facts

- #389 `Full Gate` check passed before merge.
- #389 `ai-doc-lint` check passed before merge.
- Local validation recorded on #389: `npm run lint`, `npm run build`, `npm run test:ci -- tests/unit/services/reviews/api.test.ts`, and docpact validate/lint passed.
- Promotion PR CI is expected to run against `main` as the final promotion gate.

## Integration And Follow-Up

- After merge, root workspace integration may update the `tiangong-lca-next` submodule pointer to the promoted `main` commit according to workspace policy.
- No `main -> dev` back-merge is expected because this is the normal `dev -> main` promote path.