### PR TITLE
fix: keep create-version dropdowns visible

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-05-11'
-lastReviewedCommit: 'd41c978ab936d3cd1d4b4518fbdf9e3eea278538'
+lastReviewedAt: "2026-05-14"
+lastReviewedCommit: "d3fb24a7306cac0c0ef4bba8595c759bfac72140"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: d41c978ab936d3cd1d4b4518fbdf9e3eea278538
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: d3fb24a7306cac0c0ef4bba8595c759bfac72140
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: d41c978ab936d3cd1d4b4518fbdf9e3eea278538
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: 806ed443f2a29ef1666e16f76c8ae0bec12f664f
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -20,8 +20,8 @@ checkPaths:
   - .husky/pre-push
   - package.json
   - .github/workflows/**
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: d41c978ab936d3cd1d4b4518fbdf9e3eea278538
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: d41c978ab936d3cd1d4b4518fbdf9e3eea278538
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: d3fb24a7306cac0c0ef4bba8595c759bfac72140
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: d41c978ab936d3cd1d4b4518fbdf9e3eea278538
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: d3fb24a7306cac0c0ef4bba8595c759bfac72140
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: d41c978ab936d3cd1d4b4518fbdf9e3eea278538
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: d41c978ab936d3cd1d4b4518fbdf9e3eea278538
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: d41c978ab936d3cd1d4b4518fbdf9e3eea278538
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: d41c978ab936d3cd1d4b4518fbdf9e3eea278538
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
 ---
 
 # Testing Troubleshooting

--- a/src/components/AllVersions/index.tsx
+++ b/src/components/AllVersions/index.tsx
@@ -24,6 +24,8 @@ interface AllVersionsListProps {
   addVersionComponent: ({ newVersion }: { newVersion: string }) => ReactElement;
 }
 
+export const getCreateVersionPopupContainer = () => document.body;
+
 const AllVersionsList: FC<AllVersionsListProps> = ({
   searchTableName,
   searchColume,
@@ -179,7 +181,7 @@ const AllVersionsList: FC<AllVersionsListProps> = ({
             }}
             toolBarRender={() => {
               return [
-                <ConfigProvider key={0} getPopupContainer={() => document.body}>
+                <ConfigProvider key={0} getPopupContainer={getCreateVersionPopupContainer}>
                   {addVersionComponent({ newVersion: getNewVersion() })}
                 </ConfigProvider>,
               ];

--- a/src/components/AllVersions/index.tsx
+++ b/src/components/AllVersions/index.tsx
@@ -10,7 +10,7 @@ import { ListPagination } from '@/services/general/data';
 import { getDataSource } from '@/services/general/util';
 import { BarsOutlined, CloseOutlined } from '@ant-design/icons';
 import { ActionType, ProColumns, ProTable } from '@ant-design/pro-components';
-import { Button, Card, Drawer, Tooltip } from 'antd';
+import { Button, Card, ConfigProvider, Drawer, Tooltip } from 'antd';
 import type { FC, ReactElement } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useLocation } from 'umi';
@@ -178,7 +178,11 @@ const AllVersionsList: FC<AllVersionsListProps> = ({
               pageSize: 10,
             }}
             toolBarRender={() => {
-              return [<div key={0}>{addVersionComponent({ newVersion: getNewVersion() })}</div>];
+              return [
+                <ConfigProvider key={0} getPopupContainer={() => document.body}>
+                  {addVersionComponent({ newVersion: getNewVersion() })}
+                </ConfigProvider>,
+              ];
             }}
             request={async (params: { pageSize: number; current: number }, sort) => {
               const result = await getAllVersions(

--- a/tests/unit/components/AllVersions.test.tsx
+++ b/tests/unit/components/AllVersions.test.tsx
@@ -10,7 +10,7 @@
  * - ProTable integration
  */
 
-import AllVersionsList from '@/components/AllVersions';
+import AllVersionsList, { getCreateVersionPopupContainer } from '@/components/AllVersions';
 import { getAllVersions } from '@/services/general/api';
 import { getDataSource } from '@/services/general/util';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -440,6 +440,10 @@ describe('AllVersionsList Component', () => {
       expect(screen.getByTestId('children')).toBeInTheDocument();
     });
     expect(mockAddVersionComponent).toHaveBeenCalled();
+  });
+
+  it('should place create-version popups in the document body', () => {
+    expect(getCreateVersionPopupContainer()).toBe(document.body);
   });
 
   it('should compute the next version from the highest loaded version after reopening', async () => {


### PR DESCRIPTION
## Summary
- fix create-version Select/TreeSelect dropdowns being hidden behind the parent AllVersions drawer
- override the popup container only for the create-version launcher rendered from AllVersions' ProTable toolbar, so nested drawer controls no longer inherit ProTable's popup container
- record docpact review evidence required for frontend runtime changes

## Root Cause
`addVersionComponent` is rendered inside `ProTable.toolBarRender`. The create-version drawer is portaled to `document.body`, but its React subtree still inherited ProTable's popup container context. Select/TreeSelect popups were therefore rendered back under the AllVersions ProTable/lower drawer, where they were covered by the create-version drawer. The dropdown existed in the DOM, but was visually hidden.

## Validation
- Browser: Contacts -> All Versions -> Create Version -> Classification dropdown is visible; popup container is `body`.
- Browser: Processes -> All Versions -> New Version -> Modeling Information -> Data Set Type dropdown is visible; popup container is `body`.
- `npm run lint:js`
- `npm run tsc`
- `npm run docpact:gate`
- `npm run build`
- `git diff --check`

Closes #408