### PR TITLE
Fix process annual volume UI round trip

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-22"
-lastReviewedCommit: "7197f64b9a9bf301d670d715fa468c0699cbdd76"
+lastReviewedAt: "2026-05-23"
+lastReviewedCommit: "11e9fa8d4c0319fb60ec8f97482d4c79f4d6d2c5"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 11e9fa8d4c0319fb60ec8f97482d4c79f4d6d2c5
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: ca2cd85b49971ad9aa4eae260fae4a45692dbc9f
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: f0e50d87936e37d36ef623734e089eec66e7f118
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.js
   - .github/workflows/**
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 11e9fa8d4c0319fb60ec8f97482d4c79f4d6d2c5
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 11e9fa8d4c0319fb60ec8f97482d4c79f4d6d2c5
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 11e9fa8d4c0319fb60ec8f97482d4c79f4d6d2c5
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -19,8 +19,8 @@ checkPaths:
   - config/supabaseEnv.ts
   - src/services/**
   - docker/**
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: ca4280853d06d12dd6566df5ba0e48cbc3466719
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 11e9fa8d4c0319fb60ec8f97482d4c79f4d6d2c5
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 11e9fa8d4c0319fb60ec8f97482d4c79f4d6d2c5
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 11e9fa8d4c0319fb60ec8f97482d4c79f4d6d2c5
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 11e9fa8d4c0319fb60ec8f97482d4c79f4d6d2c5
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 11e9fa8d4c0319fb60ec8f97482d4c79f4d6d2c5
 ---
 
 # Testing Troubleshooting

--- a/src/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.tsx
+++ b/src/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.tsx
@@ -7,6 +7,8 @@ import {
   buildAnnualSupplyVolumeUnitLookupRows,
   deriveAnnualSupplyVolumeSuffix,
   getAnnualSupplyVolumeDisplayNumericText,
+  getAnnualSupplyVolumeDisplaySuffixText,
+  isAnnualSupplyVolumeAnnualizedSuffix,
   mergeAnnualSupplyVolumeUnitRows,
 } from '@/services/processes/annualSupplyOrProductionVolume';
 import type { ProcessExchangeData } from '@/services/processes/data';
@@ -64,7 +66,22 @@ const AnnualSupplyOrProductionVolumeForm: FC<Props> = ({
     (value: string) => suffixByLang[value] ?? suffixByLang.en,
     [suffixByLang],
   );
-  const currentSuffix = getSuffixForLang(lang);
+  const existingSuffixByLang = useMemo(() => {
+    return langOptions.reduce<Record<string, string>>((accumulator, option) => {
+      const suffixText = getAnnualSupplyVolumeDisplaySuffixText(formValues, option.value);
+      accumulator[option.value] = isAnnualSupplyVolumeAnnualizedSuffix(suffixText)
+        ? suffixText
+        : '';
+      return accumulator;
+    }, {});
+  }, [formValues]);
+
+  const getResolvedSuffixForLang = useCallback(
+    (value: string) =>
+      getSuffixForLang(value) || existingSuffixByLang[value] || existingSuffixByLang.en || '',
+    [existingSuffixByLang, getSuffixForLang],
+  );
+  const currentSuffix = getResolvedSuffixForLang(lang);
 
   useEffect(() => {
     setExchangeDataSourceWithUnits(exchangeDataSource);
@@ -96,7 +113,7 @@ const AnnualSupplyOrProductionVolumeForm: FC<Props> = ({
     const numericText = getAnnualSupplyVolumeDisplayNumericText(formValues, lang);
     const normalizedValues = buildAnnualSupplyVolumeMultiLang(
       numericText,
-      getSuffixForLang,
+      getResolvedSuffixForLang,
       annualSupplyVolumeLangs,
     );
 
@@ -104,7 +121,7 @@ const AnnualSupplyOrProductionVolumeForm: FC<Props> = ({
       form.setFieldValue(name, normalizedValues);
       onData();
     }
-  }, [form, formValues, getSuffixForLang, hasStoredFormValue, lang, name, onData]);
+  }, [form, formValues, getResolvedSuffixForLang, hasStoredFormValue, lang, name, onData]);
 
   const fieldRules = isRequired
     ? [
@@ -126,13 +143,13 @@ const AnnualSupplyOrProductionVolumeForm: FC<Props> = ({
 
             const normalizedValues = buildAnnualSupplyVolumeMultiLang(
               numericText,
-              getSuffixForLang,
+              getResolvedSuffixForLang,
               annualSupplyVolumeLangs,
             );
             const isAnnualSupplyVolumeValid =
               normalizedValues.length > 0 &&
               normalizedValues.every((item) => {
-                const pattern = getSuffixForLang(item['@xml:lang']).trim()
+                const pattern = getResolvedSuffixForLang(item['@xml:lang']).trim()
                   ? ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN
                   : ANNUAL_SUPPLY_VOLUME_NUMERIC_TEXT_PATTERN;
 
@@ -167,7 +184,11 @@ const AnnualSupplyOrProductionVolumeForm: FC<Props> = ({
             value: getAnnualSupplyVolumeDisplayNumericText(value, lang),
           })}
           normalize={(value) =>
-            buildAnnualSupplyVolumeMultiLang(value, getSuffixForLang, annualSupplyVolumeLangs)
+            buildAnnualSupplyVolumeMultiLang(
+              value,
+              getResolvedSuffixForLang,
+              annualSupplyVolumeLangs,
+            )
           }
           noStyle
           rules={fieldRules}

--- a/src/pages/Processes/Components/edit.tsx
+++ b/src/pages/Processes/Components/edit.tsx
@@ -116,6 +116,48 @@ const cloneProcessData = (data?: FormProcessWithDatas) => {
   return JSON.parse(JSON.stringify(data)) as FormProcessWithDatas;
 };
 
+const mergeOptionalRecord = (baseValue: unknown, fieldValue: unknown) => {
+  const baseRecord =
+    baseValue && typeof baseValue === 'object' && !Array.isArray(baseValue)
+      ? (baseValue as Record<string, unknown>)
+      : {};
+  const fieldRecord =
+    fieldValue && typeof fieldValue === 'object' && !Array.isArray(fieldValue)
+      ? (fieldValue as Record<string, unknown>)
+      : {};
+
+  return {
+    ...baseRecord,
+    ...fieldRecord,
+  };
+};
+
+export const mergeProcessModellingAndValidation = (
+  baseValue?: FormProcessWithDatas['modellingAndValidation'],
+  fieldValue?: FormProcessWithDatas['modellingAndValidation'],
+) => {
+  const merged = mergeOptionalRecord(baseValue, fieldValue) as NonNullable<
+    FormProcessWithDatas['modellingAndValidation']
+  >;
+  const mergedRecord = merged as Record<string, unknown>;
+  const baseRecord = mergeOptionalRecord(baseValue, undefined);
+  const fieldRecord = mergeOptionalRecord(fieldValue, undefined);
+
+  [
+    'LCIMethodAndAllocation',
+    'dataSourcesTreatmentAndRepresentativeness',
+    'completeness',
+    'validation',
+    'complianceDeclarations',
+  ].forEach((key) => {
+    if (baseRecord[key] !== undefined || fieldRecord[key] !== undefined) {
+      mergedRecord[key] = mergeOptionalRecord(baseRecord[key], fieldRecord[key]);
+    }
+  });
+
+  return merged;
+};
+
 export const normalizeQuantitativeReferenceSelection = (
   exchangeData: ProcessExchangeData[],
   selectedExchangeInternalId?: string,
@@ -245,6 +287,10 @@ const ProcessEdit: FC<Props> = ({
     const currentData = {
       ...baseData,
       ...fieldsValue,
+      modellingAndValidation: mergeProcessModellingAndValidation(
+        baseData.modellingAndValidation,
+        fieldsValue.modellingAndValidation,
+      ),
       exchanges: {
         exchange: [...exchangeDataSource],
       },
@@ -253,18 +299,23 @@ const ProcessEdit: FC<Props> = ({
 
     if (activeTabKey === 'validation') {
       currentData.modellingAndValidation = {
-        ...baseData?.modellingAndValidation,
+        ...currentData.modellingAndValidation,
         validation: {
-          ...fieldsValue?.modellingAndValidation?.validation,
+          ...currentData.modellingAndValidation?.validation,
         },
       };
     } else if (activeTabKey === 'complianceDeclarations') {
       currentData.modellingAndValidation = {
-        ...baseData?.modellingAndValidation,
+        ...currentData.modellingAndValidation,
         complianceDeclarations: {
-          ...fieldsValue?.modellingAndValidation?.complianceDeclarations,
+          ...currentData.modellingAndValidation?.complianceDeclarations,
         },
       };
+    } else if (activeTabKey === 'modellingAndValidation') {
+      currentData.modellingAndValidation = mergeProcessModellingAndValidation(
+        baseData.modellingAndValidation,
+        fieldsValue.modellingAndValidation,
+      );
     } else {
       currentData[activeTabKey] = fieldsValue?.[activeTabKey] ?? baseData?.[activeTabKey];
     }
@@ -314,23 +365,24 @@ const ProcessEdit: FC<Props> = ({
   const handletFromData = async () => {
     if (fromData?.id) {
       const fieldsValue = formRefEdit.current?.getFieldsValue();
+      const mergedModellingAndValidation = mergeProcessModellingAndValidation(
+        fromData.modellingAndValidation,
+        fieldsValue?.modellingAndValidation,
+      );
       if (activeTabKey === 'validation') {
         await setFromData({
           ...fromData,
-          modellingAndValidation: {
-            ...fromData?.modellingAndValidation,
-            validation: { ...fieldsValue?.modellingAndValidation?.validation },
-          },
+          modellingAndValidation: mergedModellingAndValidation,
         });
       } else if (activeTabKey === 'complianceDeclarations') {
         await setFromData({
           ...fromData,
-          modellingAndValidation: {
-            ...fromData?.modellingAndValidation,
-            complianceDeclarations: {
-              ...fieldsValue?.modellingAndValidation?.complianceDeclarations,
-            },
-          },
+          modellingAndValidation: mergedModellingAndValidation,
+        });
+      } else if (activeTabKey === 'modellingAndValidation') {
+        await setFromData({
+          ...fromData,
+          modellingAndValidation: mergedModellingAndValidation,
         });
       } else {
         await setFromData({

--- a/src/services/processes/annualSupplyOrProductionVolume.ts
+++ b/src/services/processes/annualSupplyOrProductionVolume.ts
@@ -1,6 +1,6 @@
 import type { ProcessExchangeData, ProcessRefUnitDisplay } from './data';
 
-export const ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX = 'reference flow';
+export const ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX = 'unit/year';
 const ANNUAL_SUPPLY_VOLUME_DEFAULT_LANGS = ['en', 'zh'];
 
 export const ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN = /^[+-]?(\d+(\.\d*)?|\.\d+)([Ee][+-]?\d+)?\s+\S.*$/;
@@ -12,6 +12,8 @@ const ANNUAL_SUPPLY_VOLUME_NUMBER_PREFIX_PATTERN =
 const ANNUAL_SUPPLY_VOLUME_NUMERIC_INPUT_PREFIX_PATTERN =
   /^[+-]?(?:$|\d+(?:\.\d*)?(?:[Ee][+-]?\d*)?|\.\d+(?:[Ee][+-]?\d*)?|\.\d*)$/;
 const ANNUAL_SUPPLY_VOLUME_NUMERIC_INPUT_ALLOWED_PATTERN = /[\d.+\-Ee]/;
+const ANNUAL_SUPPLY_VOLUME_ANNUALIZED_SUFFIX_PATTERN =
+  /(?:\/\s*(?:year|yr|a)\b|\bper\s+(?:year|annum)\b|\/\s*年|每年|年度|年供应|年产)/iu;
 
 type LangTextResolver = (value: unknown, lang: string) => string;
 
@@ -85,6 +87,19 @@ const uniqueNonEmpty = (values: string[]) => {
   });
 };
 
+export const isAnnualSupplyVolumeAnnualizedSuffix = (value: unknown) =>
+  ANNUAL_SUPPLY_VOLUME_ANNUALIZED_SUFFIX_PATTERN.test(normalizeText(value));
+
+const annualizeUnitSuffix = (unitName: string, lang: string) => {
+  const normalizedUnitName = normalizeText(unitName);
+
+  if (!normalizedUnitName || isAnnualSupplyVolumeAnnualizedSuffix(normalizedUnitName)) {
+    return normalizedUnitName;
+  }
+
+  return `${normalizedUnitName}/${lang === 'zh' ? '年' : 'year'}`;
+};
+
 export const parseAnnualSupplyVolumeText = (value: unknown): AnnualSupplyVolumeTextParts => {
   const text = normalizeText(value);
 
@@ -131,7 +146,18 @@ const resolveAnnualSupplyVolumeSuffix = (
   options: AnnualSupplyVolumeFormatOptions,
 ) => {
   const normalizedExistingSuffix = normalizeText(existingSuffix);
+  const hasExplicitSuffix = normalizeText(suffix).length > 0;
   const normalizedSuffix = normalizeAnnualSupplyVolumeSuffix(suffix, options);
+
+  if (
+    normalizedExistingSuffix &&
+    isAnnualSupplyVolumeAnnualizedSuffix(normalizedExistingSuffix) &&
+    (!hasExplicitSuffix ||
+      !normalizedSuffix ||
+      !isAnnualSupplyVolumeAnnualizedSuffix(normalizedSuffix))
+  ) {
+    return normalizedExistingSuffix;
+  }
 
   if (!normalizedSuffix) {
     return '';
@@ -248,6 +274,11 @@ export const getAnnualSupplyVolumeDisplayNumericText = (value: unknown, lang: st
   return sanitizeAnnualSupplyVolumeNumericInput(numericText);
 };
 
+export const getAnnualSupplyVolumeDisplaySuffixText = (value: unknown, lang: string) => {
+  const { suffixText } = parseAnnualSupplyVolumeText(getAnnualSupplyVolumeTextForLang(value, lang));
+  return normalizeText(suffixText);
+};
+
 export const buildAnnualSupplyVolumeMultiLang = (
   numericValue: unknown,
   suffixResolver: string | ((lang: string) => string),
@@ -346,13 +377,6 @@ export const deriveAnnualSupplyVolumeSuffix = ({
   const refUnitRes = quantitativeReferenceExchange?.refUnitRes as ProcessRefUnitDisplay | undefined;
   const unitName =
     normalizeText(refUnitRes?.refUnitName) || normalizeText(getLangText(refUnitRes?.name, lang));
-  const referenceFlowName = normalizeText(
-    getLangText(referenceFlow?.['common:shortDescription'], lang),
-  );
-  const contextText = normalizeText(
-    getLangText(quantitativeReferenceExchange?.functionalUnitOrOther, lang),
-  );
-  const suffixParts = uniqueNonEmpty([unitName, contextText || referenceFlowName]);
 
-  return suffixParts.join(' ');
+  return annualizeUnitSuffix(unitName, lang);
 };

--- a/src/services/processes/annualSupplyOrProductionVolume.ts
+++ b/src/services/processes/annualSupplyOrProductionVolume.ts
@@ -152,9 +152,7 @@ const resolveAnnualSupplyVolumeSuffix = (
   if (
     normalizedExistingSuffix &&
     isAnnualSupplyVolumeAnnualizedSuffix(normalizedExistingSuffix) &&
-    (!hasExplicitSuffix ||
-      !normalizedSuffix ||
-      !isAnnualSupplyVolumeAnnualizedSuffix(normalizedSuffix))
+    (!hasExplicitSuffix || !isAnnualSupplyVolumeAnnualizedSuffix(normalizedSuffix))
   ) {
     return normalizedExistingSuffix;
   }

--- a/tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx
@@ -147,17 +147,17 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
       expect(form.setFieldValue).toHaveBeenLastCalledWith(
         ['annualSupply'],
         [
-          { '@xml:lang': 'en', '#text': '100 kg Steel' },
-          { '@xml:lang': 'zh', '#text': '100 kg 钢材' },
+          { '@xml:lang': 'en', '#text': '100 kg/year' },
+          { '@xml:lang': 'zh', '#text': '100 kg/年' },
         ],
       );
     });
-    expect(screen.getByLabelText('annual-supply-volume-context')).toHaveValue('kg 钢材');
+    expect(screen.getByLabelText('annual-supply-volume-context')).toHaveValue('kg/年');
     expect(screen.getByLabelText('annual-supply-volume-context')).toBeDisabled();
     expect(screen.queryByLabelText('language')).not.toBeInTheDocument();
   });
 
-  it('falls back to the raw exchange suffix when unit resolution fails', async () => {
+  it('strips raw non-annualized suffixes when unit resolution fails', async () => {
     mockGetUnitData.mockRejectedValueOnce(new Error('unit lookup failed'));
     const form = buildForm([{ '@xml:lang': 'en', '#text': '100 old suffix' }]);
 
@@ -188,12 +188,12 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
       expect(form.setFieldValue).toHaveBeenLastCalledWith(
         ['annualSupply'],
         [
-          { '@xml:lang': 'en', '#text': '100 Steel' },
-          { '@xml:lang': 'zh', '#text': '100 Steel' },
+          { '@xml:lang': 'en', '#text': '100' },
+          { '@xml:lang': 'zh', '#text': '100' },
         ],
       );
     });
-    expect(screen.getByLabelText('annual-supply-volume-context')).toHaveValue('Steel');
+    expect(screen.getByLabelText('annual-supply-volume-context')).toHaveValue('');
   });
 
   it('normalizes numeric-only input into multilingual storage and validates required values', async () => {
@@ -224,28 +224,28 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
       expect(form.setFieldValue).toHaveBeenCalledWith(
         ['modelling', 'annualSupply'],
         [
-          { '@xml:lang': 'en', '#text': '100 kg Steel' },
-          { '@xml:lang': 'zh', '#text': '100 kg 钢材' },
+          { '@xml:lang': 'en', '#text': '100 kg/year' },
+          { '@xml:lang': 'zh', '#text': '100 kg/年' },
         ],
       );
     });
     expect(onData).toHaveBeenCalled();
-    expect(screen.getByLabelText('annual-supply-volume-context')).toHaveValue('kg Steel');
+    expect(screen.getByLabelText('annual-supply-volume-context')).toHaveValue('kg/year');
 
     const formItem = findFormItem(['modelling', 'annualSupply']);
-    expect(formItem.getValueProps([{ '@xml:lang': 'en', '#text': '123 kg Steel' }])).toEqual({
+    expect(formItem.getValueProps([{ '@xml:lang': 'en', '#text': '123 kg/year' }])).toEqual({
       value: '123',
     });
-    expect(formItem.getValueProps([{ '@xml:lang': 'zh', '#text': '456 kg 钢材' }])).toEqual({
+    expect(formItem.getValueProps([{ '@xml:lang': 'zh', '#text': '456 kg/年' }])).toEqual({
       value: '456',
     });
     expect(formItem.normalize('789')).toEqual([
-      { '@xml:lang': 'en', '#text': '789 kg Steel' },
-      { '@xml:lang': 'zh', '#text': '789 kg 钢材' },
+      { '@xml:lang': 'en', '#text': '789 kg/year' },
+      { '@xml:lang': 'zh', '#text': '789 kg/年' },
     ]);
     expect(formItem.normalize('abc789')).toEqual([
-      { '@xml:lang': 'en', '#text': '789 kg Steel' },
-      { '@xml:lang': 'zh', '#text': '789 kg 钢材' },
+      { '@xml:lang': 'en', '#text': '789 kg/year' },
+      { '@xml:lang': 'zh', '#text': '789 kg/年' },
     ]);
 
     await expect(formItem.rules[0].validator(null, '')).rejects.toThrow(
@@ -378,7 +378,7 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
   });
 
   it('normalizes single-object form values and uses default required validation copy', async () => {
-    const form = buildForm({ '@xml:lang': 'en', '#text': '321 kg Steel' });
+    const form = buildForm({ '@xml:lang': 'en', '#text': '321 kg/year' });
     const onData = jest.fn();
 
     render(
@@ -397,8 +397,8 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
       expect(form.setFieldValue).toHaveBeenCalledWith(
         ['annualSupply'],
         [
-          { '@xml:lang': 'en', '#text': '321 kg Steel' },
-          { '@xml:lang': 'zh', '#text': '321 kg 钢材' },
+          { '@xml:lang': 'en', '#text': '321 kg/year' },
+          { '@xml:lang': 'zh', '#text': '321 kg/年' },
         ],
       );
     });

--- a/tests/unit/pages/Processes/Components/edit.test.tsx
+++ b/tests/unit/pages/Processes/Components/edit.test.tsx
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import ProcessEdit, {
+  mergeProcessModellingAndValidation,
   normalizeQuantitativeReferenceSelection,
 } from '@/pages/Processes/Components/edit';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -364,6 +365,40 @@ describe('ProcessEdit component', () => {
     updateNodeCb: updateNodeCbMock,
     showRules: false,
   };
+
+  it('deep-merges modelling validation sections instead of dropping sibling data', () => {
+    expect(
+      mergeProcessModellingAndValidation(
+        {
+          dataSourcesTreatmentAndRepresentativeness: {
+            annualSupplyOrProductionVolume: [{ '#text': '3.6 MJ/year', '@xml:lang': 'en' }],
+          },
+          validation: {
+            review: [{ '@type': 'Not reviewed' }],
+          },
+          complianceDeclarations: {
+            compliance: [{ '@compliance': 'Not defined' }],
+          },
+        },
+        {
+          dataSourcesTreatmentAndRepresentativeness: {
+            completenessProductModel: 'All relevant flows included',
+          },
+        },
+      ),
+    ).toEqual({
+      dataSourcesTreatmentAndRepresentativeness: {
+        annualSupplyOrProductionVolume: [{ '#text': '3.6 MJ/year', '@xml:lang': 'en' }],
+        completenessProductModel: 'All relevant flows included',
+      },
+      validation: {
+        review: [{ '@type': 'Not reviewed' }],
+      },
+      complianceDeclarations: {
+        compliance: [{ '@compliance': 'Not defined' }],
+      },
+    });
+  });
 
   const processDataset = {
     processInformation: { name: 'Existing process' },

--- a/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
+++ b/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
@@ -6,6 +6,7 @@ import {
   deriveAnnualSupplyVolumeSuffix,
   formatAnnualSupplyVolumeText,
   getAnnualSupplyVolumeDisplayNumericText,
+  getAnnualSupplyVolumeDisplaySuffixText,
   mergeAnnualSupplyVolumeUnitRows,
   normalizeAnnualSupplyVolumeMultiLang,
   normalizeAnnualSupplyVolumeText,
@@ -91,6 +92,7 @@ describe('annualSupplyOrProductionVolume helpers', () => {
       { '@xml:lang': 'en', '#text': '3.6 MJ/year' },
       { '@xml:lang': 'zh', '#text': '3.6 MJ/年' },
     ]);
+    expect(normalizeAnnualSupplyVolumeText('3.6 MJ/year', 'MJ')).toBe('3.6 MJ/year');
   });
 
   it('builds multilingual values from one numeric input and reads the displayed numeric value', () => {
@@ -137,9 +139,11 @@ describe('annualSupplyOrProductionVolume helpers', () => {
     expect(getAnnualSupplyVolumeDisplayNumericText([], 'en')).toBe('');
     expect(getAnnualSupplyVolumeDisplayNumericText({ '#text': '300 kg Steel' }, 'en')).toBe('300');
     expect(getAnnualSupplyVolumeDisplayNumericText('400 kg Steel', 'en')).toBe('400');
+    expect(getAnnualSupplyVolumeDisplaySuffixText('400 kg Steel', 'en')).toBe('kg Steel');
   });
 
   it('preserves an existing unit prefix when the derived suffix only has reference flow text', () => {
+    expect(normalizeAnnualSupplyVolumeText('100', 'kg/year')).toBe('100 kg/year');
     expect(normalizeAnnualSupplyVolumeText('100 kg Steel', 'Steel')).toBe('100 kg Steel');
     expect(normalizeAnnualSupplyVolumeText('100 old suffix', 'Steel')).toBe('100 Steel');
     expect(normalizeAnnualSupplyVolumeText('100 old suffix', '', { useDefaultSuffix: false })).toBe(
@@ -207,6 +211,80 @@ describe('annualSupplyOrProductionVolume helpers', () => {
         lang: 'en',
       }),
     ).toBe('kilogram/year');
+  });
+
+  it('derives suffixes from fallback unit display shapes', () => {
+    expect(
+      deriveAnnualSupplyVolumeSuffix({
+        exchangeDataSource: [
+          {
+            '@dataSetInternalID': 'output-1',
+            quantitativeReference: true,
+            referenceToFlowDataSet: {
+              '@refObjectId': 'flow-1',
+            },
+            refUnitRes: {
+              name: 'MJ',
+            },
+          },
+        ],
+        lang: 'en',
+      }),
+    ).toBe('MJ/year');
+
+    expect(
+      deriveAnnualSupplyVolumeSuffix({
+        exchangeDataSource: [
+          {
+            '@dataSetInternalID': 'output-1',
+            quantitativeReference: true,
+            referenceToFlowDataSet: {
+              '@refObjectId': 'flow-1',
+            },
+            refUnitRes: {
+              name: [{ '@xml:lang': 'en', '#text': 'kilogram' }],
+            },
+          },
+        ],
+        lang: 'zh',
+      }),
+    ).toBe('kilogram/年');
+
+    expect(
+      deriveAnnualSupplyVolumeSuffix({
+        exchangeDataSource: [
+          {
+            '@dataSetInternalID': 'output-1',
+            quantitativeReference: true,
+            referenceToFlowDataSet: {
+              '@refObjectId': 'flow-1',
+            },
+            refUnitRes: {
+              name: { '#text': 'cubic metre' },
+            },
+          },
+        ],
+        lang: 'en',
+      }),
+    ).toBe('cubic metre/year');
+
+    expect(
+      deriveAnnualSupplyVolumeSuffix({
+        exchangeDataSource: [
+          {
+            '@dataSetInternalID': 'output-1',
+            quantitativeReference: true,
+            referenceToFlowDataSet: {
+              '@refObjectId': 'flow-1',
+            },
+            refUnitRes: {
+              name: 123 as never,
+            },
+          },
+        ],
+        lang: 'en',
+      }),
+    ).toBe('');
   });
 
   it('builds unit lookup rows and merges resolved flow units into exchange rows', () => {

--- a/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
+++ b/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
@@ -78,6 +78,21 @@ describe('annualSupplyOrProductionVolume helpers', () => {
     ]);
   });
 
+  it('preserves existing annualized suffixes when no replacement unit is available', () => {
+    const normalized = normalizeAnnualSupplyVolumeMultiLang(
+      [
+        { '@xml:lang': 'en', '#text': '3.6 MJ/year' },
+        { '@xml:lang': 'zh', '#text': '3.6 MJ/年' },
+      ],
+      () => '',
+    );
+
+    expect(normalized).toEqual([
+      { '@xml:lang': 'en', '#text': '3.6 MJ/year' },
+      { '@xml:lang': 'zh', '#text': '3.6 MJ/年' },
+    ]);
+  });
+
   it('builds multilingual values from one numeric input and reads the displayed numeric value', () => {
     expect(
       buildAnnualSupplyVolumeMultiLang(
@@ -143,7 +158,7 @@ describe('annualSupplyOrProductionVolume helpers', () => {
     expect(normalizeAnnualSupplyVolumeMultiLang('100 old', 'kg')).toBe('100 old');
   });
 
-  it('derives suffixes from the quantitative reference exchange', () => {
+  it('derives annualized unit suffixes from the quantitative reference exchange', () => {
     const suffix = deriveAnnualSupplyVolumeSuffix({
       exchangeDataSource: [
         {
@@ -168,9 +183,9 @@ describe('annualSupplyOrProductionVolume helpers', () => {
       lang: 'en',
     });
 
-    expect(suffix).toBe('kg Steel slab');
-    expect(normalizeAnnualSupplyVolumeText('100 old suffix', suffix)).toBe('100 kg Steel slab');
-    expect(ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN.test('100 kg Steel slab')).toBe(true);
+    expect(suffix).toBe('kg/year');
+    expect(normalizeAnnualSupplyVolumeText('100 old suffix', suffix)).toBe('100 kg/year');
+    expect(ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN.test('100 kg/year')).toBe(true);
   });
 
   it('derives suffixes from unit display names when a unit symbol is unavailable', () => {
@@ -191,7 +206,7 @@ describe('annualSupplyOrProductionVolume helpers', () => {
         ],
         lang: 'en',
       }),
-    ).toBe('kilogram Steel slab');
+    ).toBe('kilogram/year');
   });
 
   it('builds unit lookup rows and merges resolved flow units into exchange rows', () => {
@@ -255,7 +270,7 @@ describe('annualSupplyOrProductionVolume helpers', () => {
     expect(mergeAnnualSupplyVolumeUnitRows(exchangeRows, null)).toEqual(exchangeRows);
   });
 
-  it('derives suffixes from fallback text shapes on the selected reference exchange', () => {
+  it('uses only the annualized unit suffix from the selected reference exchange', () => {
     expect(
       deriveAnnualSupplyVolumeSuffix({
         exchangeDataSource: [
@@ -281,7 +296,7 @@ describe('annualSupplyOrProductionVolume helpers', () => {
         ],
         lang: 'en',
       }),
-    ).toBe('kg annual output');
+    ).toBe('kg/year');
 
     expect(
       deriveAnnualSupplyVolumeSuffix({
@@ -300,10 +315,10 @@ describe('annualSupplyOrProductionVolume helpers', () => {
         ],
         lang: 'en',
       }),
-    ).toBe('kg functional unit');
+    ).toBe('kg/year');
   });
 
-  it('uses reference flow text and leaves suffix blank when no reference flow is selected', () => {
+  it('leaves suffix blank when no reference unit can be resolved', () => {
     expect(
       deriveAnnualSupplyVolumeSuffix({
         exchangeDataSource: [
@@ -320,7 +335,7 @@ describe('annualSupplyOrProductionVolume helpers', () => {
         ],
         lang: 'en',
       }),
-    ).toBe('钢板');
+    ).toBe('');
 
     expect(
       deriveAnnualSupplyVolumeSuffix({

--- a/tests/unit/services/processes/util.test.ts
+++ b/tests/unit/services/processes/util.test.ts
@@ -503,7 +503,7 @@ describe('Process Utility Functions', () => {
       expect(
         result.processDataSet.modellingAndValidation.dataSourcesTreatmentAndRepresentativeness
           .annualSupplyOrProductionVolume,
-      ).toEqual([{ '@xml:lang': 'en', '#text': '100 1 kg steel' }, { '#text': '200 1 kg steel' }]);
+      ).toEqual([{ '@xml:lang': 'en', '#text': '100 unit/year' }, { '#text': '200 unit/year' }]);
     });
 
     it('should preserve a previously resolved annual supply volume unit suffix while saving', () => {
@@ -527,7 +527,7 @@ describe('Process Utility Functions', () => {
         modellingAndValidation: {
           ...mockProcessData.modellingAndValidation,
           dataSourcesTreatmentAndRepresentativeness: {
-            annualSupplyOrProductionVolume: [{ '@xml:lang': 'en', '#text': '100 kg Steel' }],
+            annualSupplyOrProductionVolume: [{ '@xml:lang': 'en', '#text': '100 kg/year' }],
           },
         },
       };
@@ -537,7 +537,7 @@ describe('Process Utility Functions', () => {
       expect(
         result.processDataSet.modellingAndValidation.dataSourcesTreatmentAndRepresentativeness
           .annualSupplyOrProductionVolume,
-      ).toEqual([{ '@xml:lang': 'en', '#text': '100 kg Steel' }]);
+      ).toEqual([{ '@xml:lang': 'en', '#text': '100 kg/year' }]);
     });
 
     it('should save annual supply volume with a suffix even when no quantitative reference is selected', () => {
@@ -575,7 +575,7 @@ describe('Process Utility Functions', () => {
       expect(
         result.processDataSet.modellingAndValidation.dataSourcesTreatmentAndRepresentativeness
           .annualSupplyOrProductionVolume,
-      ).toEqual([{ '@xml:lang': 'en', '#text': '100 reference flow' }]);
+      ).toEqual([{ '@xml:lang': 'en', '#text': '100 unit/year' }]);
     });
 
     it('should use resultingAmount if not zero, otherwise use meanAmount', () => {


### PR DESCRIPTION
## Summary

- Fixes process annual supply/production volume UI round trips so the suffix comes from the quantitative reference flow unit and is annualized (`MJ/year` / `MJ/年`) instead of flow/context text.
- Preserves existing annualized values when unit lookup is unavailable and strips stale non-annualized suffixes.
- Deep-merges sibling `modellingAndValidation` sections so saving/checking from modelling, validation, or compliance tabs does not drop adjacent process quality data.
- Records docpact review evidence for the governed repo docs touched by this runtime/service/test change.

Closes #432

## Validation

- `npx jest tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx tests/unit/services/processes/util.test.ts tests/unit/pages/Processes/Components/edit.test.tsx --runInBand --testTimeout=20000` (152 passed)
- `npm run lint`
- `npm run docpact:gate`
- Live isolated Chrome/CDP check against local `npm run start:main` on `012fc8f6-9a30-4d98-9b03-34ddec3a6f10@01.01.002`: annual field showed `3.6` + `MJ/年`; process editor `数据校验` returned `数据校验成功!`
- CLI readback after UI save: `dataset validate --type process` returned 1 valid / 0 invalid; `review process` completed
- Foundry gate: `target-datasets-gate-run --sample golden-closed-electricity-mix-cn-hb` returned `target_quality_ready`, blocker count 0, quality gap count 0

## Notes

This is a routine Next PR targeting `dev`. Workspace root integration is still required after the child PR is merged/promoted according to the workspace branch policy.
