### PR TITLE
fix: use location code selector for exchange location

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-14"
-lastReviewedCommit: "d3fb24a7306cac0c0ef4bba8595c759bfac72140"
+lastReviewedAt: "2026-05-18"
+lastReviewedCommit: "b989f32f18a069e56caa8379e74916d043537101"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: d3fb24a7306cac0c0ef4bba8595c759bfac72140
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: b989f32f18a069e56caa8379e74916d043537101
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 806ed443f2a29ef1666e16f76c8ae0bec12f664f
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 4595d3ad2f86c3cd23dc9b9352ca6bbf31564187
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -20,8 +20,8 @@ checkPaths:
   - .husky/pre-push
   - package.json
   - .github/workflows/**
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: b989f32f18a069e56caa8379e74916d043537101
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: d3fb24a7306cac0c0ef4bba8595c759bfac72140
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: b989f32f18a069e56caa8379e74916d043537101
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: d3fb24a7306cac0c0ef4bba8595c759bfac72140
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: b989f32f18a069e56caa8379e74916d043537101
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -19,8 +19,8 @@ checkPaths:
   - config/supabaseEnv.ts
   - src/services/**
   - docker/**
-lastReviewedAt: 2026-05-11
-lastReviewedCommit: d41c978ab936d3cd1d4b4518fbdf9e3eea278538
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: b989f32f18a069e56caa8379e74916d043537101
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: b989f32f18a069e56caa8379e74916d043537101
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: b989f32f18a069e56caa8379e74916d043537101
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: b989f32f18a069e56caa8379e74916d043537101
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 6783ed3ebaf9e5c937eaa6556f5e77829443a09a
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: b989f32f18a069e56caa8379e74916d043537101
 ---
 
 # Testing Troubleshooting

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@antv/x6-react-shape": "^3.0.1",
     "@dagrejs/dagre": "^3.0.0",
     "@supabase/supabase-js": "^2.104.0",
-    "@tiangong-lca/tidas-sdk": "^0.1.36",
+    "@tiangong-lca/tidas-sdk": "^0.1.39",
     "antd": "^5.29.1",
     "bignumber.js": "^11.0.0",
     "dayjs": "^1.11.20",

--- a/src/components/LocationTextItem/codeSelect.tsx
+++ b/src/components/LocationTextItem/codeSelect.tsx
@@ -4,7 +4,6 @@ import type { SelectProps } from 'antd';
 import { Select } from 'antd';
 import type { FC } from 'react';
 import { useEffect, useMemo, useState } from 'react';
-import { FormattedMessage } from 'umi';
 
 type LocationCodeOption = {
   label: string;
@@ -97,12 +96,6 @@ const LocationCodeSelect: FC<LocationCodeSelectProps> = ({
       loading={loading}
       optionFilterProp='label'
       optionLabelProp='label'
-      placeholder={
-        <FormattedMessage
-          id='pages.process.exchange.location.placeholder'
-          defaultMessage='Select location code'
-        />
-      }
       {...selectProps}
       value={normalizedValue}
       options={options}

--- a/src/components/LocationTextItem/codeSelect.tsx
+++ b/src/components/LocationTextItem/codeSelect.tsx
@@ -1,0 +1,121 @@
+import { getILCDLocationAll } from '@/services/locations/api';
+import { normalizeExchangeLocationCode } from '@/services/processes/exchangeLocation';
+import type { SelectProps } from 'antd';
+import { Select } from 'antd';
+import type { FC } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { FormattedMessage } from 'umi';
+
+type LocationCodeOption = {
+  label: string;
+  searchText: string;
+  value: string;
+};
+
+type LocationCodeSelectProps = Omit<SelectProps<string>, 'children' | 'onChange' | 'options'> & {
+  lang: string;
+  onChange?: (value?: string) => void;
+  onData?: () => void;
+};
+
+const getLocationCodeOption = (location: Record<string, unknown>): LocationCodeOption | null => {
+  const value = normalizeExchangeLocationCode(location['@value']);
+
+  if (!value) {
+    return null;
+  }
+
+  const text = typeof location['#text'] === 'string' ? location['#text'].trim() : '';
+  const label = text ? `${value} (${text})` : value;
+
+  return {
+    label,
+    searchText: `${value} ${text}`.trim().toLowerCase(),
+    value,
+  };
+};
+
+const LocationCodeSelect: FC<LocationCodeSelectProps> = ({
+  lang,
+  onChange,
+  onData,
+  value,
+  ...selectProps
+}) => {
+  const [locationOptions, setLocationOptions] = useState<LocationCodeOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const normalizedValue = normalizeExchangeLocationCode(value);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+
+    getILCDLocationAll(lang)
+      .then((res) => {
+        if (cancelled || !res.success) {
+          return;
+        }
+
+        const data = res.data?.[0]?.location ?? [];
+        const locationList = Array.isArray(data) ? data : [data];
+        const nextOptions = locationList
+          .map((location: Record<string, unknown>) => getLocationCodeOption(location))
+          .filter((option): option is LocationCodeOption => Boolean(option));
+
+        setLocationOptions(nextOptions);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [lang]);
+
+  const options = useMemo(() => {
+    if (!normalizedValue || locationOptions.some((option) => option.value === normalizedValue)) {
+      return locationOptions;
+    }
+
+    return [
+      {
+        label: normalizedValue,
+        searchText: normalizedValue.toLowerCase(),
+        value: normalizedValue,
+      },
+      ...locationOptions,
+    ];
+  }, [locationOptions, normalizedValue]);
+
+  return (
+    <Select
+      allowClear
+      showSearch
+      loading={loading}
+      optionFilterProp='label'
+      optionLabelProp='label'
+      placeholder={
+        <FormattedMessage
+          id='pages.process.exchange.location.placeholder'
+          defaultMessage='Select location code'
+        />
+      }
+      {...selectProps}
+      value={normalizedValue}
+      options={options}
+      onChange={(nextValue) => {
+        onChange?.(normalizeExchangeLocationCode(nextValue));
+        onData?.();
+      }}
+      filterOption={(input, option) => {
+        const searchText = String(option?.searchText ?? option?.label ?? option?.value ?? '');
+        return searchText.toLowerCase().includes(input.toLowerCase());
+      }}
+    />
+  );
+};
+
+export default LocationCodeSelect;

--- a/src/pages/Processes/Components/Exchange/create.tsx
+++ b/src/pages/Processes/Components/Exchange/create.tsx
@@ -1,4 +1,5 @@
 import LangTextItemForm from '@/components/LangTextItem/form';
+import LocationCodeSelect from '@/components/LocationTextItem/codeSelect';
 import ToolBarButton from '@/components/ToolBarButton';
 import UnitConvert from '@/components/UnitConvert';
 import { UnitsContext } from '@/contexts/unitContext';
@@ -6,6 +7,7 @@ import FlowsSelectForm from '@/pages/Flows/Components/select/form';
 import SourceSelectForm from '@/pages/Sources/Components/select/form';
 import { getRules } from '@/pages/Utils';
 import { ProcessExchangeData } from '@/services/processes/data';
+import { normalizeExchangeLocationCode } from '@/services/processes/exchangeLocation';
 import styles from '@/style/custom.less';
 import { CaretRightOutlined, CloseOutlined, PlusOutlined } from '@ant-design/icons';
 import { ProForm, ProFormInstance } from '@ant-design/pro-components';
@@ -39,6 +41,14 @@ type Props = {
   showRules?: boolean;
   disabled?: boolean;
 };
+
+const normalizeExchangeFormData = (exchangeData: ProcessExchangeData): ProcessExchangeData => {
+  const { location, ...rest } = exchangeData;
+  const normalizedLocation = normalizeExchangeLocationCode(location);
+
+  return normalizedLocation ? { ...rest, location: normalizedLocation } : rest;
+};
+
 const ProcessExchangeCreate: FC<Props> = ({
   direction,
   lang,
@@ -150,7 +160,7 @@ const ProcessExchangeCreate: FC<Props> = ({
             },
           }}
           onFinish={async () => {
-            onData({ ...fromData });
+            onData(normalizeExchangeFormData({ ...fromData }));
             formRefCreate.current?.resetFields();
             setDrawerVisible(false);
             return true;
@@ -221,7 +231,7 @@ const ProcessExchangeCreate: FC<Props> = ({
               }
               name={'location'}
             >
-              <Input />
+              <LocationCodeSelect lang={lang} />
             </Form.Item>
             <Form.Item
               label={

--- a/src/pages/Processes/Components/Exchange/edit.tsx
+++ b/src/pages/Processes/Components/Exchange/edit.tsx
@@ -1,4 +1,5 @@
 import LangTextItemForm from '@/components/LangTextItem/form';
+import LocationCodeSelect from '@/components/LocationTextItem/codeSelect';
 import UnitConvert from '@/components/UnitConvert';
 import { UnitsContext } from '@/contexts/unitContext';
 import FlowsSelectForm from '@/pages/Flows/Components/select/form';
@@ -6,6 +7,7 @@ import SourceSelectForm from '@/pages/Sources/Components/select/form';
 import { getRules } from '@/pages/Utils';
 import type { ValidationIssueSdkDetail } from '@/pages/Utils/review';
 import { ProcessExchangeData } from '@/services/processes/data';
+import { normalizeExchangeLocationCode } from '@/services/processes/exchangeLocation';
 import styles from '@/style/custom.less';
 import { CaretRightOutlined, CloseOutlined, FormOutlined } from '@ant-design/icons';
 import { ProForm, ProFormInstance } from '@ant-design/pro-components';
@@ -61,11 +63,17 @@ const normalizeExchangeAmountValue = (value: string | number | null | undefined)
   return value;
 };
 
-const normalizeExchangeFormData = (exchangeData: ProcessExchangeData): ProcessExchangeData => ({
-  ...exchangeData,
-  meanAmount: normalizeExchangeAmountValue(exchangeData?.meanAmount),
-  resultingAmount: normalizeExchangeAmountValue(exchangeData?.resultingAmount),
-});
+const normalizeExchangeFormData = (exchangeData: ProcessExchangeData): ProcessExchangeData => {
+  const { location, ...rest } = exchangeData;
+  const normalizedLocation = normalizeExchangeLocationCode(location);
+
+  return {
+    ...rest,
+    ...(normalizedLocation ? { location: normalizedLocation } : {}),
+    meanAmount: normalizeExchangeAmountValue(exchangeData?.meanAmount),
+    resultingAmount: normalizeExchangeAmountValue(exchangeData?.resultingAmount),
+  };
+};
 
 const normalizeQuantitativeReferenceSelection = (
   exchangeData: ProcessExchangeData[],
@@ -419,10 +427,11 @@ const ProcessExchangeEdit: FC<Props> = ({
             },
           }}
           onFinish={async () => {
+            const nextFormData = normalizeExchangeFormData({ ...fromData });
             const nextExchangeData = normalizeQuantitativeReferenceSelection(
               data.map((item) => {
                 if (item['@dataSetInternalID'] === id) {
-                  return fromData;
+                  return nextFormData;
                 }
                 return item;
               }),
@@ -516,7 +525,7 @@ const ProcessExchangeEdit: FC<Props> = ({
                 }
                 name={'location'}
               >
-                <Input />
+                <LocationCodeSelect lang={lang} />
               </Form.Item>,
             )}
             {renderSdkHighlightedField(

--- a/src/services/processes/exchangeLocation.ts
+++ b/src/services/processes/exchangeLocation.ts
@@ -1,0 +1,31 @@
+export const normalizeExchangeLocationCode = (value: unknown): string | undefined => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number') {
+    const normalizedValue = `${value}`.trim();
+    return normalizedValue || undefined;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const normalizedValue = normalizeExchangeLocationCode(item);
+      if (normalizedValue) {
+        return normalizedValue;
+      }
+    }
+    return undefined;
+  }
+
+  if (typeof value === 'object') {
+    const locationValue = value as Record<string, unknown>;
+    return (
+      normalizeExchangeLocationCode(locationValue['#text']) ??
+      normalizeExchangeLocationCode(locationValue['@value']) ??
+      normalizeExchangeLocationCode(locationValue.value)
+    );
+  }
+
+  return undefined;
+};

--- a/src/services/processes/util.ts
+++ b/src/services/processes/util.ts
@@ -15,6 +15,7 @@ import {
   removeEmptyObjects,
   toAmountNumber,
 } from '../general/util';
+import { normalizeExchangeLocationCode } from './exchangeLocation';
 
 const normalizeExchangeAmountValue = (value: string | number | null | undefined) => {
   if (value === null || value === undefined || value === 'undefined') {
@@ -32,6 +33,11 @@ const toExchangeAmountString = (value: string | number | null | undefined) => {
   }
 
   return `${normalizedValue}`;
+};
+
+const getExchangeLocationField = (value: unknown) => {
+  const location = normalizeExchangeLocationCode(value);
+  return location ? { location } : {};
 };
 
 const normalizeReferenceYearValue = (value: string | number | null | undefined) => {
@@ -72,7 +78,7 @@ export function genProcessJsonOrdered(id: string, data: any) {
           item?.referenceToFlowDataSet?.['common:shortDescription'],
         ),
       },
-      location: item.location,
+      ...getExchangeLocationField(item.location),
       functionType: item.functionType,
       exchangeDirection: item.exchangeDirection,
       referenceToVariable: item.referenceToVariable,
@@ -1510,7 +1516,7 @@ export function genProcessFromData(data: any): FormProcess {
                   item?.referenceToFlowDataSet?.['common:shortDescription'],
                 ),
               },
-              location: item.location,
+              ...getExchangeLocationField(item.location),
               functionType: item.functionType,
               exchangeDirection: capitalize(item.exchangeDirection),
               referenceToVariable: item.referenceToVariable,
@@ -1560,7 +1566,7 @@ export function genProcessFromData(data: any): FormProcess {
                   item?.referenceToFlowDataSet?.['common:shortDescription'],
                 ),
               },
-              location: item.location,
+              ...getExchangeLocationField(item.location),
               functionType: item.functionType,
               exchangeDirection: capitalize(item.exchangeDirection),
               referenceToVariable: item.referenceToVariable,

--- a/tests/unit/components/LocationTextItem/codeSelect.test.tsx
+++ b/tests/unit/components/LocationTextItem/codeSelect.test.tsx
@@ -18,6 +18,7 @@ jest.mock('antd', () => ({
   __esModule: true,
   Select: ({
     allowClear,
+    filterOption,
     loading,
     onChange,
     options = [],
@@ -45,6 +46,18 @@ jest.mock('antd', () => ({
           clear
         </button>
       ) : null}
+      <span data-testid={`${dataTestId}-filter-search`}>
+        {String(filterOption?.('china', { searchText: 'CN China' }))}
+      </span>
+      <span data-testid={`${dataTestId}-filter-label`}>
+        {String(filterOption?.('global', { label: 'GLO (Global)' }))}
+      </span>
+      <span data-testid={`${dataTestId}-filter-value`}>
+        {String(filterOption?.('rer', { value: 'RER' }))}
+      </span>
+      <span data-testid={`${dataTestId}-filter-empty`}>
+        {String(filterOption?.('missing', undefined))}
+      </span>
     </div>
   ),
 }));
@@ -109,5 +122,68 @@ describe('LocationCodeSelect', () => {
     fireEvent.click(screen.getByTestId('loc-clear'));
 
     expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('ignores invalid location entries and falls back to the code when localized text is missing', async () => {
+    mockGetILCDLocationAll.mockResolvedValueOnce({
+      data: [
+        {
+          location: [{ '#text': 'Missing code' }, { '@value': 'RER' }],
+        },
+      ],
+      success: true,
+    });
+
+    render(<LocationCodeSelect lang='en' data-testid='loc' />);
+
+    await waitFor(() => {
+      expect(screen.getByText('RER')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Missing code')).not.toBeInTheDocument();
+  });
+
+  it('loads a single location object response', async () => {
+    mockGetILCDLocationAll.mockResolvedValueOnce({
+      data: [
+        {
+          location: { '@value': 'US', '#text': 'United States' },
+        },
+      ],
+      success: true,
+    });
+
+    render(<LocationCodeSelect lang='en' data-testid='loc' />);
+
+    await waitFor(() => {
+      expect(screen.getByText('US (United States)')).toBeInTheDocument();
+    });
+  });
+
+  it('renders no options when the location response has no data', async () => {
+    mockGetILCDLocationAll.mockResolvedValueOnce({
+      success: true,
+    });
+
+    render(<LocationCodeSelect lang='en' data-testid='loc' />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loc')).toHaveAttribute('data-loading', 'false');
+    });
+
+    expect(screen.queryByText('CN (China)')).not.toBeInTheDocument();
+  });
+
+  it('filters by search text, label, value, and empty option fallbacks', async () => {
+    render(<LocationCodeSelect lang='en' data-testid='loc' />);
+
+    await waitFor(() => {
+      expect(screen.getByText('CN (China)')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('loc-filter-search')).toHaveTextContent('true');
+    expect(screen.getByTestId('loc-filter-label')).toHaveTextContent('true');
+    expect(screen.getByTestId('loc-filter-value')).toHaveTextContent('true');
+    expect(screen.getByTestId('loc-filter-empty')).toHaveTextContent('false');
   });
 });

--- a/tests/unit/components/LocationTextItem/codeSelect.test.tsx
+++ b/tests/unit/components/LocationTextItem/codeSelect.test.tsx
@@ -1,0 +1,113 @@
+// @ts-nocheck
+import LocationCodeSelect from '@/components/LocationTextItem/codeSelect';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const mockGetILCDLocationAll = jest.fn();
+
+jest.mock('@/services/locations/api', () => ({
+  __esModule: true,
+  getILCDLocationAll: (...args: any[]) => mockGetILCDLocationAll(...args),
+}));
+
+jest.mock('umi', () => ({
+  __esModule: true,
+  FormattedMessage: ({ defaultMessage, id }: any) => defaultMessage ?? id,
+}));
+
+jest.mock('antd', () => ({
+  __esModule: true,
+  Select: ({
+    allowClear,
+    loading,
+    onChange,
+    options = [],
+    placeholder,
+    value,
+    'data-testid': dataTestId,
+  }: any) => (
+    <div>
+      <select
+        data-testid={dataTestId}
+        aria-label={placeholder}
+        data-loading={String(loading)}
+        value={value ?? ''}
+        onChange={(event) => onChange?.(event.target.value || undefined)}
+      >
+        <option value=''>empty</option>
+        {options.map((option: any) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      {allowClear ? (
+        <button type='button' data-testid={`${dataTestId}-clear`} onClick={() => onChange?.()}>
+          clear
+        </button>
+      ) : null}
+    </div>
+  ),
+}));
+
+describe('LocationCodeSelect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetILCDLocationAll.mockResolvedValue({
+      data: [
+        {
+          location: [
+            { '@value': 'CN', '#text': 'China' },
+            { '@value': 'GLO', '#text': 'Global' },
+          ],
+        },
+      ],
+      success: true,
+    });
+  });
+
+  it('loads localized location labels and returns the selected plain code', async () => {
+    const onChange = jest.fn();
+    const onData = jest.fn();
+
+    render(<LocationCodeSelect lang='en' onChange={onChange} onData={onData} data-testid='loc' />);
+
+    await waitFor(() => {
+      expect(screen.getByText('CN (China)')).toBeInTheDocument();
+      expect(screen.getByText('GLO (Global)')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('loc'), { target: { value: 'CN' } });
+
+    expect(onChange).toHaveBeenCalledWith('CN');
+    expect(onData).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a legacy plain string value visible when it is not in the location list', async () => {
+    render(<LocationCodeSelect lang='en' value='CUSTOM-REGION' data-testid='loc' />);
+
+    await waitFor(() => {
+      expect(screen.getByText('CUSTOM-REGION')).toBeInTheDocument();
+    });
+  });
+
+  it('normalizes legacy multilingual values and clears to undefined', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <LocationCodeSelect
+        lang='en'
+        value={[{ '@xml:lang': 'en', '#text': 'CN' }]}
+        onChange={onChange}
+        data-testid='loc'
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loc')).toHaveValue('CN');
+    });
+
+    fireEvent.click(screen.getByTestId('loc-clear'));
+
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/tests/unit/pages/Processes/Components/Exchange/create.test.tsx
+++ b/tests/unit/pages/Processes/Components/Exchange/create.test.tsx
@@ -126,6 +126,16 @@ jest.mock('@/components/LangTextItem/form', () => ({
   default: () => <div data-testid='lang-form'>lang-form</div>,
 }));
 
+jest.mock('@/services/locations/api', () => ({
+  __esModule: true,
+  getILCDLocationAll: jest.fn(() =>
+    Promise.resolve({
+      data: [{ location: [{ '@value': 'CN', '#text': 'China' }] }],
+      success: true,
+    }),
+  ),
+}));
+
 jest.mock('antd', () => {
   const React = require('react');
 
@@ -412,6 +422,28 @@ describe('ProcessExchangeCreate', () => {
 
     await waitFor(() => {
       expect(proFormApi?.getFieldValue('meanAmount')).toBe('123');
+    });
+  });
+
+  it('normalizes exchange location to a plain string code before saving', async () => {
+    const onData = jest.fn();
+    render(<ProcessExchangeCreate {...defaultProps} onData={onData} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Create/i }));
+
+    await act(async () => {
+      proFormApi?.setFieldsValue({
+        location: [{ '@xml:lang': 'en', '#text': 'CN' }],
+      });
+      triggerValuesChange?.({}, proFormApi?.getFieldsValue());
+    });
+
+    await act(async () => {
+      await proFormApi?.submit();
+    });
+
+    await waitFor(() => {
+      expect(onData).toHaveBeenCalledWith({ exchangeDirection: 'Output', location: 'CN' });
     });
   });
 

--- a/tests/unit/pages/Processes/Components/Exchange/edit.test.tsx
+++ b/tests/unit/pages/Processes/Components/Exchange/edit.test.tsx
@@ -131,6 +131,16 @@ jest.mock('@/components/LangTextItem/form', () => ({
   default: () => <div data-testid='lang-form'>lang</div>,
 }));
 
+jest.mock('@/services/locations/api', () => ({
+  __esModule: true,
+  getILCDLocationAll: jest.fn(() =>
+    Promise.resolve({
+      data: [{ location: [{ '@value': 'CN', '#text': 'China' }] }],
+      success: true,
+    }),
+  ),
+}));
+
 jest.mock('antd', () => {
   const React = require('react');
 
@@ -431,6 +441,27 @@ describe('ProcessExchangeEdit', () => {
     await waitFor(() => {
       expect(mockProFormApi?.getFieldValue('meanAmount')).toBeUndefined();
       expect(mockProFormApi?.getFieldValue('resultingAmount')).toBeUndefined();
+    });
+  });
+
+  it('normalizes legacy multilingual exchange location to a plain string in the form', async () => {
+    render(
+      <ProcessExchangeEdit
+        {...defaultProps}
+        data={[
+          {
+            '@dataSetInternalID': '0',
+            exchangeDirection: 'input',
+            location: [{ '@xml:lang': 'en', '#text': 'CN' }],
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(mockProFormApi?.getFieldValue('location')).toBe('CN');
     });
   });
 

--- a/tests/unit/services/processes/exchangeLocation.test.ts
+++ b/tests/unit/services/processes/exchangeLocation.test.ts
@@ -1,0 +1,33 @@
+import { normalizeExchangeLocationCode } from '@/services/processes/exchangeLocation';
+
+describe('normalizeExchangeLocationCode', () => {
+  it('normalizes primitive location codes', () => {
+    expect(normalizeExchangeLocationCode(' CN ')).toBe('CN');
+    expect(normalizeExchangeLocationCode(123)).toBe('123');
+    expect(normalizeExchangeLocationCode('   ')).toBeUndefined();
+    expect(normalizeExchangeLocationCode(null)).toBeUndefined();
+    expect(normalizeExchangeLocationCode(undefined)).toBeUndefined();
+  });
+
+  it('returns the first non-empty normalized array value', () => {
+    expect(normalizeExchangeLocationCode([' ', { '#text': ' RER ' }])).toBe('RER');
+    expect(normalizeExchangeLocationCode([])).toBeUndefined();
+  });
+
+  it('normalizes legacy object-shaped location values', () => {
+    expect(normalizeExchangeLocationCode({ '#text': ' CN ', '@value': 'GLO', value: 'US' })).toBe(
+      'CN',
+    );
+    expect(normalizeExchangeLocationCode({ '#text': ' ', '@value': ' GLO ', value: 'US' })).toBe(
+      'GLO',
+    );
+    expect(
+      normalizeExchangeLocationCode({ '#text': undefined, '@value': undefined, value: ' US ' }),
+    ).toBe('US');
+    expect(normalizeExchangeLocationCode({})).toBeUndefined();
+  });
+
+  it('ignores unsupported value types', () => {
+    expect(normalizeExchangeLocationCode(true)).toBeUndefined();
+  });
+});

--- a/tests/unit/services/processes/util.test.ts
+++ b/tests/unit/services/processes/util.test.ts
@@ -711,6 +711,53 @@ describe('Process Utility Functions', () => {
       expect(result.processDataSet.exchanges.exchange[0].resultingAmount).toBeUndefined();
     });
 
+    it('should save exchange location as a plain string code', () => {
+      const dataWithLocation = {
+        ...mockProcessData,
+        exchanges: {
+          exchange: [
+            {
+              '@dataSetInternalID': '1',
+              referenceToFlowDataSet: {
+                '@refObjectId': 'flow-id-1',
+              },
+              exchangeDirection: 'Input',
+              location: [{ '@xml:lang': 'en', '#text': 'CN' }],
+              meanAmount: '10',
+            },
+          ],
+        },
+      };
+
+      const result = genProcessJsonOrdered('test-id', dataWithLocation);
+
+      expect(result.processDataSet.exchanges.exchange[0].location).toBe('CN');
+      expect(Array.isArray(result.processDataSet.exchanges.exchange[0].location)).toBe(false);
+    });
+
+    it('should omit exchange location when the form value is cleared', () => {
+      const dataWithClearedLocation = {
+        ...mockProcessData,
+        exchanges: {
+          exchange: [
+            {
+              '@dataSetInternalID': '1',
+              referenceToFlowDataSet: {
+                '@refObjectId': 'flow-id-1',
+              },
+              exchangeDirection: 'Input',
+              location: '',
+              meanAmount: '10',
+            },
+          ],
+        },
+      };
+
+      const result = genProcessJsonOrdered('test-id', dataWithClearedLocation);
+
+      expect(result.processDataSet.exchanges.exchange[0]).not.toHaveProperty('location');
+    });
+
     it('should include allocations in exchanges', () => {
       const dataWithAllocations = {
         ...mockProcessData,
@@ -986,6 +1033,29 @@ describe('Process Utility Functions', () => {
 
       expect(result.exchanges.exchange[0].meanAmount).toBeUndefined();
       expect(result.exchanges.exchange[0].resultingAmount).toBeUndefined();
+    });
+
+    it('should normalize raw exchange location to a plain string code for forms', () => {
+      const dataWithLegacyLocation = {
+        ...mockRawData,
+        exchanges: {
+          exchange: [
+            {
+              '@dataSetInternalID': '1',
+              referenceToFlowDataSet: {
+                '@refObjectId': 'flow-id-1',
+              },
+              exchangeDirection: 'Input',
+              location: [{ '@xml:lang': 'en', '#text': 'CN' }],
+              meanAmount: '10',
+            },
+          ],
+        },
+      };
+
+      const result = genProcessFromData(dataWithLegacyLocation);
+
+      expect(result.exchanges.exchange[0].location).toBe('CN');
     });
 
     it('should handle missing exchanges', () => {


### PR DESCRIPTION
Closes #415

## Summary
- Replace exchange create/edit free-text location inputs with a searchable ILCD location code selector.
- Normalize exchange.location save/load paths so they persist a plain string code and omit cleared values.
- Preserve legacy non-enum plain string values in the selector while avoiding StringMultiLang round-trips.

## Key Decisions
- Use the existing ILCD location source and current site language for labels; persist only the selected code.
- Normalize legacy StringMultiLang-shaped location values defensively at form and process serialization boundaries.

## Validation
- npm run test:ci -- --runTestsByPath tests/unit/components/LocationTextItem/codeSelect.test.tsx tests/unit/services/processes/exchangeLocation.test.ts tests/unit/pages/Processes/Components/Exchange/create.test.tsx tests/unit/pages/Processes/Components/Exchange/edit.test.tsx tests/unit/services/processes/util.test.ts
- npm run lint
- npm run build
- npm test
- npm run prepush:gate
- npm run docpact:gate -- --base origin/dev
- Playwright smoke opened http://localhost:8001 and reached the login page.

## Risks / Rollback
- Low risk: scoped to exchange location editing and process exchange serialization; rollback reverts the selector and normalization helper.

## Follow-ups
- After merge, lca-workspace must bump the tiangong-lca-next submodule pointer when the child commit is eligible.

## Workspace Integration
- Workspace integration remains pending for tiangong-lca/workspace#109.
