### PR TITLE
fix: send team create visibility defaults

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-05-20'
-lastReviewedCommit: 'ca4280853d06d12dd6566df5ba0e48cbc3466719'
+lastReviewedAt: "2026-05-22"
+lastReviewedCommit: "7197f64b9a9bf301d670d715fa468c0699cbdd76"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: ca4280853d06d12dd6566df5ba0e48cbc3466719
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: ca4280853d06d12dd6566df5ba0e48cbc3466719
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: ca2cd85b49971ad9aa4eae260fae4a45692dbc9f
 ---
 
 # Development Bootstrap

--- a/docs/agents/data_audit_instruction.md
+++ b/docs/agents/data_audit_instruction.md
@@ -18,8 +18,8 @@ checkPaths:
   - docs/agents/data_audit_instruction.md
   - src/pages/Review/**
   - src/pages/ManageSystem/**
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: f3256848c44466801a61316127c6fe19368f63ef
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
 ---
 
 # Audit Status Reference

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.js
   - .github/workflows/**
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: ca4280853d06d12dd6566df5ba0e48cbc3466719
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: ca4280853d06d12dd6566df5ba0e48cbc3466719
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: ca4280853d06d12dd6566df5ba0e48cbc3466719
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/team_management.md
+++ b/docs/agents/team_management.md
@@ -19,8 +19,8 @@ checkPaths:
   - src/pages/Teams/**
   - src/pages/Review/**
   - src/pages/ManageSystem/**
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: f3256848c44466801a61316127c6fe19368f63ef
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
 ---
 
 # Team Management Reference

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-05-21
-lastReviewedCommit: 96b56d2b6835dae28bafca4bd5f8287012dda548
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-05-21
-lastReviewedCommit: 96b56d2b6835dae28bafca4bd5f8287012dda548
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-05-21
-lastReviewedCommit: 96b56d2b6835dae28bafca4bd5f8287012dda548
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-05-21
-lastReviewedCommit: 96b56d2b6835dae28bafca4bd5f8287012dda548
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
 ---
 
 # Testing Troubleshooting

--- a/src/pages/Teams/index.tsx
+++ b/src/pages/Teams/index.tsx
@@ -52,6 +52,9 @@ import { Children, useEffect, useRef, useState } from 'react';
 import { v4 } from 'uuid';
 import AddMemberModal from './Components/AddMemberModal';
 
+const DEFAULT_CREATE_TEAM_RANK = -1;
+const DEFAULT_CREATE_TEAM_IS_PUBLIC = false;
+
 const Team = () => {
   const { token } = theme.useToken();
   const [activeTabKey, setActiveTabKey] = useState('info');
@@ -234,10 +237,18 @@ const Team = () => {
 
     const createTeamInfo = async (values: any) => {
       const { rank, is_public } = values;
+      const normalizedRank = typeof rank === 'number' ? rank : DEFAULT_CREATE_TEAM_RANK;
+      const normalizedIsPublic =
+        typeof is_public === 'boolean' ? is_public : DEFAULT_CREATE_TEAM_IS_PUBLIC;
       delete values.rank;
       delete values.is_public;
       const params = getParams(values);
-      const error = await createTeamMessage(v4(), { ...params }, rank, is_public);
+      const error = await createTeamMessage(
+        v4(),
+        { ...params },
+        normalizedRank,
+        normalizedIsPublic,
+      );
       if (error) {
         message.error(
           intl.formatMessage({
@@ -327,16 +338,17 @@ const Team = () => {
     const submitTeamInfo = async (values: any) => {
       try {
         if (!lightLogo.length || !darkLogo.length) {
-          if (rank === 0) {
+          const currentRank = typeof values.rank === 'number' ? values.rank : rank;
+          if (currentRank === 0) {
             setLightLogoError(!lightLogo.length);
             setDarkLogoError(!darkLogo.length);
             return;
           } else {
-            if (!lightLogo.length) {
-              handleRemoveLogo('lightLogo');
+            if (!lightLogo.length && beforeLightLogoPath) {
+              await handleRemoveLogo('lightLogo');
             }
-            if (!darkLogo.length) {
-              handleRemoveLogo('darkLogo');
+            if (!darkLogo.length && beforeDarkLogoPath) {
+              await handleRemoveLogo('darkLogo');
             }
           }
         }
@@ -358,9 +370,17 @@ const Team = () => {
           return;
         }
         values.lightLogo =
-          typeof lightLogo[0] === 'string' ? lightLogo[0] : `../sys-files/${lightLogoPath}`;
+          typeof lightLogo[0] === 'string'
+            ? lightLogo[0]
+            : lightLogoPath
+              ? `../sys-files/${lightLogoPath}`
+              : null;
         values.darkLogo =
-          typeof darkLogo[0] === 'string' ? darkLogo[0] : `../sys-files/${darkLogoPath}`;
+          typeof darkLogo[0] === 'string'
+            ? darkLogo[0]
+            : darkLogoPath
+              ? `../sys-files/${darkLogoPath}`
+              : null;
 
         if (action === 'edit') {
           if (!teamId) return;
@@ -393,6 +413,10 @@ const Team = () => {
               ),
             }}
             onFinish={(values) => submitTeamInfo(values)}
+            initialValues={{
+              rank: DEFAULT_CREATE_TEAM_RANK,
+              is_public: DEFAULT_CREATE_TEAM_IS_PUBLIC,
+            }}
           >
             <Form.Item
               label={

--- a/tests/integration/teams/TeamsWorkflow.integration.test.tsx
+++ b/tests/integration/teams/TeamsWorkflow.integration.test.tsx
@@ -772,8 +772,8 @@ describe('Teams management workflows', () => {
       });
       expect(payload.lightLogo).toEqual('../sys-files/uploaded-logo.png');
       expect(payload.darkLogo).toEqual('../sys-files/uploaded-logo.png');
-      expect(rank).toBeUndefined();
-      expect(isPublic).toBeUndefined();
+      expect(rank).toBe(-1);
+      expect(isPublic).toBe(false);
 
       expect(history.replace).toHaveBeenCalledWith('/team?action=edit');
       expect(message.success).toHaveBeenCalledWith('Edit Successfully!');

--- a/tests/unit/pages/Teams/TeamPage.test.tsx
+++ b/tests/unit/pages/Teams/TeamPage.test.tsx
@@ -420,7 +420,7 @@ jest.mock('@ant-design/pro-components', () => {
     return '';
   };
 
-  const ProForm = ({ formRef, onFinish, submitter, children, disabled }: any) => {
+  const ProForm = ({ formRef, onFinish, submitter, children, disabled, initialValues }: any) => {
     const internalFormRef = React.useRef<any>(null);
 
     React.useEffect(() => {
@@ -450,7 +450,7 @@ jest.mock('@ant-design/pro-components', () => {
     const submitNodes = Array.isArray(renderedSubmitter) ? renderedSubmitter : [renderedSubmitter];
 
     return (
-      <Form ref={internalFormRef}>
+      <Form ref={internalFormRef} initialValues={initialValues}>
         <fieldset disabled={disabled}>{children}</fieldset>
         <div data-testid='pro-form-submitter'>
           {submitNodes.map((node, index) => (
@@ -704,9 +704,11 @@ describe('Team page validations', () => {
         expect.objectContaining({
           title: [{ '#text': 'Created Team', '@xml:lang': 'en' }],
           description: [{ '#text': 'Fresh team description', '@xml:lang': 'en' }],
+          lightLogo: null,
+          darkLogo: null,
         }),
-        undefined,
-        undefined,
+        -1,
+        false,
       );
     });
     expect(message.success).toHaveBeenCalledWith('Edit Successfully!');
@@ -1090,8 +1092,8 @@ describe('Team page validations', () => {
           lightLogo: '../sys-files/uploaded-logo.png',
           darkLogo: '../sys-files/uploaded-logo.png',
         }),
-        undefined,
-        undefined,
+        -1,
+        false,
       );
       expect(reloadSpy).toHaveBeenCalledTimes(1);
     } finally {

--- a/tests/unit/pages/Teams/TeamPage.test.tsx
+++ b/tests/unit/pages/Teams/TeamPage.test.tsx
@@ -817,6 +817,64 @@ describe('Team page validations', () => {
     expect(message.success).toHaveBeenCalledWith('Edit Successfully!');
   });
 
+  it('removes stored team logos from edit payload and storage when cleared', async () => {
+    setWindowLocation('?action=edit');
+    mockGetUserRoles.mockResolvedValueOnce({
+      data: [{ team_id: 'team-123', role: 'owner' }],
+      success: true,
+    } as any);
+    mockGetTeamMessageApi.mockResolvedValueOnce({
+      data: [
+        {
+          rank: -1,
+          is_public: true,
+          json: {
+            title: [{ '@xml:lang': 'en', '#text': 'Existing Team' }],
+            description: [{ '@xml:lang': 'en', '#text': 'Existing Description' }],
+            lightLogo: 'logos/light.png',
+            darkLogo: 'logos/dark.png',
+          },
+        },
+      ],
+      error: null,
+    } as any);
+    mockEditTeamMessage.mockResolvedValueOnce({ error: null } as any);
+
+    renderWithProviders(<Team />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'remove-file' })).toHaveLength(2);
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'remove-file' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'remove-file' })).toHaveLength(1);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'remove-file' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'remove-file' })).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('pro-form-submit'));
+
+    await waitFor(() => {
+      expect(mockEditTeamMessage).toHaveBeenCalledWith(
+        'team-123',
+        expect.objectContaining({
+          lightLogo: null,
+          darkLogo: null,
+        }),
+        -1,
+        true,
+      );
+    });
+    expect(mockRemoveLogoApi).toHaveBeenCalledWith(['logos/light.png']);
+    expect(mockRemoveLogoApi).toHaveBeenCalledWith(['logos/dark.png']);
+  });
+
   it('shows a generic error when edit submission fails', async () => {
     setWindowLocation('?action=edit');
     mockGetUserRoles.mockResolvedValueOnce({
@@ -909,6 +967,47 @@ describe('Team page validations', () => {
     expect(screen.getByLabelText('Team Name')).toHaveValue('');
     expect(screen.getByLabelText('Team Description')).toHaveValue('');
     expect(screen.queryByRole('button', { name: 'remove-file' })).not.toBeInTheDocument();
+  });
+
+  it('falls back to rank state when submitted edit values omit rank', async () => {
+    setWindowLocation('?action=edit');
+    mockGetUserRoles.mockResolvedValueOnce({
+      data: [{ team_id: 'team-123', role: 'owner' }],
+      success: true,
+    } as any);
+    mockGetTeamMessageApi.mockResolvedValueOnce({
+      data: [
+        {
+          is_public: true,
+          json: {
+            title: [{ '@xml:lang': 'en', '#text': 'Rankless Team' }],
+            description: [{ '@xml:lang': 'en', '#text': 'Rankless Description' }],
+          },
+        },
+      ],
+      error: null,
+    } as any);
+    mockEditTeamMessage.mockResolvedValueOnce({ error: null } as any);
+
+    renderWithProviders(<Team />);
+
+    await waitFor(() => {
+      expect(mockGetTeamMessageApi).toHaveBeenCalledWith('team-123');
+    });
+
+    fireEvent.click(screen.getByTestId('pro-form-submit'));
+
+    await waitFor(() => {
+      expect(mockEditTeamMessage).toHaveBeenCalledWith(
+        'team-123',
+        expect.objectContaining({
+          lightLogo: null,
+          darkLogo: null,
+        }),
+        undefined,
+        true,
+      );
+    });
   });
 
   it('returns early when edit mode has no resolved team id', async () => {


### PR DESCRIPTION
Closes #428

## Summary
- Default the team creation form to rank -1 and isPublic false so app_team_create receives the fields required by the Edge Function payload schema.
- Serialize missing team logos as null instead of generating ../sys-files/null or ../sys-files/undefined.
- Update Teams page unit and integration coverage for unchanged Switch defaults, empty logos, stored-logo cleanup, and the rank fallback branch.

## Key Decisions
- Keep the contract fix in tiangong-lca-next only; app_team_create and database RPC validation remain unchanged.
- Use form initialValues plus submit-time normalization so unchanged Switch controls and defensive direct calls both send valid create payloads.

## Validation
- npm run test:ci -- tests/unit/pages/Teams/TeamPage.test.tsx
- npm run test:ci -- tests/integration/teams/TeamsWorkflow.integration.test.tsx
- npx jest tests/unit/pages/Teams/TeamPage.test.tsx tests/integration/teams/TeamsWorkflow.integration.test.tsx --runInBand --coverage --collectCoverageFrom='src/pages/Teams/index.tsx' --coverageReporters=text --coverageReporters=json --coverageThreshold='{}' (Teams page 100% statements/branches/functions/lines)
- npm run lint
- npm run build
- npm run docpact:gate
- PR check ai-doc-lint: pass
- PR check Full Gate: pass

## Risks / Rollback
- Low risk: scoped to the /team?action=create submit path and existing logo serialization in the Teams page.

## Follow-ups
- After merge and promote eligibility, update the lca-workspace submodule pointer if this fix needs workspace delivery.

## Workspace Integration
- Workspace Integration remains Pending until the tiangong-lca-next child change is merged/promoted and the root workspace pointer is intentionally bumped.
