### PR TITLE
ci: retry EdgeOne Pages deploy

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-06"
-lastReviewedCommit: "0340a89c1079470aa2cbade3feb6a73ba3bba9a3"
+lastReviewedAt: '2026-05-08'
+lastReviewedCommit: '7f5bcf88987926f6dd027aefe0bdc59f734e0239'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
     env:
       EDGEONE_OUTPUT_DIR: dist
       EDGEONE_PROJECT_NAME: tiangong-lca-next-upload
+      EDGEONE_CLI_VERSION: 1.4.6
 
     steps:
       - name: Checkout repository
@@ -100,4 +101,28 @@ jobs:
       - name: Deploy to EdgeOne Pages
         env:
           EDGEONE_API_TOKEN: ${{ secrets.EDGEONE_API_TOKEN }}
-        run: npx edgeone@latest pages deploy $EDGEONE_OUTPUT_DIR -n $EDGEONE_PROJECT_NAME -t $EDGEONE_API_TOKEN
+        run: |
+          set -euo pipefail
+
+          if [ -z "${EDGEONE_API_TOKEN:-}" ]; then
+            echo "::error::EDGEONE_API_TOKEN secret is not configured."
+            exit 1
+          fi
+
+          max_attempts=3
+          for attempt in $(seq 1 "$max_attempts"); do
+            echo "Deploying to EdgeOne Pages, attempt ${attempt}/${max_attempts}."
+
+            if timeout 300s npx --yes "edgeone@${EDGEONE_CLI_VERSION}" pages deploy "$EDGEONE_OUTPUT_DIR" -n "$EDGEONE_PROJECT_NAME" -t "$EDGEONE_API_TOKEN"; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq "$max_attempts" ]; then
+              echo "EdgeOne Pages deploy failed after ${max_attempts} attempts."
+              exit 1
+            fi
+
+            sleep_seconds=$((attempt * 30))
+            echo "EdgeOne Pages deploy failed. Retrying in ${sleep_seconds}s."
+            sleep "$sleep_seconds"
+          done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 078a3cb530d7fab806a49a51ba0205d64479cee3
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: ce089c1ff562b267c0a318d54efdab25eaf23ef9
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 078a3cb530d7fab806a49a51ba0205d64479cee3
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: ce089c1ff562b267c0a318d54efdab25eaf23ef9
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -20,8 +20,8 @@ checkPaths:
   - .husky/pre-push
   - package.json
   - .github/workflows/**
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -64,6 +64,8 @@ npm run prepush:gate
 | repo docs only | `docpact lint --root . --files "<csv>" --mode enforce` | `docpact validate-config --root . --strict` when `.docpact/config.yaml` changes | still update review metadata and ownership as needed |
 
 If the change touches `scripts/test-runner.cjs` or protected-branch gate reproduction, run `npm run test:ci` and `npm run prepush:gate` serially locally because both commands regenerate `.umi-test`.
+
+For deployment-only workflow changes under `.github/workflows/ci.yml`, validate the workflow shape directly with YAML parsing, formatter checks, and shell syntax checks for edited deploy scripts. Do not run production deploy commands locally or from PR validation unless the task explicitly requires exercising live deploy credentials; the EdgeOne Pages deploy step remains a post-merge `main` push concern.
 
 Treat dataset-validation work under `src/pages/*/sdkValidation.ts`, `src/pages/Utils/validation/**`, `src/components/ValidationIssueModal/index.tsx`, and localized validator copy under `src/locales/**` as shipped runtime work even when most of the change looks like error-message plumbing.
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/testing-troubleshooting.md
   - tests/helpers/**
   - package.json
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
 ---
 
 # Testing Troubleshooting


### PR DESCRIPTION
Closes #397

## Summary
- Add a bounded retry loop around EdgeOne Pages deployment.
- Add an explicit missing-secret guard for EDGEONE_API_TOKEN.
- Pin the EdgeOne CLI version used in CI to 1.4.6.

## Key Decisions
- Keep retries scoped to the EdgeOne deploy command so build/test failures still fail normally.
- Use the repository's routine PR target dev per workspace branch policy.

## Validation
- npx prettier --check .github/workflows/ci.yml
- YAML parse check for .github/workflows/ci.yml
- bash -n check for the extracted deploy step script

## Risks / Rollback
- This only changes deploy behavior on push to main after the dev-to-main promote path; rollback is reverting the workflow commit.

## Workspace Integration
- Workspace integration is not required for this CI-only repo workflow change.