### PR TITLE
fix: restrict dashboard to system admins

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-22"
-lastReviewedCommit: "7197f64b9a9bf301d670d715fa468c0699cbdd76"
+lastReviewedAt: "2026-05-25"
+lastReviewedCommit: "7df4488a6527696c0d2dff22ebad566c2cdfb90f"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 7df4488a6527696c0d2dff22ebad566c2cdfb90f
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: ca2cd85b49971ad9aa4eae260fae4a45692dbc9f
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 333aa2eb41cd3b1519ccdf480537922bbbe25339
 ---
 
 # Development Bootstrap

--- a/config/routes.ts
+++ b/config/routes.ts
@@ -13,6 +13,7 @@
 export default [
   {
     path: '/dashboard/national-carbon',
+    access: 'canAdmin',
     layout: false,
     menu: false,
     component: './NationalCarbonDashboard',

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.js
   - .github/workflows/**
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 7df4488a6527696c0d2dff22ebad566c2cdfb90f
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 7df4488a6527696c0d2dff22ebad566c2cdfb90f
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 7df4488a6527696c0d2dff22ebad566c2cdfb90f
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 7df4488a6527696c0d2dff22ebad566c2cdfb90f
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 7df4488a6527696c0d2dff22ebad566c2cdfb90f
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 7df4488a6527696c0d2dff22ebad566c2cdfb90f
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 7197f64b9a9bf301d670d715fa468c0699cbdd76
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 7df4488a6527696c0d2dff22ebad566c2cdfb90f
 ---
 
 # Testing Troubleshooting

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,6 +4,7 @@ import {
   DarkMode,
   ExportTidasPackage,
   Footer,
+  HeaderActionIcon,
   ImportTidasPackage,
   LcaTaskCenter,
   Notification,
@@ -16,7 +17,7 @@ import { Link, getIntl, history } from '@umijs/max';
 import { getCurrentUser as queryCurrentUser } from '@/services/auth';
 import { getSystemUserRoleApi } from '@/services/roles/api';
 import styles from '@/style/custom.less';
-import { LinkOutlined } from '@ant-design/icons';
+import { DashboardOutlined, LinkOutlined } from '@ant-design/icons';
 import type { Settings as LayoutSettings } from '@ant-design/pro-components';
 import { SettingDrawer } from '@ant-design/pro-components';
 import type { RunTimeLayoutConfig } from '@umijs/max';
@@ -29,6 +30,7 @@ import { errorConfig } from './requestErrorConfig';
 
 const isDev = process.env.NODE_ENV === 'development';
 const loginPath = '/user/login';
+const dashboardPath = '/dashboard/national-carbon';
 const unAuthorizedPath = ['/user/login/password_forgot'];
 const systemAdminRoles = new Set(['admin', 'owner']);
 
@@ -99,6 +101,7 @@ export const layout: RunTimeLayoutConfig = ({ initialState, setInitialState }) =
   const appTitle =
     getLocalizedAppTitle(locale) ??
     formatMessage({ id: 'pages.name', defaultMessage: defaultAppTitle });
+  const canViewDashboard = initialState?.currentUser?.access === 'admin';
   const handleClickFunction = () => {
     setInitialState((prevState: any) => {
       const newState = {
@@ -116,22 +119,42 @@ export const layout: RunTimeLayoutConfig = ({ initialState, setInitialState }) =
     });
   };
   return {
-    actionsRender: () => [
-      <LCIACacheMonitor key='LCIACacheMonitor' />,
-      <ClassificationCacheMonitor key='ClassificationCacheMonitor' />,
-      <LocationCacheMonitor key='LocaltionCacheMonitor' />,
-      <ImportTidasPackage key='ImportTidasPackage' />,
-      <ExportTidasPackage key='ExportTidasPackage' />,
-      <LcaTaskCenter key='LcaTaskCenter' />,
-      <Notification key='Notification' />,
-      <DarkMode
-        key='DarkMode'
-        handleClick={handleClickFunction}
-        isDarkMode={initialState?.isDarkMode}
-      />,
-      <SelectLang key='SelectLang' />,
-      <Question key='doc' />,
-    ],
+    actionsRender: () => {
+      const actions = [
+        <LCIACacheMonitor key='LCIACacheMonitor' />,
+        <ClassificationCacheMonitor key='ClassificationCacheMonitor' />,
+        <LocationCacheMonitor key='LocaltionCacheMonitor' />,
+        <ImportTidasPackage key='ImportTidasPackage' />,
+        <ExportTidasPackage key='ExportTidasPackage' />,
+        <LcaTaskCenter key='LcaTaskCenter' />,
+        <Notification key='Notification' />,
+        <DarkMode
+          key='DarkMode'
+          handleClick={handleClickFunction}
+          isDarkMode={initialState?.isDarkMode}
+        />,
+        <SelectLang key='SelectLang' />,
+        <Question key='doc' />,
+      ];
+
+      if (canViewDashboard) {
+        actions.splice(
+          5,
+          0,
+          <HeaderActionIcon
+            key='NationalCarbonDashboard'
+            icon={<DashboardOutlined />}
+            onClick={() => history.push(dashboardPath)}
+            title={formatMessage({
+              id: 'menu.dashboard.nationalCarbon',
+              defaultMessage: 'Data Dashboard',
+            })}
+          />,
+        );
+      }
+
+      return actions;
+    },
     avatarProps: {
       title: <AvatarName />,
       render: () => {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -14,6 +14,7 @@ import LCIACacheMonitor from '@/components/LCIACacheMonitor';
 import { Link, getIntl, history } from '@umijs/max';
 
 import { getCurrentUser as queryCurrentUser } from '@/services/auth';
+import { getSystemUserRoleApi } from '@/services/roles/api';
 import styles from '@/style/custom.less';
 import { LinkOutlined } from '@ant-design/icons';
 import type { Settings as LayoutSettings } from '@ant-design/pro-components';
@@ -29,12 +30,15 @@ import { errorConfig } from './requestErrorConfig';
 const isDev = process.env.NODE_ENV === 'development';
 const loginPath = '/user/login';
 const unAuthorizedPath = ['/user/login/password_forgot'];
-const publicPaths = ['/dashboard/national-carbon'];
+const systemAdminRoles = new Set(['admin', 'owner']);
 
-function isPublicPath(pathname: string): boolean {
-  return publicPaths.some(
-    (publicPath) => pathname === publicPath || pathname.startsWith(`${publicPath}/`),
-  );
+async function getAdminAccess(): Promise<string | undefined> {
+  try {
+    const systemUserRole = await getSystemUserRoleApi();
+    return systemAdminRoles.has(systemUserRole?.role ?? '') ? 'admin' : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -54,7 +58,10 @@ export async function getInitialState(): Promise<{
         history.push(loginPath);
         return null;
       }
-      return msg;
+      return {
+        ...msg,
+        access: await getAdminAccess(),
+      };
     } catch (error) {
       history.push(loginPath);
     }
@@ -70,11 +77,7 @@ export async function getInitialState(): Promise<{
 
   // 如果不是登录页面，执行
   const { location } = history;
-  if (
-    location.pathname !== loginPath &&
-    !unAuthorizedPath.includes(location.pathname) &&
-    !isPublicPath(location.pathname)
-  ) {
+  if (location.pathname !== loginPath && !unAuthorizedPath.includes(location.pathname)) {
     const currentUser = await fetchUserInfo();
     return {
       fetchUserInfo,
@@ -151,8 +154,7 @@ export const layout: RunTimeLayoutConfig = ({ initialState, setInitialState }) =
       if (
         !initialState?.currentUser &&
         location.pathname !== loginPath &&
-        !unAuthorizedPath.includes(location.pathname) &&
-        !isPublicPath(location.pathname)
+        !unAuthorizedPath.includes(location.pathname)
       ) {
         history.push(loginPath);
       }
@@ -174,8 +176,7 @@ export const layout: RunTimeLayoutConfig = ({ initialState, setInitialState }) =
       if (
         !initialState?.currentUser &&
         history.location.pathname !== loginPath &&
-        !unAuthorizedPath.includes(history.location.pathname) &&
-        !isPublicPath(history.location.pathname)
+        !unAuthorizedPath.includes(history.location.pathname)
       ) {
         history.push(loginPath);
         return null;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,6 +7,7 @@
  */
 import ExportTidasPackage from './ExportTidasPackage';
 import Footer from './Footer';
+import HeaderActionIcon from './HeaderActionIcon';
 import ImportTidasPackage from './ImportTidasPackage';
 import LcaTaskCenter from './LcaTaskCenter';
 import Notification from './Notification';
@@ -20,6 +21,7 @@ export {
   DarkMode,
   ExportTidasPackage,
   Footer,
+  HeaderActionIcon,
   ImportTidasPackage,
   LcaTaskCenter,
   Notification,

--- a/src/locales/en-US/menu.ts
+++ b/src/locales/en-US/menu.ts
@@ -10,6 +10,7 @@ export default {
   'menu.dashboard': 'Dashboard',
   'menu.dashboard.analysis': 'Analysis',
   'menu.dashboard.monitor': 'Monitor',
+  'menu.dashboard.nationalCarbon': 'Data Dashboard',
   'menu.dashboard.workplace': 'Workplace',
   'menu.exception.403': '403',
   'menu.exception.404': '404',

--- a/src/locales/zh-CN/menu.ts
+++ b/src/locales/zh-CN/menu.ts
@@ -10,6 +10,7 @@ export default {
   'menu.dashboard': '仪表盘',
   'menu.dashboard.analysis': '分析页',
   'menu.dashboard.monitor': '监控页',
+  'menu.dashboard.nationalCarbon': '数据看板',
   'menu.dashboard.workplace': '工作台',
   'menu.exception.403': '403',
   'menu.exception.404': '404',

--- a/src/pages/NationalCarbonDashboard/data/mockDashboardSnapshot.json
+++ b/src/pages/NationalCarbonDashboard/data/mockDashboardSnapshot.json
@@ -2,8 +2,8 @@
   "schemaVersion": "dashboard_snapshot_v1",
   "snapshotId": "fixture-national-carbon-2026-05-19",
   "scopeKey": "national-carbon-platform",
-  "title": "国家碳数据平台建设进展",
-  "subtitle": "国家碳数据能力建设总览",
+  "title": "天工数据库建设进展",
+  "subtitle": "天工数据库建设总览",
   "dataVersion": "V2026.05",
   "generatedAt": "2026-05-19T09:30:00+08:00",
   "dataAsOf": "2026-05-19",
@@ -27,7 +27,7 @@
       "key": "publish",
       "index": "02",
       "title": "聚合发布",
-      "description": "数据聚合处理形成统一标准结果，支撑国家与区域统计分析",
+      "description": "数据聚合处理形成统一标准结果，支撑天工数据库统计分析与区域洞察",
       "tone": "cyan"
     },
     {
@@ -592,7 +592,7 @@
       },
       {
         "key": "nationalAverageResults",
-        "label": "国家平均结果",
+        "label": "天工数据库平均结果",
         "value": 218,
         "unit": "个",
         "tone": "gold"

--- a/src/pages/NationalCarbonDashboard/index.tsx
+++ b/src/pages/NationalCarbonDashboard/index.tsx
@@ -810,7 +810,7 @@ function OverviewScreen({
         subtitle={`${snapshot.summary.coveredRegions}省覆盖 / ${formatNumber(
           sumStatus(snapshot.regions, 'all'),
         )}条建设数据 / ${snapshot.summary.connectivityRate.toFixed(1)}%可计算连接`}
-        title='国家碳数据能力建设成果总览'
+        title='天工数据库建设成果总览'
       />
       <div className={styles.overviewStage}>
         <div className={styles.overviewMetricsLeft}>
@@ -858,7 +858,7 @@ function OverviewScreen({
             ))}
           </div>
           <div className={styles.overviewInsight}>
-            <b>国家级碳数据底座已形成，支撑全生命周期核算应用</b>
+            <b>天工数据库底座已形成，支撑全生命周期核算应用</b>
             <span>
               <strong>{snapshot.summary.coveredRegions}</strong>省覆盖
             </span>
@@ -1200,7 +1200,7 @@ function OutcomeMetricsScreen({
     <section className={styles.screenPanel}>
       <HeaderRibbon
         snapshot={snapshot}
-        subtitle='国家碳数据能力建设成果总览'
+        subtitle='天工数据库建设成果总览'
         title='建设成果与发布成果'
       />
       <div className={styles.outcomeTopGrid}>
@@ -1364,7 +1364,7 @@ const matrixDensityContours = [
 ] as const;
 const matrixZoneBadges = [
   { key: 'closed-process', label: '闭合高地', left: '50%', top: '36%', tone: 'cyan' },
-  { key: 'closed-factor', label: '国家级闭合带', left: '70%', top: '58%', tone: 'cyan' },
+  { key: 'closed-factor', label: '天工数据库闭合带', left: '70%', top: '58%', tone: 'cyan' },
   { key: 'gap-provider-a', label: 'provider 缺口 A', left: '31%', top: '63%', tone: 'gold' },
   { key: 'gap-provider-b', label: 'provider 缺口 B', left: '80%', top: '27%', tone: 'gold' },
 ] as const;

--- a/tests/unit/app.test.tsx
+++ b/tests/unit/app.test.tsx
@@ -178,6 +178,25 @@ describe('app runtime config', () => {
     expect(state.currentUser).toEqual({ name: 'Current User', access: undefined });
   });
 
+  it('getInitialState does not grant admin access when the system role response is empty', async () => {
+    const { getInitialState } = require('@/app');
+    mockGetSystemUserRoleApi.mockResolvedValueOnce({});
+
+    const state = await getInitialState();
+
+    expect(state.currentUser).toEqual({ name: 'Current User', access: undefined });
+  });
+
+  it('getInitialState keeps the user signed in when the system role lookup fails', async () => {
+    const { getInitialState } = require('@/app');
+    mockGetSystemUserRoleApi.mockRejectedValueOnce(new Error('role lookup failed'));
+
+    const state = await getInitialState();
+
+    expect(mockHistory.push).not.toHaveBeenCalled();
+    expect(state.currentUser).toEqual({ name: 'Current User', access: undefined });
+  });
+
   it('getInitialState redirects to login when fetching the current user fails', async () => {
     const { getInitialState } = require('@/app');
     mockQueryCurrentUser.mockRejectedValueOnce(new Error('unauthorized'));

--- a/tests/unit/app.test.tsx
+++ b/tests/unit/app.test.tsx
@@ -2,6 +2,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 
 const mockQueryCurrentUser = jest.fn();
+const mockGetSystemUserRoleApi = jest.fn();
 const mockGetLocalizedAppTitle = jest.fn(() => 'Localized TianGong');
 const mockHistory = {
   location: {
@@ -52,6 +53,11 @@ jest.mock('@/components/TidasPackageActions', () => ({
 jest.mock('@/services/auth', () => ({
   __esModule: true,
   getCurrentUser: (...args: any[]) => mockQueryCurrentUser(...args),
+}));
+
+jest.mock('@/services/roles/api', () => ({
+  __esModule: true,
+  getSystemUserRoleApi: (...args: any[]) => mockGetSystemUserRoleApi(...args),
 }));
 
 jest.mock('../../config/defaultSettings', () => ({
@@ -125,6 +131,7 @@ describe('app runtime config', () => {
     mockHistory.location.pathname = '/tgdata';
     mockHistory.location.search = '';
     mockQueryCurrentUser.mockResolvedValue({ name: 'Current User', access: 'admin' });
+    mockGetSystemUserRoleApi.mockResolvedValue({ role: 'admin' });
     mockGetLocalizedAppTitle.mockReturnValue('Localized TianGong');
   });
 
@@ -135,6 +142,7 @@ describe('app runtime config', () => {
     const state = await getInitialState();
 
     expect(mockQueryCurrentUser).toHaveBeenCalledTimes(1);
+    expect(mockGetSystemUserRoleApi).toHaveBeenCalledTimes(1);
     expect(state.currentUser).toEqual({ name: 'Current User', access: 'admin' });
     expect(state.isDarkMode).toBe(true);
     expect(state.settings).toMatchObject({
@@ -142,6 +150,26 @@ describe('app runtime config', () => {
       colorPrimary: '#9e3ffd',
       logo: '/logo_dark.svg',
     });
+  });
+
+  it('getInitialState loads dashboard users so admin route access can gate the page', async () => {
+    const { getInitialState } = require('@/app');
+    mockHistory.location.pathname = '/dashboard/national-carbon';
+
+    const state = await getInitialState();
+
+    expect(mockQueryCurrentUser).toHaveBeenCalledTimes(1);
+    expect(mockGetSystemUserRoleApi).toHaveBeenCalledTimes(1);
+    expect(state.currentUser).toEqual({ name: 'Current User', access: 'admin' });
+  });
+
+  it('getInitialState does not grant admin access to non-admin system roles', async () => {
+    const { getInitialState } = require('@/app');
+    mockGetSystemUserRoleApi.mockResolvedValueOnce({ role: 'member' });
+
+    const state = await getInitialState();
+
+    expect(state.currentUser).toEqual({ name: 'Current User', access: undefined });
   });
 
   it('getInitialState redirects to login when fetching the current user fails', async () => {

--- a/tests/unit/app.test.tsx
+++ b/tests/unit/app.test.tsx
@@ -23,6 +23,11 @@ jest.mock('@/components', () => ({
   DarkMode: 'dark-mode',
   ExportTidasPackage: 'export-tidas-package',
   Footer: () => <div data-testid='footer'>Footer</div>,
+  HeaderActionIcon: ({ title, onClick }: any) => (
+    <button data-testid='header-action-icon' onClick={onClick} type='button'>
+      {title}
+    </button>
+  ),
   ImportTidasPackage: 'import-tidas-package',
   LcaTaskCenter: 'lca-task-center',
   Notification: 'notification-center',
@@ -88,6 +93,7 @@ jest.mock('@umijs/max', () => ({
 
 jest.mock('@ant-design/icons', () => ({
   __esModule: true,
+  DashboardOutlined: () => <span data-testid='dashboard-icon'>dashboard-icon</span>,
   LinkOutlined: () => <span data-testid='link-icon'>link-icon</span>,
 }));
 
@@ -374,6 +380,27 @@ describe('app runtime config', () => {
     });
     expect(guardedLayout.childrenRender?.(<div>child</div>)).toBeNull();
     expect(mockHistory.push).toHaveBeenCalledWith('/user/login');
+  });
+
+  it('adds a national carbon dashboard shortcut for admin users', () => {
+    const { layout } = require('@/app');
+    const setInitialState = jest.fn();
+
+    const runtimeLayout = layout({
+      initialState: {
+        currentUser: { access: 'admin', name: 'Admin User' },
+        isDarkMode: false,
+        settings: { navTheme: 'light' },
+      },
+      setInitialState,
+    });
+
+    const actions = runtimeLayout.actionsRender?.();
+    expect(actions).toHaveLength(11);
+    expect(actions[5].props.title).toBe('Data Dashboard');
+
+    fireEvent.click(render(actions[5]).getByTestId('header-action-icon'));
+    expect(mockHistory.push).toHaveBeenCalledWith('/dashboard/national-carbon');
   });
 
   it('uses the dark theme algorithm when dark mode is enabled', () => {

--- a/tests/unit/config/routes.test.ts
+++ b/tests/unit/config/routes.test.ts
@@ -1,0 +1,14 @@
+import routes from '../../../config/routes';
+
+describe('route access config', () => {
+  it('protects the national carbon dashboard with admin access', () => {
+    const dashboardRoute = routes.find((route) => route.path === '/dashboard/national-carbon');
+
+    expect(dashboardRoute).toMatchObject({
+      access: 'canAdmin',
+      component: './NationalCarbonDashboard',
+      layout: false,
+      menu: false,
+    });
+  });
+});

--- a/tests/unit/pages/NationalCarbonDashboard/schema.test.ts
+++ b/tests/unit/pages/NationalCarbonDashboard/schema.test.ts
@@ -12,7 +12,7 @@ describe('NationalCarbonDashboard schema', () => {
 
   it('parses the dashboard fixture and exposes the expected wallboard metrics', () => {
     expect(snapshot.schemaVersion).toBe('dashboard_snapshot_v1');
-    expect(snapshot.title).toBe('国家碳数据平台建设进展');
+    expect(snapshot.title).toBe('天工数据库建设进展');
     expect(snapshot.summary).toMatchObject({
       coveredRegions: 29,
       totalRegions: 31,


### PR DESCRIPTION
Closes #434

## Summary
- Remove the public-path exception for /dashboard/national-carbon so unauthenticated users are redirected to login.
- Map system admin-level roles to existing canAdmin access during initial state and protect the dashboard route with access: canAdmin.
- Replace dashboard wording that described the surface as national carbon data with 天工数据库 wording.
- Add an admin-only header shortcut that opens the dashboard route.

## Key Decisions
- Treat system owner and admin roles as admin-level for route access, matching existing system-admin-only export behavior.
- Keep the fullscreen dashboard layout disabled while adding Umi access metadata to the route.

## Validation
- npm run test:ci -- tests/unit/app.test.tsx tests/unit/config/routes.test.ts tests/unit/pages/NationalCarbonDashboard/schema.test.ts --runInBand
- npm run lint
- npm run build
- npm run docpact:gate

## Risks / Rollback
- Low runtime risk: if system role lookup fails, the admin access flag is not granted and the route remains denied.

## Follow-ups
- After merge to dev and later promotion to main, lca-workspace still needs the normal submodule pointer integration.

## Workspace Integration
- Next uses dev as the routine PR base; root lca-workspace/main should only bump this after the change is promoted according to workspace policy.
