### PR TITLE
ci: fail docpact gate on terminated subprocess

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-05-08'
-lastReviewedCommit: '7f5bcf88987926f6dd027aefe0bdc59f734e0239'
+lastReviewedCommit: 'de2e3f56b98c5d6f36e7480b40544b85fcb3bf58'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: ce089c1ff562b267c0a318d54efdab25eaf23ef9
+lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: ce089c1ff562b267c0a318d54efdab25eaf23ef9
+lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .github/workflows/**
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
+lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
+lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 060d35503eb9afd69ff6862c0e984a7737664625
+lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 060d35503eb9afd69ff6862c0e984a7737664625
+lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/helpers/**
   - package.json
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 060d35503eb9afd69ff6862c0e984a7737664625
+lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
+lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
 ---
 
 # Testing Troubleshooting

--- a/scripts/docpact-gate.js
+++ b/scripts/docpact-gate.js
@@ -86,6 +86,10 @@ function runDocpact(docpact, args) {
     console.error(result.error.message);
     process.exit(1);
   }
+  if (result.signal || result.status === null) {
+    console.error(`docpact was terminated${result.signal ? ` by ${result.signal}` : ''}.`);
+    process.exit(1);
+  }
   if (result.status !== 0) {
     process.exit(result.status);
   }


### PR DESCRIPTION
Closes #401

## Summary
- Handle docpact subprocess signal termination and null status as local gate failures.
- Refresh required gate documentation review metadata.

## Key Decisions
- Treat result.signal or status === null as exit 1 before forwarding normal non-zero status codes.

## Validation
- node --check scripts/docpact-gate.js
- npm run docpact:gate -- --base origin/dev
- fake DOCPACT_BIN killed by SIGTERM exits non-zero and prints the signal
- docpact lint --root . --base origin/dev --head HEAD --mode enforce

## Risks / Rollback
- Low; only affects failure handling in the local docpact gate and makes interrupted subprocesses fail closed.

## Workspace Integration
- Workspace integration is not required for this repo-local tooling fix.