### PR TITLE
[codex] Expand Electron release platform matrix

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-05-08'
-lastReviewedCommit: 'de2e3f56b98c5d6f36e7480b40544b85fcb3bf58'
+lastReviewedAt: "2026-05-10"
+lastReviewedCommit: "884ec46b2d1e1dc8ac4c4bdf071a028fd960144e"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-latest-large
-            arch: x64
-          - os: macos-latest
-            arch: arm64
           - os: ubuntu-latest
             arch: x64
           - os: windows-latest
             arch: x64
+          - os: macos-latest
+            arch: arm64
+          - os: ubuntu-24.04-arm
+            arch: arm64
 
     steps:
       - name: Check out Git repository

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: cd3f259972a49c387cffab9d5f4c902df2638daa
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: cd3f259972a49c387cffab9d5f4c902df2638daa
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -20,8 +20,8 @@ checkPaths:
   - .husky/pre-push
   - package.json
   - .github/workflows/**
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: 884ec46b2d1e1dc8ac4c4bdf071a028fd960144e
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: 884ec46b2d1e1dc8ac4c4bdf071a028fd960144e
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: 884ec46b2d1e1dc8ac4c4bdf071a028fd960144e
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: 884ec46b2d1e1dc8ac4c4bdf071a028fd960144e
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/testing-troubleshooting.md
   - tests/helpers/**
   - package.json
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: 884ec46b2d1e1dc8ac4c4bdf071a028fd960144e
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: de2e3f56b98c5d6f36e7480b40544b85fcb3bf58
+lastReviewedAt: 2026-05-10
+lastReviewedCommit: 884ec46b2d1e1dc8ac4c4bdf071a028fd960144e
 ---
 
 # Testing Troubleshooting


### PR DESCRIPTION
## Summary
- Replace the tag-based Electron build/release matrix with ubuntu x64, windows x64, macOS arm64, and ubuntu arm64.
- Record docpact review evidence required for the release workflow change.

## Validation
- npm run docpact:gate -- --base origin/dev
- YAML syntax parsed locally before push
- Note: .github/workflows/build.yml only runs on v* tag pushes, so PR checks validate repository health but do not execute the tag release workflow itself.