### PR TITLE
chore: promote CI tooling fixes to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-05-08'
-lastReviewedCommit: '7f5bcf88987926f6dd027aefe0bdc59f734e0239'
+lastReviewedCommit: 'de2e3f56b98c5d6f36e7480b40544b85fcb3bf58'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-06"
-lastReviewedCommit: "0340a89c1079470aa2cbade3feb6a73ba3bba9a3"
+lastReviewedAt: '2026-05-08'
+lastReviewedCommit: '7f5bcf88987926f6dd027aefe0bdc59f734e0239'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -52,6 +52,7 @@ ownership:
           - .github/workflows/ci.yml
           - .github/workflows/build.yml
           - .github/workflows/ai-doc-lint.yml
+          - scripts/docpact-gate.js
           - scripts/test-runner.cjs
           - scripts/test-coverage-report.js
       ownerRepo: next
@@ -92,6 +93,7 @@ coverage:
     - .github/workflows/ai-doc-lint.yml
     - .github/workflows/build.yml
     - .github/workflows/ci.yml
+    - scripts/docpact-gate.js
     - scripts/test-runner.cjs
     - scripts/test-coverage-report.js
   exclude:
@@ -132,6 +134,7 @@ routing:
         - .github/workflows/ci.yml
         - .github/workflows/build.yml
         - .github/workflows/ai-doc-lint.yml
+        - scripts/docpact-gate.js
         - scripts/test-runner.cjs
         - scripts/test-coverage-report.js
         - tests/**
@@ -165,6 +168,7 @@ routing:
         - .husky/pre-push
         - .github/workflows/ci.yml
         - .github/workflows/build.yml
+        - scripts/docpact-gate.js
         - tests/**
         - docs/agents/test_todo_list.md
         - docs/agents/testing-patterns.md
@@ -422,6 +426,8 @@ rules:
         kind: ci
       - path: .github/workflows/build.yml
         kind: ci
+      - path: scripts/docpact-gate.js
+        kind: test-gate
       - path: scripts/test-runner.cjs
         kind: test-gate
       - path: scripts/test-coverage-report.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
     env:
       EDGEONE_OUTPUT_DIR: dist
       EDGEONE_PROJECT_NAME: tiangong-lca-next-upload
+      EDGEONE_CLI_VERSION: 1.4.6
 
     steps:
       - name: Checkout repository
@@ -100,4 +101,28 @@ jobs:
       - name: Deploy to EdgeOne Pages
         env:
           EDGEONE_API_TOKEN: ${{ secrets.EDGEONE_API_TOKEN }}
-        run: npx edgeone@latest pages deploy $EDGEONE_OUTPUT_DIR -n $EDGEONE_PROJECT_NAME -t $EDGEONE_API_TOKEN
+        run: |
+          set -euo pipefail
+
+          if [ -z "${EDGEONE_API_TOKEN:-}" ]; then
+            echo "::error::EDGEONE_API_TOKEN secret is not configured."
+            exit 1
+          fi
+
+          max_attempts=3
+          for attempt in $(seq 1 "$max_attempts"); do
+            echo "Deploying to EdgeOne Pages, attempt ${attempt}/${max_attempts}."
+
+            if timeout 300s npx --yes "edgeone@${EDGEONE_CLI_VERSION}" pages deploy "$EDGEONE_OUTPUT_DIR" -n "$EDGEONE_PROJECT_NAME" -t "$EDGEONE_API_TOKEN"; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq "$max_attempts" ]; then
+              echo "EdgeOne Pages deploy failed after ${max_attempts} attempts."
+              exit 1
+            fi
+
+            sleep_seconds=$((attempt * 30))
+            echo "EdgeOne Pages deploy failed. Retrying in ${sleep_seconds}s."
+            sleep "$sleep_seconds"
+          done

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 export NVM_DIR="$HOME/.nvm"
 if [ -s "$NVM_DIR/nvm.sh" ]; then
@@ -8,11 +9,21 @@ fi
 
 current_branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
 
+docpact_base_ref="${DOCPACT_BASE_REF:-origin/dev}"
+case "$current_branch" in
+  main | master | promote/* | hotfix/*)
+    docpact_base_ref="${DOCPACT_BASE_REF:-origin/main}"
+    ;;
+esac
+
+echo "Running docpact gate against ${docpact_base_ref}."
+npm run docpact:gate -- --base "$docpact_base_ref"
+
 if [ "$current_branch" != "main" ]; then
   if [ -n "$current_branch" ]; then
-    echo "Skipping prepush:gate on branch '$current_branch'. Full gate is enforced on PRs to dev/main."
+    echo "Skipping full prepush:gate on branch '$current_branch'. Full gate is enforced on PRs to dev/main."
   else
-    echo "Skipping prepush:gate because HEAD is detached. Full gate is enforced on PRs to dev/main."
+    echo "Skipping full prepush:gate because HEAD is detached. Full gate is enforced on PRs to dev/main."
   fi
   exit 0
 fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 078a3cb530d7fab806a49a51ba0205d64479cee3
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: ce089c1ff562b267c0a318d54efdab25eaf23ef9
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: ce089c1ff562b267c0a318d54efdab25eaf23ef9
+lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ Keep these entry-level facts in `AGENTS.md`. Use `DEV.md` and `docs/agents/repo-
 - shared dev environment: `npm start` (`npm run start:dev` is equivalent)
 - explicit main-environment run: `npm run start:main`
 - default lint gate: `npm run lint`
+- local documentation gate before push: `npm run docpact:gate`
 - default CI-style test entry: `npm test`
 - build when shipped behavior, branding/package surfaces, or static assets change: `npm run build`
 - protected-branch parity gate: `npm run prepush:gate`

--- a/DEV.md
+++ b/DEV.md
@@ -71,6 +71,7 @@ npm install
 | start shared `dev` env | `npm start` |
 | explicit shared `dev` env | `npm run start:dev` |
 | explicit `main` env | `npm run start:main` |
+| local docpact gate | `npm run docpact:gate` |
 | lint + typecheck | `npm run lint` |
 | shared CI-style test runner | `npm test` |
 | focused Jest suite | `npm run test:ci -- <jest-args>` |
@@ -86,6 +87,7 @@ npm install
 - `npm start` and `npm run start:dev` are equivalent
 - use `npm run start:main` only when the task explicitly requires the `main` environment
 - prefer `npm run test:ci -- <jest-args>` over stacking flags after `npm test`
+- local pushes run `npm run docpact:gate` before branch-specific push policy
 - treat `npm run prepush:gate` as the authoritative local parity check
 - when reproducing both CI lanes locally, run `npm run test:ci` and `npm run prepush:gate` serially because both regenerate `.umi-test`
 

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 078a3cb530d7fab806a49a51ba0205d64479cee3
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: ce089c1ff562b267c0a318d54efdab25eaf23ef9
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: ce089c1ff562b267c0a318d54efdab25eaf23ef9
+lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .github/workflows/**
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
+lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -30,9 +30,13 @@ lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
 
 ## Purpose
 
-Define the intended trigger policy for the existing `npm run prepush:gate` command without changing the quality bar.
+Define the intended trigger policy for the existing local docpact gate and `npm run prepush:gate` command without changing the quality bar.
 
 ## Exact Gate Command
+
+```bash
+npm run docpact:gate
+```
 
 ```bash
 npm run prepush:gate
@@ -52,10 +56,10 @@ It does not own:
 
 | Surface                         | Target rule                                            |
 | ------------------------------- | ------------------------------------------------------ |
-| local `pre-push` hook on `main` | always run the full gate                               |
+| local `pre-push` hook on `main` | run docpact first, then always run the full gate       |
 | PRs into `dev`                  | run the full gate in CI                                |
 | PRs into `main`                 | run the full gate in CI                                |
-| feature-branch local pushes     | do not force the full gate automatically               |
+| feature-branch local pushes     | run docpact only; do not force the full gate           |
 | post-merge pushes               | keep branch-specific protection, do not lower the gate |
 
 ## Adoption Conditions
@@ -68,6 +72,7 @@ It does not own:
 ## Short Rule Summary
 
 - keep one authoritative full gate
+- run the lightweight docpact gate before local push so governed-doc review failures surface before GitHub PR checks
 - protect the actual merge points
 - avoid forcing the heaviest gate on every local feature push
 - reproduce `lint-and-test` and `Full Gate` serially on one workstation; GitHub runs them in isolated jobs

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -20,8 +20,8 @@ checkPaths:
   - .husky/pre-push
   - package.json
   - .github/workflows/**
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -49,6 +49,10 @@ npm run build
 The authoritative protected-branch gate is:
 
 ```bash
+npm run docpact:gate
+```
+
+```bash
 npm run prepush:gate
 ```
 
@@ -60,8 +64,10 @@ npm run prepush:gate
 | services or env selection | `npm run lint`; focused `npm run test:ci -- <jest-args>`; `npm run build` | `npm run prepush:gate` | companion proof may live in another repo if schema or Edge runtime changed |
 | static bundles under `public/**` | `npm run lint`; `npm run build` | focused tests near the consuming feature | check both the asset and its readers |
 | sync helpers under `docker/**` | `npm run lint`; `npm run build` | run the exact helper only when the task includes it | do not hand-edit synced mirrors |
-| tests, coverage, or gate scripts | `npm run lint`; `npm run test:ci`; `npm run test:coverage`; `npm run test:coverage:assert-full` | `npm run prepush:gate` | coverage expectations remain strict |
+| tests, coverage, or gate scripts | `npm run docpact:gate`; `npm run lint`; `npm run test:ci`; `npm run test:coverage`; `npm run test:coverage:assert-full` | `npm run prepush:gate` | coverage expectations remain strict |
 | repo docs only | `docpact lint --root . --files "<csv>" --mode enforce` | `docpact validate-config --root . --strict` when `.docpact/config.yaml` changes | still update review metadata and ownership as needed |
+
+The local `pre-push` hook always runs `npm run docpact:gate` first. Non-main branches then skip the heavy `npm run prepush:gate`; local `main` pushes run both. The docpact gate defaults to `origin/dev` and can be redirected with `DOCPACT_BASE_REF=<ref>` for promote or hotfix branches.
 
 If the change touches `scripts/test-runner.cjs` or protected-branch gate reproduction, run `npm run test:ci` and `npm run prepush:gate` serially locally because both commands regenerate `.umi-test`.
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -64,6 +64,8 @@ npm run prepush:gate
 | repo docs only | `docpact lint --root . --files "<csv>" --mode enforce` | `docpact validate-config --root . --strict` when `.docpact/config.yaml` changes | still update review metadata and ownership as needed |
 
 If the change touches `scripts/test-runner.cjs` or protected-branch gate reproduction, run `npm run test:ci` and `npm run prepush:gate` serially locally because both commands regenerate `.umi-test`.
+
+For deployment-only workflow changes under `.github/workflows/ci.yml`, validate the workflow shape directly with YAML parsing, formatter checks, and shell syntax checks for edited deploy scripts. Do not run production deploy commands locally or from PR validation unless the task explicitly requires exercising live deploy credentials; the EdgeOne Pages deploy step remains a post-merge `main` push concern.
 
 Treat dataset-validation work under `src/pages/*/sdkValidation.ts`, `src/pages/Utils/validation/**`, `src/components/ValidationIssueModal/index.tsx`, and localized validator copy under `src/locales/**` as shipped runtime work even when most of the change looks like error-message plumbing.
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
+lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 060d35503eb9afd69ff6862c0e984a7737664625
+lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
+lastReviewedCommit: 060d35503eb9afd69ff6862c0e984a7737664625
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
+lastReviewedCommit: 060d35503eb9afd69ff6862c0e984a7737664625
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 060d35503eb9afd69ff6862c0e984a7737664625
+lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/helpers/**
   - package.json
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 060d35503eb9afd69ff6862c0e984a7737664625
+lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/helpers/**
   - package.json
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
+lastReviewedCommit: 060d35503eb9afd69ff6862c0e984a7737664625
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/testing-troubleshooting.md
   - tests/helpers/**
   - package.json
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
+lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: 0340a89c1079470aa2cbade3feb6a73ba3bba9a3
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 7f5bcf88987926f6dd027aefe0bdc59f734e0239
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -48,7 +48,7 @@ Canonical baseline and proof ownership stays with `DEV.md` and `docs/agents/repo
 | mock not hit | wrong import path or mock order | verify module path and set mocks before importing the subject |
 | provider or context error | missing wrapper or wrong test utility | use the repo helper that already provides the required wrapper |
 | one gate fails only while another heavy gate is running locally | shared `.umi-test` regeneration from concurrent commands | rerun `npm run test:ci` and `npm run prepush:gate` serially |
-| `ai-doc-lint` fails with `missing-review` after runtime, service, or test changes | required governed docs were not reviewed in the same PR | rerun `docpact lint`, inspect the required docs from `.docpact/config.yaml`, and touch the owning docs with a real review/update |
+| local `docpact:gate` or remote `ai-doc-lint` fails with `missing-review` after runtime, service, or test changes | required governed docs were not reviewed in the same PR | rerun `npm run docpact:gate`, inspect the required docs from `.docpact/config.yaml`, and touch the owning docs with a real review/update |
 
 ## Open-Handle Playbook
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "max build",
     "deploy": "npm run build && npm run gh-pages",
     "dev": "npm run start:dev",
+    "docpact:gate": "node scripts/docpact-gate.js",
     "dist": "npm run build && tsc --project tsconfig.electron.json && electron-builder --config electron-builder.json",
     "electron": "tsc --project tsconfig.electron.json && electron dist-electron/main.js",
     "gh-pages": "gh-pages -d dist",

--- a/scripts/docpact-gate.js
+++ b/scripts/docpact-gate.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function parseArgs(argv) {
+  const args = {
+    base: process.env.DOCPACT_BASE_REF || 'origin/dev',
+    head: process.env.DOCPACT_HEAD_REF || 'HEAD',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--base') {
+      args.base = argv[index + 1];
+      index += 1;
+    } else if (arg === '--head') {
+      args.head = argv[index + 1];
+      index += 1;
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      process.exit(2);
+    }
+  }
+
+  return args;
+}
+
+function spawn(command, args, options = {}) {
+  return spawnSync(command, args, {
+    encoding: 'utf8',
+    stdio: options.stdio || 'pipe',
+    ...options,
+  });
+}
+
+function findDocpact() {
+  const candidates = [];
+  if (process.env.DOCPACT_BIN) {
+    candidates.push(process.env.DOCPACT_BIN);
+  }
+  candidates.push(path.join(os.homedir(), '.cargo', 'bin', 'docpact'));
+  candidates.push('docpact');
+
+  for (const candidate of candidates) {
+    if (candidate !== 'docpact' && !fs.existsSync(candidate)) {
+      continue;
+    }
+    const result = spawn(candidate, ['--version'], { stdio: 'ignore' });
+    if (result.status === 0) {
+      return candidate;
+    }
+  }
+
+  console.error(
+    'docpact was not found. Install it with `cargo install docpact --version 0.1.4 --force` or set DOCPACT_BIN.',
+  );
+  process.exit(127);
+}
+
+function git(args) {
+  const result = spawn('git', args);
+  if (result.status !== 0) {
+    const message = result.stderr.trim() || result.stdout.trim();
+    throw new Error(`git ${args.join(' ')} failed${message ? `: ${message}` : ''}`);
+  }
+  return result.stdout.trim();
+}
+
+function resolveBase(baseRef, headRef) {
+  const result = spawn('git', ['merge-base', headRef, baseRef]);
+  if (result.status === 0 && result.stdout.trim()) {
+    return result.stdout.trim();
+  }
+
+  throw new Error(
+    `Could not resolve merge-base for ${headRef} and ${baseRef}. Fetch the base ref or rerun with DOCPACT_BASE_REF=<ref>.`,
+  );
+}
+
+function runDocpact(docpact, args) {
+  const result = spawn(docpact, args, { stdio: 'inherit' });
+  if (result.error) {
+    console.error(result.error.message);
+    process.exit(1);
+  }
+  if (result.status !== 0) {
+    process.exit(result.status);
+  }
+}
+
+const args = parseArgs(process.argv.slice(2));
+const docpact = findDocpact();
+const base = resolveBase(args.base, args.head);
+const head = git(['rev-parse', args.head]);
+
+console.log(`Running docpact gate: base=${base} head=${head}`);
+runDocpact(docpact, ['validate-config', '--root', '.', '--strict']);
+runDocpact(docpact, ['lint', '--root', '.', '--base', base, '--head', head, '--mode', 'enforce']);

--- a/scripts/docpact-gate.js
+++ b/scripts/docpact-gate.js
@@ -86,6 +86,10 @@ function runDocpact(docpact, args) {
     console.error(result.error.message);
     process.exit(1);
   }
+  if (result.signal || result.status === null) {
+    console.error(`docpact was terminated${result.signal ? ` by ${result.signal}` : ''}.`);
+    process.exit(1);
+  }
   if (result.status !== 0) {
     process.exit(result.status);
   }


### PR DESCRIPTION
Closes #403

## Summary
- Promote the verified dev CI/tooling delta from PRs #398, #400, and #402 to main.

## Key Decisions
- Use a dedicated promote branch from origin/dev instead of targeting main directly from the long-lived dev branch.
- origin/main..origin/dev contains the EdgeOne retry workflow update, local docpact pre-push gate, and docpact signal-failure guard.

## Validation
- npm run docpact:gate -- --base origin/main --head origin/dev
- GitHub Full Gate and main deployment checks will validate the protected branch path.

## Risks / Rollback
- Moderate deployment risk because main pushes deploy the web app; rollback is reverting the promote merge on main.

## Workspace Integration
- After merge, update lca-workspace/main to pin the promoted tiangong-lca-next main commit.