### PR TITLE
fix: retry stale TIDAS package export jobs

### DIFF
--- a/docker/volumes/functions/_shared/tidas_package.ts
+++ b/docker/volumes/functions/_shared/tidas_package.ts
@@ -173,6 +173,8 @@ const IMPORT_SOURCE_FILENAME = 'import-source.zip';
 const DEFAULT_STORAGE_BUCKET = 'lca_results';
 const DEFAULT_STORAGE_PREFIX = 'lca-results';
 const SIGNED_URL_EXPIRES_IN_SECONDS = 60 * 60;
+const EXPORT_QUEUED_STALE_MS = 5 * 60 * 1000;
+const EXPORT_RUNNING_STALE_MS = 2 * 60 * 60 * 1000;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export class TidasPackageError extends Error {
@@ -1143,9 +1145,14 @@ function buildRetryIdempotencyKey(
 
 export function resolveExportCacheAction(
   cacheRow: ExportRequestCacheRow,
-  jobRow: Pick<PackageJobRow, 'status'> | null,
+  jobRow: Pick<PackageJobRow, 'status' | 'created_at' | 'started_at' | 'updated_at'> | null,
+  now = Date.now(),
 ): ExportCacheAction {
   if (!cacheRow.job_id || !jobRow) {
+    return 'retry';
+  }
+
+  if (isStaleExportJob(jobRow, now)) {
     return 'retry';
   }
 
@@ -1154,6 +1161,34 @@ export function resolveExportCacheAction(
   }
 
   return 'retry';
+}
+
+function isStaleExportJob(
+  jobRow: Pick<PackageJobRow, 'status' | 'created_at' | 'started_at' | 'updated_at'>,
+  now: number,
+): boolean {
+  if (jobRow.status === 'queued') {
+    return hasElapsed(jobRow.updated_at ?? jobRow.created_at, now, EXPORT_QUEUED_STALE_MS);
+  }
+
+  if (jobRow.status === 'running') {
+    return hasElapsed(
+      jobRow.started_at ?? jobRow.updated_at ?? jobRow.created_at,
+      now,
+      EXPORT_RUNNING_STALE_MS,
+    );
+  }
+
+  return false;
+}
+
+function hasElapsed(value: string | null, now: number, thresholdMs: number): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && now - timestamp > thresholdMs;
 }
 
 function parsePrepareImportRequest(body: unknown): Required<NormalizedPrepareImportUploadRequest> {

--- a/src/services/tidasPackage/taskCenter.ts
+++ b/src/services/tidasPackage/taskCenter.ts
@@ -47,6 +47,7 @@ const STORAGE_SCHEMA_VERSION = 1;
 const STORAGE_TTL_MS = 72 * 60 * 60 * 1000;
 const POLL_INTERVAL_MS = 1500;
 const POLL_TIMEOUT_MS = 2 * 60 * 60 * 1000;
+const QUEUED_PICKUP_TIMEOUT_MS = 5 * 60 * 1000;
 const POLL_TRANSIENT_ERROR_RETRY_LIMIT = 5;
 
 let taskSequence = 0;
@@ -435,6 +436,16 @@ async function pollTask(taskId: string, jobId: string): Promise<void> {
         return;
       }
       if (data.status === 'ready' || data.status === 'completed') {
+        return;
+      }
+      if (data.status === 'queued' && Date.now() - startedAt > QUEUED_PICKUP_TIMEOUT_MS) {
+        upsertTask(taskId, {
+          phase: 'failed',
+          state: 'failed',
+          message: 'Export task was not picked up by the package worker',
+          error:
+            'Package export stayed queued. Check that the TIDAS package worker is deployed and consuming lca_package_jobs.',
+        });
         return;
       }
 

--- a/tests/unit/services/tidasPackage/taskCenter.test.ts
+++ b/tests/unit/services/tidasPackage/taskCenter.test.ts
@@ -457,6 +457,49 @@ describe('tidasPackage/taskCenter', () => {
     nowSpy.mockRestore();
   });
 
+  it('marks queued exports as failed when the package worker never picks them up', async () => {
+    mockQueueExportTidasPackageApi.mockResolvedValue({
+      data: {
+        ok: true,
+        mode: 'queued',
+        job_id: 'job-stuck-queued',
+        scope: 'current_user',
+        root_count: 1,
+      },
+      error: null,
+    });
+    mockGetTidasPackageJobApi.mockResolvedValue({
+      data: {
+        ok: true,
+        status: 'queued',
+        job_id: 'job-stuck-queued',
+        diagnostics: {},
+        artifacts_by_kind: {},
+      },
+      error: null,
+    });
+
+    const nowSpy = jest.spyOn(Date, 'now');
+    const sequence = [100, 100, 100, 100 + 6 * 60 * 1000];
+    nowSpy.mockImplementation(() => sequence.shift() ?? 100 + 6 * 60 * 1000);
+
+    const timeoutModule = loadTaskCenterModule();
+    const timeoutTask = timeoutModule.submitTidasPackageExportTask({
+      roots: [{ table: 'unitgroups', id: 'ug-1', version: '01.00.000' }],
+    });
+    await flushPromises();
+
+    await waitFor(() => {
+      const failed = timeoutModule
+        .listTidasPackageTasks()
+        .find((item) => item.id === timeoutTask.id)!;
+      expect(failed.state).toBe('failed');
+      expect(failed.message).toBe('Export task was not picked up by the package worker');
+      expect(failed.error).toContain('lca_package_jobs');
+    });
+    nowSpy.mockRestore();
+  });
+
   it('uses fallback messages for invalid queue responses and terminal poll failures without error payloads', async () => {
     jest.useFakeTimers();
     mockQueueExportTidasPackageApi


### PR DESCRIPTION
## Why

TIDAS package export jobs can remain queued indefinitely when the backend package worker does not consume `lca_package_jobs`.

Observed job:

- job_id: `350aaf94-8506-4e04-9bdb-7c79e7000fa3`
- scope: `selected_roots`
- root table: `unitgroups`
- root count: `1`
- stayed queued for over 30 minutes

The Edge Function successfully creates the package job and enqueues it, so this points to the backend package worker not picking up the queue message, or not consuming the expected queue.

## What Changed

- Treat stale queued/running export jobs as retryable instead of always reusing the cached in-progress job.
- Mark frontend export tasks as failed if they remain queued for 5 minutes.
- Show a clear diagnostic telling operators to check the TIDAS package worker and `lca_package_jobs`.

## Test

```bash
npm run test:ci -- tests/unit/services/tidasPackage/taskCenter.test.ts --runInBand --testTimeout=20000 --no-coverage