### PR TITLE
docs: hide README metadata from public landing page

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -262,11 +262,9 @@ rules:
         kind: repo-landing
     requiredDocs:
       - path: AGENTS.md
-        mode: review_or_update
-      - path: README.md
-        mode: review_or_update
-      - path: README_CN.md
-        mode: review_or_update
+        mode: must_exist
+      - path: .docpact/config.yaml
+        mode: must_exist
     reason: Repo landing docs should stay aligned with the repo contract and current entry guidance.
   - id: next-pr-handoff-contract
     scope: repo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-06
-lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
+lastReviewedCommit: 078a3cb530d7fab806a49a51ba0205d64479cee3
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-05-06
-lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
+lastReviewedCommit: 078a3cb530d7fab806a49a51ba0205d64479cee3
 ---
 
 # Development Bootstrap

--- a/README.md
+++ b/README.md
@@ -1,25 +1,3 @@
----
-title: TianGong LCA Data Platform Landing
-docType: landing
-scope: repo
-status: active
-authoritative: false
-owner: next
-language: en
-whenToUse:
-  - when you need the public-facing repo landing summary
-  - when checking whether the high-level product overview still matches the current repo contract
-whenToUpdate:
-  - when the public repo landing summary changes
-  - when linked docs-site entrypoints or deployment references change
-checkPaths:
-  - README.md
-  - README_CN.md
-  - AGENTS.md
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: eb445ef00ab1d07b76a46d471e54377801117ee7
----
-
 # TianGong LCA Data Platform
 
 [English](https://github.com/linancn/tiangong-lca-next/blob/main/README.md) | [中文](https://github.com/linancn/tiangong-lca-next/blob/main/README_CN.md)


### PR DESCRIPTION
Closes #391

## Summary
- Remove visible YAML front matter from the root README so GitHub renders the public landing page from the heading.
- Adjust the README landing docpact rule to keep README changes covered without requiring README.md to carry governance metadata.
- Refresh review metadata on the repo entry/governance docs required by the docpact rule change.

## Key Decisions
- README landing rules now use must_exist checks for AGENTS.md and .docpact/config.yaml instead of review_or_update on README.md.

## Validation
- docpact validate-config --strict
- docpact lint --merge-base <target-base> --mode enforce

## Risks / Rollback
- Low-risk docs/governance change; rollback is restoring the prior README front matter and rule modes.

## Workspace Integration
- After merge, lca-workspace should bump the submodule pointer for this repo.