### PR TITLE
feat: adjust process annual volume and exchange location forms

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-14"
-lastReviewedCommit: "d3fb24a7306cac0c0ef4bba8595c759bfac72140"
+lastReviewedAt: "2026-05-18"
+lastReviewedCommit: "997f79c642ef4bc2cc7715db07057944ffa15665"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-14"
-lastReviewedCommit: "d3fb24a7306cac0c0ef4bba8595c759bfac72140"
+lastReviewedAt: "2026-05-18"
+lastReviewedCommit: "b989f32f18a069e56caa8379e74916d043537101"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: d3fb24a7306cac0c0ef4bba8595c759bfac72140
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: b989f32f18a069e56caa8379e74916d043537101
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: d3fb24a7306cac0c0ef4bba8595c759bfac72140
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 997f79c642ef4bc2cc7715db07057944ffa15665
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 806ed443f2a29ef1666e16f76c8ae0bec12f664f
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 4595d3ad2f86c3cd23dc9b9352ca6bbf31564187
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 806ed443f2a29ef1666e16f76c8ae0bec12f664f
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: dee91ee1856e0411ec8fb0ccf53dc860d3dffb49
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -20,8 +20,8 @@ checkPaths:
   - .husky/pre-push
   - package.json
   - .github/workflows/**
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 997f79c642ef4bc2cc7715db07057944ffa15665
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -20,8 +20,8 @@ checkPaths:
   - .husky/pre-push
   - package.json
   - .github/workflows/**
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: b989f32f18a069e56caa8379e74916d043537101
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: d3fb24a7306cac0c0ef4bba8595c759bfac72140
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 997f79c642ef4bc2cc7715db07057944ffa15665
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: d3fb24a7306cac0c0ef4bba8595c759bfac72140
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: b989f32f18a069e56caa8379e74916d043537101
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: d3fb24a7306cac0c0ef4bba8595c759bfac72140
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 997f79c642ef4bc2cc7715db07057944ffa15665
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: d3fb24a7306cac0c0ef4bba8595c759bfac72140
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: b989f32f18a069e56caa8379e74916d043537101
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -19,8 +19,8 @@ checkPaths:
   - config/supabaseEnv.ts
   - src/services/**
   - docker/**
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: d41c978ab936d3cd1d4b4518fbdf9e3eea278538
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: b989f32f18a069e56caa8379e74916d043537101
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -19,8 +19,8 @@ checkPaths:
   - config/supabaseEnv.ts
   - src/services/**
   - docker/**
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: d41c978ab936d3cd1d4b4518fbdf9e3eea278538
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 997f79c642ef4bc2cc7715db07057944ffa15665
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 997f79c642ef4bc2cc7715db07057944ffa15665
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: b989f32f18a069e56caa8379e74916d043537101
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: b989f32f18a069e56caa8379e74916d043537101
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 997f79c642ef4bc2cc7715db07057944ffa15665
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: b989f32f18a069e56caa8379e74916d043537101
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 997f79c642ef4bc2cc7715db07057944ffa15665
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 997f79c642ef4bc2cc7715db07057944ffa15665
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: b989f32f18a069e56caa8379e74916d043537101
 ---
 
 # Testing Troubleshooting

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@antv/x6-react-shape": "^3.0.1",
     "@dagrejs/dagre": "^3.0.0",
     "@supabase/supabase-js": "^2.104.0",
-    "@tiangong-lca/tidas-sdk": "^0.1.36",
+    "@tiangong-lca/tidas-sdk": "^0.1.38",
     "antd": "^5.29.1",
     "bignumber.js": "^11.0.0",
     "dayjs": "^1.11.20",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@antv/x6-react-shape": "^3.0.1",
     "@dagrejs/dagre": "^3.0.0",
     "@supabase/supabase-js": "^2.104.0",
-    "@tiangong-lca/tidas-sdk": "^0.1.36",
+    "@tiangong-lca/tidas-sdk": "^0.1.39",
     "antd": "^5.29.1",
     "bignumber.js": "^11.0.0",
     "dayjs": "^1.11.20",

--- a/src/components/LocationTextItem/codeSelect.tsx
+++ b/src/components/LocationTextItem/codeSelect.tsx
@@ -4,7 +4,6 @@ import type { SelectProps } from 'antd';
 import { Select } from 'antd';
 import type { FC } from 'react';
 import { useEffect, useMemo, useState } from 'react';
-import { FormattedMessage } from 'umi';
 
 type LocationCodeOption = {
   label: string;
@@ -97,12 +96,6 @@ const LocationCodeSelect: FC<LocationCodeSelectProps> = ({
       loading={loading}
       optionFilterProp='label'
       optionLabelProp='label'
-      placeholder={
-        <FormattedMessage
-          id='pages.process.exchange.location.placeholder'
-          defaultMessage='Select location code'
-        />
-      }
       {...selectProps}
       value={normalizedValue}
       options={options}

--- a/src/components/LocationTextItem/codeSelect.tsx
+++ b/src/components/LocationTextItem/codeSelect.tsx
@@ -1,0 +1,121 @@
+import { getILCDLocationAll } from '@/services/locations/api';
+import { normalizeExchangeLocationCode } from '@/services/processes/exchangeLocation';
+import type { SelectProps } from 'antd';
+import { Select } from 'antd';
+import type { FC } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { FormattedMessage } from 'umi';
+
+type LocationCodeOption = {
+  label: string;
+  searchText: string;
+  value: string;
+};
+
+type LocationCodeSelectProps = Omit<SelectProps<string>, 'children' | 'onChange' | 'options'> & {
+  lang: string;
+  onChange?: (value?: string) => void;
+  onData?: () => void;
+};
+
+const getLocationCodeOption = (location: Record<string, unknown>): LocationCodeOption | null => {
+  const value = normalizeExchangeLocationCode(location['@value']);
+
+  if (!value) {
+    return null;
+  }
+
+  const text = typeof location['#text'] === 'string' ? location['#text'].trim() : '';
+  const label = text ? `${value} (${text})` : value;
+
+  return {
+    label,
+    searchText: `${value} ${text}`.trim().toLowerCase(),
+    value,
+  };
+};
+
+const LocationCodeSelect: FC<LocationCodeSelectProps> = ({
+  lang,
+  onChange,
+  onData,
+  value,
+  ...selectProps
+}) => {
+  const [locationOptions, setLocationOptions] = useState<LocationCodeOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const normalizedValue = normalizeExchangeLocationCode(value);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+
+    getILCDLocationAll(lang)
+      .then((res) => {
+        if (cancelled || !res.success) {
+          return;
+        }
+
+        const data = res.data?.[0]?.location ?? [];
+        const locationList = Array.isArray(data) ? data : [data];
+        const nextOptions = locationList
+          .map((location: Record<string, unknown>) => getLocationCodeOption(location))
+          .filter((option): option is LocationCodeOption => Boolean(option));
+
+        setLocationOptions(nextOptions);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [lang]);
+
+  const options = useMemo(() => {
+    if (!normalizedValue || locationOptions.some((option) => option.value === normalizedValue)) {
+      return locationOptions;
+    }
+
+    return [
+      {
+        label: normalizedValue,
+        searchText: normalizedValue.toLowerCase(),
+        value: normalizedValue,
+      },
+      ...locationOptions,
+    ];
+  }, [locationOptions, normalizedValue]);
+
+  return (
+    <Select
+      allowClear
+      showSearch
+      loading={loading}
+      optionFilterProp='label'
+      optionLabelProp='label'
+      placeholder={
+        <FormattedMessage
+          id='pages.process.exchange.location.placeholder'
+          defaultMessage='Select location code'
+        />
+      }
+      {...selectProps}
+      value={normalizedValue}
+      options={options}
+      onChange={(nextValue) => {
+        onChange?.(normalizeExchangeLocationCode(nextValue));
+        onData?.();
+      }}
+      filterOption={(input, option) => {
+        const searchText = String(option?.searchText ?? option?.label ?? option?.value ?? '');
+        return searchText.toLowerCase().includes(input.toLowerCase());
+      }}
+    />
+  );
+};
+
+export default LocationCodeSelect;

--- a/src/locales/en-US/pages_process.ts
+++ b/src/locales/en-US/pages_process.ts
@@ -643,6 +643,8 @@ export default {
   'pages.process.validator.typeOfDataSet.required': 'Please input type of data set',
   'pages.process.validator.dataCutOffAndCompletenessPrinciples.required': 'Please input data cut-off and completeness principles',
   'pages.process.validator.referenceToDataSource.required': 'Please input data source(s) used for this data set',
+  'pages.process.validator.annualSupplyOrProductionVolume.required': 'Please input annual supply or production volume',
+  'pages.process.validator.annualSupplyOrProductionVolume.pattern': 'Please enter a number; the reference flow suffix is added automatically.',
   'pages.process.validator.reviewType.required': 'Please input type of review',
   'pages.process.validator.scopeName.required': 'Please input scope name',
   'pages.process.validator.methodName.required': 'Please input method name',

--- a/src/locales/en-US/pages_process.ts
+++ b/src/locales/en-US/pages_process.ts
@@ -644,7 +644,7 @@ export default {
   'pages.process.validator.dataCutOffAndCompletenessPrinciples.required': 'Please input data cut-off and completeness principles',
   'pages.process.validator.referenceToDataSource.required': 'Please input data source(s) used for this data set',
   'pages.process.validator.annualSupplyOrProductionVolume.required': 'Please input annual supply or production volume',
-  'pages.process.validator.annualSupplyOrProductionVolume.pattern': 'Please enter a number; the reference flow suffix is added automatically.',
+  'pages.process.validator.annualSupplyOrProductionVolume.pattern': 'Please enter a number.',
   'pages.process.validator.reviewType.required': 'Please input type of review',
   'pages.process.validator.scopeName.required': 'Please input scope name',
   'pages.process.validator.methodName.required': 'Please input method name',

--- a/src/locales/zh-CN/pages_process.ts
+++ b/src/locales/zh-CN/pages_process.ts
@@ -641,7 +641,7 @@ export default {
   'pages.process.validator.dataCutOffAndCompletenessPrinciples.required': '请输入数据切断和完整性原则',
   'pages.process.validator.referenceToDataSource.required': '请输入使用的数据来源',
   'pages.process.validator.annualSupplyOrProductionVolume.required': '请输入年供应量或生产量',
-  'pages.process.validator.annualSupplyOrProductionVolume.pattern': '请输入数值；基准流后缀将自动补充。',
+  'pages.process.validator.annualSupplyOrProductionVolume.pattern': '请输入数值。',
   'pages.process.validator.reviewType.required': '请输入审查类型',
   'pages.process.validator.scopeName.required': '请输入范围名称',
   'pages.process.validator.methodName.required': '请输入方法名称',

--- a/src/locales/zh-CN/pages_process.ts
+++ b/src/locales/zh-CN/pages_process.ts
@@ -640,6 +640,8 @@ export default {
   'pages.process.validator.typeOfDataSet.required': '请输入数据集类型',
   'pages.process.validator.dataCutOffAndCompletenessPrinciples.required': '请输入数据切断和完整性原则',
   'pages.process.validator.referenceToDataSource.required': '请输入使用的数据来源',
+  'pages.process.validator.annualSupplyOrProductionVolume.required': '请输入年供应量或生产量',
+  'pages.process.validator.annualSupplyOrProductionVolume.pattern': '请输入数值；基准流后缀将自动补充。',
   'pages.process.validator.reviewType.required': '请输入审查类型',
   'pages.process.validator.scopeName.required': '请输入范围名称',
   'pages.process.validator.methodName.required': '请输入方法名称',

--- a/src/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.tsx
+++ b/src/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.tsx
@@ -1,0 +1,290 @@
+import { langOptions } from '@/services/general/data';
+import { getLangText } from '@/services/general/util';
+import {
+  ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN,
+  deriveAnnualSupplyVolumeSuffix,
+  formatAnnualSupplyVolumeText,
+  normalizeAnnualSupplyVolumeMultiLang,
+  parseAnnualSupplyVolumeText,
+} from '@/services/processes/annualSupplyOrProductionVolume';
+import type { ProcessExchangeData } from '@/services/processes/data';
+import { CloseOutlined } from '@ant-design/icons';
+import type { ProFormInstance } from '@ant-design/pro-components';
+import { Button, Col, Form, Input, Row, Select, message } from 'antd';
+import type { FC, ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { FormattedMessage, useIntl } from 'umi';
+
+type Props = {
+  exchangeDataSource: ProcessExchangeData[];
+  formRef: React.MutableRefObject<ProFormInstance | undefined>;
+  label: ReactNode | string;
+  lang: string;
+  name: Array<string | number>;
+  onData: () => void;
+  rules?: any[];
+  setRuleErrorState?: (showError: boolean) => void;
+};
+
+const normalizeTextValue = (value: unknown) => {
+  return typeof value === 'string' ? value.trim() : '';
+};
+
+const AnnualSupplyOrProductionVolumeForm: FC<Props> = ({
+  exchangeDataSource,
+  formRef,
+  label,
+  lang,
+  name,
+  onData,
+  rules = [],
+  setRuleErrorState,
+}) => {
+  const intl = useIntl();
+  const initialRenderRef = useRef(true);
+  const form = formRef?.current;
+  const formValues = typeof form?.getFieldValue === 'function' ? form.getFieldValue(name) : [];
+  const formValueList = Array.isArray(formValues) ? formValues : formValues ? [formValues] : [];
+  const isRequired = rules?.some((rule) => rule.required);
+  const requiredRule = rules?.find((rule) => rule.required);
+  const selectedLangValues = formValueList
+    .filter((item: any) => item && item['@xml:lang'])
+    .map((item: any) => item['@xml:lang']);
+  const suffixByLang = useMemo(() => {
+    return langOptions.reduce<Record<string, string>>((accumulator, option) => {
+      accumulator[option.value] = deriveAnnualSupplyVolumeSuffix({
+        exchangeDataSource,
+        getLangText,
+        lang: option.value,
+      });
+      return accumulator;
+    }, {});
+  }, [exchangeDataSource]);
+
+  const getSuffixForLang = useCallback(
+    (value?: string) => suffixByLang[value || lang] ?? suffixByLang.en,
+    [lang, suffixByLang],
+  );
+
+  useEffect(() => {
+    if (
+      !form ||
+      typeof form.setFieldValue !== 'function' ||
+      !Array.isArray(formValueList) ||
+      formValueList.length === 0
+    ) {
+      return;
+    }
+
+    const normalizedValues = normalizeAnnualSupplyVolumeMultiLang(formValueList, (item) =>
+      getSuffixForLang(String(item['@xml:lang'] ?? lang)),
+    );
+
+    if (JSON.stringify(normalizedValues) !== JSON.stringify(formValueList)) {
+      form.setFieldValue(name, normalizedValues);
+      onData();
+    }
+  }, [form, formValueList, getSuffixForLang, lang, name, onData]);
+
+  return (
+    <Form.Item>
+      <Form.List
+        name={name}
+        rules={
+          isRequired
+            ? [
+                {
+                  validator: async (_, value) => {
+                    const normalizedValue = Array.isArray(value) ? value : [];
+                    const hasAnyMeaningfulValue = normalizedValue.some((item: any) => {
+                      return (
+                        !!item &&
+                        (!!item['@xml:lang'] || normalizeTextValue(item['#text']).length > 0)
+                      );
+                    });
+
+                    if (!hasAnyMeaningfulValue) {
+                      if (setRuleErrorState) setRuleErrorState(false);
+                      return Promise.resolve();
+                    }
+
+                    const lists = normalizedValue.filter(
+                      (item: any) => item && item.hasOwnProperty('@xml:lang'),
+                    );
+                    const langs = lists.map((item: any) => item['@xml:lang']);
+                    const enIndex = langs.indexOf('en');
+                    if (langs && langs.length && enIndex === -1) {
+                      if (setRuleErrorState) {
+                        setRuleErrorState(true);
+                      } else {
+                        message.error(
+                          intl.formatMessage({
+                            id: 'validator.lang.mustBeEnglish',
+                            defaultMessage: 'English is a required language!',
+                          }),
+                        );
+                      }
+                      return Promise.reject(new Error());
+                    }
+                    if (setRuleErrorState) setRuleErrorState(false);
+                    return Promise.resolve();
+                  },
+                },
+              ]
+            : []
+        }
+      >
+        {(subFields, subOpt) => {
+          if (isRequired && subFields.length === 0 && initialRenderRef.current) {
+            initialRenderRef.current = false;
+            requestAnimationFrame(() => {
+              subOpt.add();
+            });
+          }
+
+          return (
+            <div style={{ display: 'flex', flexDirection: 'column', rowGap: 16 }}>
+              {subFields.map((subField) => {
+                const currentLang = formValues?.[subField.name]?.['@xml:lang'];
+                const currentSuffix = getSuffixForLang(currentLang);
+                const optionsWithDisabled = langOptions.map((option) => ({
+                  ...option,
+                  disabled:
+                    selectedLangValues.includes(option.value) && option.value !== currentLang,
+                }));
+                const textRules = isRequired
+                  ? [
+                      {
+                        validator: async (_: unknown, value: unknown) => {
+                          const normalizedValue = normalizeTextValue(value);
+
+                          if (normalizedValue.length === 0) {
+                            return Promise.reject(
+                              new Error(
+                                intl.formatMessage({
+                                  id: requiredRule?.messageKey ?? 'validator.lang.text.required',
+                                  defaultMessage:
+                                    requiredRule?.defaultMessage ?? 'Please input this field!',
+                                }),
+                              ),
+                            );
+                          }
+
+                          if (!ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN.test(normalizedValue)) {
+                            return Promise.reject(
+                              new Error(
+                                intl.formatMessage({
+                                  id: 'pages.process.validator.annualSupplyOrProductionVolume.pattern',
+                                  defaultMessage:
+                                    'Please enter a number; the reference flow suffix is added automatically.',
+                                }),
+                              ),
+                            );
+                          }
+
+                          return Promise.resolve();
+                        },
+                      },
+                    ]
+                  : [];
+
+                return (
+                  <Row key={subField.key} gutter={[10, 0]} align='top'>
+                    <Col flex='180px'>
+                      <Form.Item
+                        name={[subField.name, '@xml:lang']}
+                        rules={
+                          isRequired
+                            ? [
+                                {
+                                  validator: async (_, value) => {
+                                    if (!value) {
+                                      return Promise.reject(
+                                        new Error(
+                                          intl.formatMessage({
+                                            id: 'validator.lang.select',
+                                            defaultMessage: 'Please select a language!',
+                                          }),
+                                        ),
+                                      );
+                                    }
+
+                                    if (value === 'en' && setRuleErrorState) {
+                                      setRuleErrorState(false);
+                                    }
+                                    return Promise.resolve();
+                                  },
+                                },
+                              ]
+                            : []
+                        }
+                        style={{ marginBottom: 0 }}
+                      >
+                        <Select
+                          placeholder={
+                            <FormattedMessage
+                              id='pages.lang.select'
+                              defaultMessage='Select a lang'
+                            />
+                          }
+                          optionFilterProp='lang'
+                          options={optionsWithDisabled}
+                          onChange={() => onData()}
+                        />
+                      </Form.Item>
+                    </Col>
+                    <Col flex='auto'>
+                      <Form.Item
+                        name={[subField.name, '#text']}
+                        getValueProps={(value) => ({
+                          value: parseAnnualSupplyVolumeText(value).numericText,
+                        })}
+                        normalize={(value) => formatAnnualSupplyVolumeText(value, currentSuffix)}
+                        rules={textRules}
+                        style={{ marginBottom: 0 }}
+                      >
+                        <Input
+                          inputMode='decimal'
+                          onChange={() => onData()}
+                          suffix={currentSuffix}
+                        />
+                      </Form.Item>
+                    </Col>
+                    <Col flex='20px' style={{ paddingTop: '8px' }}>
+                      <CloseOutlined
+                        style={{
+                          cursor: isRequired && subFields.length === 1 ? 'not-allowed' : 'pointer',
+                        }}
+                        onClick={() => {
+                          if (isRequired && subFields.length === 1) {
+                            return;
+                          }
+                          subOpt.remove(subField.name);
+                          onData();
+                        }}
+                      />
+                    </Col>
+                  </Row>
+                );
+              })}
+              <Button
+                type='dashed'
+                onClick={() => {
+                  subOpt.add();
+                  onData();
+                }}
+                block
+                style={{ marginTop: '8px' }}
+              >
+                + <FormattedMessage id='pages.button.item.add' defaultMessage='Add' /> {label}{' '}
+                <FormattedMessage id='pages.button.item.label' defaultMessage='Item' />
+              </Button>
+            </div>
+          );
+        }}
+      </Form.List>
+    </Form.Item>
+  );
+};
+
+export default AnnualSupplyOrProductionVolumeForm;

--- a/src/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.tsx
+++ b/src/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.tsx
@@ -1,9 +1,11 @@
 import { langOptions } from '@/services/general/data';
-import { getLangText } from '@/services/general/util';
+import { getLangText, getUnitData } from '@/services/general/util';
 import {
   ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN,
+  buildAnnualSupplyVolumeUnitLookupRows,
   deriveAnnualSupplyVolumeSuffix,
   formatAnnualSupplyVolumeText,
+  mergeAnnualSupplyVolumeUnitRows,
   normalizeAnnualSupplyVolumeMultiLang,
   parseAnnualSupplyVolumeText,
   sanitizeAnnualSupplyVolumeNumericInput,
@@ -13,7 +15,7 @@ import { CloseOutlined } from '@ant-design/icons';
 import type { ProFormInstance } from '@ant-design/pro-components';
 import { Button, Col, Form, InputNumber, Row, Select, message } from 'antd';
 import type { FC, ReactNode } from 'react';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 
 type Props = {
@@ -43,6 +45,8 @@ const AnnualSupplyOrProductionVolumeForm: FC<Props> = ({
 }) => {
   const intl = useIntl();
   const initialRenderRef = useRef(true);
+  const [exchangeDataSourceWithUnits, setExchangeDataSourceWithUnits] =
+    useState(exchangeDataSource);
   const form = formRef?.current;
   const formValues = typeof form?.getFieldValue === 'function' ? form.getFieldValue(name) : [];
   const formValueList = Array.isArray(formValues) ? formValues : formValues ? [formValues] : [];
@@ -54,18 +58,40 @@ const AnnualSupplyOrProductionVolumeForm: FC<Props> = ({
   const suffixByLang = useMemo(() => {
     return langOptions.reduce<Record<string, string>>((accumulator, option) => {
       accumulator[option.value] = deriveAnnualSupplyVolumeSuffix({
-        exchangeDataSource,
+        exchangeDataSource: exchangeDataSourceWithUnits,
         getLangText,
         lang: option.value,
       });
       return accumulator;
     }, {});
-  }, [exchangeDataSource]);
+  }, [exchangeDataSourceWithUnits]);
 
   const getSuffixForLang = useCallback(
     (value?: string) => suffixByLang[value || lang] ?? suffixByLang.en,
     [lang, suffixByLang],
   );
+
+  useEffect(() => {
+    setExchangeDataSourceWithUnits(exchangeDataSource);
+
+    const unitLookupRows = buildAnnualSupplyVolumeUnitLookupRows(exchangeDataSource);
+    const hasReferenceFlow = unitLookupRows.some((row) => row.referenceToFlowDataSetId);
+
+    if (!hasReferenceFlow) {
+      return;
+    }
+
+    getUnitData('flow', unitLookupRows).then(
+      (unitRows) => {
+        setExchangeDataSourceWithUnits(
+          mergeAnnualSupplyVolumeUnitRows(exchangeDataSource, unitRows),
+        );
+      },
+      () => {
+        setExchangeDataSourceWithUnits(exchangeDataSource);
+      },
+    );
+  }, [exchangeDataSource]);
 
   useEffect(() => {
     if (

--- a/src/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.tsx
+++ b/src/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.tsx
@@ -182,7 +182,7 @@ const AnnualSupplyOrProductionVolumeForm: FC<Props> = ({
         </Form.Item>
         <Input
           aria-label='annual-supply-volume-context'
-          readOnly
+          disabled
           style={{ width: '50%' }}
           value={currentSuffix}
         />

--- a/src/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.tsx
+++ b/src/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.tsx
@@ -2,21 +2,18 @@ import { langOptions } from '@/services/general/data';
 import { getLangText, getUnitData } from '@/services/general/util';
 import {
   ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN,
+  buildAnnualSupplyVolumeMultiLang,
   buildAnnualSupplyVolumeUnitLookupRows,
   deriveAnnualSupplyVolumeSuffix,
-  formatAnnualSupplyVolumeText,
+  getAnnualSupplyVolumeDisplayNumericText,
   mergeAnnualSupplyVolumeUnitRows,
-  normalizeAnnualSupplyVolumeMultiLang,
-  parseAnnualSupplyVolumeText,
-  sanitizeAnnualSupplyVolumeNumericInput,
 } from '@/services/processes/annualSupplyOrProductionVolume';
 import type { ProcessExchangeData } from '@/services/processes/data';
-import { CloseOutlined } from '@ant-design/icons';
 import type { ProFormInstance } from '@ant-design/pro-components';
-import { Button, Col, Form, InputNumber, Row, Select, message } from 'antd';
+import { Form, InputNumber } from 'antd';
 import type { FC, ReactNode } from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { FormattedMessage, useIntl } from 'umi';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useIntl } from 'umi';
 
 type Props = {
   exchangeDataSource: ProcessExchangeData[];
@@ -29,14 +26,11 @@ type Props = {
   setRuleErrorState?: (showError: boolean) => void;
 };
 
-const normalizeTextValue = (value: unknown) => {
-  return typeof value === 'string' ? value.trim() : '';
-};
+const annualSupplyVolumeLangs = langOptions.map((option) => option.value);
 
 const AnnualSupplyOrProductionVolumeForm: FC<Props> = ({
   exchangeDataSource,
   formRef,
-  label,
   lang,
   name,
   onData,
@@ -44,17 +38,16 @@ const AnnualSupplyOrProductionVolumeForm: FC<Props> = ({
   setRuleErrorState,
 }) => {
   const intl = useIntl();
-  const initialRenderRef = useRef(true);
   const [exchangeDataSourceWithUnits, setExchangeDataSourceWithUnits] =
     useState(exchangeDataSource);
   const form = formRef?.current;
   const formValues = typeof form?.getFieldValue === 'function' ? form.getFieldValue(name) : [];
-  const formValueList = Array.isArray(formValues) ? formValues : formValues ? [formValues] : [];
+  const hasStoredFormValue = Array.isArray(formValues)
+    ? formValues.length > 0
+    : formValues !== undefined && formValues !== null;
   const isRequired = rules?.some((rule) => rule.required);
   const requiredRule = rules?.find((rule) => rule.required);
-  const selectedLangValues = formValueList
-    .filter((item: any) => item && item['@xml:lang'])
-    .map((item: any) => item['@xml:lang']);
+
   const suffixByLang = useMemo(() => {
     return langOptions.reduce<Record<string, string>>((accumulator, option) => {
       accumulator[option.value] = deriveAnnualSupplyVolumeSuffix({
@@ -67,9 +60,10 @@ const AnnualSupplyOrProductionVolumeForm: FC<Props> = ({
   }, [exchangeDataSourceWithUnits]);
 
   const getSuffixForLang = useCallback(
-    (value?: string) => suffixByLang[value || lang] ?? suffixByLang.en,
-    [lang, suffixByLang],
+    (value: string) => suffixByLang[value] ?? suffixByLang.en,
+    [suffixByLang],
   );
+  const currentSuffix = getSuffixForLang(lang);
 
   useEffect(() => {
     setExchangeDataSourceWithUnits(exchangeDataSource);
@@ -94,227 +88,91 @@ const AnnualSupplyOrProductionVolumeForm: FC<Props> = ({
   }, [exchangeDataSource]);
 
   useEffect(() => {
-    if (
-      !form ||
-      typeof form.setFieldValue !== 'function' ||
-      !Array.isArray(formValueList) ||
-      formValueList.length === 0
-    ) {
+    if (!form || typeof form.setFieldValue !== 'function' || !hasStoredFormValue) {
       return;
     }
 
-    const normalizedValues = normalizeAnnualSupplyVolumeMultiLang(formValueList, (item) =>
-      getSuffixForLang(String(item['@xml:lang'] ?? lang)),
+    const numericText = getAnnualSupplyVolumeDisplayNumericText(formValues, lang);
+    const normalizedValues = buildAnnualSupplyVolumeMultiLang(
+      numericText,
+      getSuffixForLang,
+      annualSupplyVolumeLangs,
     );
 
-    if (JSON.stringify(normalizedValues) !== JSON.stringify(formValueList)) {
+    if (JSON.stringify(normalizedValues) !== JSON.stringify(formValues)) {
       form.setFieldValue(name, normalizedValues);
       onData();
     }
-  }, [form, formValueList, getSuffixForLang, lang, name, onData]);
+  }, [form, formValues, getSuffixForLang, hasStoredFormValue, lang, name, onData]);
+
+  const fieldRules = isRequired
+    ? [
+        {
+          validator: async (_: unknown, value: unknown) => {
+            const numericText = getAnnualSupplyVolumeDisplayNumericText(value, lang);
+
+            if (numericText.trim().length === 0) {
+              setRuleErrorState?.(true);
+              return Promise.reject(
+                new Error(
+                  intl.formatMessage({
+                    id: requiredRule?.messageKey ?? 'validator.lang.text.required',
+                    defaultMessage: requiredRule?.defaultMessage ?? 'Please input this field!',
+                  }),
+                ),
+              );
+            }
+
+            const normalizedValues = buildAnnualSupplyVolumeMultiLang(
+              numericText,
+              getSuffixForLang,
+              annualSupplyVolumeLangs,
+            );
+            const isAnnualSupplyVolumeValid =
+              normalizedValues.length > 0 &&
+              normalizedValues.every((item) =>
+                ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN.test(String(item['#text']).trim()),
+              );
+
+            if (!isAnnualSupplyVolumeValid) {
+              setRuleErrorState?.(true);
+              return Promise.reject(
+                new Error(
+                  intl.formatMessage({
+                    id: 'pages.process.validator.annualSupplyOrProductionVolume.pattern',
+                    defaultMessage: 'Please enter a number.',
+                  }),
+                ),
+              );
+            }
+
+            setRuleErrorState?.(false);
+            return Promise.resolve();
+          },
+        },
+      ]
+    : [];
 
   return (
-    <Form.Item>
-      <Form.List
-        name={name}
-        rules={
-          isRequired
-            ? [
-                {
-                  validator: async (_, value) => {
-                    const normalizedValue = Array.isArray(value) ? value : [];
-                    const hasAnyMeaningfulValue = normalizedValue.some((item: any) => {
-                      return (
-                        !!item &&
-                        (!!item['@xml:lang'] || normalizeTextValue(item['#text']).length > 0)
-                      );
-                    });
-
-                    if (!hasAnyMeaningfulValue) {
-                      if (setRuleErrorState) setRuleErrorState(false);
-                      return Promise.resolve();
-                    }
-
-                    const lists = normalizedValue.filter(
-                      (item: any) => item && item.hasOwnProperty('@xml:lang'),
-                    );
-                    const langs = lists.map((item: any) => item['@xml:lang']);
-                    const enIndex = langs.indexOf('en');
-                    if (langs && langs.length && enIndex === -1) {
-                      if (setRuleErrorState) {
-                        setRuleErrorState(true);
-                      } else {
-                        message.error(
-                          intl.formatMessage({
-                            id: 'validator.lang.mustBeEnglish',
-                            defaultMessage: 'English is a required language!',
-                          }),
-                        );
-                      }
-                      return Promise.reject(new Error());
-                    }
-                    if (setRuleErrorState) setRuleErrorState(false);
-                    return Promise.resolve();
-                  },
-                },
-              ]
-            : []
-        }
-      >
-        {(subFields, subOpt) => {
-          if (isRequired && subFields.length === 0 && initialRenderRef.current) {
-            initialRenderRef.current = false;
-            requestAnimationFrame(() => {
-              subOpt.add();
-            });
-          }
-
-          return (
-            <div style={{ display: 'flex', flexDirection: 'column', rowGap: 16 }}>
-              {subFields.map((subField) => {
-                const currentLang = formValues?.[subField.name]?.['@xml:lang'];
-                const currentSuffix = getSuffixForLang(currentLang);
-                const optionsWithDisabled = langOptions.map((option) => ({
-                  ...option,
-                  disabled:
-                    selectedLangValues.includes(option.value) && option.value !== currentLang,
-                }));
-                const textRules = isRequired
-                  ? [
-                      {
-                        validator: async (_: unknown, value: unknown) => {
-                          const normalizedValue = normalizeTextValue(value);
-
-                          if (normalizedValue.length === 0) {
-                            return Promise.reject(
-                              new Error(
-                                intl.formatMessage({
-                                  id: requiredRule?.messageKey ?? 'validator.lang.text.required',
-                                  defaultMessage:
-                                    requiredRule?.defaultMessage ?? 'Please input this field!',
-                                }),
-                              ),
-                            );
-                          }
-
-                          if (!ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN.test(normalizedValue)) {
-                            return Promise.reject(
-                              new Error(
-                                intl.formatMessage({
-                                  id: 'pages.process.validator.annualSupplyOrProductionVolume.pattern',
-                                  defaultMessage:
-                                    'Please enter a number; the reference flow suffix is added automatically.',
-                                }),
-                              ),
-                            );
-                          }
-
-                          return Promise.resolve();
-                        },
-                      },
-                    ]
-                  : [];
-
-                return (
-                  <Row key={subField.key} gutter={[10, 0]} align='top'>
-                    <Col flex='180px'>
-                      <Form.Item
-                        name={[subField.name, '@xml:lang']}
-                        rules={
-                          isRequired
-                            ? [
-                                {
-                                  validator: async (_, value) => {
-                                    if (!value) {
-                                      return Promise.reject(
-                                        new Error(
-                                          intl.formatMessage({
-                                            id: 'validator.lang.select',
-                                            defaultMessage: 'Please select a language!',
-                                          }),
-                                        ),
-                                      );
-                                    }
-
-                                    if (value === 'en' && setRuleErrorState) {
-                                      setRuleErrorState(false);
-                                    }
-                                    return Promise.resolve();
-                                  },
-                                },
-                              ]
-                            : []
-                        }
-                        style={{ marginBottom: 0 }}
-                      >
-                        <Select
-                          placeholder={
-                            <FormattedMessage
-                              id='pages.lang.select'
-                              defaultMessage='Select a lang'
-                            />
-                          }
-                          optionFilterProp='lang'
-                          options={optionsWithDisabled}
-                          onChange={() => onData()}
-                        />
-                      </Form.Item>
-                    </Col>
-                    <Col flex='auto'>
-                      <Form.Item
-                        name={[subField.name, '#text']}
-                        getValueProps={(value) => ({
-                          value: sanitizeAnnualSupplyVolumeNumericInput(
-                            parseAnnualSupplyVolumeText(value).numericText,
-                          ),
-                        })}
-                        normalize={(value) => formatAnnualSupplyVolumeText(value, currentSuffix)}
-                        rules={textRules}
-                        style={{ marginBottom: 0 }}
-                      >
-                        <InputNumber
-                          controls={false}
-                          inputMode='decimal'
-                          onChange={() => onData()}
-                          stringMode
-                          style={{ width: '100%' }}
-                          suffix={currentSuffix}
-                        />
-                      </Form.Item>
-                    </Col>
-                    <Col flex='20px' style={{ paddingTop: '8px' }}>
-                      <CloseOutlined
-                        style={{
-                          cursor: isRequired && subFields.length === 1 ? 'not-allowed' : 'pointer',
-                        }}
-                        onClick={() => {
-                          if (isRequired && subFields.length === 1) {
-                            return;
-                          }
-                          subOpt.remove(subField.name);
-                          onData();
-                        }}
-                      />
-                    </Col>
-                  </Row>
-                );
-              })}
-              <Button
-                type='dashed'
-                onClick={() => {
-                  subOpt.add();
-                  onData();
-                }}
-                block
-                style={{ marginTop: '8px' }}
-              >
-                + <FormattedMessage id='pages.button.item.add' defaultMessage='Add' /> {label}{' '}
-                <FormattedMessage id='pages.button.item.label' defaultMessage='Item' />
-              </Button>
-            </div>
-          );
-        }}
-      </Form.List>
+    <Form.Item
+      name={name}
+      getValueProps={(value) => ({
+        value: getAnnualSupplyVolumeDisplayNumericText(value, lang),
+      })}
+      normalize={(value) =>
+        buildAnnualSupplyVolumeMultiLang(value, getSuffixForLang, annualSupplyVolumeLangs)
+      }
+      rules={fieldRules}
+      style={{ marginBottom: 0 }}
+    >
+      <InputNumber
+        controls={false}
+        inputMode='decimal'
+        onChange={() => onData()}
+        stringMode
+        style={{ width: '100%' }}
+        suffix={currentSuffix}
+      />
     </Form.Item>
   );
 };

--- a/src/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.tsx
+++ b/src/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.tsx
@@ -1,6 +1,7 @@
 import { langOptions } from '@/services/general/data';
 import { getLangText, getUnitData } from '@/services/general/util';
 import {
+  ANNUAL_SUPPLY_VOLUME_NUMERIC_TEXT_PATTERN,
   ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN,
   buildAnnualSupplyVolumeMultiLang,
   buildAnnualSupplyVolumeUnitLookupRows,
@@ -10,7 +11,7 @@ import {
 } from '@/services/processes/annualSupplyOrProductionVolume';
 import type { ProcessExchangeData } from '@/services/processes/data';
 import type { ProFormInstance } from '@ant-design/pro-components';
-import { Form, InputNumber } from 'antd';
+import { Form, Input, InputNumber, Space } from 'antd';
 import type { FC, ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'umi';
@@ -130,9 +131,13 @@ const AnnualSupplyOrProductionVolumeForm: FC<Props> = ({
             );
             const isAnnualSupplyVolumeValid =
               normalizedValues.length > 0 &&
-              normalizedValues.every((item) =>
-                ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN.test(String(item['#text']).trim()),
-              );
+              normalizedValues.every((item) => {
+                const pattern = getSuffixForLang(item['@xml:lang']).trim()
+                  ? ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN
+                  : ANNUAL_SUPPLY_VOLUME_NUMERIC_TEXT_PATTERN;
+
+                return pattern.test(String(item['#text']).trim());
+              });
 
             if (!isAnnualSupplyVolumeValid) {
               setRuleErrorState?.(true);
@@ -154,25 +159,34 @@ const AnnualSupplyOrProductionVolumeForm: FC<Props> = ({
     : [];
 
   return (
-    <Form.Item
-      name={name}
-      getValueProps={(value) => ({
-        value: getAnnualSupplyVolumeDisplayNumericText(value, lang),
-      })}
-      normalize={(value) =>
-        buildAnnualSupplyVolumeMultiLang(value, getSuffixForLang, annualSupplyVolumeLangs)
-      }
-      rules={fieldRules}
-      style={{ marginBottom: 0 }}
-    >
-      <InputNumber
-        controls={false}
-        inputMode='decimal'
-        onChange={() => onData()}
-        stringMode
-        style={{ width: '100%' }}
-        suffix={currentSuffix}
-      />
+    <Form.Item style={{ marginBottom: 0 }}>
+      <Space.Compact block>
+        <Form.Item
+          name={name}
+          getValueProps={(value) => ({
+            value: getAnnualSupplyVolumeDisplayNumericText(value, lang),
+          })}
+          normalize={(value) =>
+            buildAnnualSupplyVolumeMultiLang(value, getSuffixForLang, annualSupplyVolumeLangs)
+          }
+          noStyle
+          rules={fieldRules}
+        >
+          <InputNumber
+            controls={false}
+            inputMode='decimal'
+            onChange={() => onData()}
+            stringMode
+            style={{ width: '50%' }}
+          />
+        </Form.Item>
+        <Input
+          aria-label='annual-supply-volume-context'
+          readOnly
+          style={{ width: '50%' }}
+          value={currentSuffix}
+        />
+      </Space.Compact>
     </Form.Item>
   );
 };

--- a/src/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.tsx
+++ b/src/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.tsx
@@ -6,11 +6,12 @@ import {
   formatAnnualSupplyVolumeText,
   normalizeAnnualSupplyVolumeMultiLang,
   parseAnnualSupplyVolumeText,
+  sanitizeAnnualSupplyVolumeNumericInput,
 } from '@/services/processes/annualSupplyOrProductionVolume';
 import type { ProcessExchangeData } from '@/services/processes/data';
 import { CloseOutlined } from '@ant-design/icons';
 import type { ProFormInstance } from '@ant-design/pro-components';
-import { Button, Col, Form, Input, Row, Select, message } from 'antd';
+import { Button, Col, Form, InputNumber, Row, Select, message } from 'antd';
 import type { FC, ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
@@ -237,15 +238,20 @@ const AnnualSupplyOrProductionVolumeForm: FC<Props> = ({
                       <Form.Item
                         name={[subField.name, '#text']}
                         getValueProps={(value) => ({
-                          value: parseAnnualSupplyVolumeText(value).numericText,
+                          value: sanitizeAnnualSupplyVolumeNumericInput(
+                            parseAnnualSupplyVolumeText(value).numericText,
+                          ),
                         })}
                         normalize={(value) => formatAnnualSupplyVolumeText(value, currentSuffix)}
                         rules={textRules}
                         style={{ marginBottom: 0 }}
                       >
-                        <Input
+                        <InputNumber
+                          controls={false}
                           inputMode='decimal'
                           onChange={() => onData()}
+                          stringMode
+                          style={{ width: '100%' }}
                           suffix={currentSuffix}
                         />
                       </Form.Item>

--- a/src/pages/Processes/Components/Exchange/create.tsx
+++ b/src/pages/Processes/Components/Exchange/create.tsx
@@ -1,4 +1,5 @@
 import LangTextItemForm from '@/components/LangTextItem/form';
+import LocationCodeSelect from '@/components/LocationTextItem/codeSelect';
 import ToolBarButton from '@/components/ToolBarButton';
 import UnitConvert from '@/components/UnitConvert';
 import { UnitsContext } from '@/contexts/unitContext';
@@ -6,6 +7,7 @@ import FlowsSelectForm from '@/pages/Flows/Components/select/form';
 import SourceSelectForm from '@/pages/Sources/Components/select/form';
 import { getRules } from '@/pages/Utils';
 import { ProcessExchangeData } from '@/services/processes/data';
+import { normalizeExchangeLocationCode } from '@/services/processes/exchangeLocation';
 import styles from '@/style/custom.less';
 import { CaretRightOutlined, CloseOutlined, PlusOutlined } from '@ant-design/icons';
 import { ProForm, ProFormInstance } from '@ant-design/pro-components';
@@ -39,6 +41,14 @@ type Props = {
   showRules?: boolean;
   disabled?: boolean;
 };
+
+const normalizeExchangeFormData = (exchangeData: ProcessExchangeData): ProcessExchangeData => {
+  const { location, ...rest } = exchangeData;
+  const normalizedLocation = normalizeExchangeLocationCode(location);
+
+  return normalizedLocation ? { ...rest, location: normalizedLocation } : rest;
+};
+
 const ProcessExchangeCreate: FC<Props> = ({
   direction,
   lang,
@@ -150,7 +160,7 @@ const ProcessExchangeCreate: FC<Props> = ({
             },
           }}
           onFinish={async () => {
-            onData({ ...fromData });
+            onData(normalizeExchangeFormData({ ...fromData }));
             formRefCreate.current?.resetFields();
             setDrawerVisible(false);
             return true;
@@ -221,7 +231,7 @@ const ProcessExchangeCreate: FC<Props> = ({
               }
               name={'location'}
             >
-              <Input />
+              <LocationCodeSelect lang={lang} />
             </Form.Item>
             <Form.Item
               label={

--- a/src/pages/Processes/Components/Exchange/edit.tsx
+++ b/src/pages/Processes/Components/Exchange/edit.tsx
@@ -1,4 +1,5 @@
 import LangTextItemForm from '@/components/LangTextItem/form';
+import LocationCodeSelect from '@/components/LocationTextItem/codeSelect';
 import UnitConvert from '@/components/UnitConvert';
 import { UnitsContext } from '@/contexts/unitContext';
 import FlowsSelectForm from '@/pages/Flows/Components/select/form';
@@ -6,6 +7,7 @@ import SourceSelectForm from '@/pages/Sources/Components/select/form';
 import { getRules } from '@/pages/Utils';
 import type { ValidationIssueSdkDetail } from '@/pages/Utils/review';
 import { ProcessExchangeData } from '@/services/processes/data';
+import { normalizeExchangeLocationCode } from '@/services/processes/exchangeLocation';
 import styles from '@/style/custom.less';
 import { CaretRightOutlined, CloseOutlined, FormOutlined } from '@ant-design/icons';
 import { ProForm, ProFormInstance } from '@ant-design/pro-components';
@@ -61,11 +63,17 @@ const normalizeExchangeAmountValue = (value: string | number | null | undefined)
   return value;
 };
 
-const normalizeExchangeFormData = (exchangeData: ProcessExchangeData): ProcessExchangeData => ({
-  ...exchangeData,
-  meanAmount: normalizeExchangeAmountValue(exchangeData?.meanAmount),
-  resultingAmount: normalizeExchangeAmountValue(exchangeData?.resultingAmount),
-});
+const normalizeExchangeFormData = (exchangeData: ProcessExchangeData): ProcessExchangeData => {
+  const { location, ...rest } = exchangeData;
+  const normalizedLocation = normalizeExchangeLocationCode(location);
+
+  return {
+    ...rest,
+    ...(normalizedLocation ? { location: normalizedLocation } : {}),
+    meanAmount: normalizeExchangeAmountValue(exchangeData?.meanAmount),
+    resultingAmount: normalizeExchangeAmountValue(exchangeData?.resultingAmount),
+  };
+};
 
 const normalizeQuantitativeReferenceSelection = (
   exchangeData: ProcessExchangeData[],
@@ -419,10 +427,11 @@ const ProcessExchangeEdit: FC<Props> = ({
             },
           }}
           onFinish={async () => {
+            const nextFormData = normalizeExchangeFormData({ ...fromData });
             const nextExchangeData = normalizeQuantitativeReferenceSelection(
               data.map((item) => {
                 if (item['@dataSetInternalID'] === id) {
-                  return fromData;
+                  return nextFormData;
                 }
                 return item;
               }),
@@ -516,7 +525,7 @@ const ProcessExchangeEdit: FC<Props> = ({
                 }
                 name={'location'}
               >
-                <Input />
+                <LocationCodeSelect lang={lang} />
               </Form.Item>,
             )}
             {renderSdkHighlightedField(

--- a/src/pages/Processes/Components/form.tsx
+++ b/src/pages/Processes/Components/form.tsx
@@ -33,6 +33,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type FC } from 'reac
 import { FormattedMessage, useIntl } from 'umi';
 import schema from '../processes_schema.json';
 import { getSdkSuggestedFixMessage, resolveRequiredValidationMessage } from '../sdkValidationUi';
+import AnnualSupplyOrProductionVolumeForm from './AnnualSupplyOrProductionVolume/form';
 import ComplianceItemForm from './Compliance/form';
 import { getExchangeColumns } from './Exchange/column';
 import ProcessExchangeCreate from './Exchange/create';
@@ -291,6 +292,8 @@ export const ProcessForm: FC<Props> = ({
     setTechnologyDescriptionAndIncludedProcessesError,
   ] = useState(false);
   const [dataCutOffAndCompletenessPrinciplesError, setDataCutOffAndCompletenessPrinciplesError] =
+    useState(false);
+  const [annualSupplyOrProductionVolumeError, setAnnualSupplyOrProductionVolumeError] =
     useState(false);
   const [intendedApplicationsError, setIntendedApplicationsError] = useState(false);
   const [generalCommentError, setGeneralCommentError] = useState(false);
@@ -1848,13 +1851,18 @@ export const ProcessForm: FC<Props> = ({
           >
             <Input />
           </Form.Item>
-          <Divider orientationMargin='0' orientation='left' plain>
-            <FormattedMessage
-              id='pages.process.view.modellingAndValidation.annualSupplyOrProductionVolume'
-              defaultMessage='Annual supply or production volume'
+          <Divider className='required-divider' orientationMargin='0' orientation='left' plain>
+            <RequiredMark
+              label={
+                <FormattedMessage
+                  id='pages.process.view.modellingAndValidation.annualSupplyOrProductionVolume'
+                  defaultMessage='Annual supply or production volume'
+                />
+              }
+              showError={annualSupplyOrProductionVolumeError}
             />
           </Divider>
-          <LangTextItemForm
+          <AnnualSupplyOrProductionVolumeForm
             name={[
               'modellingAndValidation',
               'dataSourcesTreatmentAndRepresentativeness',
@@ -1866,6 +1874,20 @@ export const ProcessForm: FC<Props> = ({
                 defaultMessage='Annual supply or production volume'
               />
             }
+            lang={lang}
+            formRef={formRef}
+            onData={onData}
+            exchangeDataSource={exchangeDataSource}
+            rules={
+              showRules
+                ? getRules(
+                    schema['processDataSet']['modellingAndValidation'][
+                      'dataSourcesTreatmentAndRepresentativeness'
+                    ]['annualSupplyOrProductionVolume']['rules'],
+                  )
+                : []
+            }
+            setRuleErrorState={setAnnualSupplyOrProductionVolumeError}
           />
 
           <Divider orientationMargin='0' orientation='left' plain>

--- a/src/pages/Processes/Components/form.tsx
+++ b/src/pages/Processes/Components/form.tsx
@@ -293,8 +293,6 @@ export const ProcessForm: FC<Props> = ({
   ] = useState(false);
   const [dataCutOffAndCompletenessPrinciplesError, setDataCutOffAndCompletenessPrinciplesError] =
     useState(false);
-  const [annualSupplyOrProductionVolumeError, setAnnualSupplyOrProductionVolumeError] =
-    useState(false);
   const [intendedApplicationsError, setIntendedApplicationsError] = useState(false);
   const [generalCommentError, setGeneralCommentError] = useState(false);
 
@@ -1859,7 +1857,7 @@ export const ProcessForm: FC<Props> = ({
                   defaultMessage='Annual supply or production volume'
                 />
               }
-              showError={annualSupplyOrProductionVolumeError}
+              showError={false}
             />
           </Divider>
           <AnnualSupplyOrProductionVolumeForm
@@ -1887,7 +1885,6 @@ export const ProcessForm: FC<Props> = ({
                   )
                 : []
             }
-            setRuleErrorState={setAnnualSupplyOrProductionVolumeError}
           />
 
           <Divider orientationMargin='0' orientation='left' plain>

--- a/src/pages/Processes/processes_schema.json
+++ b/src/pages/Processes/processes_schema.json
@@ -459,12 +459,21 @@
           ]
         },
         "percentageSupplyOrProductionCovered": "str",
-        "annualSupplyOrProductionVolume": [
-          {
-            "@xml:lang": "str",
-            "#text": "str"
-          }
-        ],
+        "annualSupplyOrProductionVolume": {
+          "value": [
+            {
+              "@xml:lang": "str",
+              "#text": "str"
+            }
+          ],
+          "rules": [
+            {
+              "required": true,
+              "messageKey": "pages.process.validator.annualSupplyOrProductionVolume.required",
+              "defaultMessage": "Please input annual supply or production volume"
+            }
+          ]
+        },
         "samplingProcedure": [
           {
             "@xml:lang": "str",

--- a/src/pages/Processes/requiredFields.ts
+++ b/src/pages/Processes/requiredFields.ts
@@ -18,6 +18,8 @@ const requiredFields = {
     'modellingAndValidation',
   'modellingAndValidation.dataSourcesTreatmentAndRepresentativeness.referenceToDataSource':
     'modellingAndValidation',
+  'modellingAndValidation.dataSourcesTreatmentAndRepresentativeness.annualSupplyOrProductionVolume':
+    'modellingAndValidation',
 
   'administrativeInformation.common:commissionerAndGoal.common:referenceToCommissioner':
     'administrativeInformation',

--- a/src/pages/Processes/sdkValidation.ts
+++ b/src/pages/Processes/sdkValidation.ts
@@ -54,6 +54,7 @@ const PROCESS_REQUIRED_LANG_TEXT_FIELDS = new Set<string>([
   'processInformation.dataSetInformation.common:generalComment',
   'processInformation.technology.technologyDescriptionAndIncludedProcesses',
   'modellingAndValidation.dataSourcesTreatmentAndRepresentativeness.dataCutOffAndCompletenessPrinciples',
+  'modellingAndValidation.dataSourcesTreatmentAndRepresentativeness.annualSupplyOrProductionVolume',
   'administrativeInformation.common:commissionerAndGoal.common:intendedApplications',
 ]);
 

--- a/src/pages/Processes/sdkValidationUi.ts
+++ b/src/pages/Processes/sdkValidationUi.ts
@@ -44,6 +44,7 @@ const PROCESS_LOCAL_REQUIRED_LANG_TEXT_FIELDS = new Set<string>([
   'processInformation.dataSetInformation.common:generalComment',
   'processInformation.technology.technologyDescriptionAndIncludedProcesses',
   'modellingAndValidation.dataSourcesTreatmentAndRepresentativeness.dataCutOffAndCompletenessPrinciples',
+  'modellingAndValidation.dataSourcesTreatmentAndRepresentativeness.annualSupplyOrProductionVolume',
   'administrativeInformation.common:commissionerAndGoal.common:intendedApplications',
 ]);
 

--- a/src/services/processes/annualSupplyOrProductionVolume.ts
+++ b/src/services/processes/annualSupplyOrProductionVolume.ts
@@ -6,6 +6,9 @@ export const ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN = /^[+-]?(\d+(\.\d*)?|\.\d+)([Ee]
 
 const ANNUAL_SUPPLY_VOLUME_NUMBER_PREFIX_PATTERN =
   /^\s*([+-]?(\d+(\.\d*)?|\.\d+)([Ee][+-]?\d+)?)(?:\s+(.*))?$/;
+const ANNUAL_SUPPLY_VOLUME_NUMERIC_INPUT_PREFIX_PATTERN =
+  /^[+-]?(?:$|\d+(?:\.\d*)?(?:[Ee][+-]?\d*)?|\.\d+(?:[Ee][+-]?\d*)?|\.\d*)$/;
+const ANNUAL_SUPPLY_VOLUME_NUMERIC_INPUT_ALLOWED_PATTERN = /[\d.+\-Ee]/;
 
 type LangTextResolver = (value: unknown, lang: string) => string;
 
@@ -90,8 +93,24 @@ export const parseAnnualSupplyVolumeText = (value: unknown): AnnualSupplyVolumeT
 export const normalizeAnnualSupplyVolumeSuffix = (suffix: unknown) =>
   normalizeText(suffix) || ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX;
 
+export const sanitizeAnnualSupplyVolumeNumericInput = (value: unknown) => {
+  const text = typeof value === 'string' ? value.trim() : '';
+
+  return Array.from(text).reduce((sanitizedText, character) => {
+    if (!ANNUAL_SUPPLY_VOLUME_NUMERIC_INPUT_ALLOWED_PATTERN.test(character)) {
+      return sanitizedText;
+    }
+
+    const nextText = `${sanitizedText}${character}`;
+
+    return ANNUAL_SUPPLY_VOLUME_NUMERIC_INPUT_PREFIX_PATTERN.test(nextText)
+      ? nextText
+      : sanitizedText;
+  }, '');
+};
+
 export const formatAnnualSupplyVolumeText = (numericText: unknown, suffix: unknown) => {
-  const normalizedNumericText = typeof numericText === 'string' ? numericText.trim() : '';
+  const normalizedNumericText = sanitizeAnnualSupplyVolumeNumericInput(numericText);
 
   if (!normalizedNumericText) {
     return '';

--- a/src/services/processes/annualSupplyOrProductionVolume.ts
+++ b/src/services/processes/annualSupplyOrProductionVolume.ts
@@ -1,6 +1,7 @@
 import type { ProcessExchangeData, ProcessRefUnitDisplay } from './data';
 
 export const ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX = 'reference flow';
+const ANNUAL_SUPPLY_VOLUME_DEFAULT_LANGS = ['en', 'zh'];
 
 export const ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN = /^[+-]?(\d+(\.\d*)?|\.\d+)([Ee][+-]?\d+)?\s+\S.*$/;
 
@@ -181,6 +182,56 @@ export const normalizeAnnualSupplyVolumeMultiLang = (
   }
 
   return normalizeItem(value);
+};
+
+const getAnnualSupplyVolumeTextForLang = (value: unknown, lang: string) => {
+  if (Array.isArray(value)) {
+    const valueItems = value.filter(
+      (item): item is Record<string, unknown> => !!item && typeof item === 'object',
+    );
+    const langItem =
+      valueItems.find((item) => item['@xml:lang'] === lang) ??
+      valueItems.find((item) => item['@xml:lang'] === 'en') ??
+      valueItems.find((item) => normalizeText(item['#text'])) ??
+      valueItems[0];
+
+    return langItem ? langItem['#text'] : undefined;
+  }
+
+  if (value && typeof value === 'object') {
+    return (value as Record<string, unknown>)['#text'];
+  }
+
+  return value;
+};
+
+export const getAnnualSupplyVolumeDisplayNumericText = (value: unknown, lang: string) => {
+  const { numericText } = parseAnnualSupplyVolumeText(
+    getAnnualSupplyVolumeTextForLang(value, lang),
+  );
+  return sanitizeAnnualSupplyVolumeNumericInput(numericText);
+};
+
+export const buildAnnualSupplyVolumeMultiLang = (
+  numericValue: unknown,
+  suffixResolver: string | ((lang: string) => string),
+  languages = ANNUAL_SUPPLY_VOLUME_DEFAULT_LANGS,
+) => {
+  const { numericText } = parseAnnualSupplyVolumeText(numericValue);
+  const normalizedNumericText = sanitizeAnnualSupplyVolumeNumericInput(numericText);
+
+  if (!normalizedNumericText) {
+    return [];
+  }
+
+  return uniqueNonEmpty(languages).map((lang) => {
+    const suffix = typeof suffixResolver === 'function' ? suffixResolver(lang) : suffixResolver;
+
+    return {
+      '@xml:lang': lang,
+      '#text': formatAnnualSupplyVolumeText(normalizedNumericText, suffix),
+    };
+  });
 };
 
 export const getQuantitativeReferenceExchange = (exchangeDataSource: ProcessExchangeData[]) => {

--- a/src/services/processes/annualSupplyOrProductionVolume.ts
+++ b/src/services/processes/annualSupplyOrProductionVolume.ts
@@ -272,13 +272,7 @@ export const buildAnnualSupplyVolumeMultiLang = (
 };
 
 export const getQuantitativeReferenceExchange = (exchangeDataSource: ProcessExchangeData[]) => {
-  return (
-    exchangeDataSource.find((exchange) => exchange?.quantitativeReference === true) ??
-    exchangeDataSource.find(
-      (exchange) => normalizeText(exchange?.exchangeDirection).toLowerCase() === 'output',
-    ) ??
-    exchangeDataSource[0]
-  );
+  return exchangeDataSource.find((exchange) => exchange?.quantitativeReference === true);
 };
 
 export const buildAnnualSupplyVolumeUnitLookupRows = (

--- a/src/services/processes/annualSupplyOrProductionVolume.ts
+++ b/src/services/processes/annualSupplyOrProductionVolume.ts
@@ -74,12 +74,12 @@ export const parseAnnualSupplyVolumeText = (value: unknown): AnnualSupplyVolumeT
 
   if (matched) {
     return {
-      numericText: matched[1] ?? '',
+      numericText: matched[1],
       suffixText: normalizeText(matched[5]),
     };
   }
 
-  const [numericText = '', ...suffixParts] = text.split(/\s+/);
+  const [numericText, ...suffixParts] = text.split(/\s+/);
 
   return {
     numericText,

--- a/src/services/processes/annualSupplyOrProductionVolume.ts
+++ b/src/services/processes/annualSupplyOrProductionVolume.ts
@@ -4,6 +4,8 @@ export const ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX = 'reference flow';
 const ANNUAL_SUPPLY_VOLUME_DEFAULT_LANGS = ['en', 'zh'];
 
 export const ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN = /^[+-]?(\d+(\.\d*)?|\.\d+)([Ee][+-]?\d+)?\s+\S.*$/;
+export const ANNUAL_SUPPLY_VOLUME_NUMERIC_TEXT_PATTERN =
+  /^[+-]?(\d+(\.\d*)?|\.\d+)([Ee][+-]?\d+)?$/;
 
 const ANNUAL_SUPPLY_VOLUME_NUMBER_PREFIX_PATTERN =
   /^\s*([+-]?(\d+(\.\d*)?|\.\d+)([Ee][+-]?\d+)?)(?:\s+(.*))?$/;
@@ -16,6 +18,10 @@ type LangTextResolver = (value: unknown, lang: string) => string;
 type AnnualSupplyVolumeTextParts = {
   numericText: string;
   suffixText: string;
+};
+
+type AnnualSupplyVolumeFormatOptions = {
+  useDefaultSuffix?: boolean;
 };
 
 type AnnualSupplyVolumeUnitLookupRow = {
@@ -106,12 +112,30 @@ export const parseAnnualSupplyVolumeText = (value: unknown): AnnualSupplyVolumeT
   };
 };
 
-export const normalizeAnnualSupplyVolumeSuffix = (suffix: unknown) =>
-  normalizeText(suffix) || ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX;
+export const normalizeAnnualSupplyVolumeSuffix = (
+  suffix: unknown,
+  options: AnnualSupplyVolumeFormatOptions,
+) => {
+  const normalizedSuffix = normalizeText(suffix);
 
-const resolveAnnualSupplyVolumeSuffix = (existingSuffix: unknown, suffix: unknown) => {
+  if (normalizedSuffix || options.useDefaultSuffix === false) {
+    return normalizedSuffix;
+  }
+
+  return ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX;
+};
+
+const resolveAnnualSupplyVolumeSuffix = (
+  existingSuffix: unknown,
+  suffix: unknown,
+  options: AnnualSupplyVolumeFormatOptions,
+) => {
   const normalizedExistingSuffix = normalizeText(existingSuffix);
-  const normalizedSuffix = normalizeAnnualSupplyVolumeSuffix(suffix);
+  const normalizedSuffix = normalizeAnnualSupplyVolumeSuffix(suffix, options);
+
+  if (!normalizedSuffix) {
+    return '';
+  }
 
   if (
     normalizedExistingSuffix &&
@@ -140,27 +164,39 @@ export const sanitizeAnnualSupplyVolumeNumericInput = (value: unknown) => {
   }, '');
 };
 
-export const formatAnnualSupplyVolumeText = (numericText: unknown, suffix: unknown) => {
+export const formatAnnualSupplyVolumeText = (
+  numericText: unknown,
+  suffix: unknown,
+  options: AnnualSupplyVolumeFormatOptions = {},
+) => {
   const normalizedNumericText = sanitizeAnnualSupplyVolumeNumericInput(numericText);
 
   if (!normalizedNumericText) {
     return '';
   }
 
-  return `${normalizedNumericText} ${normalizeAnnualSupplyVolumeSuffix(suffix)}`;
+  const normalizedSuffix = normalizeAnnualSupplyVolumeSuffix(suffix, options);
+
+  return normalizedSuffix ? `${normalizedNumericText} ${normalizedSuffix}` : normalizedNumericText;
 };
 
-export const normalizeAnnualSupplyVolumeText = (value: unknown, suffix: unknown) => {
+export const normalizeAnnualSupplyVolumeText = (
+  value: unknown,
+  suffix: unknown,
+  options: AnnualSupplyVolumeFormatOptions = {},
+) => {
   const { numericText, suffixText } = parseAnnualSupplyVolumeText(value);
   return formatAnnualSupplyVolumeText(
     numericText,
-    resolveAnnualSupplyVolumeSuffix(suffixText, suffix),
+    resolveAnnualSupplyVolumeSuffix(suffixText, suffix, options),
+    options,
   );
 };
 
 export const normalizeAnnualSupplyVolumeMultiLang = (
   value: unknown,
   suffixResolver: string | ((item: Record<string, unknown>) => string),
+  options: AnnualSupplyVolumeFormatOptions = {},
 ) => {
   const normalizeItem = (item: unknown) => {
     if (!item || typeof item !== 'object') {
@@ -173,7 +209,7 @@ export const normalizeAnnualSupplyVolumeMultiLang = (
 
     return {
       ...itemRecord,
-      '#text': normalizeAnnualSupplyVolumeText(itemRecord['#text'], suffix),
+      '#text': normalizeAnnualSupplyVolumeText(itemRecord['#text'], suffix, options),
     };
   };
 
@@ -216,6 +252,7 @@ export const buildAnnualSupplyVolumeMultiLang = (
   numericValue: unknown,
   suffixResolver: string | ((lang: string) => string),
   languages = ANNUAL_SUPPLY_VOLUME_DEFAULT_LANGS,
+  options: AnnualSupplyVolumeFormatOptions = { useDefaultSuffix: false },
 ) => {
   const { numericText } = parseAnnualSupplyVolumeText(numericValue);
   const normalizedNumericText = sanitizeAnnualSupplyVolumeNumericInput(numericText);
@@ -229,7 +266,7 @@ export const buildAnnualSupplyVolumeMultiLang = (
 
     return {
       '@xml:lang': lang,
-      '#text': formatAnnualSupplyVolumeText(normalizedNumericText, suffix),
+      '#text': formatAnnualSupplyVolumeText(normalizedNumericText, suffix, options),
     };
   });
 };
@@ -308,6 +345,10 @@ export const deriveAnnualSupplyVolumeSuffix = ({
 }) => {
   const quantitativeReferenceExchange = getQuantitativeReferenceExchange(exchangeDataSource);
   const referenceFlow = toReferenceValue(quantitativeReferenceExchange?.referenceToFlowDataSet);
+  if (!referenceFlow) {
+    return '';
+  }
+
   const refUnitRes = quantitativeReferenceExchange?.refUnitRes as ProcessRefUnitDisplay | undefined;
   const unitName =
     normalizeText(refUnitRes?.refUnitName) || normalizeText(getLangText(refUnitRes?.name, lang));
@@ -319,5 +360,5 @@ export const deriveAnnualSupplyVolumeSuffix = ({
   );
   const suffixParts = uniqueNonEmpty([unitName, contextText || referenceFlowName]);
 
-  return suffixParts.join(' ') || ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX;
+  return suffixParts.join(' ');
 };

--- a/src/services/processes/annualSupplyOrProductionVolume.ts
+++ b/src/services/processes/annualSupplyOrProductionVolume.ts
@@ -1,4 +1,4 @@
-import type { ProcessExchangeData } from './data';
+import type { ProcessExchangeData, ProcessRefUnitDisplay } from './data';
 
 export const ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX = 'reference flow';
 
@@ -17,11 +17,26 @@ type AnnualSupplyVolumeTextParts = {
   suffixText: string;
 };
 
+type AnnualSupplyVolumeUnitLookupRow = {
+  referenceToFlowDataSetId?: unknown;
+  referenceToFlowDataSetVersion?: unknown;
+  refUnitRes?: ProcessRefUnitDisplay;
+};
+
 const normalizeText = (value: unknown) =>
   typeof value === 'string' && value.trim() && value.trim() !== '-' ? value.trim() : '';
 
 const toReferenceValue = (reference?: ProcessExchangeData['referenceToFlowDataSet']) => {
   return Array.isArray(reference) ? reference[0] : reference;
+};
+
+const getReferenceFlowIdentity = (exchange?: ProcessExchangeData) => {
+  const referenceFlow = toReferenceValue(exchange?.referenceToFlowDataSet);
+
+  return {
+    id: normalizeText(referenceFlow?.['@refObjectId']),
+    version: normalizeText(referenceFlow?.['@version']),
+  };
 };
 
 const getFallbackLangText = (value: unknown, lang: string): string => {
@@ -93,6 +108,21 @@ export const parseAnnualSupplyVolumeText = (value: unknown): AnnualSupplyVolumeT
 export const normalizeAnnualSupplyVolumeSuffix = (suffix: unknown) =>
   normalizeText(suffix) || ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX;
 
+const resolveAnnualSupplyVolumeSuffix = (existingSuffix: unknown, suffix: unknown) => {
+  const normalizedExistingSuffix = normalizeText(existingSuffix);
+  const normalizedSuffix = normalizeAnnualSupplyVolumeSuffix(suffix);
+
+  if (
+    normalizedExistingSuffix &&
+    normalizedExistingSuffix !== normalizedSuffix &&
+    normalizedExistingSuffix.endsWith(` ${normalizedSuffix}`)
+  ) {
+    return normalizedExistingSuffix;
+  }
+
+  return normalizedSuffix;
+};
+
 export const sanitizeAnnualSupplyVolumeNumericInput = (value: unknown) => {
   const text = typeof value === 'string' ? value.trim() : '';
 
@@ -120,8 +150,11 @@ export const formatAnnualSupplyVolumeText = (numericText: unknown, suffix: unkno
 };
 
 export const normalizeAnnualSupplyVolumeText = (value: unknown, suffix: unknown) => {
-  const { numericText } = parseAnnualSupplyVolumeText(value);
-  return formatAnnualSupplyVolumeText(numericText, suffix);
+  const { numericText, suffixText } = parseAnnualSupplyVolumeText(value);
+  return formatAnnualSupplyVolumeText(
+    numericText,
+    resolveAnnualSupplyVolumeSuffix(suffixText, suffix),
+  );
 };
 
 export const normalizeAnnualSupplyVolumeMultiLang = (
@@ -160,6 +193,59 @@ export const getQuantitativeReferenceExchange = (exchangeDataSource: ProcessExch
   );
 };
 
+export const buildAnnualSupplyVolumeUnitLookupRows = (
+  exchangeDataSource: ProcessExchangeData[],
+): AnnualSupplyVolumeUnitLookupRow[] => {
+  if (!Array.isArray(exchangeDataSource)) {
+    return [];
+  }
+
+  return exchangeDataSource.map((exchange) => {
+    const { id, version } = getReferenceFlowIdentity(exchange);
+
+    return {
+      referenceToFlowDataSetId: id,
+      referenceToFlowDataSetVersion: version,
+    };
+  });
+};
+
+export const mergeAnnualSupplyVolumeUnitRows = (
+  exchangeDataSource: ProcessExchangeData[],
+  unitRows: unknown,
+) => {
+  if (!Array.isArray(exchangeDataSource)) {
+    return [];
+  }
+
+  const normalizedUnitRows = Array.isArray(unitRows)
+    ? (unitRows as AnnualSupplyVolumeUnitLookupRow[])
+    : [];
+
+  return exchangeDataSource.map((exchange) => {
+    const { id, version } = getReferenceFlowIdentity(exchange);
+    const unitRow =
+      normalizedUnitRows.find((row) => {
+        const rowId = normalizeText(row?.referenceToFlowDataSetId);
+        const rowVersion = normalizeText(row?.referenceToFlowDataSetVersion);
+
+        return rowId === id && rowVersion === version;
+      }) ??
+      normalizedUnitRows.find((row) => {
+        return normalizeText(row?.referenceToFlowDataSetId) === id;
+      });
+
+    if (!unitRow?.refUnitRes) {
+      return exchange;
+    }
+
+    return {
+      ...exchange,
+      refUnitRes: unitRow.refUnitRes,
+    };
+  });
+};
+
 export const deriveAnnualSupplyVolumeSuffix = ({
   exchangeDataSource,
   getLangText = getFallbackLangText,
@@ -171,10 +257,9 @@ export const deriveAnnualSupplyVolumeSuffix = ({
 }) => {
   const quantitativeReferenceExchange = getQuantitativeReferenceExchange(exchangeDataSource);
   const referenceFlow = toReferenceValue(quantitativeReferenceExchange?.referenceToFlowDataSet);
-  const unitName = normalizeText(
-    (quantitativeReferenceExchange?.refUnitRes as { refUnitName?: unknown } | undefined)
-      ?.refUnitName,
-  );
+  const refUnitRes = quantitativeReferenceExchange?.refUnitRes as ProcessRefUnitDisplay | undefined;
+  const unitName =
+    normalizeText(refUnitRes?.refUnitName) || normalizeText(getLangText(refUnitRes?.name, lang));
   const referenceFlowName = normalizeText(
     getLangText(referenceFlow?.['common:shortDescription'], lang),
   );

--- a/src/services/processes/annualSupplyOrProductionVolume.ts
+++ b/src/services/processes/annualSupplyOrProductionVolume.ts
@@ -1,0 +1,168 @@
+import type { ProcessExchangeData } from './data';
+
+export const ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX = 'reference flow';
+
+export const ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN = /^[+-]?(\d+(\.\d*)?|\.\d+)([Ee][+-]?\d+)?\s+\S.*$/;
+
+const ANNUAL_SUPPLY_VOLUME_NUMBER_PREFIX_PATTERN =
+  /^\s*([+-]?(\d+(\.\d*)?|\.\d+)([Ee][+-]?\d+)?)(?:\s+(.*))?$/;
+
+type LangTextResolver = (value: unknown, lang: string) => string;
+
+type AnnualSupplyVolumeTextParts = {
+  numericText: string;
+  suffixText: string;
+};
+
+const normalizeText = (value: unknown) =>
+  typeof value === 'string' && value.trim() && value.trim() !== '-' ? value.trim() : '';
+
+const toReferenceValue = (reference?: ProcessExchangeData['referenceToFlowDataSet']) => {
+  return Array.isArray(reference) ? reference[0] : reference;
+};
+
+const getFallbackLangText = (value: unknown, lang: string): string => {
+  if (!value) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return normalizeText(value);
+  }
+
+  if (Array.isArray(value)) {
+    const localizedItem =
+      value.find((item) => item?.['@xml:lang'] === lang) ??
+      value.find((item) => normalizeText(item?.['#text']));
+
+    return normalizeText(localizedItem?.['#text']);
+  }
+
+  if (typeof value === 'object') {
+    return normalizeText((value as Record<string, unknown>)['#text']);
+  }
+
+  return '';
+};
+
+const uniqueNonEmpty = (values: string[]) => {
+  const seen = new Set<string>();
+
+  return values.filter((value) => {
+    const normalizedValue = normalizeText(value);
+
+    if (!normalizedValue || seen.has(normalizedValue)) {
+      return false;
+    }
+
+    seen.add(normalizedValue);
+    return true;
+  });
+};
+
+export const parseAnnualSupplyVolumeText = (value: unknown): AnnualSupplyVolumeTextParts => {
+  const text = normalizeText(value);
+
+  if (!text) {
+    return {
+      numericText: '',
+      suffixText: '',
+    };
+  }
+
+  const matched = text.match(ANNUAL_SUPPLY_VOLUME_NUMBER_PREFIX_PATTERN);
+
+  if (matched) {
+    return {
+      numericText: matched[1] ?? '',
+      suffixText: normalizeText(matched[5]),
+    };
+  }
+
+  const [numericText = '', ...suffixParts] = text.split(/\s+/);
+
+  return {
+    numericText,
+    suffixText: normalizeText(suffixParts.join(' ')),
+  };
+};
+
+export const normalizeAnnualSupplyVolumeSuffix = (suffix: unknown) =>
+  normalizeText(suffix) || ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX;
+
+export const formatAnnualSupplyVolumeText = (numericText: unknown, suffix: unknown) => {
+  const normalizedNumericText = typeof numericText === 'string' ? numericText.trim() : '';
+
+  if (!normalizedNumericText) {
+    return '';
+  }
+
+  return `${normalizedNumericText} ${normalizeAnnualSupplyVolumeSuffix(suffix)}`;
+};
+
+export const normalizeAnnualSupplyVolumeText = (value: unknown, suffix: unknown) => {
+  const { numericText } = parseAnnualSupplyVolumeText(value);
+  return formatAnnualSupplyVolumeText(numericText, suffix);
+};
+
+export const normalizeAnnualSupplyVolumeMultiLang = (
+  value: unknown,
+  suffixResolver: string | ((item: Record<string, unknown>) => string),
+) => {
+  const normalizeItem = (item: unknown) => {
+    if (!item || typeof item !== 'object') {
+      return item;
+    }
+
+    const itemRecord = item as Record<string, unknown>;
+    const suffix =
+      typeof suffixResolver === 'function' ? suffixResolver(itemRecord) : suffixResolver;
+
+    return {
+      ...itemRecord,
+      '#text': normalizeAnnualSupplyVolumeText(itemRecord['#text'], suffix),
+    };
+  };
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeItem);
+  }
+
+  return normalizeItem(value);
+};
+
+export const getQuantitativeReferenceExchange = (exchangeDataSource: ProcessExchangeData[]) => {
+  return (
+    exchangeDataSource.find((exchange) => exchange?.quantitativeReference === true) ??
+    exchangeDataSource.find(
+      (exchange) => normalizeText(exchange?.exchangeDirection).toLowerCase() === 'output',
+    ) ??
+    exchangeDataSource[0]
+  );
+};
+
+export const deriveAnnualSupplyVolumeSuffix = ({
+  exchangeDataSource,
+  getLangText = getFallbackLangText,
+  lang,
+}: {
+  exchangeDataSource: ProcessExchangeData[];
+  getLangText?: LangTextResolver;
+  lang: string;
+}) => {
+  const quantitativeReferenceExchange = getQuantitativeReferenceExchange(exchangeDataSource);
+  const referenceFlow = toReferenceValue(quantitativeReferenceExchange?.referenceToFlowDataSet);
+  const unitName = normalizeText(
+    (quantitativeReferenceExchange?.refUnitRes as { refUnitName?: unknown } | undefined)
+      ?.refUnitName,
+  );
+  const referenceFlowName = normalizeText(
+    getLangText(referenceFlow?.['common:shortDescription'], lang),
+  );
+  const contextText = normalizeText(
+    getLangText(quantitativeReferenceExchange?.functionalUnitOrOther, lang),
+  );
+  const suffixParts = uniqueNonEmpty([unitName, contextText || referenceFlowName]);
+
+  return suffixParts.join(' ') || ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX;
+};

--- a/src/services/processes/exchangeLocation.ts
+++ b/src/services/processes/exchangeLocation.ts
@@ -1,0 +1,31 @@
+export const normalizeExchangeLocationCode = (value: unknown): string | undefined => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number') {
+    const normalizedValue = `${value}`.trim();
+    return normalizedValue || undefined;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const normalizedValue = normalizeExchangeLocationCode(item);
+      if (normalizedValue) {
+        return normalizedValue;
+      }
+    }
+    return undefined;
+  }
+
+  if (typeof value === 'object') {
+    const locationValue = value as Record<string, unknown>;
+    return (
+      normalizeExchangeLocationCode(locationValue['#text']) ??
+      normalizeExchangeLocationCode(locationValue['@value']) ??
+      normalizeExchangeLocationCode(locationValue.value)
+    );
+  }
+
+  return undefined;
+};

--- a/src/services/processes/util.ts
+++ b/src/services/processes/util.ts
@@ -56,11 +56,14 @@ export function genProcessJsonOrdered(id: string, data: any) {
   let quantitativeReference = {};
   const exchangeList = jsonToList(data?.exchanges?.exchange);
   const normalizeAnnualSupplyOrProductionVolume = (value: unknown) =>
-    normalizeAnnualSupplyVolumeMultiLang(value, (item) =>
-      deriveAnnualSupplyVolumeSuffix({
-        exchangeDataSource: exchangeList,
-        lang: typeof item?.['@xml:lang'] === 'string' ? item['@xml:lang'] : 'en',
-      }),
+    normalizeAnnualSupplyVolumeMultiLang(
+      value,
+      (item) =>
+        deriveAnnualSupplyVolumeSuffix({
+          exchangeDataSource: exchangeList,
+          lang: typeof item?.['@xml:lang'] === 'string' ? item['@xml:lang'] : 'en',
+        }),
+      { useDefaultSuffix: false },
     );
   const exchange = exchangeList.map((item: any) => {
     if (item?.quantitativeReference === true) {

--- a/src/services/processes/util.ts
+++ b/src/services/processes/util.ts
@@ -15,6 +15,10 @@ import {
   removeEmptyObjects,
   toAmountNumber,
 } from '../general/util';
+import {
+  deriveAnnualSupplyVolumeSuffix,
+  normalizeAnnualSupplyVolumeMultiLang,
+} from './annualSupplyOrProductionVolume';
 
 const normalizeExchangeAmountValue = (value: string | number | null | undefined) => {
   if (value === null || value === undefined || value === 'undefined') {
@@ -51,6 +55,13 @@ const normalizeReferenceYearValue = (value: string | number | null | undefined) 
 export function genProcessJsonOrdered(id: string, data: any) {
   let quantitativeReference = {};
   const exchangeList = jsonToList(data?.exchanges?.exchange);
+  const normalizeAnnualSupplyOrProductionVolume = (value: unknown) =>
+    normalizeAnnualSupplyVolumeMultiLang(value, (item) =>
+      deriveAnnualSupplyVolumeSuffix({
+        exchangeDataSource: exchangeList,
+        lang: typeof item?.['@xml:lang'] === 'string' ? item['@xml:lang'] : 'en',
+      }),
+    );
   const exchange = exchangeList.map((item: any) => {
     if (item?.quantitativeReference === true) {
       quantitativeReference = {
@@ -400,8 +411,10 @@ export function genProcessJsonOrdered(id: string, data: any) {
             data?.modellingAndValidation?.dataSourcesTreatmentAndRepresentativeness
               ?.percentageSupplyOrProductionCovered ?? {},
           annualSupplyOrProductionVolume: getLangJson(
-            data?.modellingAndValidation?.dataSourcesTreatmentAndRepresentativeness
-              ?.annualSupplyOrProductionVolume,
+            normalizeAnnualSupplyOrProductionVolume(
+              data?.modellingAndValidation?.dataSourcesTreatmentAndRepresentativeness
+                ?.annualSupplyOrProductionVolume,
+            ),
           ),
           samplingProcedure: getLangJson(
             data?.modellingAndValidation?.dataSourcesTreatmentAndRepresentativeness

--- a/src/services/processes/util.ts
+++ b/src/services/processes/util.ts
@@ -56,14 +56,11 @@ export function genProcessJsonOrdered(id: string, data: any) {
   let quantitativeReference = {};
   const exchangeList = jsonToList(data?.exchanges?.exchange);
   const normalizeAnnualSupplyOrProductionVolume = (value: unknown) =>
-    normalizeAnnualSupplyVolumeMultiLang(
-      value,
-      (item) =>
-        deriveAnnualSupplyVolumeSuffix({
-          exchangeDataSource: exchangeList,
-          lang: typeof item?.['@xml:lang'] === 'string' ? item['@xml:lang'] : 'en',
-        }),
-      { useDefaultSuffix: false },
+    normalizeAnnualSupplyVolumeMultiLang(value, (item) =>
+      deriveAnnualSupplyVolumeSuffix({
+        exchangeDataSource: exchangeList,
+        lang: typeof item?.['@xml:lang'] === 'string' ? item['@xml:lang'] : 'en',
+      }),
     );
   const exchange = exchangeList.map((item: any) => {
     if (item?.quantitativeReference === true) {

--- a/src/services/processes/util.ts
+++ b/src/services/processes/util.ts
@@ -15,6 +15,7 @@ import {
   removeEmptyObjects,
   toAmountNumber,
 } from '../general/util';
+import { normalizeExchangeLocationCode } from './exchangeLocation';
 
 const normalizeExchangeAmountValue = (value: string | number | null | undefined) => {
   if (value === null || value === undefined || value === 'undefined') {
@@ -32,6 +33,11 @@ const toExchangeAmountString = (value: string | number | null | undefined) => {
   }
 
   return `${normalizedValue}`;
+};
+
+const getExchangeLocationField = (value: unknown) => {
+  const location = normalizeExchangeLocationCode(value);
+  return location ? { location } : {};
 };
 
 const normalizeReferenceYearValue = (value: string | number | null | undefined) => {
@@ -72,7 +78,7 @@ export function genProcessJsonOrdered(id: string, data: any) {
           item?.referenceToFlowDataSet?.['common:shortDescription'],
         ),
       },
-      location: item.location,
+      ...getExchangeLocationField(item.location),
       functionType: item.functionType,
       exchangeDirection: item.exchangeDirection,
       referenceToVariable: item.referenceToVariable,
@@ -1510,7 +1516,7 @@ export function genProcessFromData(data: any): FormProcess {
                   item?.referenceToFlowDataSet?.['common:shortDescription'],
                 ),
               },
-              location: item.location,
+              ...getExchangeLocationField(item.location),
               functionType: item.functionType,
               exchangeDirection: capitalize(item.exchangeDirection),
               referenceToVariable: item.referenceToVariable,
@@ -1560,7 +1566,7 @@ export function genProcessFromData(data: any): FormProcess {
                   item?.referenceToFlowDataSet?.['common:shortDescription'],
                 ),
               },
-              location: item.location,
+              ...getExchangeLocationField(item.location),
               functionType: item.functionType,
               exchangeDirection: capitalize(item.exchangeDirection),
               referenceToVariable: item.referenceToVariable,

--- a/tests/unit/components/LocationTextItem/codeSelect.test.tsx
+++ b/tests/unit/components/LocationTextItem/codeSelect.test.tsx
@@ -18,6 +18,7 @@ jest.mock('antd', () => ({
   __esModule: true,
   Select: ({
     allowClear,
+    filterOption,
     loading,
     onChange,
     options = [],
@@ -45,6 +46,18 @@ jest.mock('antd', () => ({
           clear
         </button>
       ) : null}
+      <span data-testid={`${dataTestId}-filter-search`}>
+        {String(filterOption?.('china', { searchText: 'CN China' }))}
+      </span>
+      <span data-testid={`${dataTestId}-filter-label`}>
+        {String(filterOption?.('global', { label: 'GLO (Global)' }))}
+      </span>
+      <span data-testid={`${dataTestId}-filter-value`}>
+        {String(filterOption?.('rer', { value: 'RER' }))}
+      </span>
+      <span data-testid={`${dataTestId}-filter-empty`}>
+        {String(filterOption?.('missing', undefined))}
+      </span>
     </div>
   ),
 }));
@@ -109,5 +122,68 @@ describe('LocationCodeSelect', () => {
     fireEvent.click(screen.getByTestId('loc-clear'));
 
     expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('ignores invalid location entries and falls back to the code when localized text is missing', async () => {
+    mockGetILCDLocationAll.mockResolvedValueOnce({
+      data: [
+        {
+          location: [{ '#text': 'Missing code' }, { '@value': 'RER' }],
+        },
+      ],
+      success: true,
+    });
+
+    render(<LocationCodeSelect lang='en' data-testid='loc' />);
+
+    await waitFor(() => {
+      expect(screen.getByText('RER')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Missing code')).not.toBeInTheDocument();
+  });
+
+  it('loads a single location object response', async () => {
+    mockGetILCDLocationAll.mockResolvedValueOnce({
+      data: [
+        {
+          location: { '@value': 'US', '#text': 'United States' },
+        },
+      ],
+      success: true,
+    });
+
+    render(<LocationCodeSelect lang='en' data-testid='loc' />);
+
+    await waitFor(() => {
+      expect(screen.getByText('US (United States)')).toBeInTheDocument();
+    });
+  });
+
+  it('renders no options when the location response has no data', async () => {
+    mockGetILCDLocationAll.mockResolvedValueOnce({
+      success: true,
+    });
+
+    render(<LocationCodeSelect lang='en' data-testid='loc' />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loc')).toHaveAttribute('data-loading', 'false');
+    });
+
+    expect(screen.queryByText('CN (China)')).not.toBeInTheDocument();
+  });
+
+  it('filters by search text, label, value, and empty option fallbacks', async () => {
+    render(<LocationCodeSelect lang='en' data-testid='loc' />);
+
+    await waitFor(() => {
+      expect(screen.getByText('CN (China)')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('loc-filter-search')).toHaveTextContent('true');
+    expect(screen.getByTestId('loc-filter-label')).toHaveTextContent('true');
+    expect(screen.getByTestId('loc-filter-value')).toHaveTextContent('true');
+    expect(screen.getByTestId('loc-filter-empty')).toHaveTextContent('false');
   });
 });

--- a/tests/unit/components/LocationTextItem/codeSelect.test.tsx
+++ b/tests/unit/components/LocationTextItem/codeSelect.test.tsx
@@ -1,0 +1,113 @@
+// @ts-nocheck
+import LocationCodeSelect from '@/components/LocationTextItem/codeSelect';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const mockGetILCDLocationAll = jest.fn();
+
+jest.mock('@/services/locations/api', () => ({
+  __esModule: true,
+  getILCDLocationAll: (...args: any[]) => mockGetILCDLocationAll(...args),
+}));
+
+jest.mock('umi', () => ({
+  __esModule: true,
+  FormattedMessage: ({ defaultMessage, id }: any) => defaultMessage ?? id,
+}));
+
+jest.mock('antd', () => ({
+  __esModule: true,
+  Select: ({
+    allowClear,
+    loading,
+    onChange,
+    options = [],
+    placeholder,
+    value,
+    'data-testid': dataTestId,
+  }: any) => (
+    <div>
+      <select
+        data-testid={dataTestId}
+        aria-label={placeholder}
+        data-loading={String(loading)}
+        value={value ?? ''}
+        onChange={(event) => onChange?.(event.target.value || undefined)}
+      >
+        <option value=''>empty</option>
+        {options.map((option: any) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      {allowClear ? (
+        <button type='button' data-testid={`${dataTestId}-clear`} onClick={() => onChange?.()}>
+          clear
+        </button>
+      ) : null}
+    </div>
+  ),
+}));
+
+describe('LocationCodeSelect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetILCDLocationAll.mockResolvedValue({
+      data: [
+        {
+          location: [
+            { '@value': 'CN', '#text': 'China' },
+            { '@value': 'GLO', '#text': 'Global' },
+          ],
+        },
+      ],
+      success: true,
+    });
+  });
+
+  it('loads localized location labels and returns the selected plain code', async () => {
+    const onChange = jest.fn();
+    const onData = jest.fn();
+
+    render(<LocationCodeSelect lang='en' onChange={onChange} onData={onData} data-testid='loc' />);
+
+    await waitFor(() => {
+      expect(screen.getByText('CN (China)')).toBeInTheDocument();
+      expect(screen.getByText('GLO (Global)')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('loc'), { target: { value: 'CN' } });
+
+    expect(onChange).toHaveBeenCalledWith('CN');
+    expect(onData).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a legacy plain string value visible when it is not in the location list', async () => {
+    render(<LocationCodeSelect lang='en' value='CUSTOM-REGION' data-testid='loc' />);
+
+    await waitFor(() => {
+      expect(screen.getByText('CUSTOM-REGION')).toBeInTheDocument();
+    });
+  });
+
+  it('normalizes legacy multilingual values and clears to undefined', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <LocationCodeSelect
+        lang='en'
+        value={[{ '@xml:lang': 'en', '#text': 'CN' }]}
+        onChange={onChange}
+        data-testid='loc'
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loc')).toHaveValue('CN');
+    });
+
+    fireEvent.click(screen.getByTestId('loc-clear'));
+
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx
@@ -333,6 +333,50 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
     await expect(formItem.rules[0].validator(null, '123')).resolves.toBeUndefined();
   });
 
+  it('keeps unit and flow context blank when exchanges exist but no reference flow is selected', async () => {
+    const form = buildForm([{ '@xml:lang': 'en', '#text': '100 old suffix' }]);
+
+    render(
+      <AnnualSupplyOrProductionVolumeForm
+        exchangeDataSource={[
+          {
+            '@dataSetInternalID': '1',
+            exchangeDirection: 'Output',
+            quantitativeReference: false,
+            referenceToFlowDataSet: {
+              '@refObjectId': 'flow-1',
+              '@version': '01.00.000',
+              'common:shortDescription': [
+                { '@xml:lang': 'en', '#text': 'Steel' },
+                { '@xml:lang': 'zh', '#text': '钢材' },
+              ],
+            },
+            refUnitRes: {
+              refUnitName: 'kg',
+            },
+          },
+        ]}
+        formRef={{ current: form }}
+        label='Annual volume'
+        lang='zh'
+        name={['annualSupply']}
+        onData={jest.fn()}
+        rules={[{ required: true }]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(form.setFieldValue).toHaveBeenLastCalledWith(
+        ['annualSupply'],
+        [
+          { '@xml:lang': 'en', '#text': '100' },
+          { '@xml:lang': 'zh', '#text': '100' },
+        ],
+      );
+    });
+    expect(screen.getByLabelText('annual-supply-volume-context')).toHaveValue('');
+  });
+
   it('normalizes single-object form values and uses default required validation copy', async () => {
     const form = buildForm({ '@xml:lang': 'en', '#text': '321 kg Steel' });
     const onData = jest.fn();

--- a/tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx
@@ -49,17 +49,27 @@ jest.mock('antd', () => {
   };
   FormComponent.Item = FormItem;
 
-  const InputNumber = ({ onChange, suffix }: any) => (
+  const InputNumber = ({ onChange, style }: any) => (
     <label>
-      <input aria-label='annual-volume' onChange={(event) => onChange?.(event.target.value)} />
-      <span>{suffix}</span>
+      <input
+        aria-label='annual-volume'
+        onChange={(event) => onChange?.(event.target.value)}
+        style={style}
+      />
     </label>
   );
+  const Input = ({ 'aria-label': ariaLabel, readOnly, style, value = '' }: any) => (
+    <input aria-label={ariaLabel} readOnly={readOnly} style={style} value={value} />
+  );
+  const Space = ({ children }: any) => <div>{children}</div>;
+  Space.Compact = ({ children }: any) => <div data-testid='annual-volume-compact'>{children}</div>;
 
   return {
     __esModule: true,
     Form: FormComponent,
+    Input,
     InputNumber,
+    Space,
   };
 });
 
@@ -87,7 +97,7 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
     mockGetUnitData.mockImplementation(async (_idType: string, rows: any[]) => rows);
   });
 
-  it('resolves the reference flow unit and displays the current-language suffix through InputNumber', async () => {
+  it('resolves the reference flow unit and displays the current-language suffix in a read-only input', async () => {
     mockGetUnitData.mockResolvedValueOnce([
       {
         referenceToFlowDataSetId: 'flow-1',
@@ -142,7 +152,8 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
         ],
       );
     });
-    expect(screen.getByText('kg 钢材')).toBeInTheDocument();
+    expect(screen.getByLabelText('annual-supply-volume-context')).toHaveValue('kg 钢材');
+    expect(screen.getByLabelText('annual-supply-volume-context')).toHaveAttribute('readonly');
     expect(screen.queryByLabelText('language')).not.toBeInTheDocument();
   });
 
@@ -182,7 +193,7 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
         ],
       );
     });
-    expect(screen.getByText('Steel')).toBeInTheDocument();
+    expect(screen.getByLabelText('annual-supply-volume-context')).toHaveValue('Steel');
   });
 
   it('normalizes numeric-only input into multilingual storage and validates required values', async () => {
@@ -219,7 +230,7 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
       );
     });
     expect(onData).toHaveBeenCalled();
-    expect(screen.getByText('kg Steel')).toBeInTheDocument();
+    expect(screen.getByLabelText('annual-supply-volume-context')).toHaveValue('kg Steel');
 
     const formItem = findFormItem(['modelling', 'annualSupply']);
     expect(formItem.getValueProps([{ '@xml:lang': 'en', '#text': '123 kg Steel' }])).toEqual({
@@ -271,7 +282,7 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
     expect(formItem.rules).toEqual([]);
     expect(form.setFieldValue).not.toHaveBeenCalled();
     expect(onData).not.toHaveBeenCalled();
-    expect(screen.getByText('reference flow')).toBeInTheDocument();
+    expect(screen.getByLabelText('annual-supply-volume-context')).toHaveValue('');
 
     mockFormItems.length = 0;
     render(
@@ -286,6 +297,40 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
       />,
     );
     expect(findFormItem(['annualSupplyWithoutForm']).rules).toHaveLength(1);
+  });
+
+  it('keeps unit and flow context blank when no reference flow exists', async () => {
+    const form = buildForm([{ '@xml:lang': 'en', '#text': '100 old suffix' }]);
+
+    render(
+      <AnnualSupplyOrProductionVolumeForm
+        exchangeDataSource={[]}
+        formRef={{ current: form }}
+        label='Annual volume'
+        lang='en'
+        name={['annualSupply']}
+        onData={jest.fn()}
+        rules={[{ required: true }]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(form.setFieldValue).toHaveBeenLastCalledWith(
+        ['annualSupply'],
+        [
+          { '@xml:lang': 'en', '#text': '100' },
+          { '@xml:lang': 'zh', '#text': '100' },
+        ],
+      );
+    });
+    expect(screen.getByLabelText('annual-supply-volume-context')).toHaveValue('');
+
+    const formItem = findFormItem(['annualSupply']);
+    expect(formItem.normalize('789')).toEqual([
+      { '@xml:lang': 'en', '#text': '789' },
+      { '@xml:lang': 'zh', '#text': '789' },
+    ]);
+    await expect(formItem.rules[0].validator(null, '123')).resolves.toBeUndefined();
   });
 
   it('normalizes single-object form values and uses default required validation copy', async () => {

--- a/tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx
@@ -85,7 +85,7 @@ jest.mock('antd', () => {
   );
   const Col = ({ children }: any) => <div>{children}</div>;
   const Row = ({ children }: any) => <div>{children}</div>;
-  const Input = ({ onChange, suffix }: any) => (
+  const InputNumber = ({ onChange, suffix }: any) => (
     <label>
       <span>{suffix}</span>
       <input aria-label='annual-volume' onChange={(event) => onChange?.(event)} />
@@ -106,7 +106,7 @@ jest.mock('antd', () => {
     Button,
     Col,
     Form: FormComponent,
-    Input,
+    InputNumber,
     Row,
     Select,
     message: {
@@ -176,7 +176,9 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
 
     const textItem = findFormItem([0, '#text']);
     expect(textItem.getValueProps('123 kg Steel')).toEqual({ value: '123' });
+    expect(textItem.getValueProps('abc kg Steel')).toEqual({ value: '' });
     expect(textItem.normalize('456')).toBe('456 kg Steel');
+    expect(textItem.normalize('abc789')).toBe('789 kg Steel');
 
     await expect(textItem.rules[0].validator(null, '')).rejects.toThrow(
       'Annual volume is required',

--- a/tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx
@@ -2,21 +2,8 @@
 import AnnualSupplyOrProductionVolumeForm from '@/pages/Processes/Components/AnnualSupplyOrProductionVolume/form';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
-const mockMessageError = jest.fn();
 const mockGetUnitData = jest.fn(async (_idType: string, rows: any[]) => rows);
 const mockFormItems: any[] = [];
-let mockListFields: any[] = [{ key: 0, name: 0 }];
-let mockListOperations: any;
-
-const textOf = (node: any): string => {
-  if (node === null || node === undefined) return '';
-  if (typeof node === 'string' || typeof node === 'number') return String(node);
-  if (Array.isArray(node)) return node.map(textOf).join('');
-  if (node?.props?.defaultMessage) return node.props.defaultMessage;
-  if (node?.props?.id) return node.props.id;
-  if (node?.props?.children) return textOf(node.props.children);
-  return '';
-};
 
 const findFormItem = (name: Array<string | number>) => {
   return mockFormItems.find((item) => JSON.stringify(item.name) === JSON.stringify(name));
@@ -29,19 +16,9 @@ const buildForm = (value: unknown) => ({
 
 jest.mock('umi', () => ({
   __esModule: true,
-  FormattedMessage: ({ defaultMessage, id }: any) => defaultMessage ?? id,
   useIntl: () => ({
     formatMessage: ({ defaultMessage, id }: any) => defaultMessage ?? id,
   }),
-}));
-
-jest.mock('@ant-design/icons', () => ({
-  __esModule: true,
-  CloseOutlined: ({ onClick, style }: any) => (
-    <button type='button' aria-label='remove-language' onClick={onClick} style={style}>
-      remove
-    </button>
-  ),
 }));
 
 jest.mock('@/services/general/util', () => ({
@@ -71,49 +48,18 @@ jest.mock('antd', () => {
     );
   };
   FormComponent.Item = FormItem;
-  FormComponent.List = ({ children, name, rules = [] }: any) => {
-    mockFormItems.push({ name, rules, list: true });
-    mockListOperations = {
-      add: jest.fn(),
-      remove: jest.fn(),
-    };
-    return <div data-testid='form-list'>{children(mockListFields, mockListOperations)}</div>;
-  };
 
-  const Button = ({ children, disabled, onClick }: any) => (
-    <button type='button' disabled={disabled} onClick={disabled ? undefined : onClick}>
-      {textOf(children)}
-    </button>
-  );
-  const Col = ({ children }: any) => <div>{children}</div>;
-  const Row = ({ children }: any) => <div>{children}</div>;
   const InputNumber = ({ onChange, suffix }: any) => (
     <label>
+      <input aria-label='annual-volume' onChange={(event) => onChange?.(event.target.value)} />
       <span>{suffix}</span>
-      <input aria-label='annual-volume' onChange={(event) => onChange?.(event)} />
     </label>
-  );
-  const Select = ({ onChange, options = [] }: any) => (
-    <select aria-label='language' onChange={(event) => onChange?.(event.target.value)}>
-      {options.map((option: any) => (
-        <option key={option.value} value={option.value} disabled={option.disabled}>
-          {option.label}
-        </option>
-      ))}
-    </select>
   );
 
   return {
     __esModule: true,
-    Button,
-    Col,
     Form: FormComponent,
     InputNumber,
-    Row,
-    Select,
-    message: {
-      error: (...args: any[]) => mockMessageError(...args),
-    },
   };
 });
 
@@ -124,7 +70,10 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
       exchangeDirection: 'Output',
       quantitativeReference: true,
       referenceToFlowDataSet: {
-        'common:shortDescription': [{ '@xml:lang': 'en', '#text': 'Steel' }],
+        'common:shortDescription': [
+          { '@xml:lang': 'en', '#text': 'Steel' },
+          { '@xml:lang': 'zh', '#text': '钢材' },
+        ],
       },
       refUnitRes: {
         refUnitName: 'kg',
@@ -136,15 +85,9 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
     jest.clearAllMocks();
     mockFormItems.length = 0;
     mockGetUnitData.mockImplementation(async (_idType: string, rows: any[]) => rows);
-    mockListFields = [{ key: 0, name: 0 }];
-    mockListOperations = undefined;
-    global.requestAnimationFrame = (callback: FrameRequestCallback) => {
-      callback(0);
-      return 0;
-    };
   });
 
-  it('resolves the reference flow unit before deriving the displayed suffix', async () => {
+  it('resolves the reference flow unit and displays the current-language suffix through InputNumber', async () => {
     mockGetUnitData.mockResolvedValueOnce([
       {
         referenceToFlowDataSetId: 'flow-1',
@@ -166,13 +109,16 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
             referenceToFlowDataSet: {
               '@refObjectId': 'flow-1',
               '@version': '01.00.000',
-              'common:shortDescription': [{ '@xml:lang': 'en', '#text': 'Steel' }],
+              'common:shortDescription': [
+                { '@xml:lang': 'en', '#text': 'Steel' },
+                { '@xml:lang': 'zh', '#text': '钢材' },
+              ],
             },
           },
         ]}
         formRef={{ current: form }}
         label='Annual volume'
-        lang='en'
+        lang='zh'
         name={['annualSupply']}
         onData={jest.fn()}
         rules={[{ required: true }]}
@@ -190,10 +136,14 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
     await waitFor(() => {
       expect(form.setFieldValue).toHaveBeenLastCalledWith(
         ['annualSupply'],
-        [{ '@xml:lang': 'en', '#text': '100 kg Steel' }],
+        [
+          { '@xml:lang': 'en', '#text': '100 kg Steel' },
+          { '@xml:lang': 'zh', '#text': '100 kg 钢材' },
+        ],
       );
     });
-    expect(screen.getByText('kg Steel')).toBeInTheDocument();
+    expect(screen.getByText('kg 钢材')).toBeInTheDocument();
+    expect(screen.queryByLabelText('language')).not.toBeInTheDocument();
   });
 
   it('falls back to the raw exchange suffix when unit resolution fails', async () => {
@@ -226,13 +176,16 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
     await waitFor(() => {
       expect(form.setFieldValue).toHaveBeenLastCalledWith(
         ['annualSupply'],
-        [{ '@xml:lang': 'en', '#text': '100 Steel' }],
+        [
+          { '@xml:lang': 'en', '#text': '100 Steel' },
+          { '@xml:lang': 'zh', '#text': '100 Steel' },
+        ],
       );
     });
     expect(screen.getByText('Steel')).toBeInTheDocument();
   });
 
-  it('normalizes persisted text, exposes numeric input helpers, and validates required entries', async () => {
+  it('normalizes numeric-only input into multilingual storage and validates required values', async () => {
     const form = buildForm([{ '@xml:lang': 'en', '#text': '100 old suffix' }]);
     const onData = jest.fn();
     const setRuleErrorState = jest.fn();
@@ -259,151 +212,85 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
     await waitFor(() => {
       expect(form.setFieldValue).toHaveBeenCalledWith(
         ['modelling', 'annualSupply'],
-        [{ '@xml:lang': 'en', '#text': '100 kg Steel' }],
+        [
+          { '@xml:lang': 'en', '#text': '100 kg Steel' },
+          { '@xml:lang': 'zh', '#text': '100 kg 钢材' },
+        ],
       );
     });
     expect(onData).toHaveBeenCalled();
     expect(screen.getByText('kg Steel')).toBeInTheDocument();
 
-    const textItem = findFormItem([0, '#text']);
-    expect(textItem.getValueProps('123 kg Steel')).toEqual({ value: '123' });
-    expect(textItem.getValueProps('abc kg Steel')).toEqual({ value: '' });
-    expect(textItem.normalize('456')).toBe('456 kg Steel');
-    expect(textItem.normalize('abc789')).toBe('789 kg Steel');
+    const formItem = findFormItem(['modelling', 'annualSupply']);
+    expect(formItem.getValueProps([{ '@xml:lang': 'en', '#text': '123 kg Steel' }])).toEqual({
+      value: '123',
+    });
+    expect(formItem.getValueProps([{ '@xml:lang': 'zh', '#text': '456 kg 钢材' }])).toEqual({
+      value: '456',
+    });
+    expect(formItem.normalize('789')).toEqual([
+      { '@xml:lang': 'en', '#text': '789 kg Steel' },
+      { '@xml:lang': 'zh', '#text': '789 kg 钢材' },
+    ]);
+    expect(formItem.normalize('abc789')).toEqual([
+      { '@xml:lang': 'en', '#text': '789 kg Steel' },
+      { '@xml:lang': 'zh', '#text': '789 kg 钢材' },
+    ]);
 
-    await expect(textItem.rules[0].validator(null, '')).rejects.toThrow(
+    await expect(formItem.rules[0].validator(null, '')).rejects.toThrow(
       'Annual volume is required',
     );
-    await expect(textItem.rules[0].validator(null, 123)).rejects.toThrow(
-      'Annual volume is required',
-    );
-    await expect(textItem.rules[0].validator(null, 'abc')).rejects.toThrow(
-      'Please enter a number; the reference flow suffix is added automatically.',
-    );
-    await expect(textItem.rules[0].validator(null, '456 kg Steel')).resolves.toBeUndefined();
-
-    const langItem = findFormItem([0, '@xml:lang']);
-    await expect(langItem.rules[0].validator(null, undefined)).rejects.toThrow(
-      'Please select a language!',
-    );
-    await expect(langItem.rules[0].validator(null, 'en')).resolves.toBeUndefined();
-    expect(setRuleErrorState).toHaveBeenLastCalledWith(false);
-
-    const listItem = mockFormItems.find((item) => item.list);
-    await expect(listItem.rules[0].validator(null, null)).resolves.toBeUndefined();
-    await expect(listItem.rules[0].validator(null, [])).resolves.toBeUndefined();
-    await expect(listItem.rules[0].validator(null, [{ '#text': '' }])).resolves.toBeUndefined();
-    await expect(
-      listItem.rules[0].validator(null, [{ '@xml:lang': 'zh', '#text': '100 kg Steel' }]),
-    ).rejects.toThrow();
     expect(setRuleErrorState).toHaveBeenLastCalledWith(true);
-    await expect(
-      listItem.rules[0].validator(null, [{ '@xml:lang': 'en', '#text': '100 kg Steel' }]),
-    ).resolves.toBeUndefined();
+    await expect(formItem.rules[0].validator(null, '1E-')).rejects.toThrow(
+      'Please enter a number.',
+    );
+    expect(setRuleErrorState).toHaveBeenLastCalledWith(true);
+    await expect(formItem.rules[0].validator(null, '123')).resolves.toBeUndefined();
     expect(setRuleErrorState).toHaveBeenLastCalledWith(false);
-  });
 
-  it('shows the message fallback when the required language validator has no grouped error setter', async () => {
-    const form = buildForm([{ '@xml:lang': 'zh', '#text': '100 old suffix' }]);
-
-    render(
-      <AnnualSupplyOrProductionVolumeForm
-        exchangeDataSource={defaultExchangeDataSource}
-        formRef={{ current: form }}
-        label='Annual volume'
-        lang='zh'
-        name={['annualSupply']}
-        onData={jest.fn()}
-        rules={[{ required: true }]}
-      />,
-    );
-
-    const listItem = mockFormItems.find((item) => item.list);
-    const textItem = findFormItem([0, '#text']);
-    await expect(textItem.rules[0].validator(null, '')).rejects.toThrow('Please input this field!');
-    await expect(
-      listItem.rules[0].validator(null, [{ '@xml:lang': 'zh', '#text': '100 kg Steel' }]),
-    ).rejects.toThrow();
-    expect(mockMessageError).toHaveBeenCalledWith('English is a required language!');
-  });
-
-  it('adds and removes language rows while protecting the final required row', () => {
-    const form = buildForm([{ '@xml:lang': 'en', '#text': '100 kg Steel' }]);
-    const onData = jest.fn();
-
-    render(
-      <AnnualSupplyOrProductionVolumeForm
-        exchangeDataSource={defaultExchangeDataSource}
-        formRef={{ current: form }}
-        label='Annual volume'
-        lang='en'
-        name={['annualSupply']}
-        onData={onData}
-        rules={[{ required: true }]}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: 'remove-language' }));
-    expect(mockListOperations.remove).not.toHaveBeenCalled();
-
-    fireEvent.click(screen.getByRole('button', { name: '+ Add Annual volume Item' }));
-    expect(mockListOperations.add).toHaveBeenCalledTimes(1);
+    fireEvent.change(screen.getByLabelText('annual-volume'), { target: { value: '300' } });
     expect(onData).toHaveBeenCalled();
   });
 
-  it('removes non-final rows and wires input and select change callbacks', () => {
-    mockListFields = [
-      { key: 0, name: 0 },
-      { key: 1, name: 1 },
-    ];
-    const form = buildForm([
-      { '@xml:lang': 'en', '#text': '100 kg Steel' },
-      { '@xml:lang': 'zh', '#text': '200 kg Steel' },
-    ]);
+  it('skips required rules for optional fields and tolerates empty or missing form state', () => {
+    const form = buildForm(undefined);
     const onData = jest.fn();
 
     render(
       <AnnualSupplyOrProductionVolumeForm
-        exchangeDataSource={defaultExchangeDataSource}
+        exchangeDataSource={[]}
         formRef={{ current: form }}
         label='Annual volume'
-        lang='en'
+        lang='fr'
         name={['annualSupply']}
         onData={onData}
-        rules={[{ required: true }]}
       />,
     );
 
-    fireEvent.change(screen.getAllByLabelText('annual-volume')[0], { target: { value: '300' } });
-    fireEvent.change(screen.getAllByLabelText('language')[0], { target: { value: 'zh' } });
-    fireEvent.click(screen.getAllByRole('button', { name: 'remove-language' })[0]);
+    const formItem = findFormItem(['annualSupply']);
+    expect(formItem.rules).toEqual([]);
+    expect(form.setFieldValue).not.toHaveBeenCalled();
+    expect(onData).not.toHaveBeenCalled();
+    expect(screen.getByText('reference flow')).toBeInTheDocument();
 
-    expect(mockListOperations.remove).toHaveBeenCalledWith(0);
-    expect(onData).toHaveBeenCalledTimes(3);
-  });
-
-  it('auto-adds the initial required row and tolerates missing form instances', () => {
-    mockListFields = [];
-    const onData = jest.fn();
-
+    mockFormItems.length = 0;
     render(
       <AnnualSupplyOrProductionVolumeForm
         exchangeDataSource={[]}
         formRef={{ current: undefined }}
         label='Annual volume'
-        lang='fr'
-        name={['annualSupply']}
+        lang='en'
+        name={['annualSupplyWithoutForm']}
         onData={onData}
         rules={[{ required: true }]}
       />,
     );
-
-    expect(mockListOperations.add).toHaveBeenCalledTimes(1);
-    expect(onData).not.toHaveBeenCalled();
+    expect(findFormItem(['annualSupplyWithoutForm']).rules).toHaveLength(1);
   });
 
-  it('skips required rules for optional fields and wraps non-array form values', () => {
-    const form = buildForm({ '#text': '100 old suffix' });
+  it('normalizes single-object form values and uses default required validation copy', async () => {
+    const form = buildForm({ '@xml:lang': 'en', '#text': '321 kg Steel' });
+    const onData = jest.fn();
 
     render(
       <AnnualSupplyOrProductionVolumeForm
@@ -412,31 +299,22 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
         label='Annual volume'
         lang='en'
         name={['annualSupply']}
-        onData={jest.fn()}
-      />,
-    );
-
-    const listItem = mockFormItems.find((item) => item.list);
-    expect(listItem.rules).toEqual([]);
-    expect(findFormItem([0, '#text']).rules).toEqual([]);
-    expect(findFormItem([0, '@xml:lang']).rules).toEqual([]);
-  });
-
-  it('falls back to the english suffix when the current language is unavailable', () => {
-    const form = buildForm(undefined);
-
-    render(
-      <AnnualSupplyOrProductionVolumeForm
-        exchangeDataSource={[]}
-        formRef={{ current: form }}
-        label='Annual volume'
-        lang='fr'
-        name={['annualSupply']}
-        onData={jest.fn()}
+        onData={onData}
         rules={[{ required: true }]}
       />,
     );
 
-    expect(screen.getByText('reference flow')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(form.setFieldValue).toHaveBeenCalledWith(
+        ['annualSupply'],
+        [
+          { '@xml:lang': 'en', '#text': '321 kg Steel' },
+          { '@xml:lang': 'zh', '#text': '321 kg 钢材' },
+        ],
+      );
+    });
+
+    const formItem = findFormItem(['annualSupply']);
+    await expect(formItem.rules[0].validator(null, '')).rejects.toThrow('Please input this field!');
   });
 });

--- a/tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx
@@ -1,0 +1,349 @@
+// @ts-nocheck
+import AnnualSupplyOrProductionVolumeForm from '@/pages/Processes/Components/AnnualSupplyOrProductionVolume/form';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const mockMessageError = jest.fn();
+const mockFormItems: any[] = [];
+let mockListFields: any[] = [{ key: 0, name: 0 }];
+let mockListOperations: any;
+
+const textOf = (node: any): string => {
+  if (node === null || node === undefined) return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(textOf).join('');
+  if (node?.props?.defaultMessage) return node.props.defaultMessage;
+  if (node?.props?.id) return node.props.id;
+  if (node?.props?.children) return textOf(node.props.children);
+  return '';
+};
+
+const findFormItem = (name: Array<string | number>) => {
+  return mockFormItems.find((item) => JSON.stringify(item.name) === JSON.stringify(name));
+};
+
+const buildForm = (value: unknown) => ({
+  getFieldValue: jest.fn(() => value),
+  setFieldValue: jest.fn(),
+});
+
+jest.mock('umi', () => ({
+  __esModule: true,
+  FormattedMessage: ({ defaultMessage, id }: any) => defaultMessage ?? id,
+  useIntl: () => ({
+    formatMessage: ({ defaultMessage, id }: any) => defaultMessage ?? id,
+  }),
+}));
+
+jest.mock('@ant-design/icons', () => ({
+  __esModule: true,
+  CloseOutlined: ({ onClick, style }: any) => (
+    <button type='button' aria-label='remove-language' onClick={onClick} style={style}>
+      remove
+    </button>
+  ),
+}));
+
+jest.mock('@/services/general/util', () => ({
+  __esModule: true,
+  getLangText: (value: any, lang: string) => {
+    if (typeof value === 'string') return value;
+    if (Array.isArray(value)) {
+      return (
+        value.find((item) => item?.['@xml:lang'] === lang)?.['#text'] ??
+        value.find((item) => item?.['#text'])?.['#text'] ??
+        ''
+      );
+    }
+    return value?.['#text'] ?? '';
+  },
+}));
+
+jest.mock('antd', () => {
+  const FormComponent = ({ children }: any) => <form>{children}</form>;
+  const FormItem = (props: any) => {
+    mockFormItems.push(props);
+    return (
+      <div data-testid={props.name ? `form-item-${props.name.join('.')}` : 'form-item'}>
+        {props.children}
+      </div>
+    );
+  };
+  FormComponent.Item = FormItem;
+  FormComponent.List = ({ children, name, rules = [] }: any) => {
+    mockFormItems.push({ name, rules, list: true });
+    mockListOperations = {
+      add: jest.fn(),
+      remove: jest.fn(),
+    };
+    return <div data-testid='form-list'>{children(mockListFields, mockListOperations)}</div>;
+  };
+
+  const Button = ({ children, disabled, onClick }: any) => (
+    <button type='button' disabled={disabled} onClick={disabled ? undefined : onClick}>
+      {textOf(children)}
+    </button>
+  );
+  const Col = ({ children }: any) => <div>{children}</div>;
+  const Row = ({ children }: any) => <div>{children}</div>;
+  const Input = ({ onChange, suffix }: any) => (
+    <label>
+      <span>{suffix}</span>
+      <input aria-label='annual-volume' onChange={(event) => onChange?.(event)} />
+    </label>
+  );
+  const Select = ({ onChange, options = [] }: any) => (
+    <select aria-label='language' onChange={(event) => onChange?.(event.target.value)}>
+      {options.map((option: any) => (
+        <option key={option.value} value={option.value} disabled={option.disabled}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+
+  return {
+    __esModule: true,
+    Button,
+    Col,
+    Form: FormComponent,
+    Input,
+    Row,
+    Select,
+    message: {
+      error: (...args: any[]) => mockMessageError(...args),
+    },
+  };
+});
+
+describe('AnnualSupplyOrProductionVolumeForm', () => {
+  const defaultExchangeDataSource = [
+    {
+      '@dataSetInternalID': '1',
+      exchangeDirection: 'Output',
+      quantitativeReference: true,
+      referenceToFlowDataSet: {
+        'common:shortDescription': [{ '@xml:lang': 'en', '#text': 'Steel' }],
+      },
+      refUnitRes: {
+        refUnitName: 'kg',
+      },
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFormItems.length = 0;
+    mockListFields = [{ key: 0, name: 0 }];
+    mockListOperations = undefined;
+    global.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    };
+  });
+
+  it('normalizes persisted text, exposes numeric input helpers, and validates required entries', async () => {
+    const form = buildForm([{ '@xml:lang': 'en', '#text': '100 old suffix' }]);
+    const onData = jest.fn();
+    const setRuleErrorState = jest.fn();
+
+    render(
+      <AnnualSupplyOrProductionVolumeForm
+        exchangeDataSource={defaultExchangeDataSource}
+        formRef={{ current: form }}
+        label='Annual volume'
+        lang='en'
+        name={['modelling', 'annualSupply']}
+        onData={onData}
+        rules={[
+          {
+            required: true,
+            messageKey: 'annual.required',
+            defaultMessage: 'Annual volume is required',
+          },
+        ]}
+        setRuleErrorState={setRuleErrorState}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(form.setFieldValue).toHaveBeenCalledWith(
+        ['modelling', 'annualSupply'],
+        [{ '@xml:lang': 'en', '#text': '100 kg Steel' }],
+      );
+    });
+    expect(onData).toHaveBeenCalled();
+    expect(screen.getByText('kg Steel')).toBeInTheDocument();
+
+    const textItem = findFormItem([0, '#text']);
+    expect(textItem.getValueProps('123 kg Steel')).toEqual({ value: '123' });
+    expect(textItem.normalize('456')).toBe('456 kg Steel');
+
+    await expect(textItem.rules[0].validator(null, '')).rejects.toThrow(
+      'Annual volume is required',
+    );
+    await expect(textItem.rules[0].validator(null, 123)).rejects.toThrow(
+      'Annual volume is required',
+    );
+    await expect(textItem.rules[0].validator(null, 'abc')).rejects.toThrow(
+      'Please enter a number; the reference flow suffix is added automatically.',
+    );
+    await expect(textItem.rules[0].validator(null, '456 kg Steel')).resolves.toBeUndefined();
+
+    const langItem = findFormItem([0, '@xml:lang']);
+    await expect(langItem.rules[0].validator(null, undefined)).rejects.toThrow(
+      'Please select a language!',
+    );
+    await expect(langItem.rules[0].validator(null, 'en')).resolves.toBeUndefined();
+    expect(setRuleErrorState).toHaveBeenLastCalledWith(false);
+
+    const listItem = mockFormItems.find((item) => item.list);
+    await expect(listItem.rules[0].validator(null, null)).resolves.toBeUndefined();
+    await expect(listItem.rules[0].validator(null, [])).resolves.toBeUndefined();
+    await expect(listItem.rules[0].validator(null, [{ '#text': '' }])).resolves.toBeUndefined();
+    await expect(
+      listItem.rules[0].validator(null, [{ '@xml:lang': 'zh', '#text': '100 kg Steel' }]),
+    ).rejects.toThrow();
+    expect(setRuleErrorState).toHaveBeenLastCalledWith(true);
+    await expect(
+      listItem.rules[0].validator(null, [{ '@xml:lang': 'en', '#text': '100 kg Steel' }]),
+    ).resolves.toBeUndefined();
+    expect(setRuleErrorState).toHaveBeenLastCalledWith(false);
+  });
+
+  it('shows the message fallback when the required language validator has no grouped error setter', async () => {
+    const form = buildForm([{ '@xml:lang': 'zh', '#text': '100 old suffix' }]);
+
+    render(
+      <AnnualSupplyOrProductionVolumeForm
+        exchangeDataSource={defaultExchangeDataSource}
+        formRef={{ current: form }}
+        label='Annual volume'
+        lang='zh'
+        name={['annualSupply']}
+        onData={jest.fn()}
+        rules={[{ required: true }]}
+      />,
+    );
+
+    const listItem = mockFormItems.find((item) => item.list);
+    const textItem = findFormItem([0, '#text']);
+    await expect(textItem.rules[0].validator(null, '')).rejects.toThrow('Please input this field!');
+    await expect(
+      listItem.rules[0].validator(null, [{ '@xml:lang': 'zh', '#text': '100 kg Steel' }]),
+    ).rejects.toThrow();
+    expect(mockMessageError).toHaveBeenCalledWith('English is a required language!');
+  });
+
+  it('adds and removes language rows while protecting the final required row', () => {
+    const form = buildForm([{ '@xml:lang': 'en', '#text': '100 kg Steel' }]);
+    const onData = jest.fn();
+
+    render(
+      <AnnualSupplyOrProductionVolumeForm
+        exchangeDataSource={defaultExchangeDataSource}
+        formRef={{ current: form }}
+        label='Annual volume'
+        lang='en'
+        name={['annualSupply']}
+        onData={onData}
+        rules={[{ required: true }]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'remove-language' }));
+    expect(mockListOperations.remove).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Annual volume Item' }));
+    expect(mockListOperations.add).toHaveBeenCalledTimes(1);
+    expect(onData).toHaveBeenCalled();
+  });
+
+  it('removes non-final rows and wires input and select change callbacks', () => {
+    mockListFields = [
+      { key: 0, name: 0 },
+      { key: 1, name: 1 },
+    ];
+    const form = buildForm([
+      { '@xml:lang': 'en', '#text': '100 kg Steel' },
+      { '@xml:lang': 'zh', '#text': '200 kg Steel' },
+    ]);
+    const onData = jest.fn();
+
+    render(
+      <AnnualSupplyOrProductionVolumeForm
+        exchangeDataSource={defaultExchangeDataSource}
+        formRef={{ current: form }}
+        label='Annual volume'
+        lang='en'
+        name={['annualSupply']}
+        onData={onData}
+        rules={[{ required: true }]}
+      />,
+    );
+
+    fireEvent.change(screen.getAllByLabelText('annual-volume')[0], { target: { value: '300' } });
+    fireEvent.change(screen.getAllByLabelText('language')[0], { target: { value: 'zh' } });
+    fireEvent.click(screen.getAllByRole('button', { name: 'remove-language' })[0]);
+
+    expect(mockListOperations.remove).toHaveBeenCalledWith(0);
+    expect(onData).toHaveBeenCalledTimes(3);
+  });
+
+  it('auto-adds the initial required row and tolerates missing form instances', () => {
+    mockListFields = [];
+    const onData = jest.fn();
+
+    render(
+      <AnnualSupplyOrProductionVolumeForm
+        exchangeDataSource={[]}
+        formRef={{ current: undefined }}
+        label='Annual volume'
+        lang='fr'
+        name={['annualSupply']}
+        onData={onData}
+        rules={[{ required: true }]}
+      />,
+    );
+
+    expect(mockListOperations.add).toHaveBeenCalledTimes(1);
+    expect(onData).not.toHaveBeenCalled();
+  });
+
+  it('skips required rules for optional fields and wraps non-array form values', () => {
+    const form = buildForm({ '#text': '100 old suffix' });
+
+    render(
+      <AnnualSupplyOrProductionVolumeForm
+        exchangeDataSource={defaultExchangeDataSource}
+        formRef={{ current: form }}
+        label='Annual volume'
+        lang='en'
+        name={['annualSupply']}
+        onData={jest.fn()}
+      />,
+    );
+
+    const listItem = mockFormItems.find((item) => item.list);
+    expect(listItem.rules).toEqual([]);
+    expect(findFormItem([0, '#text']).rules).toEqual([]);
+    expect(findFormItem([0, '@xml:lang']).rules).toEqual([]);
+  });
+
+  it('falls back to the english suffix when the current language is unavailable', () => {
+    const form = buildForm(undefined);
+
+    render(
+      <AnnualSupplyOrProductionVolumeForm
+        exchangeDataSource={[]}
+        formRef={{ current: form }}
+        label='Annual volume'
+        lang='fr'
+        name={['annualSupply']}
+        onData={jest.fn()}
+        rules={[{ required: true }]}
+      />,
+    );
+
+    expect(screen.getByText('reference flow')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx
@@ -3,6 +3,7 @@ import AnnualSupplyOrProductionVolumeForm from '@/pages/Processes/Components/Ann
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 const mockMessageError = jest.fn();
+const mockGetUnitData = jest.fn(async (_idType: string, rows: any[]) => rows);
 const mockFormItems: any[] = [];
 let mockListFields: any[] = [{ key: 0, name: 0 }];
 let mockListOperations: any;
@@ -45,6 +46,7 @@ jest.mock('@ant-design/icons', () => ({
 
 jest.mock('@/services/general/util', () => ({
   __esModule: true,
+  getUnitData: (...args: any[]) => mockGetUnitData(...args),
   getLangText: (value: any, lang: string) => {
     if (typeof value === 'string') return value;
     if (Array.isArray(value)) {
@@ -133,12 +135,101 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFormItems.length = 0;
+    mockGetUnitData.mockImplementation(async (_idType: string, rows: any[]) => rows);
     mockListFields = [{ key: 0, name: 0 }];
     mockListOperations = undefined;
     global.requestAnimationFrame = (callback: FrameRequestCallback) => {
       callback(0);
       return 0;
     };
+  });
+
+  it('resolves the reference flow unit before deriving the displayed suffix', async () => {
+    mockGetUnitData.mockResolvedValueOnce([
+      {
+        referenceToFlowDataSetId: 'flow-1',
+        referenceToFlowDataSetVersion: '01.00.000',
+        refUnitRes: {
+          refUnitName: 'kg',
+        },
+      },
+    ]);
+    const form = buildForm([{ '@xml:lang': 'en', '#text': '100 old suffix' }]);
+
+    render(
+      <AnnualSupplyOrProductionVolumeForm
+        exchangeDataSource={[
+          {
+            '@dataSetInternalID': '1',
+            exchangeDirection: 'Output',
+            quantitativeReference: true,
+            referenceToFlowDataSet: {
+              '@refObjectId': 'flow-1',
+              '@version': '01.00.000',
+              'common:shortDescription': [{ '@xml:lang': 'en', '#text': 'Steel' }],
+            },
+          },
+        ]}
+        formRef={{ current: form }}
+        label='Annual volume'
+        lang='en'
+        name={['annualSupply']}
+        onData={jest.fn()}
+        rules={[{ required: true }]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockGetUnitData).toHaveBeenCalledWith('flow', [
+        {
+          referenceToFlowDataSetId: 'flow-1',
+          referenceToFlowDataSetVersion: '01.00.000',
+        },
+      ]);
+    });
+    await waitFor(() => {
+      expect(form.setFieldValue).toHaveBeenLastCalledWith(
+        ['annualSupply'],
+        [{ '@xml:lang': 'en', '#text': '100 kg Steel' }],
+      );
+    });
+    expect(screen.getByText('kg Steel')).toBeInTheDocument();
+  });
+
+  it('falls back to the raw exchange suffix when unit resolution fails', async () => {
+    mockGetUnitData.mockRejectedValueOnce(new Error('unit lookup failed'));
+    const form = buildForm([{ '@xml:lang': 'en', '#text': '100 old suffix' }]);
+
+    render(
+      <AnnualSupplyOrProductionVolumeForm
+        exchangeDataSource={[
+          {
+            '@dataSetInternalID': '1',
+            exchangeDirection: 'Output',
+            quantitativeReference: true,
+            referenceToFlowDataSet: {
+              '@refObjectId': 'flow-1',
+              '@version': '01.00.000',
+              'common:shortDescription': [{ '@xml:lang': 'en', '#text': 'Steel' }],
+            },
+          },
+        ]}
+        formRef={{ current: form }}
+        label='Annual volume'
+        lang='en'
+        name={['annualSupply']}
+        onData={jest.fn()}
+        rules={[{ required: true }]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(form.setFieldValue).toHaveBeenLastCalledWith(
+        ['annualSupply'],
+        [{ '@xml:lang': 'en', '#text': '100 Steel' }],
+      );
+    });
+    expect(screen.getByText('Steel')).toBeInTheDocument();
   });
 
   it('normalizes persisted text, exposes numeric input helpers, and validates required entries', async () => {

--- a/tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx
@@ -58,8 +58,8 @@ jest.mock('antd', () => {
       />
     </label>
   );
-  const Input = ({ 'aria-label': ariaLabel, readOnly, style, value = '' }: any) => (
-    <input aria-label={ariaLabel} readOnly={readOnly} style={style} value={value} />
+  const Input = ({ 'aria-label': ariaLabel, disabled, style, value = '' }: any) => (
+    <input aria-label={ariaLabel} disabled={disabled} style={style} value={value} />
   );
   const Space = ({ children }: any) => <div>{children}</div>;
   Space.Compact = ({ children }: any) => <div data-testid='annual-volume-compact'>{children}</div>;
@@ -97,7 +97,7 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
     mockGetUnitData.mockImplementation(async (_idType: string, rows: any[]) => rows);
   });
 
-  it('resolves the reference flow unit and displays the current-language suffix in a read-only input', async () => {
+  it('resolves the reference flow unit and displays the current-language suffix in a disabled input', async () => {
     mockGetUnitData.mockResolvedValueOnce([
       {
         referenceToFlowDataSetId: 'flow-1',
@@ -153,7 +153,7 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
       );
     });
     expect(screen.getByLabelText('annual-supply-volume-context')).toHaveValue('kg 钢材');
-    expect(screen.getByLabelText('annual-supply-volume-context')).toHaveAttribute('readonly');
+    expect(screen.getByLabelText('annual-supply-volume-context')).toBeDisabled();
     expect(screen.queryByLabelText('language')).not.toBeInTheDocument();
   });
 

--- a/tests/unit/pages/Processes/Components/Exchange/create.test.tsx
+++ b/tests/unit/pages/Processes/Components/Exchange/create.test.tsx
@@ -126,6 +126,16 @@ jest.mock('@/components/LangTextItem/form', () => ({
   default: () => <div data-testid='lang-form'>lang-form</div>,
 }));
 
+jest.mock('@/services/locations/api', () => ({
+  __esModule: true,
+  getILCDLocationAll: jest.fn(() =>
+    Promise.resolve({
+      data: [{ location: [{ '@value': 'CN', '#text': 'China' }] }],
+      success: true,
+    }),
+  ),
+}));
+
 jest.mock('antd', () => {
   const React = require('react');
 
@@ -412,6 +422,28 @@ describe('ProcessExchangeCreate', () => {
 
     await waitFor(() => {
       expect(proFormApi?.getFieldValue('meanAmount')).toBe('123');
+    });
+  });
+
+  it('normalizes exchange location to a plain string code before saving', async () => {
+    const onData = jest.fn();
+    render(<ProcessExchangeCreate {...defaultProps} onData={onData} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Create/i }));
+
+    await act(async () => {
+      proFormApi?.setFieldsValue({
+        location: [{ '@xml:lang': 'en', '#text': 'CN' }],
+      });
+      triggerValuesChange?.({}, proFormApi?.getFieldsValue());
+    });
+
+    await act(async () => {
+      await proFormApi?.submit();
+    });
+
+    await waitFor(() => {
+      expect(onData).toHaveBeenCalledWith({ exchangeDirection: 'Output', location: 'CN' });
     });
   });
 

--- a/tests/unit/pages/Processes/Components/Exchange/edit.test.tsx
+++ b/tests/unit/pages/Processes/Components/Exchange/edit.test.tsx
@@ -131,6 +131,16 @@ jest.mock('@/components/LangTextItem/form', () => ({
   default: () => <div data-testid='lang-form'>lang</div>,
 }));
 
+jest.mock('@/services/locations/api', () => ({
+  __esModule: true,
+  getILCDLocationAll: jest.fn(() =>
+    Promise.resolve({
+      data: [{ location: [{ '@value': 'CN', '#text': 'China' }] }],
+      success: true,
+    }),
+  ),
+}));
+
 jest.mock('antd', () => {
   const React = require('react');
 
@@ -431,6 +441,27 @@ describe('ProcessExchangeEdit', () => {
     await waitFor(() => {
       expect(mockProFormApi?.getFieldValue('meanAmount')).toBeUndefined();
       expect(mockProFormApi?.getFieldValue('resultingAmount')).toBeUndefined();
+    });
+  });
+
+  it('normalizes legacy multilingual exchange location to a plain string in the form', async () => {
+    render(
+      <ProcessExchangeEdit
+        {...defaultProps}
+        data={[
+          {
+            '@dataSetInternalID': '0',
+            exchangeDirection: 'input',
+            location: [{ '@xml:lang': 'en', '#text': 'CN' }],
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(mockProFormApi?.getFieldValue('location')).toBe('CN');
     });
   });
 

--- a/tests/unit/pages/Processes/Components/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/form.test.tsx
@@ -293,6 +293,7 @@ jest.mock('antd', () => {
   );
 
   const Space = ({ children }: any) => <div>{children}</div>;
+  Space.Compact = ({ children }: any) => <div>{children}</div>;
   const Row = ({ children }: any) => <div>{children}</div>;
   const Col = ({ children }: any) => <div>{children}</div>;
 
@@ -371,9 +372,19 @@ jest.mock('antd', () => {
   };
   FormComponent.List = MockFormList;
 
-  const Input = ({ onChange, value, 'data-testid': dataTestId }: any) => (
+  const Input = ({
+    onChange,
+    value,
+    'data-testid': dataTestId,
+    'aria-label': ariaLabel,
+    readOnly,
+    style,
+  }: any) => (
     <input
+      aria-label={ariaLabel}
       data-testid={dataTestId}
+      readOnly={readOnly}
+      style={style}
       value={value ?? ''}
       onChange={(event) => onChange?.(event.target.value)}
     />

--- a/tests/unit/pages/Processes/Components/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/form.test.tsx
@@ -377,13 +377,13 @@ jest.mock('antd', () => {
     value,
     'data-testid': dataTestId,
     'aria-label': ariaLabel,
-    readOnly,
+    disabled,
     style,
   }: any) => (
     <input
       aria-label={ariaLabel}
       data-testid={dataTestId}
-      readOnly={readOnly}
+      disabled={disabled}
       style={style}
       value={value ?? ''}
       onChange={(event) => onChange?.(event.target.value)}

--- a/tests/unit/pages/Processes/Components/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/form.test.tsx
@@ -293,6 +293,8 @@ jest.mock('antd', () => {
   );
 
   const Space = ({ children }: any) => <div>{children}</div>;
+  const Row = ({ children }: any) => <div>{children}</div>;
+  const Col = ({ children }: any) => <div>{children}</div>;
 
   const Card = ({ tabList = [], activeTabKey, onTabChange, children }: any) => (
     <div data-testid='card' data-active-key={activeTabKey}>
@@ -409,11 +411,13 @@ jest.mock('antd', () => {
   return {
     __esModule: true,
     Button,
+    Col,
     Space,
     Card,
     Collapse,
     Form: FormComponent,
     Input,
+    Row,
     Select,
     InputNumber,
     Switch,

--- a/tests/unit/pages/Processes/requiredFields.test.ts
+++ b/tests/unit/pages/Processes/requiredFields.test.ts
@@ -12,6 +12,11 @@ describe('Processes requiredFields', () => {
     );
     expect(
       requiredFieldsMap[
+        'modellingAndValidation.dataSourcesTreatmentAndRepresentativeness.annualSupplyOrProductionVolume'
+      ],
+    ).toBe('modellingAndValidation');
+    expect(
+      requiredFieldsMap[
         'administrativeInformation.publicationAndOwnership.common:referenceToOwnershipOfDataSet'
       ],
     ).toBe('administrativeInformation');

--- a/tests/unit/pages/Processes/sdkValidation.test.ts
+++ b/tests/unit/pages/Processes/sdkValidation.test.ts
@@ -60,6 +60,48 @@ describe('process sdk validation mapping', () => {
     ]);
   });
 
+  it('maps annual supply volume required issues to the localized numeric text field', () => {
+    const details = normalizeProcessSdkValidationDetails(
+      [
+        {
+          code: 'invalid_type',
+          expected: 'object',
+          message: 'Invalid input: expected object, received undefined',
+          path: [
+            'processDataSet',
+            'modellingAndValidation',
+            'dataSourcesTreatmentAndRepresentativeness',
+            'annualSupplyOrProductionVolume',
+          ],
+          severity: 'error',
+        },
+      ],
+      {
+        processDataSet: {
+          modellingAndValidation: {
+            dataSourcesTreatmentAndRepresentativeness: {},
+          },
+        },
+      },
+    );
+
+    expect(details).toEqual([
+      expect.objectContaining({
+        fieldPath:
+          'modellingAndValidation.dataSourcesTreatmentAndRepresentativeness.annualSupplyOrProductionVolume.0.#text',
+        formName: [
+          'modellingAndValidation',
+          'dataSourcesTreatmentAndRepresentativeness',
+          'annualSupplyOrProductionVolume',
+          0,
+          '#text',
+        ],
+        tabName: 'modellingAndValidation',
+        validationCode: 'required_missing',
+      }),
+    ]);
+  });
+
   it('keeps missing review list issues on the validation section anchor', () => {
     const details = normalizeProcessSdkValidationDetails(
       [

--- a/tests/unit/pages/Processes/sdkValidationUi.test.ts
+++ b/tests/unit/pages/Processes/sdkValidationUi.test.ts
@@ -40,6 +40,16 @@ describe('process sdk validation ui helpers', () => {
         '@refObjectId',
       ]),
     ).toBe(true);
+
+    expect(
+      usesProcessLocalRequiredValidationUi([
+        'modellingAndValidation',
+        'dataSourcesTreatmentAndRepresentativeness',
+        'annualSupplyOrProductionVolume',
+        0,
+        '#text',
+      ]),
+    ).toBe(true);
   });
 
   it('only treats exchange reference selectors as local required ui owners', () => {

--- a/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
+++ b/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
@@ -20,6 +20,21 @@ describe('annualSupplyOrProductionVolume helpers', () => {
     });
   });
 
+  it('parses empty and non-numeric legacy text without dropping the editable prefix', () => {
+    expect(parseAnnualSupplyVolumeText('')).toEqual({
+      numericText: '',
+      suffixText: '',
+    });
+    expect(parseAnnualSupplyVolumeText('-')).toEqual({
+      numericText: '',
+      suffixText: '',
+    });
+    expect(parseAnnualSupplyVolumeText('legacy suffix text')).toEqual({
+      numericText: 'legacy',
+      suffixText: 'suffix text',
+    });
+  });
+
   it('formats numeric input with a derived suffix and keeps partial numeric edits visible', () => {
     expect(formatAnnualSupplyVolumeText('123', 'kg/year')).toBe('123 kg/year');
     expect(formatAnnualSupplyVolumeText('-', 'kg/year')).toBe('- kg/year');
@@ -27,6 +42,7 @@ describe('annualSupplyOrProductionVolume helpers', () => {
     expect(formatAnnualSupplyVolumeText('123', '')).toBe(
       `123 ${ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX}`,
     );
+    expect(formatAnnualSupplyVolumeText(123, 'kg/year')).toBe('');
   });
 
   it('normalizes localized values with a suffix per language', () => {
@@ -42,6 +58,17 @@ describe('annualSupplyOrProductionVolume helpers', () => {
       { '@xml:lang': 'en', '#text': '100 kg/year' },
       { '@xml:lang': 'zh', '#text': '200 千克/年' },
     ]);
+  });
+
+  it('normalizes object values with a shared suffix and leaves malformed values unchanged', () => {
+    expect(
+      normalizeAnnualSupplyVolumeMultiLang({ '@xml:lang': 'en', '#text': '50 old' }, 'kg'),
+    ).toEqual({
+      '@xml:lang': 'en',
+      '#text': '50 kg',
+    });
+    expect(normalizeAnnualSupplyVolumeMultiLang(null, 'kg')).toBeNull();
+    expect(normalizeAnnualSupplyVolumeMultiLang('100 old', 'kg')).toBe('100 old');
   });
 
   it('derives suffixes from the quantitative reference exchange', () => {
@@ -72,5 +99,77 @@ describe('annualSupplyOrProductionVolume helpers', () => {
     expect(suffix).toBe('kg Steel slab');
     expect(normalizeAnnualSupplyVolumeText('100 old suffix', suffix)).toBe('100 kg Steel slab');
     expect(ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN.test('100 kg Steel slab')).toBe(true);
+  });
+
+  it('derives suffixes from fallback text shapes and output exchange fallback', () => {
+    expect(
+      deriveAnnualSupplyVolumeSuffix({
+        exchangeDataSource: [
+          {
+            '@dataSetInternalID': 'input-1',
+            exchangeDirection: 'Input',
+            referenceToFlowDataSet: {
+              'common:shortDescription': [{ '@xml:lang': 'en', '#text': 'Iron ore' }],
+            },
+          },
+          {
+            '@dataSetInternalID': 'output-1',
+            exchangeDirection: 'Output',
+            functionalUnitOrOther: 'annual output' as unknown as { '#text': string },
+            referenceToFlowDataSet: {
+              'common:shortDescription': [{ '@xml:lang': 'zh', '#text': '钢板' }],
+            },
+            refUnitRes: {
+              refUnitName: 'kg',
+            },
+          },
+        ],
+        lang: 'en',
+      }),
+    ).toBe('kg annual output');
+
+    expect(
+      deriveAnnualSupplyVolumeSuffix({
+        exchangeDataSource: [
+          {
+            '@dataSetInternalID': 'first-1',
+            functionalUnitOrOther: { '#text': 'functional unit' },
+            referenceToFlowDataSet: {
+              'common:shortDescription': [{ '@xml:lang': 'zh', '#text': '钢板' }],
+            },
+            refUnitRes: {
+              refUnitName: 'kg',
+            },
+          },
+        ],
+        lang: 'en',
+      }),
+    ).toBe('kg functional unit');
+  });
+
+  it('uses reference flow text and the default suffix when no better context exists', () => {
+    expect(
+      deriveAnnualSupplyVolumeSuffix({
+        exchangeDataSource: [
+          {
+            '@dataSetInternalID': 'first-1',
+            functionalUnitOrOther: 123 as unknown as { '#text': string },
+            referenceToFlowDataSet: [
+              {
+                'common:shortDescription': [{ '@xml:lang': 'zh', '#text': '钢板' }],
+              },
+            ],
+          },
+        ],
+        lang: 'en',
+      }),
+    ).toBe('钢板');
+
+    expect(
+      deriveAnnualSupplyVolumeSuffix({
+        exchangeDataSource: [],
+        lang: 'en',
+      }),
+    ).toBe(ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX);
   });
 });

--- a/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
+++ b/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
@@ -1,9 +1,11 @@
 import {
   ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX,
   ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN,
+  buildAnnualSupplyVolumeMultiLang,
   buildAnnualSupplyVolumeUnitLookupRows,
   deriveAnnualSupplyVolumeSuffix,
   formatAnnualSupplyVolumeText,
+  getAnnualSupplyVolumeDisplayNumericText,
   mergeAnnualSupplyVolumeUnitRows,
   normalizeAnnualSupplyVolumeMultiLang,
   normalizeAnnualSupplyVolumeText,
@@ -73,6 +75,48 @@ describe('annualSupplyOrProductionVolume helpers', () => {
       { '@xml:lang': 'en', '#text': '100 kg/year' },
       { '@xml:lang': 'zh', '#text': '200 千克/年' },
     ]);
+  });
+
+  it('builds multilingual values from one numeric input and reads the displayed numeric value', () => {
+    expect(
+      buildAnnualSupplyVolumeMultiLang(
+        'abc123',
+        (lang) => (lang === 'zh' ? '千克 钢材' : 'kg Steel'),
+        ['en', 'zh', 'en', ''],
+      ),
+    ).toEqual([
+      { '@xml:lang': 'en', '#text': '123 kg Steel' },
+      { '@xml:lang': 'zh', '#text': '123 千克 钢材' },
+    ]);
+    expect(buildAnnualSupplyVolumeMultiLang('', 'kg Steel')).toEqual([]);
+    expect(buildAnnualSupplyVolumeMultiLang('500', 'kg Steel')).toEqual([
+      { '@xml:lang': 'en', '#text': '500 kg Steel' },
+      { '@xml:lang': 'zh', '#text': '500 kg Steel' },
+    ]);
+    expect(
+      getAnnualSupplyVolumeDisplayNumericText(
+        [
+          { '@xml:lang': 'en', '#text': '100 kg Steel' },
+          { '@xml:lang': 'zh', '#text': '200 千克 钢材' },
+        ],
+        'zh',
+      ),
+    ).toBe('200');
+    expect(
+      getAnnualSupplyVolumeDisplayNumericText(
+        [
+          { '@xml:lang': 'en', '#text': '100 kg Steel' },
+          { '@xml:lang': 'zh', '#text': '200 千克 钢材' },
+        ],
+        'de',
+      ),
+    ).toBe('100');
+    expect(
+      getAnnualSupplyVolumeDisplayNumericText([null, { '#text': '600 kg Steel' }] as never, 'de'),
+    ).toBe('600');
+    expect(getAnnualSupplyVolumeDisplayNumericText([], 'en')).toBe('');
+    expect(getAnnualSupplyVolumeDisplayNumericText({ '#text': '300 kg Steel' }, 'en')).toBe('300');
+    expect(getAnnualSupplyVolumeDisplayNumericText('400 kg Steel', 'en')).toBe('400');
   });
 
   it('preserves an existing unit prefix when the derived suffix only has reference flow text', () => {

--- a/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
+++ b/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
@@ -48,6 +48,7 @@ describe('annualSupplyOrProductionVolume helpers', () => {
     expect(formatAnnualSupplyVolumeText('123', '')).toBe(
       `123 ${ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX}`,
     );
+    expect(formatAnnualSupplyVolumeText('123', '', { useDefaultSuffix: false })).toBe('123');
     expect(formatAnnualSupplyVolumeText(123, 'kg/year')).toBe('');
   });
 
@@ -93,6 +94,10 @@ describe('annualSupplyOrProductionVolume helpers', () => {
       { '@xml:lang': 'en', '#text': '500 kg Steel' },
       { '@xml:lang': 'zh', '#text': '500 kg Steel' },
     ]);
+    expect(buildAnnualSupplyVolumeMultiLang('500', '')).toEqual([
+      { '@xml:lang': 'en', '#text': '500' },
+      { '@xml:lang': 'zh', '#text': '500' },
+    ]);
     expect(
       getAnnualSupplyVolumeDisplayNumericText(
         [
@@ -122,6 +127,9 @@ describe('annualSupplyOrProductionVolume helpers', () => {
   it('preserves an existing unit prefix when the derived suffix only has reference flow text', () => {
     expect(normalizeAnnualSupplyVolumeText('100 kg Steel', 'Steel')).toBe('100 kg Steel');
     expect(normalizeAnnualSupplyVolumeText('100 old suffix', 'Steel')).toBe('100 Steel');
+    expect(normalizeAnnualSupplyVolumeText('100 old suffix', '', { useDefaultSuffix: false })).toBe(
+      '100',
+    );
   });
 
   it('normalizes object values with a shared suffix and leaves malformed values unchanged', () => {
@@ -293,7 +301,7 @@ describe('annualSupplyOrProductionVolume helpers', () => {
     ).toBe('kg functional unit');
   });
 
-  it('uses reference flow text and the default suffix when no better context exists', () => {
+  it('uses reference flow text and leaves suffix blank when no reference flow exists', () => {
     expect(
       deriveAnnualSupplyVolumeSuffix({
         exchangeDataSource: [
@@ -316,6 +324,6 @@ describe('annualSupplyOrProductionVolume helpers', () => {
         exchangeDataSource: [],
         lang: 'en',
       }),
-    ).toBe(ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX);
+    ).toBe('');
   });
 });

--- a/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
+++ b/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
@@ -1,8 +1,10 @@
 import {
   ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX,
   ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN,
+  buildAnnualSupplyVolumeUnitLookupRows,
   deriveAnnualSupplyVolumeSuffix,
   formatAnnualSupplyVolumeText,
+  mergeAnnualSupplyVolumeUnitRows,
   normalizeAnnualSupplyVolumeMultiLang,
   normalizeAnnualSupplyVolumeText,
   parseAnnualSupplyVolumeText,
@@ -73,6 +75,11 @@ describe('annualSupplyOrProductionVolume helpers', () => {
     ]);
   });
 
+  it('preserves an existing unit prefix when the derived suffix only has reference flow text', () => {
+    expect(normalizeAnnualSupplyVolumeText('100 kg Steel', 'Steel')).toBe('100 kg Steel');
+    expect(normalizeAnnualSupplyVolumeText('100 old suffix', 'Steel')).toBe('100 Steel');
+  });
+
   it('normalizes object values with a shared suffix and leaves malformed values unchanged', () => {
     expect(
       normalizeAnnualSupplyVolumeMultiLang({ '@xml:lang': 'en', '#text': '50 old' }, 'kg'),
@@ -112,6 +119,88 @@ describe('annualSupplyOrProductionVolume helpers', () => {
     expect(suffix).toBe('kg Steel slab');
     expect(normalizeAnnualSupplyVolumeText('100 old suffix', suffix)).toBe('100 kg Steel slab');
     expect(ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN.test('100 kg Steel slab')).toBe(true);
+  });
+
+  it('derives suffixes from unit display names when a unit symbol is unavailable', () => {
+    expect(
+      deriveAnnualSupplyVolumeSuffix({
+        exchangeDataSource: [
+          {
+            '@dataSetInternalID': 'output-1',
+            exchangeDirection: 'Output',
+            quantitativeReference: true,
+            referenceToFlowDataSet: {
+              'common:shortDescription': [{ '@xml:lang': 'en', '#text': 'Steel slab' }],
+            },
+            refUnitRes: {
+              name: [{ '@xml:lang': 'en', '#text': 'kilogram' }],
+            },
+          },
+        ],
+        lang: 'en',
+      }),
+    ).toBe('kilogram Steel slab');
+  });
+
+  it('builds unit lookup rows and merges resolved flow units into exchange rows', () => {
+    const exchangeRows = [
+      {
+        '@dataSetInternalID': 'output-1',
+        referenceToFlowDataSet: {
+          '@refObjectId': 'flow-1',
+          '@version': '01.00.000',
+        },
+      },
+      {
+        '@dataSetInternalID': 'output-2',
+        referenceToFlowDataSet: [
+          {
+            '@refObjectId': 'flow-2',
+            '@version': '01.00.000',
+          },
+        ],
+      },
+    ];
+
+    expect(buildAnnualSupplyVolumeUnitLookupRows(exchangeRows)).toEqual([
+      {
+        referenceToFlowDataSetId: 'flow-1',
+        referenceToFlowDataSetVersion: '01.00.000',
+      },
+      {
+        referenceToFlowDataSetId: 'flow-2',
+        referenceToFlowDataSetVersion: '01.00.000',
+      },
+    ]);
+
+    expect(buildAnnualSupplyVolumeUnitLookupRows(null as never)).toEqual([]);
+    expect(mergeAnnualSupplyVolumeUnitRows(null as never, [])).toEqual([]);
+
+    expect(
+      mergeAnnualSupplyVolumeUnitRows(exchangeRows, [
+        {
+          referenceToFlowDataSetId: 'flow-1',
+          referenceToFlowDataSetVersion: '01.00.000',
+          refUnitRes: { refUnitName: 'kg' },
+        },
+        {
+          referenceToFlowDataSetId: 'flow-2',
+          referenceToFlowDataSetVersion: '02.00.000',
+          refUnitRes: { refUnitName: 'm3' },
+        },
+      ]),
+    ).toEqual([
+      {
+        ...exchangeRows[0],
+        refUnitRes: { refUnitName: 'kg' },
+      },
+      {
+        ...exchangeRows[1],
+        refUnitRes: { refUnitName: 'm3' },
+      },
+    ]);
+
+    expect(mergeAnnualSupplyVolumeUnitRows(exchangeRows, null)).toEqual(exchangeRows);
   });
 
   it('derives suffixes from fallback text shapes and output exchange fallback', () => {

--- a/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
+++ b/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
@@ -1,0 +1,76 @@
+import {
+  ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX,
+  ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN,
+  deriveAnnualSupplyVolumeSuffix,
+  formatAnnualSupplyVolumeText,
+  normalizeAnnualSupplyVolumeMultiLang,
+  normalizeAnnualSupplyVolumeText,
+  parseAnnualSupplyVolumeText,
+} from '@/services/processes/annualSupplyOrProductionVolume';
+
+describe('annualSupplyOrProductionVolume helpers', () => {
+  it('parses full numeric text into editable numeric and suffix parts', () => {
+    expect(parseAnnualSupplyVolumeText('123 kg/year')).toEqual({
+      numericText: '123',
+      suffixText: 'kg/year',
+    });
+    expect(parseAnnualSupplyVolumeText('-1.2E+3 kg Steel')).toEqual({
+      numericText: '-1.2E+3',
+      suffixText: 'kg Steel',
+    });
+  });
+
+  it('formats numeric input with a derived suffix and keeps partial numeric edits visible', () => {
+    expect(formatAnnualSupplyVolumeText('123', 'kg/year')).toBe('123 kg/year');
+    expect(formatAnnualSupplyVolumeText('-', 'kg/year')).toBe('- kg/year');
+    expect(formatAnnualSupplyVolumeText('', 'kg/year')).toBe('');
+    expect(formatAnnualSupplyVolumeText('123', '')).toBe(
+      `123 ${ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX}`,
+    );
+  });
+
+  it('normalizes localized values with a suffix per language', () => {
+    const normalized = normalizeAnnualSupplyVolumeMultiLang(
+      [
+        { '@xml:lang': 'en', '#text': '100 old suffix' },
+        { '@xml:lang': 'zh', '#text': '200 旧后缀' },
+      ],
+      (item) => (item['@xml:lang'] === 'zh' ? '千克/年' : 'kg/year'),
+    );
+
+    expect(normalized).toEqual([
+      { '@xml:lang': 'en', '#text': '100 kg/year' },
+      { '@xml:lang': 'zh', '#text': '200 千克/年' },
+    ]);
+  });
+
+  it('derives suffixes from the quantitative reference exchange', () => {
+    const suffix = deriveAnnualSupplyVolumeSuffix({
+      exchangeDataSource: [
+        {
+          '@dataSetInternalID': 'input-1',
+          exchangeDirection: 'Input',
+          referenceToFlowDataSet: {
+            'common:shortDescription': [{ '@xml:lang': 'en', '#text': 'Iron ore' }],
+          },
+        },
+        {
+          '@dataSetInternalID': 'output-1',
+          exchangeDirection: 'Output',
+          quantitativeReference: true,
+          referenceToFlowDataSet: {
+            'common:shortDescription': [{ '@xml:lang': 'en', '#text': 'Steel slab' }],
+          },
+          refUnitRes: {
+            refUnitName: 'kg',
+          },
+        },
+      ],
+      lang: 'en',
+    });
+
+    expect(suffix).toBe('kg Steel slab');
+    expect(normalizeAnnualSupplyVolumeText('100 old suffix', suffix)).toBe('100 kg Steel slab');
+    expect(ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN.test('100 kg Steel slab')).toBe(true);
+  });
+});

--- a/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
+++ b/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
@@ -255,7 +255,7 @@ describe('annualSupplyOrProductionVolume helpers', () => {
     expect(mergeAnnualSupplyVolumeUnitRows(exchangeRows, null)).toEqual(exchangeRows);
   });
 
-  it('derives suffixes from fallback text shapes and output exchange fallback', () => {
+  it('derives suffixes from fallback text shapes on the selected reference exchange', () => {
     expect(
       deriveAnnualSupplyVolumeSuffix({
         exchangeDataSource: [
@@ -269,6 +269,7 @@ describe('annualSupplyOrProductionVolume helpers', () => {
           {
             '@dataSetInternalID': 'output-1',
             exchangeDirection: 'Output',
+            quantitativeReference: true,
             functionalUnitOrOther: 'annual output' as unknown as { '#text': string },
             referenceToFlowDataSet: {
               'common:shortDescription': [{ '@xml:lang': 'zh', '#text': '钢板' }],
@@ -287,6 +288,7 @@ describe('annualSupplyOrProductionVolume helpers', () => {
         exchangeDataSource: [
           {
             '@dataSetInternalID': 'first-1',
+            quantitativeReference: true,
             functionalUnitOrOther: { '#text': 'functional unit' },
             referenceToFlowDataSet: {
               'common:shortDescription': [{ '@xml:lang': 'zh', '#text': '钢板' }],
@@ -301,12 +303,13 @@ describe('annualSupplyOrProductionVolume helpers', () => {
     ).toBe('kg functional unit');
   });
 
-  it('uses reference flow text and leaves suffix blank when no reference flow exists', () => {
+  it('uses reference flow text and leaves suffix blank when no reference flow is selected', () => {
     expect(
       deriveAnnualSupplyVolumeSuffix({
         exchangeDataSource: [
           {
             '@dataSetInternalID': 'first-1',
+            quantitativeReference: true,
             functionalUnitOrOther: 123 as unknown as { '#text': string },
             referenceToFlowDataSet: [
               {
@@ -321,7 +324,19 @@ describe('annualSupplyOrProductionVolume helpers', () => {
 
     expect(
       deriveAnnualSupplyVolumeSuffix({
-        exchangeDataSource: [],
+        exchangeDataSource: [
+          {
+            '@dataSetInternalID': 'output-1',
+            exchangeDirection: 'Output',
+            quantitativeReference: false,
+            referenceToFlowDataSet: {
+              'common:shortDescription': [{ '@xml:lang': 'en', '#text': 'Steel' }],
+            },
+            refUnitRes: {
+              refUnitName: 'kg',
+            },
+          },
+        ],
         lang: 'en',
       }),
     ).toBe('');

--- a/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
+++ b/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeAnnualSupplyVolumeMultiLang,
   normalizeAnnualSupplyVolumeText,
   parseAnnualSupplyVolumeText,
+  sanitizeAnnualSupplyVolumeNumericInput,
 } from '@/services/processes/annualSupplyOrProductionVolume';
 
 describe('annualSupplyOrProductionVolume helpers', () => {
@@ -39,10 +40,22 @@ describe('annualSupplyOrProductionVolume helpers', () => {
     expect(formatAnnualSupplyVolumeText('123', 'kg/year')).toBe('123 kg/year');
     expect(formatAnnualSupplyVolumeText('-', 'kg/year')).toBe('- kg/year');
     expect(formatAnnualSupplyVolumeText('', 'kg/year')).toBe('');
+    expect(formatAnnualSupplyVolumeText('abc123', 'kg/year')).toBe('123 kg/year');
     expect(formatAnnualSupplyVolumeText('123', '')).toBe(
       `123 ${ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX}`,
     );
     expect(formatAnnualSupplyVolumeText(123, 'kg/year')).toBe('');
+  });
+
+  it('sanitizes editable numeric input while keeping real-number partial states', () => {
+    expect(sanitizeAnnualSupplyVolumeNumericInput('abc')).toBe('');
+    expect(sanitizeAnnualSupplyVolumeNumericInput('abc123')).toBe('123');
+    expect(sanitizeAnnualSupplyVolumeNumericInput('12abc')).toBe('12');
+    expect(sanitizeAnnualSupplyVolumeNumericInput('1.2.3')).toBe('1.23');
+    expect(sanitizeAnnualSupplyVolumeNumericInput('--1.2E++3')).toBe('-1.2E+3');
+    expect(sanitizeAnnualSupplyVolumeNumericInput('.')).toBe('.');
+    expect(sanitizeAnnualSupplyVolumeNumericInput('1E-')).toBe('1E-');
+    expect(sanitizeAnnualSupplyVolumeNumericInput(123)).toBe('');
   });
 
   it('normalizes localized values with a suffix per language', () => {

--- a/tests/unit/services/processes/exchangeLocation.test.ts
+++ b/tests/unit/services/processes/exchangeLocation.test.ts
@@ -1,0 +1,33 @@
+import { normalizeExchangeLocationCode } from '@/services/processes/exchangeLocation';
+
+describe('normalizeExchangeLocationCode', () => {
+  it('normalizes primitive location codes', () => {
+    expect(normalizeExchangeLocationCode(' CN ')).toBe('CN');
+    expect(normalizeExchangeLocationCode(123)).toBe('123');
+    expect(normalizeExchangeLocationCode('   ')).toBeUndefined();
+    expect(normalizeExchangeLocationCode(null)).toBeUndefined();
+    expect(normalizeExchangeLocationCode(undefined)).toBeUndefined();
+  });
+
+  it('returns the first non-empty normalized array value', () => {
+    expect(normalizeExchangeLocationCode([' ', { '#text': ' RER ' }])).toBe('RER');
+    expect(normalizeExchangeLocationCode([])).toBeUndefined();
+  });
+
+  it('normalizes legacy object-shaped location values', () => {
+    expect(normalizeExchangeLocationCode({ '#text': ' CN ', '@value': 'GLO', value: 'US' })).toBe(
+      'CN',
+    );
+    expect(normalizeExchangeLocationCode({ '#text': ' ', '@value': ' GLO ', value: 'US' })).toBe(
+      'GLO',
+    );
+    expect(
+      normalizeExchangeLocationCode({ '#text': undefined, '@value': undefined, value: ' US ' }),
+    ).toBe('US');
+    expect(normalizeExchangeLocationCode({})).toBeUndefined();
+  });
+
+  it('ignores unsupported value types', () => {
+    expect(normalizeExchangeLocationCode(true)).toBeUndefined();
+  });
+});

--- a/tests/unit/services/processes/util.test.ts
+++ b/tests/unit/services/processes/util.test.ts
@@ -547,20 +547,27 @@ describe('Process Utility Functions', () => {
           exchange: [
             {
               '@dataSetInternalID': '1',
-              referenceToFlowDataSet: {
-                '@refObjectId': 'flow-id-1',
-              },
               exchangeDirection: 'Input',
               meanAmount: '10',
               quantitativeReference: false,
             },
           ],
         },
+        modellingAndValidation: {
+          ...mockProcessData.modellingAndValidation,
+          dataSourcesTreatmentAndRepresentativeness: {
+            annualSupplyOrProductionVolume: [{ '@xml:lang': 'en', '#text': '100 old suffix' }],
+          },
+        },
       };
 
       const result = genProcessJsonOrdered('test-id', dataWithoutRef);
 
       expect(result.processDataSet.processInformation.quantitativeReference).toEqual({});
+      expect(
+        result.processDataSet.modellingAndValidation.dataSourcesTreatmentAndRepresentativeness
+          .annualSupplyOrProductionVolume,
+      ).toEqual([{ '@xml:lang': 'en', '#text': '100' }]);
     });
 
     it('should use resultingAmount if not zero, otherwise use meanAmount', () => {

--- a/tests/unit/services/processes/util.test.ts
+++ b/tests/unit/services/processes/util.test.ts
@@ -490,7 +490,10 @@ describe('Process Utility Functions', () => {
         modellingAndValidation: {
           ...mockProcessData.modellingAndValidation,
           dataSourcesTreatmentAndRepresentativeness: {
-            annualSupplyOrProductionVolume: [{ '@xml:lang': 'en', '#text': '100 old suffix' }],
+            annualSupplyOrProductionVolume: [
+              { '@xml:lang': 'en', '#text': '100 old suffix' },
+              { '#text': '200 stale fallback suffix' },
+            ],
           },
         },
       };
@@ -500,7 +503,7 @@ describe('Process Utility Functions', () => {
       expect(
         result.processDataSet.modellingAndValidation.dataSourcesTreatmentAndRepresentativeness
           .annualSupplyOrProductionVolume,
-      ).toEqual([{ '@xml:lang': 'en', '#text': '100 1 kg steel' }]);
+      ).toEqual([{ '@xml:lang': 'en', '#text': '100 1 kg steel' }, { '#text': '200 1 kg steel' }]);
     });
 
     it('should handle process with no quantitative reference', () => {

--- a/tests/unit/services/processes/util.test.ts
+++ b/tests/unit/services/processes/util.test.ts
@@ -506,6 +506,40 @@ describe('Process Utility Functions', () => {
       ).toEqual([{ '@xml:lang': 'en', '#text': '100 1 kg steel' }, { '#text': '200 1 kg steel' }]);
     });
 
+    it('should preserve a previously resolved annual supply volume unit suffix while saving', () => {
+      const dataWithAnnualSupplyVolume = {
+        ...mockProcessData,
+        exchanges: {
+          exchange: [
+            {
+              '@dataSetInternalID': '1',
+              referenceToFlowDataSet: {
+                '@refObjectId': 'flow-id-1',
+                '@version': '01.00.000',
+                'common:shortDescription': [{ '@xml:lang': 'en', '#text': 'Steel' }],
+              },
+              exchangeDirection: 'Output',
+              meanAmount: '1',
+              quantitativeReference: true,
+            },
+          ],
+        },
+        modellingAndValidation: {
+          ...mockProcessData.modellingAndValidation,
+          dataSourcesTreatmentAndRepresentativeness: {
+            annualSupplyOrProductionVolume: [{ '@xml:lang': 'en', '#text': '100 kg Steel' }],
+          },
+        },
+      };
+
+      const result = genProcessJsonOrdered('test-id', dataWithAnnualSupplyVolume);
+
+      expect(
+        result.processDataSet.modellingAndValidation.dataSourcesTreatmentAndRepresentativeness
+          .annualSupplyOrProductionVolume,
+      ).toEqual([{ '@xml:lang': 'en', '#text': '100 kg Steel' }]);
+    });
+
     it('should handle process with no quantitative reference', () => {
       const dataWithoutRef = {
         ...mockProcessData,

--- a/tests/unit/services/processes/util.test.ts
+++ b/tests/unit/services/processes/util.test.ts
@@ -540,7 +540,7 @@ describe('Process Utility Functions', () => {
       ).toEqual([{ '@xml:lang': 'en', '#text': '100 kg Steel' }]);
     });
 
-    it('should handle process with no quantitative reference', () => {
+    it('should save annual supply volume with a suffix even when no quantitative reference is selected', () => {
       const dataWithoutRef = {
         ...mockProcessData,
         exchanges: {
@@ -575,7 +575,7 @@ describe('Process Utility Functions', () => {
       expect(
         result.processDataSet.modellingAndValidation.dataSourcesTreatmentAndRepresentativeness
           .annualSupplyOrProductionVolume,
-      ).toEqual([{ '@xml:lang': 'en', '#text': '100' }]);
+      ).toEqual([{ '@xml:lang': 'en', '#text': '100 reference flow' }]);
     });
 
     it('should use resultingAmount if not zero, otherwise use meanAmount', () => {

--- a/tests/unit/services/processes/util.test.ts
+++ b/tests/unit/services/processes/util.test.ts
@@ -711,6 +711,53 @@ describe('Process Utility Functions', () => {
       expect(result.processDataSet.exchanges.exchange[0].resultingAmount).toBeUndefined();
     });
 
+    it('should save exchange location as a plain string code', () => {
+      const dataWithLocation = {
+        ...mockProcessData,
+        exchanges: {
+          exchange: [
+            {
+              '@dataSetInternalID': '1',
+              referenceToFlowDataSet: {
+                '@refObjectId': 'flow-id-1',
+              },
+              exchangeDirection: 'Input',
+              location: [{ '@xml:lang': 'en', '#text': 'CN' }],
+              meanAmount: '10',
+            },
+          ],
+        },
+      };
+
+      const result = genProcessJsonOrdered('test-id', dataWithLocation);
+
+      expect(result.processDataSet.exchanges.exchange[0].location).toBe('CN');
+      expect(Array.isArray(result.processDataSet.exchanges.exchange[0].location)).toBe(false);
+    });
+
+    it('should omit exchange location when the form value is cleared', () => {
+      const dataWithClearedLocation = {
+        ...mockProcessData,
+        exchanges: {
+          exchange: [
+            {
+              '@dataSetInternalID': '1',
+              referenceToFlowDataSet: {
+                '@refObjectId': 'flow-id-1',
+              },
+              exchangeDirection: 'Input',
+              location: '',
+              meanAmount: '10',
+            },
+          ],
+        },
+      };
+
+      const result = genProcessJsonOrdered('test-id', dataWithClearedLocation);
+
+      expect(result.processDataSet.exchanges.exchange[0]).not.toHaveProperty('location');
+    });
+
     it('should include allocations in exchanges', () => {
       const dataWithAllocations = {
         ...mockProcessData,
@@ -986,6 +1033,29 @@ describe('Process Utility Functions', () => {
 
       expect(result.exchanges.exchange[0].meanAmount).toBeUndefined();
       expect(result.exchanges.exchange[0].resultingAmount).toBeUndefined();
+    });
+
+    it('should normalize raw exchange location to a plain string code for forms', () => {
+      const dataWithLegacyLocation = {
+        ...mockRawData,
+        exchanges: {
+          exchange: [
+            {
+              '@dataSetInternalID': '1',
+              referenceToFlowDataSet: {
+                '@refObjectId': 'flow-id-1',
+              },
+              exchangeDirection: 'Input',
+              location: [{ '@xml:lang': 'en', '#text': 'CN' }],
+              meanAmount: '10',
+            },
+          ],
+        },
+      };
+
+      const result = genProcessFromData(dataWithLegacyLocation);
+
+      expect(result.exchanges.exchange[0].location).toBe('CN');
     });
 
     it('should handle missing exchanges', () => {

--- a/tests/unit/services/processes/util.test.ts
+++ b/tests/unit/services/processes/util.test.ts
@@ -547,6 +547,14 @@ describe('Process Utility Functions', () => {
           exchange: [
             {
               '@dataSetInternalID': '1',
+              referenceToFlowDataSet: {
+                '@refObjectId': 'flow-id-1',
+                '@version': '01.00.000',
+                'common:shortDescription': [{ '@xml:lang': 'en', '#text': 'Steel' }],
+              },
+              refUnitRes: {
+                refUnitName: 'kg',
+              },
               exchangeDirection: 'Input',
               meanAmount: '10',
               quantitativeReference: false,

--- a/tests/unit/services/processes/util.test.ts
+++ b/tests/unit/services/processes/util.test.ts
@@ -484,6 +484,25 @@ describe('Process Utility Functions', () => {
       ).toBe('2');
     });
 
+    it('should normalize annual supply volume numeric text with the quantitative reference suffix', () => {
+      const dataWithAnnualSupplyVolume = {
+        ...mockProcessData,
+        modellingAndValidation: {
+          ...mockProcessData.modellingAndValidation,
+          dataSourcesTreatmentAndRepresentativeness: {
+            annualSupplyOrProductionVolume: [{ '@xml:lang': 'en', '#text': '100 old suffix' }],
+          },
+        },
+      };
+
+      const result = genProcessJsonOrdered('test-id', dataWithAnnualSupplyVolume);
+
+      expect(
+        result.processDataSet.modellingAndValidation.dataSourcesTreatmentAndRepresentativeness
+          .annualSupplyOrProductionVolume,
+      ).toEqual([{ '@xml:lang': 'en', '#text': '100 1 kg steel' }]);
+    });
+
     it('should handle process with no quantitative reference', () => {
       const dataWithoutRef = {
         ...mockProcessData,


### PR DESCRIPTION
Closes #413
Closes #415

## Summary
- Replace annualSupplyOrProductionVolume with a numeric-first multilingual field while keeping the persisted TIDAS shape as localized `#text` values.
- Show the derived unit/flow context in a separate read-only input next to the Ant Design `InputNumber`; the context follows the current site language.
- Derive context from the quantitative reference exchange unit/flow, leave the context blank when no reference flow exists, and save numeric-only multilingual text in that blank-context case.
- Replace exchange create/edit free-text location inputs with a searchable ILCD location code selector.
- Normalize `exchange.location` save/load paths so they persist a plain string code and omit cleared values.

## Key Decisions
- Keep the annual volume UI edit surface to a single numeric input; users no longer choose or edit language-specific text rows for this field.
- Preserve previously resolved unit prefixes when the current form state can only derive the reference-flow name.
- Use the existing ILCD location source and current site language for exchange location labels; persist only the selected location code.
- Normalize legacy StringMultiLang-shaped exchange location values defensively at form and process serialization boundaries.
- Bump `@tiangong-lca/tidas-sdk` to `^0.1.39` so SDK validation matches the process schema requirements used by this combined change.

## Validation
- `npm run test:ci -- --runTestsByPath tests/unit/components/LocationTextItem/codeSelect.test.tsx tests/unit/services/processes/exchangeLocation.test.ts tests/unit/pages/Processes/Components/Exchange/create.test.tsx tests/unit/pages/Processes/Components/Exchange/edit.test.tsx tests/unit/services/processes/util.test.ts tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts tests/unit/pages/Processes/requiredFields.test.ts tests/unit/pages/Processes/sdkValidation.test.ts tests/unit/pages/Processes/sdkValidationUi.test.ts tests/unit/pages/Processes/Components/form.test.tsx`
- `npm run docpact:gate -- --base origin/dev`
- `npm run prepush:gate`
- `npm run build`
- Earlier Playwright CLI smoke opened the local app and verified the login page render.

## Risks / Rollback
- Context derivation is limited to exchange metadata already available in frontend form state; rollback is reverting this PR and the SDK version bump.
- Exchange location selector behavior is scoped to exchange create/edit; process geography location behavior is unchanged.

## Follow-ups
- After merge/promote, update the lca-workspace submodule pointer when the child commit is eligible for workspace integration.

## Workspace Integration
- Parent workspace delivery remains tracked under tiangong-lca/workspace#109; this PR now carries both next frontend child tasks from #413 and #415.
