### PR TITLE
chore: standardize docpact CLI wrapper

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -52,6 +52,7 @@ ownership:
           - .github/workflows/ci.yml
           - .github/workflows/build.yml
           - .github/workflows/ai-doc-lint.yml
+          - scripts/docpact
           - scripts/docpact-gate.js
           - scripts/test-runner.cjs
           - scripts/test-coverage-report.js
@@ -93,6 +94,7 @@ coverage:
     - .github/workflows/ai-doc-lint.yml
     - .github/workflows/build.yml
     - .github/workflows/ci.yml
+    - scripts/docpact
     - scripts/docpact-gate.js
     - scripts/test-runner.cjs
     - scripts/test-coverage-report.js
@@ -135,6 +137,7 @@ routing:
         - .github/workflows/ci.yml
         - .github/workflows/build.yml
         - .github/workflows/ai-doc-lint.yml
+        - scripts/docpact
         - scripts/docpact-gate.js
         - scripts/test-runner.cjs
         - scripts/test-coverage-report.js
@@ -169,6 +172,7 @@ routing:
         - .husky/pre-push
         - .github/workflows/ci.yml
         - .github/workflows/build.yml
+        - scripts/docpact
         - scripts/docpact-gate.js
         - tests/**
         - docs/agents/test_todo_list.md
@@ -438,6 +442,8 @@ rules:
         kind: ci
       - path: .github/workflows/build.yml
         kind: ci
+      - path: scripts/docpact
+        kind: local-automation
       - path: scripts/docpact-gate.js
         kind: test-gate
       - path: scripts/test-runner.cjs

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -20,14 +20,14 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
-        run: cargo install docpact --version 0.1.4 --force
+        run: cargo install docpact --version 0.1.9 --force
 
       - name: Validate docpact config
-        run: docpact validate-config --root . --strict
+        run: scripts/docpact validate-config --root . --strict
 
       - name: Run docpact lint
         run: >
-          docpact lint
+          scripts/docpact lint
           --root .
           --base "${{ github.event.pull_request.base.sha }}"
           --head "${{ github.event.pull_request.head.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ Keep these entry-level facts in `AGENTS.md`. Use `DEV.md` and `docs/agents/repo-
 - shared dev environment: `npm start` (`npm run start:dev` is equivalent)
 - explicit main-environment run: `npm run start:main`
 - default lint gate: `npm run lint`
-- local documentation gate before push: `npm run docpact:gate`
+- local documentation gate before push: `npm run docpact:gate`, backed by `scripts/docpact` for local CLI discovery
 - default CI-style test entry: `npm test`
 - build when shipped behavior, branding/package surfaces, or static assets change: `npm run build`
 - protected-branch parity gate: `npm run prepush:gate`

--- a/DEV.md
+++ b/DEV.md
@@ -83,7 +83,7 @@ npm install
 | coverage report + queue summary | `npm run test:coverage:report` |
 | build | `npm run build` |
 | protected-branch parity gate | `npm run prepush:gate` |
-| repo AI-doc lint | `~/.cargo/bin/docpact validate-config --root . --strict && ~/.cargo/bin/docpact lint --root . --base <base> --head <head> --mode enforce` |
+| repo AI-doc lint | `scripts/docpact validate-config --root . --strict && scripts/docpact lint --root . --base <base> --head <head> --mode enforce` |
 
 ## Command Rules
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -19,6 +19,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - .husky/pre-push
   - package.json
+  - scripts/docpact
+  - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-05-20
 lastReviewedCommit: ca4280853d06d12dd6566df5ba0e48cbc3466719
@@ -37,6 +39,8 @@ Define the intended trigger policy for the existing local docpact gate and `npm 
 ```bash
 npm run docpact:gate
 ```
+
+`npm run docpact:gate` resolves the `docpact` CLI through `scripts/docpact`, so local pushes do not depend on bare `docpact` being available on `PATH`.
 
 ```bash
 npm run prepush:gate

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -66,7 +66,7 @@ npm run prepush:gate
 | sync helpers under `docker/**` | `npm run lint`; `npm run build` | run the exact helper only when the task includes it | do not hand-edit synced mirrors |
 | tests, coverage, or gate scripts | `npm run docpact:gate`; `npm run lint`; `npm run test:ci`; `npm run test:coverage`; `npm run test:coverage:assert-full` | `npm run prepush:gate` | coverage expectations remain strict |
 | data workflow fixtures or workflow smoke harnesses | `npm run docpact:gate`; `npm run test:data-workflows:unit` | affected live smoke script only when credentials and target environment are part of the task, using `npm run test:workflows -- --<workflow> <workflow-args>`; `npm run test:api:smoke -- <workflow-args>` for broad supported API smoke coverage, then inspect its summary because child workflow failures do not make the command exit non-zero | keep `fixtures/data/**`, `fixtures/result/**`, workflow defaults, and unit path assertions aligned |
-| repo docs only | `docpact lint --root . --files "<csv>" --mode enforce` | `docpact validate-config --root . --strict` when `.docpact/config.yaml` changes | still update review metadata and ownership as needed |
+| repo docs only | `scripts/docpact lint --root . --files "<csv>" --mode enforce` | `scripts/docpact validate-config --root . --strict` when `.docpact/config.yaml` changes | still update review metadata and ownership as needed |
 
 The local `pre-push` hook always runs `npm run docpact:gate` first. Non-main branches then skip the heavy `npm run prepush:gate`; local `main` pushes run both. The docpact gate defaults to `origin/dev` and can be redirected with `DOCPACT_BASE_REF=<ref>` for promote or hotfix branches.
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: ca4280853d06d12dd6566df5ba0e48cbc3466719
+lastReviewedAt: 2026-05-21
+lastReviewedCommit: 96b56d2b6835dae28bafca4bd5f8287012dda548
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: ca4280853d06d12dd6566df5ba0e48cbc3466719
+lastReviewedAt: 2026-05-21
+lastReviewedCommit: 96b56d2b6835dae28bafca4bd5f8287012dda548
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: ca4280853d06d12dd6566df5ba0e48cbc3466719
+lastReviewedAt: 2026-05-21
+lastReviewedCommit: 96b56d2b6835dae28bafca4bd5f8287012dda548
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: ca4280853d06d12dd6566df5ba0e48cbc3466719
+lastReviewedAt: 2026-05-21
+lastReviewedCommit: 96b56d2b6835dae28bafca4bd5f8287012dda548
 ---
 
 # Testing Troubleshooting

--- a/scripts/docpact
+++ b/scripts/docpact
@@ -1,0 +1,65 @@
+#!/bin/sh
+set -eu
+
+docpact_version="${DOCPACT_VERSION:-0.1.9}"
+
+use_candidate() {
+  candidate="$1"
+  if [ -n "$candidate" ] && [ -x "$candidate" ] && "$candidate" --version >/dev/null 2>&1; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+  return 1
+}
+
+find_docpact() {
+  if [ -n "${DOCPACT_BIN:-}" ]; then
+    if use_candidate "$DOCPACT_BIN"; then
+      return 0
+    fi
+    echo "DOCPACT_BIN is set but is not an executable docpact binary: $DOCPACT_BIN" >&2
+    return 127
+  fi
+
+  if [ -n "${CARGO_HOME:-}" ] && use_candidate "$CARGO_HOME/bin/docpact"; then
+    return 0
+  fi
+
+  if [ -n "${HOME:-}" ] && use_candidate "$HOME/.cargo/bin/docpact"; then
+    return 0
+  fi
+
+  if use_candidate "/opt/homebrew/bin/docpact"; then
+    return 0
+  fi
+
+  if use_candidate "/usr/local/bin/docpact"; then
+    return 0
+  fi
+
+  if command -v docpact >/dev/null 2>&1; then
+    candidate="$(command -v docpact)"
+    case "$candidate" in
+      */scripts/docpact | scripts/docpact | ./scripts/docpact)
+        ;;
+      *)
+        if use_candidate "$candidate"; then
+          return 0
+        fi
+        ;;
+    esac
+  fi
+
+  echo "docpact was not found." >&2
+  echo "Install it with: cargo install docpact --version $docpact_version --force" >&2
+  echo "Or set DOCPACT_BIN to an executable docpact binary." >&2
+  return 127
+}
+
+if [ "${1:-}" = "--print-bin" ]; then
+  find_docpact
+  exit 0
+fi
+
+docpact_bin="$(find_docpact)"
+exec "$docpact_bin" "$@"

--- a/scripts/docpact-gate.js
+++ b/scripts/docpact-gate.js
@@ -36,12 +36,18 @@ function spawn(command, args, options = {}) {
   });
 }
 
-function findDocpact() {
+function findDocpact(repoRoot) {
   const candidates = [];
   if (process.env.DOCPACT_BIN) {
     candidates.push(process.env.DOCPACT_BIN);
   }
+  candidates.push(path.join(repoRoot, 'scripts', 'docpact'));
+  if (process.env.CARGO_HOME) {
+    candidates.push(path.join(process.env.CARGO_HOME, 'bin', 'docpact'));
+  }
   candidates.push(path.join(os.homedir(), '.cargo', 'bin', 'docpact'));
+  candidates.push('/opt/homebrew/bin/docpact');
+  candidates.push('/usr/local/bin/docpact');
   candidates.push('docpact');
 
   for (const candidate of candidates) {
@@ -55,7 +61,7 @@ function findDocpact() {
   }
 
   console.error(
-    'docpact was not found. Install it with `cargo install docpact --version 0.1.4 --force` or set DOCPACT_BIN.',
+    'docpact was not found. Install it with `cargo install docpact --version 0.1.9 --force` or set DOCPACT_BIN.',
   );
   process.exit(127);
 }
@@ -96,10 +102,22 @@ function runDocpact(docpact, args) {
 }
 
 const args = parseArgs(process.argv.slice(2));
-const docpact = findDocpact();
+const repoRoot = git(['rev-parse', '--show-toplevel']);
+process.chdir(repoRoot);
+const docpact = findDocpact(repoRoot);
 const base = resolveBase(args.base, args.head);
 const head = git(['rev-parse', args.head]);
 
 console.log(`Running docpact gate: base=${base} head=${head}`);
-runDocpact(docpact, ['validate-config', '--root', '.', '--strict']);
-runDocpact(docpact, ['lint', '--root', '.', '--base', base, '--head', head, '--mode', 'enforce']);
+runDocpact(docpact, ['validate-config', '--root', repoRoot, '--strict']);
+runDocpact(docpact, [
+  'lint',
+  '--root',
+  repoRoot,
+  '--base',
+  base,
+  '--head',
+  head,
+  '--mode',
+  'enforce',
+]);


### PR DESCRIPTION
## Summary
- add a repo-local `scripts/docpact` wrapper for local CLI discovery
- route local docpact gates and CI doc-governance checks through the wrapper
- update docpact install guidance to the confirmed stable 0.1.9 release
- refresh repo-local governance docs so submodule working directories no longer depend on bare `docpact` being on `PATH`

## Validation
- `scripts/docpact validate-config --root <repo> --strict`
- `scripts/docpact lint --root <repo> --worktree --mode enforce`
- local docpact gate against the target base branch

No tracked issue was provided; this PR records the user-requested batch governance standardization.
