### PR TITLE
[codex] Promote dev to main for process exchange table overflow fix

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-25"
-lastReviewedCommit: "7df4488a6527696c0d2dff22ebad566c2cdfb90f"
+lastReviewedAt: '2026-05-25'
+lastReviewedCommit: '9c3796275fa3826651e7f23df018261b5c7ee7da'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: 7df4488a6527696c0d2dff22ebad566c2cdfb90f
+lastReviewedCommit: 9c3796275fa3826651e7f23df018261b5c7ee7da
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: 333aa2eb41cd3b1519ccdf480537922bbbe25339
+lastReviewedCommit: 9c3796275fa3826651e7f23df018261b5c7ee7da
 ---
 
 # Development Bootstrap

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: 7df4488a6527696c0d2dff22ebad566c2cdfb90f
+lastReviewedCommit: 9c3796275fa3826651e7f23df018261b5c7ee7da
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: 7df4488a6527696c0d2dff22ebad566c2cdfb90f
+lastReviewedCommit: 9c3796275fa3826651e7f23df018261b5c7ee7da
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/src/pages/Processes/Components/Exchange/column.tsx
+++ b/src/pages/Processes/Components/Exchange/column.tsx
@@ -7,12 +7,15 @@ import { ProColumns } from '@ant-design/pro-components';
 import { FormattedMessage } from '@umijs/max';
 import { Tooltip } from 'antd';
 
+export const PROCESS_EXCHANGE_TABLE_SCROLL = { x: 'max-content' };
+
 export function getExchangeColumns(lang: string): ProColumns<ProcessExchangeTable>[] {
   return [
     {
       title: <FormattedMessage id='pages.table.title.index' defaultMessage='Index' />,
       dataIndex: 'index',
       valueType: 'index',
+      width: 64,
       search: false,
     },
     // {
@@ -36,6 +39,7 @@ export function getExchangeColumns(lang: string): ProColumns<ProcessExchangeTabl
       dataIndex: 'referenceToFlowDataSet',
       sorter: false,
       search: false,
+      width: 220,
       render: (_, row) => [
         <Tooltip key={0} placement='topLeft' title={row.generalComment}>
           {row.referenceToFlowDataSet}
@@ -49,6 +53,7 @@ export function getExchangeColumns(lang: string): ProColumns<ProcessExchangeTabl
       dataIndex: 'typeOfDataSet',
       sorter: false,
       search: false,
+      width: 110,
       render: (_, row) => {
         return getFolwypeOfDataSetOptions(row.typeOfDataSet ?? '');
       },
@@ -59,6 +64,7 @@ export function getExchangeColumns(lang: string): ProColumns<ProcessExchangeTabl
       ),
       dataIndex: 'classification',
       search: false,
+      width: 240,
       render: (_, row) => {
         return row?.classification && row?.classification !== 'undefined'
           ? row.classification
@@ -70,6 +76,7 @@ export function getExchangeColumns(lang: string): ProColumns<ProcessExchangeTabl
       dataIndex: 'referenceToFlowDataSetVersion',
       sorter: false,
       search: false,
+      width: 110,
     },
     {
       title: (
@@ -110,6 +117,7 @@ export function getExchangeColumns(lang: string): ProColumns<ProcessExchangeTabl
       dataIndex: 'refUnitGroup',
       sorter: false,
       search: false,
+      width: 150,
       render: (_, row) => {
         return [
           // <ReferenceUnit
@@ -143,6 +151,7 @@ export function getExchangeColumns(lang: string): ProColumns<ProcessExchangeTabl
       dataIndex: 'dataDerivationTypeStatus',
       sorter: false,
       search: false,
+      width: 190,
     },
     {
       title: (
@@ -154,6 +163,7 @@ export function getExchangeColumns(lang: string): ProColumns<ProcessExchangeTabl
       dataIndex: 'quantitativeReference',
       sorter: false,
       search: false,
+      width: 150,
       render: (_, row) => {
         return <QuantitativeReferenceIcon value={row.quantitativeReference} />;
       },
@@ -165,7 +175,7 @@ export function getExchangeColumns(lang: string): ProColumns<ProcessExchangeTabl
       dataIndex: 'reviewType',
       sorter: false,
       search: false,
-      width: 80,
+      width: 100,
       render: (_, row) => {
         return (
           <>

--- a/src/pages/Processes/Components/form.tsx
+++ b/src/pages/Processes/Components/form.tsx
@@ -35,7 +35,7 @@ import schema from '../processes_schema.json';
 import { getSdkSuggestedFixMessage, resolveRequiredValidationMessage } from '../sdkValidationUi';
 import AnnualSupplyOrProductionVolumeForm from './AnnualSupplyOrProductionVolume/form';
 import ComplianceItemForm from './Compliance/form';
-import { getExchangeColumns } from './Exchange/column';
+import { getExchangeColumns, PROCESS_EXCHANGE_TABLE_SCROLL } from './Exchange/column';
 import ProcessExchangeCreate from './Exchange/create';
 import ProcessExchangeDelete from './Exchange/delete';
 import ProcessExchangeEdit from './Exchange/edit';
@@ -753,6 +753,7 @@ export const ProcessForm: FC<Props> = ({
       title: <FormattedMessage id='pages.table.title.option' defaultMessage='Option' />,
       dataIndex: 'option',
       search: false,
+      width: 128,
       render: (_, row) => {
         const rowSdkHighlights = sdkExchangeFieldDetailsByExchangeId[row.dataSetInternalID] ?? [];
 
@@ -2574,6 +2575,7 @@ export const ProcessForm: FC<Props> = ({
                     return rowClasses.join(' ').trim();
                   }}
                   className='process-exchange-table'
+                  scroll={PROCESS_EXCHANGE_TABLE_SCROLL}
                   toolBarRender={() => {
                     return [
                       <ProcessExchangeCreate
@@ -2684,6 +2686,7 @@ export const ProcessForm: FC<Props> = ({
                     return rowClasses.join(' ').trim();
                   }}
                   className='process-exchange-table'
+                  scroll={PROCESS_EXCHANGE_TABLE_SCROLL}
                   toolBarRender={() => {
                     return [
                       <ProcessExchangeCreate

--- a/src/pages/Processes/Components/view.tsx
+++ b/src/pages/Processes/Components/view.tsx
@@ -47,7 +47,7 @@ import {
 } from './optiondata';
 import ReviewItemView from './Review/view';
 
-import { getExchangeColumns } from './Exchange/column';
+import { getExchangeColumns, PROCESS_EXCHANGE_TABLE_SCROLL } from './Exchange/column';
 import {
   buildMergedLcaRows as buildMergedLciaRows,
   getLcaMethodMetaMap,
@@ -219,6 +219,7 @@ const ProcessView: FC<Props> = ({
       title: <FormattedMessage id='pages.table.title.option' defaultMessage='Option' />,
       dataIndex: 'option',
       search: false,
+      width: 80,
       render: (_, row) => {
         return [
           <Space size={'small'} key={0}>
@@ -1479,6 +1480,7 @@ const ProcessView: FC<Props> = ({
               children: (
                 <ProTable<ProcessExchangeTable, ListPagination>
                   search={false}
+                  scroll={PROCESS_EXCHANGE_TABLE_SCROLL}
                   pagination={{
                     showSizeChanger: false,
                     pageSize: 10,
@@ -1540,6 +1542,7 @@ const ProcessView: FC<Props> = ({
               children: (
                 <ProTable<ProcessExchangeTable, ListPagination>
                   search={false}
+                  scroll={PROCESS_EXCHANGE_TABLE_SCROLL}
                   pagination={{
                     showSizeChanger: false,
                     pageSize: 10,


### PR DESCRIPTION
## Promotion Contract

- base branch: `main`
- source branch: fork branch `ForeverYoung5:codex/promote-dev-to-main-issue-438`, created from `origin/dev`
- validated environment before promotion: PR #439 CI / local checks
- back-merge required after merge: `No`
- root workspace integration expected: `Yes`, update `lca-workspace` submodule pointer after this promote PR merges to `main`

- [x] this PR promotes `dev` into `main`
- [x] integrated behavior was verified in `dev` before promotion by the merged PR #439 Full Gate
- [x] if the PR includes a direct `main` hotfix path, the required `main -> dev` back-merge plan is documented

## Linked Issue

Closes #438

## Promotion Facts

Promotes the process Input/Output exchange table overflow fix merged in #439 from `dev` to `main`. `origin/dev` is currently ahead of `origin/main` by the #439 merge commit and its table sizing fix.

## Validation Facts

Source PR #439 validation:

- `npx prettier --write .docpact/config.yaml AGENTS.md DEV.md docs/agents/repo-architecture.md docs/agents/repo-validation.md src/pages/Processes/Components/Exchange/column.tsx src/pages/Processes/Components/form.tsx src/pages/Processes/Components/view.tsx`
- `npm run tsc -- --pretty false`
- `npx eslint --cache --ext .js,.jsx,.ts,.tsx --format=stylish src/pages/Processes/Components/Exchange/column.tsx src/pages/Processes/Components/form.tsx src/pages/Processes/Components/view.tsx`
- `scripts/docpact lint --root . --files "src/pages/Processes/Components/Exchange/column.tsx,src/pages/Processes/Components/form.tsx,src/pages/Processes/Components/view.tsx,.docpact/config.yaml,AGENTS.md,DEV.md,docs/agents/repo-architecture.md,docs/agents/repo-validation.md" --format json --output .docpact/runs/latest.json`
- #439 CI: `Full Gate` passed; `ai-doc-lint` passed
- promote branch push hook: `npm run docpact:gate -- --base origin/dev` passed with no changed paths relative to `origin/dev`

Visual browser verification for #439 reached the local login page but could not enter process details without an authenticated/data-ready session.

## Integration And Follow-Up

After this PR merges, update the root `lca-workspace` submodule pointer to the promoted `tiangong-lca-next/main` commit according to workspace integration policy.