### PR TITLE
refactor: route internal links through Umi

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-25"
-lastReviewedCommit: "21afcff860e46ae6d8ffeda53c82c76286651c3e"
+lastReviewedCommit: "7dcef870dab3ceb461d9646a7248da8ef87be684"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: 21afcff860e46ae6d8ffeda53c82c76286651c3e
+lastReviewedCommit: 7dcef870dab3ceb461d9646a7248da8ef87be684
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: 21afcff860e46ae6d8ffeda53c82c76286651c3e
+lastReviewedCommit: 7dcef870dab3ceb461d9646a7248da8ef87be684
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: 21afcff860e46ae6d8ffeda53c82c76286651c3e
+lastReviewedCommit: 7dcef870dab3ceb461d9646a7248da8ef87be684
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: 9c3796275fa3826651e7f23df018261b5c7ee7da
+lastReviewedCommit: 7dcef870dab3ceb461d9646a7248da8ef87be684
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: 9c3796275fa3826651e7f23df018261b5c7ee7da
+lastReviewedCommit: 7dcef870dab3ceb461d9646a7248da8ef87be684
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -19,8 +19,8 @@ checkPaths:
   - config/supabaseEnv.ts
   - src/services/**
   - docker/**
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 21afcff860e46ae6d8ffeda53c82c76286651c3e
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: c519bd8bd2fa51f86bdd39399d13ae5c3eedd2d5
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: 21afcff860e46ae6d8ffeda53c82c76286651c3e
+lastReviewedCommit: 7dcef870dab3ceb461d9646a7248da8ef87be684
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: 21afcff860e46ae6d8ffeda53c82c76286651c3e
+lastReviewedCommit: 7dcef870dab3ceb461d9646a7248da8ef87be684
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: 21afcff860e46ae6d8ffeda53c82c76286651c3e
+lastReviewedCommit: 7dcef870dab3ceb461d9646a7248da8ef87be684
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: 21afcff860e46ae6d8ffeda53c82c76286651c3e
+lastReviewedCommit: 7dcef870dab3ceb461d9646a7248da8ef87be684
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/2026-05-25-umi-routing-unification.md
+++ b/docs/plans/2026-05-25-umi-routing-unification.md
@@ -1,0 +1,892 @@
+# Umi 路由统一实施计划
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**目标：** 统一应用内 React 导航到 Umi 路由能力，只在 Umi 无法接管的边界保留自定义绝对 URL 构造。
+
+**架构：** 应用内路由以 Umi route path 为唯一语义源，例如 `/mydata/processes?id=...`。React UI 中的声明式跳转优先使用 Umi `Link`，命令式跳转继续使用 Umi `history.push` / `history.replace`。`buildAppAbsoluteUrl` 只保留给必须生成真实 URL 字符串的边界，例如 Supabase 邮件重定向、导出的 HTML、持久化通知链接、外部/存储对象链接。
+
+**技术栈：** Umi 4 / `@umijs/max`、React 18、Ant Design 5、Jest、Testing Library、TypeScript。
+
+---
+
+## 现状盘点
+
+本节是执行前的排查清单。执行任务时先按这些类别确认“哪些要改、哪些不该改”。
+
+### 1. 路由配置源
+
+**文件：** `/Users/biao/Code/lca-workspace/lca-workspace/tiangong-lca-next/config/routes.ts`
+
+当前 Umi route path：
+
+- `/dashboard/national-carbon`
+- `/manageSystem`
+- `/review`
+- `/tgdata`，重定向到 `/tgdata/models`
+- `/tgdata/models`
+- `/tgdata/processes`
+- `/tgdata/flows`
+- `/tgdata/flowproperties`
+- `/tgdata/unitgroups`
+- `/tgdata/sources`
+- `/tgdata/contacts`
+- `/codata`，重定向到 `/codata/models`
+- `/codata/models`
+- `/codata/processes`
+- `/codata/flows`
+- `/codata/flowproperties`
+- `/codata/unitgroups`
+- `/codata/sources`
+- `/codata/contacts`
+- `/mydata`，重定向到 `/mydata/models`
+- `/mydata/models`
+- `/mydata/processes/analysis`
+- `/mydata/processes`
+- `/mydata/flows`
+- `/mydata/flowproperties`
+- `/mydata/unitgroups`
+- `/mydata/sources`
+- `/mydata/contacts`
+- `/tedata`，重定向到 `/tedata/models`
+- `/tedata/models`
+- `/tedata/processes`
+- `/tedata/flows`
+- `/tedata/flowproperties`
+- `/tedata/unitgroups`
+- `/tedata/sources`
+- `/tedata/contacts`
+- `/account`
+- `/team`
+- `/user/login`
+- `/user/login/password_forgot`
+- `/user/login/password_reset`
+- `/welcome`
+- `/admin`
+- `/admin/sub-page`
+- `/`
+- `*`
+
+**配置事实：**
+
+- `/Users/biao/Code/lca-workspace/lca-workspace/tiangong-lca-next/config/config.ts` 当前配置 `history: { type: 'hash' }`。
+- 本计划不改 history 类型，只减少 UI 代码对 `/#/...` 序列化细节的直接依赖。
+
+### 2. 已经正确使用 Umi 的导航
+
+这些位置当前已经走 Umi 路由，不应改成手写 URL。
+
+| 文件 | 位置 | 现状 | 处理 |
+| --- | --- | --- | --- | --- | --- |
+| `src/app.tsx` | `history.push(loginPath)` | 未登录时跳登录 | 保留 |
+| `src/app.tsx` | `history.push(dashboardPath)` | 顶部 Dashboard 入口 | 保留 |
+| `src/app.tsx` | `<Link to='/umi/plugin/openapi' target='_blank'>` | dev OpenAPI 链接 | 保留，已是 Umi Link |
+| `src/app.tsx` | `menuItemRender` 中 `<Link to={menuItemProps.path}>` | 菜单跳转 | 保留 |
+| `src/components/RightContent/AvatarDropdown.tsx` | `history.replace({ pathname: '/user/login', search })` | 退出登录 redirect | 保留 |
+| `src/components/RightContent/AvatarDropdown.tsx` | `history.push('/manageSystem')` | 用户菜单系统管理 | 保留 |
+| `src/components/RightContent/AvatarDropdown.tsx` | `history.push('/review')` | 用户菜单审核 | 保留 |
+| `src/components/RightContent/AvatarDropdown.tsx` | `history.push('/team?action=edit')` | 团队入口 | 保留 |
+| `src/components/RightContent/AvatarDropdown.tsx` | `history.replace({ pathname: '/team', search })` | 团队创建状态切换 | 保留 |
+| `src/components/RightContent/AvatarDropdown.tsx` | `history.push('/team?action=create')` | 团队创建入口 | 保留 |
+| `src/components/RightContent/AvatarDropdown.tsx` | `history.push('/account')` | 账户入口 | 保留 |
+| `src/pages/404.tsx` | `history.push('/')` | 返回首页 | 保留 |
+| `src/pages/Processes/Analysis/index.tsx` | `history.push('/mydata/processes')` | 分析页返回 | 保留 |
+| `src/pages/Processes/index.tsx` | `history.push('/mydata/processes/analysis')` | 进入分析页 | 保留 |
+| `src/pages/Teams/index.tsx` | `history.replace('/team?action=edit')` | 团队页状态同步 | 保留 |
+| `src/pages/User/Login/index.tsx` | `history.push(urlParams.get('redirect') |  | '/')` | 登录后跳转 | 保留，但需确认 redirect 安全性不是本计划范围 |
+| `src/pages/User/Login/password_forgot.tsx` | `<Link to='/'>` | 返回首页 | 保留 |
+| `src/pages/User/Login/password_reset.tsx` | `history.push('/')` | 重置后返回首页 | 保留 |
+| `src/pages/Welcome.tsx` | `history.push('/tgdata/models?tid=...')` | 团队数据入口 | 保留 |
+
+### 3. 当前 UI 中直接构造 hash/internal URL 的位置
+
+这些是本计划的主要改造对象。
+
+| 文件 | 位置 | 现状 | 目标 |
+| --- | --- | --- | --- |
+| `src/pages/User/Login/index.tsx` | `href={buildAppHashPath('/user/login/password_forgot')}` | React UI 直接使用 hash URL helper | 改为 Umi `<Link to='/user/login/password_forgot'>` |
+| `src/components/Notification/DataNotification.tsx` | `buildAppAbsoluteUrl('/mydata/...')` + `window.open(...)` | 表格操作按钮生成绝对 hash URL 并新开页 | 普通记录改为 Umi `Link target='_blank'`；拒绝记录保留按钮打开 modal，modal footer 用 Umi `Link` |
+
+### 4. 必须保留绝对 URL helper 的边界
+
+这些不是普通 React UI 导航，不能简单改成 Umi `Link`。
+
+| 文件 | 位置 | 原因 | 处理 |
+| --- | --- | --- | --- |
+| `src/services/auth/password.ts` | `supabase.auth.resetPasswordForEmail(..., { redirectTo })` | 邮件客户端和 Supabase 需要完整 URL，Umi 不在该环境运行 | 保留 `buildAppAbsoluteUrl('/user/login/password_reset')` |
+| `src/pages/Utils/review.tsx` | `getDatasetDetailUrl()` / `ValidationIssue.link` | link 会进入 validation issue 数据结构，后续可被通知、导出 HTML、`window.open` 使用 | 保留绝对 URL，但重命名为 `getDatasetDetailAbsoluteUrl` 明确语义 |
+| `src/components/ValidationIssueModal/index.tsx` | 导出 HTML 中 `<a href="...">` | 下载后的 HTML 是独立文档，不能依赖 Umi runtime | 保留绝对 URL |
+| `src/components/ValidationIssueModal/index.tsx` | `openValidationIssueLink(link)` | 打开的 link 来自 validation issue 数据，不一定是当前 React render 可控的 Umi route | 保留，但依赖上游生成 hash-compatible 绝对 URL |
+| `src/services/notifications/api.ts` | `link: normalizeNotificationLink(...)` | 通知 link 是持久化/服务端返回数据 | 保留 link 字符串模型 |
+| `src/components/Notification/IssueNotification.tsx` | `window.open(safeLink, '_blank', ...)` | issue notification 打开持久化 link，可能是内部绝对 URL 或外部 URL | 保留；本计划只验证安全过滤和 hash-compatible 数据来源 |
+
+### 5. 外部链接、静态文件和对象 URL
+
+这些不是 Umi 应用内路由，默认不改。
+
+| 文件 | 位置 | 类型 | 处理 |
+| --- | --- | --- | --- |
+| `src/pages/Admin.tsx` | `https://pro.ant.design/docs/block-cn` | 外部文档 | 保留原生 `<a>` |
+| `src/components/ImportTidasPackage/index.tsx` | `https://docs.tiangong.earth` / `<Typography.Link href={docsUrl}>` | 外部文档 | 保留 |
+| `src/components/RightContent/index.tsx` | `window.open(docsUrl)` | 外部文档 | 保留 |
+| `src/pages/User/Login/Components/LoginTopActions.tsx` | `window.open(docsUrl)` | 外部文档 | 保留 |
+| `src/pages/User/Login/index.tsx` | `/terms_of_use.html` | public 静态文件 | 保留 AntD `Typography.Link href` |
+| `src/pages/User/Login/index.tsx` | `/privacy_notice.html` | public 静态文件 | 保留 AntD `Typography.Link href` |
+| `src/pages/Welcome.tsx` | `href='#'` | 本页锚点/占位式交互 | 不纳入本计划；如要清理另开任务 |
+| `src/pages/Welcome.tsx` | `tidasDocUrl` | 外部 TIDAS 文档 | 保留 |
+| `src/pages/Sources/Components/view.tsx` | `sourceCitation` 的 `Button href` | 用户/数据源外部 URL | 保留，但可单独修 `target='blank'` 为 `target='_blank'`，不属于本计划主线 |
+| `src/components/Footer/index.tsx` | `https://www.tiangong.earth`、GitHub URL | 外部链接 | 保留 |
+| `src/components/FileViewer/gallery.tsx` | `window.open(res.url, '_blank')` | 文件/存储 URL | 保留 |
+| `src/pages/Sources/Components/form.tsx` | `window.open(res.url, '_blank')` | 文件/存储 URL | 保留 |
+| `src/components/ImportTidasPackage/index.tsx` | `URL.createObjectURL(blob)` | 下载对象 URL | 保留 |
+| `src/components/ValidationIssueModal/index.tsx` | `URL.createObjectURL(blob)` | 下载对象 URL | 保留 |
+| `src/services/general/api.ts` | `URL.createObjectURL(blob)` | 下载对象 URL | 保留 |
+| `src/services/supabase/storage.ts` | `URL.createObjectURL(...)` | 本地预览对象 URL | 保留 |
+
+### 6. 查询参数读取/构造点
+
+这些是 route state 解析或构造，不是 hash URL 序列化。默认不改，但测试时要避免破坏。
+
+| 文件 | 用途 |
+| --- | --- |
+| `src/app.tsx` | 从 `history.location.search` 读取 `tid`，给菜单 path 追加 `?tid=...` |
+| `src/components/RightContent/AvatarDropdown.tsx` | 读取/构造 login redirect、team action |
+| `src/pages/User/Login/index.tsx` | 读取 `redirect` 参数 |
+| `src/pages/NationalCarbonDashboard/index.tsx` | 从 hash/search 读取 dashboard 参数 |
+| `src/pages/Flows/index.tsx` | 读取列表页查询参数 |
+| `src/pages/Sources/index.tsx` | 读取列表页查询参数 |
+| `src/pages/Unitgroups/index.tsx` | 读取列表页查询参数 |
+| `src/pages/Contacts/index.tsx` | 读取列表页查询参数 |
+| `src/pages/LifeCycleModels/index.tsx` | 读取列表页查询参数 |
+| `src/pages/Processes/index.tsx` | 读取列表页查询参数 |
+| `src/pages/Teams/index.tsx` | 读取 `action` 参数 |
+| `src/pages/LifeCycleModels/Components/connectableProcesses/index.tsx` | 读取 `tid` 参数 |
+| `src/pages/Utils/review.tsx` | 用 `URLSearchParams` 构造 dataset detail route/query |
+
+### 7. 数据标准 URL / XML namespace / permanentDataSetURI
+
+源码中还有大量 `http://lca.jrc...`、`https://lcdn.tiangong.earth/...`、`@xmlns`、`@xsi:schemaLocation`、`common:permanentDataSetURI`。这些是数据格式、ILCD/TIDAS 元数据或永久数据集 URI，不是 Umi 应用路由。本计划不修改这些内容。
+
+### 8. 相关测试覆盖点
+
+执行时重点更新这些测试：
+
+- `tests/unit/utils/appUrl.test.ts`
+- `tests/unit/pages/User/Login/index.test.tsx`
+- `tests/unit/components/DataNotification.test.tsx`
+- `tests/unit/services/auth/password.test.ts`
+- `tests/unit/utils/review.validation.test.ts`
+- `tests/unit/components/ValidationIssueModal.test.tsx`，只在改名或绝对 URL 语义影响到它时调整
+- `tests/unit/components/IssueNotification.test.tsx`，只做回归确认，默认不改
+
+---
+
+## 实施任务
+
+### Task 0：交付准备
+
+**文件：**
+
+- 读取：`/Users/biao/Code/lca-workspace/lca-workspace/AGENTS.md`
+- 读取：`/Users/biao/Code/lca-workspace/lca-workspace/_docs/workspace-branch-policy-contract.md`
+- 读取：`/Users/biao/Code/lca-workspace/lca-workspace/tiangong-lca-next/AGENTS.md`
+- 读取：`/Users/biao/Code/lca-workspace/lca-workspace/tiangong-lca-next/docs/agents/repo-validation.md`
+
+**Step 1：确认跟踪记录**
+
+实施前确认已有可执行 GitHub Issue 和 Project item。
+
+期望：
+
+- 目标仓库是 `linancn/tiangong-lca-next`。
+- routine branch base 是 `dev`。
+- Issue scope 明确是“Umi 路由统一”，并明确不改变 `history: { type: 'hash' }`。
+
+**Step 2：从 daily trunk 创建分支**
+
+运行：
+
+```bash
+git fetch origin dev
+git switch -c fix/issue-<id>-umi-routing origin/dev
+```
+
+期望：
+
+- 分支基于 `origin/dev`。
+- 不包含无关本地改动。
+
+**Step 3：同步 Project 状态**
+
+第一次代码编辑前，把对应 Project item 更新为 `In Progress`。
+
+### Task 1：收紧 app URL helper 的公共边界
+
+**文件：**
+
+- 修改：`/Users/biao/Code/lca-workspace/lca-workspace/tiangong-lca-next/src/utils/appUrl.ts`
+- 修改：`/Users/biao/Code/lca-workspace/lca-workspace/tiangong-lca-next/tests/unit/utils/appUrl.test.ts`
+
+**Step 1：先写失败测试**
+
+把 `buildAppHashPath` 的测试改成“helper 只服务绝对 URL 边界”的测试：
+
+```ts
+import { buildAppAbsoluteUrl, getAppOrigin } from '@/utils/appUrl';
+
+describe('appUrl helpers', () => {
+  it('returns the browser origin when window is available', () => {
+    expect(getAppOrigin()).toBe('http://localhost:8000');
+  });
+
+  it('falls back to the production origin when window is unavailable', () => {
+    const originalWindow = global.window;
+    Object.defineProperty(global, 'window', {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      expect(getAppOrigin()).toBe('https://lca.tiangong.earth');
+      expect(buildAppAbsoluteUrl('/user/login/password_reset')).toBe(
+        'https://lca.tiangong.earth/#/user/login/password_reset',
+      );
+    } finally {
+      Object.defineProperty(global, 'window', {
+        configurable: true,
+        value: originalWindow,
+      });
+    }
+  });
+
+  it('builds absolute app urls for off-app consumers and trims trailing slashes', () => {
+    expect(buildAppAbsoluteUrl('/user/login/password_reset', 'https://demo.example/')).toBe(
+      'https://demo.example/#/user/login/password_reset',
+    );
+  });
+
+  it('normalizes already-hashed route input before building absolute URLs', () => {
+    expect(buildAppAbsoluteUrl('/#/user/login/password_reset', 'https://demo.example')).toBe(
+      'https://demo.example/#/user/login/password_reset',
+    );
+    expect(buildAppAbsoluteUrl('#/user/login/password_reset', 'https://demo.example')).toBe(
+      'https://demo.example/#/user/login/password_reset',
+    );
+  });
+});
+```
+
+**Step 2：运行目标测试确认失败**
+
+运行：
+
+```bash
+npx jest tests/unit/utils/appUrl.test.ts --runInBand --testTimeout=20000
+```
+
+期望：
+
+- FAIL，因为当前测试和导出仍包含 `buildAppHashPath`。
+
+**Step 3：改实现**
+
+把 `buildAppHashPath` 改成模块内部函数，不再导出：
+
+```ts
+const DEFAULT_APP_ORIGIN = 'https://lca.tiangong.earth';
+
+const normalizeAppPath = (path: string) => {
+  if (!path) {
+    return '/';
+  }
+
+  if (path.startsWith('/#/')) {
+    return path.slice(2);
+  }
+
+  if (path.startsWith('#/')) {
+    return path.slice(1);
+  }
+
+  return path.startsWith('/') ? path : `/${path}`;
+};
+
+const normalizeOrigin = (origin: string) => origin.replace(/\/+$/, '');
+
+const buildHashHistoryPath = (path: string) => `/#${normalizeAppPath(path)}`;
+
+export const getAppOrigin = () =>
+  typeof window !== 'undefined' ? window.location.origin : DEFAULT_APP_ORIGIN;
+
+export const buildAppAbsoluteUrl = (path: string, origin: string = getAppOrigin()) =>
+  `${normalizeOrigin(origin)}${buildHashHistoryPath(path)}`;
+```
+
+**Step 4：运行目标测试确认通过**
+
+运行：
+
+```bash
+npx jest tests/unit/utils/appUrl.test.ts --runInBand --testTimeout=20000
+```
+
+期望：
+
+- PASS。
+
+**Step 5：提交**
+
+运行：
+
+```bash
+git add src/utils/appUrl.ts tests/unit/utils/appUrl.test.ts
+git commit -m "test: define app url helper boundary"
+```
+
+### Task 2：登录页忘记密码入口改用 Umi Link
+
+**文件：**
+
+- 修改：`/Users/biao/Code/lca-workspace/lca-workspace/tiangong-lca-next/src/pages/User/Login/index.tsx`
+- 修改：`/Users/biao/Code/lca-workspace/lca-workspace/tiangong-lca-next/tests/unit/pages/User/Login/index.test.tsx`
+
+**Step 1：先写失败测试**
+
+把现有 “hash-compatible app route” 测试改成 Umi route 语义测试：
+
+```ts
+it('renders the forgot-password link as an Umi app route', () => {
+  render(<LoginPage />);
+
+  const link = screen.getByText('Forgot password').closest('a');
+  expect(link).toHaveAttribute('href', expect.stringContaining('/user/login/password_forgot'));
+  expect(link).not.toHaveAttribute('href', '/user/login/password_forgot');
+});
+```
+
+说明：
+
+- 第一条确认目标 route。
+- 第二条防止退回原生 browser-history path。
+- 测试不强耦合 `/#/...` 的最终序列化。
+
+**Step 2：运行目标测试确认失败**
+
+运行：
+
+```bash
+npx jest tests/unit/pages/User/Login/index.test.tsx --runInBand --testTimeout=20000
+```
+
+期望：
+
+- FAIL，因为组件仍直接 import/use `buildAppHashPath`。
+
+**Step 3：改组件**
+
+修改 imports：
+
+```ts
+- import { Helmet, history, useIntl, useLocation, useModel } from 'umi';
++ import { Helmet, Link, history, useIntl, useLocation, useModel } from 'umi';
+```
+
+删除：
+
+```ts
+import { buildAppHashPath } from '@/utils/appUrl';
+```
+
+避免和 AntD `Typography.Link` 命名冲突：
+
+```ts
+- const { Link } = Typography;
++ const { Link: TypographyLink } = Typography;
+```
+
+静态文件链接继续用 AntD：
+
+```tsx
+<TypographyLink href='/terms_of_use.html' target='_blank' rel='noopener noreferrer'>
+  <FormattedMessage id='pages.login.termsOfUse' defaultMessage='Terms of Use' />
+</TypographyLink>
+```
+
+```tsx
+<TypographyLink href='/privacy_notice.html' target='_blank' rel='noopener noreferrer'>
+  <FormattedMessage id='pages.login.privacyNotice' defaultMessage='Privacy Notice' />
+</TypographyLink>
+```
+
+忘记密码入口改为：
+
+```tsx
+<Link
+  style={{
+    float: 'right',
+  }}
+  to='/user/login/password_forgot'
+>
+  <FormattedMessage id='pages.login.forgotPassword' defaultMessage='Forgot password' />
+</Link>
+```
+
+**Step 4：运行目标测试确认通过**
+
+运行：
+
+```bash
+npx jest tests/unit/pages/User/Login/index.test.tsx --runInBand --testTimeout=20000
+```
+
+期望：
+
+- PASS。
+
+**Step 5：提交**
+
+运行：
+
+```bash
+git add src/pages/User/Login/index.tsx tests/unit/pages/User/Login/index.test.tsx
+git commit -m "fix: route forgot password link through umi"
+```
+
+### Task 3：DataNotification 的 UI 跳转改用 Umi Link
+
+**文件：**
+
+- 修改：`/Users/biao/Code/lca-workspace/lca-workspace/tiangong-lca-next/src/components/Notification/DataNotification.tsx`
+- 修改：`/Users/biao/Code/lca-workspace/lca-workspace/tiangong-lca-next/tests/unit/components/DataNotification.test.tsx`
+
+**Step 1：先写失败测试**
+
+把非拒绝记录的 `window.open` 断言改成 link 断言：
+
+```ts
+it('renders process view route as an Umi link for non-rejected process notifications', async () => {
+  render(
+    <ConfigProvider>
+      <DataNotification {...defaultProps} />
+    </ConfigProvider>,
+  );
+
+  const viewLink = await screen.findByRole('link', { name: 'View' });
+
+  expect(viewLink).toHaveAttribute('target', '_blank');
+  expect(viewLink).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  expect(viewLink).toHaveAttribute('href', expect.stringContaining('/mydata/processes'));
+  expect(viewLink).toHaveAttribute('href', expect.stringContaining('id=process-1'));
+  expect(viewLink).toHaveAttribute('href', expect.stringContaining('version=1.0.0'));
+  expect(viewLink).toHaveAttribute('href', expect.stringContaining('mode=view'));
+});
+```
+
+拒绝记录 modal 测试保留，但把 “Fix Data” 改成 link 断言：
+
+```ts
+expect(screen.getByRole('link', { name: 'Fix Data' })).toHaveAttribute(
+  'href',
+  expect.stringContaining('/mydata/processes'),
+);
+```
+
+**Step 2：运行目标测试确认失败**
+
+运行：
+
+```bash
+npx jest tests/unit/components/DataNotification.test.tsx --runInBand --testTimeout=20000
+```
+
+期望：
+
+- FAIL，因为组件仍通过 `window.open(getNotificationDataPath(...))` 打开。
+
+**Step 3：组件改为返回 route path**
+
+删除：
+
+```ts
+import { buildAppAbsoluteUrl } from '@/utils/appUrl';
+```
+
+改 import：
+
+```ts
+- import { useIntl } from 'umi';
++ import { Link, useIntl } from 'umi';
+```
+
+把 `getNotificationDataPath` 改成 Umi route path：
+
+```ts
+const getNotificationDataRoute = (
+  record: DataNotificationItem,
+  mode: 'view' | 'edit',
+  options: { forceProcess?: boolean } = {},
+) => {
+  const dataId = record?.json?.data?.id ?? '';
+  const dataVersion = record?.json?.data?.version ?? '';
+  const basePath =
+    options.forceProcess || !record.isFromLifeCycle ? '/mydata/processes' : '/mydata/models';
+  return `${basePath}?id=${encodeURIComponent(dataId)}&version=${encodeURIComponent(
+    dataVersion,
+  )}&mode=${mode}`;
+};
+```
+
+删除 `openNotificationData`。
+
+**Step 4：按交互类型拆分 action**
+
+拒绝记录仍然是按钮，因为要先打开拒绝原因 modal：
+
+```tsx
+const renderAction = (record: DataNotificationItem) => {
+  const label = intl.formatMessage({ id: 'pages.review.table.view', defaultMessage: 'View' });
+
+  if (record.stateCode === -1) {
+    return (
+      <Button
+        type='link'
+        size='small'
+        style={{ color: token.colorPrimary }}
+        onClick={() => setSelectedRejectedRecord(record)}
+      >
+        {label}
+      </Button>
+    );
+  }
+
+  return (
+    <Link
+      className='ant-btn ant-btn-link ant-btn-sm'
+      style={{ color: token.colorPrimary }}
+      target='_blank'
+      rel='noopener noreferrer'
+      to={getNotificationDataRoute(record, 'view')}
+    >
+      <span>{label}</span>
+    </Link>
+  );
+};
+```
+
+table column 使用：
+
+```tsx
+render: (record: DataNotificationItem) => <Space>{renderAction(record)}</Space>,
+```
+
+**Step 5：modal footer 改成 Umi Link**
+
+把 modal 的 `onOk` / `okText` / `cancelText` 改为自定义 footer：
+
+```tsx
+footer={
+  selectedRejectedRecord
+    ? [
+        <Button key='close' onClick={() => setSelectedRejectedRecord(null)}>
+          {intl.formatMessage({
+            id: 'notifications.data.rejectionModal.close',
+            defaultMessage: 'Close',
+          })}
+        </Button>,
+        <Link
+          key='fix'
+          className='ant-btn ant-btn-primary'
+          target='_blank'
+          rel='noopener noreferrer'
+          to={getNotificationDataRoute(selectedRejectedRecord, 'edit', { forceProcess: true })}
+          onClick={() => setSelectedRejectedRecord(null)}
+        >
+          <span>
+            {intl.formatMessage({
+              id: 'notifications.data.rejectionModal.fix',
+              defaultMessage: 'Fix Data',
+            })}
+          </span>
+        </Link>,
+      ]
+    : undefined
+}
+```
+
+**Step 6：运行目标测试确认通过**
+
+运行：
+
+```bash
+npx jest tests/unit/components/DataNotification.test.tsx --runInBand --testTimeout=20000
+```
+
+期望：
+
+- PASS。
+
+**Step 7：提交**
+
+运行：
+
+```bash
+git add src/components/Notification/DataNotification.tsx tests/unit/components/DataNotification.test.tsx
+git commit -m "fix: use umi links for data notification routes"
+```
+
+### Task 4：Validation issue 保留绝对 URL，但改名明确语义
+
+**文件：**
+
+- 修改：`/Users/biao/Code/lca-workspace/lca-workspace/tiangong-lca-next/src/pages/Utils/review.tsx`
+- 修改：`/Users/biao/Code/lca-workspace/lca-workspace/tiangong-lca-next/tests/unit/utils/review.validation.test.ts`
+- 回归：`/Users/biao/Code/lca-workspace/lca-workspace/tiangong-lca-next/src/components/ValidationIssueModal/index.tsx`
+
+**Step 1：保持 link 为绝对 URL 的决策**
+
+不要把 `ValidationIssue.link` 改成 Umi `Link` 或纯 route path，因为它会：
+
+- 写入下载的 HTML。
+- 作为通知 payload 调用 `upsertValidationIssueNotification`。
+- 作为持久化 link 被 `IssueNotification` 打开。
+- 在 modal 中通过 `window.open` 打开。
+
+**Step 2：重命名 helper**
+
+在 `src/pages/Utils/review.tsx` 中把：
+
+```ts
+export const getDatasetDetailUrl = (ref: refDataType, origin?: string) => {
+```
+
+改成：
+
+```ts
+export const getDatasetDetailAbsoluteUrl = (ref: refDataType, origin?: string) => {
+```
+
+同步更新 `buildValidationIssues` 内部所有调用。
+
+**Step 3：更新测试 import 和测试名称**
+
+在 `tests/unit/utils/review.validation.test.ts` 中更新：
+
+```ts
+getDatasetDetailAbsoluteUrl,
+```
+
+绝对 URL 断言保持不变：
+
+```ts
+expect(getDatasetDetailAbsoluteUrl(ref, 'https://demo.example')).toBe(
+  'https://demo.example/#/mydata/processes?id=process-1&version=01.00.000&required=1',
+);
+```
+
+**Step 4：运行目标测试**
+
+运行：
+
+```bash
+npx jest tests/unit/utils/review.validation.test.ts --runInBand --testTimeout=20000
+```
+
+期望：
+
+- PASS。
+
+**Step 5：提交**
+
+运行：
+
+```bash
+git add src/pages/Utils/review.tsx tests/unit/utils/review.validation.test.ts
+git commit -m "refactor: clarify validation issue absolute urls"
+```
+
+### Task 5：按现状盘点做全量排查
+
+**文件：**
+
+- 检查：`/Users/biao/Code/lca-workspace/lca-workspace/tiangong-lca-next/src`
+- 检查：`/Users/biao/Code/lca-workspace/lca-workspace/tiangong-lca-next/tests/unit`
+
+**Step 1：确认没有 UI 继续依赖 hash helper**
+
+运行：
+
+```bash
+rg -n "buildAppHashPath|/#/|href=\\{buildApp|window\\.open\\(buildApp" src tests/unit
+```
+
+期望：
+
+- `buildAppHashPath` 不存在。
+- `/#/` 只出现在 `appUrl` 测试、absolute URL 边界测试或既有 validation/notification 绝对 URL 断言中。
+- React UI 组件不再为了普通应用内导航手写 `/#/...`。
+
+**Step 2：确认没有原生 href 指向应用内路由**
+
+运行：
+
+```bash
+rg -n "href=(['\\\"]/[A-Za-z0-9_#?./-]+|\\{[^}]*'/)" src
+```
+
+允许：
+
+- `/terms_of_use.html`
+- `/privacy_notice.html`
+- `src/global.less` 中针对 `/umi/plugin/openapi` 的样式选择器
+- `href='#'` 这种既有锚点/占位逻辑，暂不纳入本计划
+
+不允许：
+
+- `/user/...`
+- `/mydata/...`
+- `/tgdata/...`
+- `/codata/...`
+- `/tedata/...`
+- `/review`
+- `/team`
+- `/account`
+- `/manageSystem`
+
+这些如果出现在 React UI 原生 `href` 中，应改成 Umi `Link` 或 `history`。
+
+**Step 3：确认 window.open 分类正确**
+
+运行：
+
+```bash
+rg -n "window\\.open\\(" src
+```
+
+允许：
+
+- 外部文档 URL：`docs.tiangong.earth`、`tidas.tiangong.earth` 等。
+- 文件/存储 URL：`res.url`。
+- 持久化通知/validation link。
+
+不允许：
+
+- 在 React UI 中直接 `window.open('/mydata/...')`。
+- 在 React UI 中直接 `window.open(buildAppAbsoluteUrl('/mydata/...'))`。
+
+**Step 4：确认查询参数逻辑未破坏**
+
+运行相关 focused tests，尤其覆盖：
+
+- 登录 redirect。
+- team action。
+- `/mydata/processes/analysis` 跳转。
+- DataNotification 的 `id/version/mode` query。
+
+**Step 5：如有遗漏，补小提交**
+
+如果排查发现遗漏，修复后提交：
+
+```bash
+git add <changed-files>
+git commit -m "chore: remove leftover manual app route links"
+```
+
+如果没有遗漏，不要创建空提交。
+
+### Task 6：验证与 PR 交付
+
+**文件：**
+
+- 参考：`/Users/biao/Code/lca-workspace/lca-workspace/tiangong-lca-next/package.json`
+- 参考：`/Users/biao/Code/lca-workspace/lca-workspace/tiangong-lca-next/docs/agents/repo-validation.md`
+
+**Step 1：运行 focused tests**
+
+运行：
+
+```bash
+npx jest tests/unit/utils/appUrl.test.ts tests/unit/pages/User/Login/index.test.tsx tests/unit/components/DataNotification.test.tsx tests/unit/services/auth/password.test.ts tests/unit/utils/review.validation.test.ts --runInBand --testTimeout=20000
+```
+
+期望：
+
+- PASS。
+
+**Step 2：运行 TypeScript**
+
+运行：
+
+```bash
+npm run tsc
+```
+
+期望：
+
+- PASS。
+
+**Step 3：运行 CI 风格测试**
+
+运行：
+
+```bash
+npm run test:ci
+```
+
+期望：
+
+- PASS。
+
+**Step 4：运行 protected-branch parity gate**
+
+运行：
+
+```bash
+npm run prepush:gate
+```
+
+期望：
+
+- PASS。
+
+**Step 5：打开 PR**
+
+推送分支并开 PR 到 `dev`，不是 `main`：
+
+```bash
+git push -u <push-remote> fix/issue-<id>-umi-routing
+```
+
+PR body 必须包含：
+
+- `Closes #<id>`
+- Summary：React UI 内部导航改用 Umi `Link` / route path；绝对 URL helper 仅保留给 off-app boundary。
+- Validation：列出上面实际跑过的命令和结果。
+- Risk：`DataNotification` modal footer 从默认 OK 按钮改为 link button，需要关注样式和新开页行为。
+- Workspace Integration：合并后如要进入 workspace delivery，需要 root submodule bump。
+
+**Step 6：同步 Issue / Project**
+
+PR 打开后：
+
+- 把 PR 关联到 Issue。
+- 按 workspace delivery workflow 更新 Project 状态。
+- 在 Issue 评论中记录路由边界决策。
+
+建议评论：
+
+```markdown
+Implemented routing boundary decision:
+
+- React UI internal navigation uses Umi `Link` / route paths.
+- Custom hash absolute URL generation remains only for off-app consumers: Supabase email redirect, exported validation HTML, persisted notification links, and external/storage URLs.
+- The app still runs with `history: { type: 'hash' }`; this change does not alter history mode.
+```
+
+**Step 7：合并后的 workspace integration**
+
+PR 合并后，按 root workspace 流程处理：
+
+- 根据 workspace branch policy 确认 child SHA 是否适合进入 root。
+- 精确更新 `tiangong-lca-next` submodule pointer。
+- 按需运行 workspace-level validation。
+- 按策略打开或更新 root integration PR。

--- a/docs/plans/2026-05-25-umi-routing-unification.md
+++ b/docs/plans/2026-05-25-umi-routing-unification.md
@@ -4,7 +4,7 @@
 
 **目标：** 统一应用内 React 导航到 Umi 路由能力，只在 Umi 无法接管的边界保留自定义绝对 URL 构造。
 
-**架构：** 应用内路由以 Umi route path 为唯一语义源，例如 `/mydata/processes?id=...`。React UI 中的声明式跳转优先使用 Umi `Link`，命令式跳转继续使用 Umi `history.push` / `history.replace`。`buildAppAbsoluteUrl` 只保留给必须生成真实 URL 字符串的边界，例如 Supabase 邮件重定向、导出的 HTML、持久化通知链接、外部/存储对象链接。
+**架构：** 应用内路由以 Umi route path 为唯一语义源，例如 `/mydata/processes?id=...`。React UI 中的声明式跳转优先使用 Umi `Link`，命令式跳转继续使用 Umi `history.push` / `history.replace`。`buildExternalUrl` 只保留给必须生成真实 URL 字符串的边界，例如 Supabase 邮件重定向、导出的 HTML、持久化通知链接、外部/存储对象链接。
 
 **技术栈：** Umi 4 / `@umijs/max`、React 18、Ant Design 5、Jest、Testing Library、TypeScript。
 
@@ -105,7 +105,7 @@
 | 文件 | 位置 | 现状 | 目标 |
 | --- | --- | --- | --- |
 | `src/pages/User/Login/index.tsx` | `href={buildAppHashPath('/user/login/password_forgot')}` | React UI 直接使用 hash URL helper | 改为 Umi `<Link to='/user/login/password_forgot'>` |
-| `src/components/Notification/DataNotification.tsx` | `buildAppAbsoluteUrl('/mydata/...')` + `window.open(...)` | 表格操作按钮生成绝对 hash URL 并新开页 | 普通记录改为 Umi `Link target='_blank'`；拒绝记录保留按钮打开 modal，modal footer 用 Umi `Link` |
+| `src/components/Notification/DataNotification.tsx` | `buildExternalUrl('/mydata/...')` + `window.open(...)` | 表格操作按钮生成绝对 hash URL 并新开页 | 普通记录改为 Umi `Link target='_blank'`；拒绝记录保留按钮打开 modal，modal footer 用 Umi `Link` |
 
 ### 4. 必须保留绝对 URL helper 的边界
 
@@ -113,7 +113,7 @@
 
 | 文件 | 位置 | 原因 | 处理 |
 | --- | --- | --- | --- |
-| `src/services/auth/password.ts` | `supabase.auth.resetPasswordForEmail(..., { redirectTo })` | 邮件客户端和 Supabase 需要完整 URL，Umi 不在该环境运行 | 保留 `buildAppAbsoluteUrl('/user/login/password_reset')` |
+| `src/services/auth/password.ts` | `supabase.auth.resetPasswordForEmail(..., { redirectTo })` | 邮件客户端和 Supabase 需要完整 URL，Umi 不在该环境运行 | 保留 `buildExternalUrl('/user/login/password_reset')` |
 | `src/pages/Utils/review.tsx` | `getDatasetDetailUrl()` / `ValidationIssue.link` | link 会进入 validation issue 数据结构，后续可被通知、导出 HTML、`window.open` 使用 | 保留绝对 URL，但重命名为 `getDatasetDetailAbsoluteUrl` 明确语义 |
 | `src/components/ValidationIssueModal/index.tsx` | 导出 HTML 中 `<a href="...">` | 下载后的 HTML 是独立文档，不能依赖 Umi runtime | 保留绝对 URL |
 | `src/components/ValidationIssueModal/index.tsx` | `openValidationIssueLink(link)` | 打开的 link 来自 validation issue 数据，不一定是当前 React render 可控的 Umi route | 保留，但依赖上游生成 hash-compatible 绝对 URL |
@@ -232,7 +232,7 @@ git switch -c fix/issue-<id>-umi-routing origin/dev
 把 `buildAppHashPath` 的测试改成“helper 只服务绝对 URL 边界”的测试：
 
 ```ts
-import { buildAppAbsoluteUrl, getAppOrigin } from '@/utils/appUrl';
+import { buildExternalUrl, getAppOrigin } from '@/utils/appUrl';
 
 describe('appUrl helpers', () => {
   it('returns the browser origin when window is available', () => {
@@ -248,7 +248,7 @@ describe('appUrl helpers', () => {
 
     try {
       expect(getAppOrigin()).toBe('https://lca.tiangong.earth');
-      expect(buildAppAbsoluteUrl('/user/login/password_reset')).toBe(
+      expect(buildExternalUrl('/user/login/password_reset')).toBe(
         'https://lca.tiangong.earth/#/user/login/password_reset',
       );
     } finally {
@@ -260,16 +260,16 @@ describe('appUrl helpers', () => {
   });
 
   it('builds absolute app urls for off-app consumers and trims trailing slashes', () => {
-    expect(buildAppAbsoluteUrl('/user/login/password_reset', 'https://demo.example/')).toBe(
+    expect(buildExternalUrl('/user/login/password_reset', 'https://demo.example/')).toBe(
       'https://demo.example/#/user/login/password_reset',
     );
   });
 
   it('normalizes already-hashed route input before building absolute URLs', () => {
-    expect(buildAppAbsoluteUrl('/#/user/login/password_reset', 'https://demo.example')).toBe(
+    expect(buildExternalUrl('/#/user/login/password_reset', 'https://demo.example')).toBe(
       'https://demo.example/#/user/login/password_reset',
     );
-    expect(buildAppAbsoluteUrl('#/user/login/password_reset', 'https://demo.example')).toBe(
+    expect(buildExternalUrl('#/user/login/password_reset', 'https://demo.example')).toBe(
       'https://demo.example/#/user/login/password_reset',
     );
   });
@@ -318,7 +318,7 @@ const buildHashHistoryPath = (path: string) => `/#${normalizeAppPath(path)}`;
 export const getAppOrigin = () =>
   typeof window !== 'undefined' ? window.location.origin : DEFAULT_APP_ORIGIN;
 
-export const buildAppAbsoluteUrl = (path: string, origin: string = getAppOrigin()) =>
+export const buildExternalUrl = (path: string, origin: string = getAppOrigin()) =>
   `${normalizeOrigin(origin)}${buildHashHistoryPath(path)}`;
 ```
 
@@ -508,7 +508,7 @@ npx jest tests/unit/components/DataNotification.test.tsx --runInBand --testTimeo
 删除：
 
 ```ts
-import { buildAppAbsoluteUrl } from '@/utils/appUrl';
+import { buildExternalUrl } from '@/utils/appUrl';
 ```
 
 改 import：
@@ -771,7 +771,7 @@ rg -n "window\\.open\\(" src
 不允许：
 
 - 在 React UI 中直接 `window.open('/mydata/...')`。
-- 在 React UI 中直接 `window.open(buildAppAbsoluteUrl('/mydata/...'))`。
+- 在 React UI 中直接 `window.open(buildExternalUrl('/mydata/...'))`。
 
 **Step 4：确认查询参数逻辑未破坏**
 

--- a/src/components/Notification/DataNotification.tsx
+++ b/src/components/Notification/DataNotification.tsx
@@ -1,10 +1,9 @@
 import { getNotifyReviews } from '@/services/reviews/api';
 import type { ReviewsTable } from '@/services/reviews/data';
-import { buildAppAbsoluteUrl } from '@/utils/appUrl';
 import { Button, Modal, Space, Table, Tag, Typography, theme } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import React, { useEffect, useState } from 'react';
-import { useIntl } from 'umi';
+import { Link, useIntl } from 'umi';
 
 interface DataNotificationItem {
   key: string;
@@ -38,7 +37,7 @@ const DataNotification: React.FC<DataNotificationProps> = ({ timeFilter, onDataL
   const intl = useIntl();
   const { token } = theme.useToken();
 
-  const getNotificationDataPath = (
+  const getNotificationDataRoute = (
     record: DataNotificationItem,
     mode: 'view' | 'edit',
     options: { forceProcess?: boolean } = {},
@@ -47,19 +46,9 @@ const DataNotification: React.FC<DataNotificationProps> = ({ timeFilter, onDataL
     const dataVersion = record?.json?.data?.version ?? '';
     const basePath =
       options.forceProcess || !record.isFromLifeCycle ? '/mydata/processes' : '/mydata/models';
-    return buildAppAbsoluteUrl(
-      `${basePath}?id=${encodeURIComponent(dataId)}&version=${encodeURIComponent(
-        dataVersion,
-      )}&mode=${mode}`,
-    );
-  };
-
-  const openNotificationData = (
-    record: DataNotificationItem,
-    mode: 'view' | 'edit',
-    options?: { forceProcess?: boolean },
-  ) => {
-    window.open(getNotificationDataPath(record, mode, options), '_blank', 'noopener,noreferrer');
+    return `${basePath}?id=${encodeURIComponent(dataId)}&version=${encodeURIComponent(
+      dataVersion,
+    )}&mode=${mode}`;
   };
 
   const getRejectReason = (item: ReviewsTable) => {
@@ -162,22 +151,36 @@ const DataNotification: React.FC<DataNotificationProps> = ({ timeFilter, onDataL
     }
   };
 
-  const handleActionClick = (record: DataNotificationItem) => {
-    if (record.stateCode === -1) {
-      setSelectedRejectedRecord(record);
-      return;
-    }
-    openNotificationData(record, 'view');
-  };
-
-  const handleFixRejectedData = () => {
-    openNotificationData(selectedRejectedRecord as DataNotificationItem, 'edit', {
-      forceProcess: true,
-    });
-    setSelectedRejectedRecord(null);
-  };
-
   const rejectReason = selectedRejectedRecord?.rejectReason;
+
+  const renderAction = (record: DataNotificationItem) => {
+    const label = intl.formatMessage({ id: 'pages.review.table.view', defaultMessage: 'View' });
+
+    if (record.stateCode === -1) {
+      return (
+        <Button
+          type='link'
+          size='small'
+          style={{ color: token.colorPrimary }}
+          onClick={() => setSelectedRejectedRecord(record)}
+        >
+          {label}
+        </Button>
+      );
+    }
+
+    return (
+      <Link
+        className='ant-btn ant-btn-link ant-btn-sm'
+        style={{ color: token.colorPrimary }}
+        target='_blank'
+        rel='noopener noreferrer'
+        to={getNotificationDataRoute(record, 'view')}
+      >
+        <span>{label}</span>
+      </Link>
+    );
+  };
 
   const columns: ColumnsType<DataNotificationItem> = [
     {
@@ -234,18 +237,7 @@ const DataNotification: React.FC<DataNotificationProps> = ({ timeFilter, onDataL
     {
       title: intl.formatMessage({ id: 'pages.review.table.actions', defaultMessage: 'Actions' }),
       key: 'actions',
-      render: (record: DataNotificationItem) => (
-        <Space>
-          <Button
-            type='link'
-            size='small'
-            style={{ color: token.colorPrimary }}
-            onClick={() => handleActionClick(record)}
-          >
-            {intl.formatMessage({ id: 'pages.review.table.view', defaultMessage: 'View' })}
-          </Button>
-        </Space>
-      ),
+      render: (_: unknown, record: DataNotificationItem) => <Space>{renderAction(record)}</Space>,
     },
   ];
 
@@ -280,15 +272,35 @@ const DataNotification: React.FC<DataNotificationProps> = ({ timeFilter, onDataL
         })}
         open={!!selectedRejectedRecord}
         onCancel={() => setSelectedRejectedRecord(null)}
-        onOk={handleFixRejectedData}
-        cancelText={intl.formatMessage({
-          id: 'notifications.data.rejectionModal.close',
-          defaultMessage: 'Close',
-        })}
-        okText={intl.formatMessage({
-          id: 'notifications.data.rejectionModal.fix',
-          defaultMessage: 'Fix Data',
-        })}
+        footer={
+          selectedRejectedRecord
+            ? [
+                <Button key='close' onClick={() => setSelectedRejectedRecord(null)}>
+                  {intl.formatMessage({
+                    id: 'notifications.data.rejectionModal.close',
+                    defaultMessage: 'Close',
+                  })}
+                </Button>,
+                <Link
+                  key='fix'
+                  className='ant-btn ant-btn-primary'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  to={getNotificationDataRoute(selectedRejectedRecord, 'edit', {
+                    forceProcess: true,
+                  })}
+                  onClick={() => setSelectedRejectedRecord(null)}
+                >
+                  <span>
+                    {intl.formatMessage({
+                      id: 'notifications.data.rejectionModal.fix',
+                      defaultMessage: 'Fix Data',
+                    })}
+                  </span>
+                </Link>,
+              ]
+            : undefined
+        }
         width={640}
       >
         <Typography.Paragraph

--- a/src/pages/User/Login/index.tsx
+++ b/src/pages/User/Login/index.tsx
@@ -12,8 +12,7 @@ import React, { useState } from 'react';
 import { Helmet, history, useIntl, useLocation, useModel } from 'umi';
 
 import { Footer } from '@/components';
-import { buildAppHashPath } from '@/utils/appUrl';
-import { FormattedMessage } from '@umijs/max';
+import { FormattedMessage, Link } from '@umijs/max';
 import { Typography } from 'antd';
 import { flushSync } from 'react-dom';
 import { getBrandTheme } from '../../../../config/branding';
@@ -38,18 +37,18 @@ const LoginMessage: React.FC<{
   />
 );
 
-const { Link } = Typography;
+const { Link: TypographyLink } = Typography;
 
 const termsOfServiceLink = (
-  <Link href='/terms_of_use.html' target='_blank' rel='noopener noreferrer'>
+  <TypographyLink href='/terms_of_use.html' target='_blank' rel='noopener noreferrer'>
     <FormattedMessage id='pages.login.termsOfUse' defaultMessage='Terms of Use' />
-  </Link>
+  </TypographyLink>
 );
 
 const privacyPolicyLink = (
-  <Link href='/privacy_notice.html' target='_blank' rel='noopener noreferrer'>
+  <TypographyLink href='/privacy_notice.html' target='_blank' rel='noopener noreferrer'>
     <FormattedMessage id='pages.login.privacyNotice' defaultMessage='Privacy Notice' />
-  </Link>
+  </TypographyLink>
 );
 
 const Login: React.FC = () => {
@@ -333,17 +332,17 @@ const Login: React.FC = () => {
                           defaultMessage='Remember me'
                         />
                       </ProFormCheckbox>
-                      <a
+                      <Link
                         style={{
                           float: 'right',
                         }}
-                        href={buildAppHashPath('/user/login/password_forgot')}
+                        to='/user/login/password_forgot'
                       >
                         <FormattedMessage
                           id='pages.login.forgotPassword'
                           defaultMessage='Forgot password'
                         />
-                      </a>
+                      </Link>
                     </div>
                   </>
                 )}

--- a/src/pages/User/Login/password_reset.tsx
+++ b/src/pages/User/Login/password_reset.tsx
@@ -63,7 +63,6 @@ const PasswordSet: FC = () => {
     if (spinning) {
       getCurrentUser().then((res) => {
         if (!res?.userid) {
-          // history.push('/#/user/login');
           return;
         }
         setInitData([

--- a/src/pages/Utils/review.tsx
+++ b/src/pages/Utils/review.tsx
@@ -348,7 +348,7 @@ export const getDatasetPath = (
   return `${route}?${searchParams.toString()}`;
 };
 
-export const getDatasetDetailUrl = (ref: refDataType, origin?: string) => {
+export const getDatasetDetailAbsoluteUrl = (ref: refDataType, origin?: string) => {
   const path = getDatasetPath(ref, { required: true });
   if (!path) {
     return '';
@@ -859,7 +859,7 @@ export const buildValidationIssues = ({
   if (!datasetSdkValid) {
     pushValidationIssue(issues, issueKeys, {
       code: 'sdkInvalid',
-      link: getDatasetDetailUrl(rootRef),
+      link: getDatasetDetailAbsoluteUrl(rootRef),
       ref: rootRef,
       sdkDetails: sdkInvalidDetails,
       tabNames: sdkInvalidTabNames.filter(
@@ -875,7 +875,7 @@ export const buildValidationIssues = ({
 
     pushValidationIssue(issues, issueKeys, {
       code: 'ruleVerificationFailed',
-      link: getDatasetDetailUrl(ref),
+      link: getDatasetDetailAbsoluteUrl(ref),
       ref,
     });
   });
@@ -883,7 +883,7 @@ export const buildValidationIssues = ({
   nonExistentRef.forEach((ref) => {
     pushValidationIssue(issues, issueKeys, {
       code: 'nonExistentRef',
-      link: getDatasetDetailUrl(ref),
+      link: getDatasetDetailAbsoluteUrl(ref),
       ref,
     });
   });
@@ -898,7 +898,7 @@ export const buildValidationIssues = ({
     if (node.versionIsInTg) {
       pushValidationIssue(issues, issueKeys, {
         code: 'versionIsInTg',
-        link: getDatasetDetailUrl(ref),
+        link: getDatasetDetailAbsoluteUrl(ref),
         ref,
       });
       return;
@@ -910,7 +910,7 @@ export const buildValidationIssues = ({
           actionFrom === 'review' && node.underReviewVersion === node['@version']
             ? 'underReview'
             : 'versionUnderReview',
-        link: getDatasetDetailUrl(ref),
+        link: getDatasetDetailAbsoluteUrl(ref),
         ref,
         underReviewVersion: node.underReviewVersion,
       });

--- a/src/pages/Utils/review.tsx
+++ b/src/pages/Utils/review.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/services/reviews/api';
 import { getSourcesByIdsAndVersions } from '@/services/sources/api';
 import { getUserId, getUsersByIds } from '@/services/users/api';
-import { buildAppAbsoluteUrl } from '@/utils/appUrl';
+import { buildExternalUrl } from '@/utils/appUrl';
 import {
   createContact as createTidasContact,
   createFlow as createTidasFlow,
@@ -353,7 +353,7 @@ export const getDatasetDetailAbsoluteUrl = (ref: refDataType, origin?: string) =
   if (!path) {
     return '';
   }
-  return buildAppAbsoluteUrl(path, origin);
+  return buildExternalUrl(path, origin);
 };
 
 const getIssueKey = (code: ValidationIssueCode, ref: refDataType) =>

--- a/src/services/auth/password.ts
+++ b/src/services/auth/password.ts
@@ -1,5 +1,5 @@
 import { supabase } from '@/services/supabase';
-import { buildAppAbsoluteUrl } from '@/utils/appUrl';
+import { buildExternalUrl } from '@/utils/appUrl';
 
 /**
  * Change user password
@@ -62,7 +62,7 @@ export async function setPassword(body: any): Promise<Auth.LoginResult> {
  */
 export async function forgotPasswordSendEmail(body: Auth.LoginParams): Promise<Auth.LoginResult> {
   const { error } = await supabase.auth.resetPasswordForEmail(body.email ?? '', {
-    redirectTo: buildAppAbsoluteUrl('/user/login/password_reset'),
+    redirectTo: buildExternalUrl('/user/login/password_reset'),
   });
 
   if (error) {

--- a/src/utils/appUrl.ts
+++ b/src/utils/appUrl.ts
@@ -23,5 +23,10 @@ export const getAppOrigin = () =>
 
 const buildHashHistoryPath = (path: string) => `/#${normalizeAppPath(path)}`;
 
-export const buildAppAbsoluteUrl = (path: string, origin: string = getAppOrigin()) =>
+/**
+ * Serialize an app route path into an absolute URL for consumers outside Umi's
+ * runtime, such as email redirects, exported HTML, or persisted links. React UI
+ * navigation should use Umi Link/history with plain route paths instead.
+ */
+export const buildExternalUrl = (path: string, origin: string = getAppOrigin()) =>
   `${normalizeOrigin(origin)}${buildHashHistoryPath(path)}`;

--- a/src/utils/appUrl.ts
+++ b/src/utils/appUrl.ts
@@ -21,7 +21,7 @@ const normalizeOrigin = (origin: string) => origin.replace(/\/+$/, '');
 export const getAppOrigin = () =>
   typeof window !== 'undefined' ? window.location.origin : DEFAULT_APP_ORIGIN;
 
-export const buildAppHashPath = (path: string) => `/#${normalizeAppPath(path)}`;
+const buildHashHistoryPath = (path: string) => `/#${normalizeAppPath(path)}`;
 
 export const buildAppAbsoluteUrl = (path: string, origin: string = getAppOrigin()) =>
-  `${normalizeOrigin(origin)}${buildAppHashPath(path)}`;
+  `${normalizeOrigin(origin)}${buildHashHistoryPath(path)}`;

--- a/tests/mocks/umi.tsx
+++ b/tests/mocks/umi.tsx
@@ -41,6 +41,11 @@ export const createUmiMock = () => ({
   FormattedMessage: ({ defaultMessage, id, values }: any) => (
     <span>{renderMessageWithValues(defaultMessage ?? id ?? '', values)}</span>
   ),
+  Link: ({ children, to, ...props }: any) => (
+    <a href={typeof to === 'string' ? to : '#'} data-umi-to={to} {...props}>
+      {children}
+    </a>
+  ),
   useIntl: () => umiMocks.useIntl(),
   useLocation: () => umiMocks.useLocation(),
   useModel: (...args: any[]) => umiMocks.useModel(...args),

--- a/tests/unit/components/DataNotification.test.tsx
+++ b/tests/unit/components/DataNotification.test.tsx
@@ -25,6 +25,11 @@ jest.mock('@/services/reviews/api', () => ({
 let mockIntlLocale = 'en';
 
 jest.mock('umi', () => ({
+  Link: ({ children, to, ...props }: any) => (
+    <a data-umi-to={to} href={to} {...props}>
+      {children}
+    </a>
+  ),
   useIntl: () => ({
     formatMessage: (
       { id, defaultMessage }: { id: string; defaultMessage?: string },
@@ -348,37 +353,23 @@ describe('DataNotification Component', () => {
     });
   });
 
-  it('opens process view mode when a non-rejected process notification is viewed', async () => {
-    const mockOpen = jest.fn();
-    Object.defineProperty(window, 'open', {
-      value: mockOpen,
-      writable: true,
-    });
-
+  it('renders process view mode as an Umi link for non-rejected process notifications', async () => {
     render(
       <ConfigProvider>
         <DataNotification {...defaultProps} />
       </ConfigProvider>,
     );
 
-    await waitFor(() => {
-      const viewButton = screen.getAllByText('View')[0];
-      fireEvent.click(viewButton);
-    });
-
-    expect(mockOpen).toHaveBeenCalledWith(
-      'http://localhost:8000/#/mydata/processes?id=process-1&version=1.0.0&mode=view',
-      '_blank',
-      'noopener,noreferrer',
+    const viewLinks = await screen.findAllByRole('link', { name: 'View' });
+    expect(viewLinks[0]).toHaveAttribute(
+      'data-umi-to',
+      '/mydata/processes?id=process-1&version=1.0.0&mode=view',
     );
+    expect(viewLinks[0]).toHaveAttribute('target', '_blank');
+    expect(viewLinks[0]).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
-  it('opens model view mode when a non-rejected lifecycle notification is viewed', async () => {
-    const mockOpen = jest.fn();
-    Object.defineProperty(window, 'open', {
-      value: mockOpen,
-      writable: true,
-    });
+  it('renders model view mode as an Umi link for non-rejected lifecycle notifications', async () => {
     mockGetNotifyReviews.mockResolvedValue({
       ...mockReviewData,
       data: [
@@ -396,22 +387,14 @@ describe('DataNotification Component', () => {
       </ConfigProvider>,
     );
 
-    const viewButton = await screen.findByText('View');
-    fireEvent.click(viewButton);
-
-    expect(mockOpen).toHaveBeenCalledWith(
-      'http://localhost:8000/#/mydata/models?id=process-2&version=2.0.0&mode=view',
-      '_blank',
-      'noopener,noreferrer',
+    const viewLink = await screen.findByRole('link', { name: 'View' });
+    expect(viewLink).toHaveAttribute(
+      'data-umi-to',
+      '/mydata/models?id=process-2&version=2.0.0&mode=view',
     );
   });
 
   it('uses empty route params when notification data identifiers are missing', async () => {
-    const mockOpen = jest.fn();
-    Object.defineProperty(window, 'open', {
-      value: mockOpen,
-      writable: true,
-    });
     mockGetNotifyReviews.mockResolvedValue({
       ...mockReviewData,
       data: [
@@ -432,13 +415,8 @@ describe('DataNotification Component', () => {
       </ConfigProvider>,
     );
 
-    fireEvent.click(await screen.findByText('View'));
-
-    expect(mockOpen).toHaveBeenCalledWith(
-      'http://localhost:8000/#/mydata/processes?id=&version=&mode=view',
-      '_blank',
-      'noopener,noreferrer',
-    );
+    const viewLink = await screen.findByRole('link', { name: 'View' });
+    expect(viewLink).toHaveAttribute('data-umi-to', '/mydata/processes?id=&version=&mode=view');
   });
 
   it('should handle pagination correctly', async () => {
@@ -550,13 +528,7 @@ describe('DataNotification Component', () => {
     expect(screen.queryByText('View')).not.toBeInTheDocument();
   });
 
-  it('opens rejection comment modal and fixes rejected data from the current process link', async () => {
-    const mockOpen = jest.fn();
-    Object.defineProperty(window, 'open', {
-      value: mockOpen,
-      writable: true,
-    });
-
+  it('opens rejection comment modal and renders the fix route as an Umi link', async () => {
     render(
       <ConfigProvider>
         <DataNotification {...defaultProps} />
@@ -571,13 +543,19 @@ describe('DataNotification Component', () => {
       expect(screen.getByText('Rejected comment')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Fix Data' }));
-
-    expect(mockOpen).toHaveBeenCalledWith(
-      'http://localhost:8000/#/mydata/processes?id=process-2&version=2.0.0&mode=edit',
-      '_blank',
-      'noopener,noreferrer',
+    const fixLink = screen.getByRole('link', { name: 'Fix Data' });
+    expect(fixLink).toHaveAttribute(
+      'data-umi-to',
+      '/mydata/processes?id=process-2&version=2.0.0&mode=edit',
     );
+    expect(fixLink).toHaveAttribute('target', '_blank');
+    expect(fixLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+    fireEvent.click(fixLink);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Review Comment' })).not.toBeInTheDocument();
+    });
   });
 
   it('shows rejection comments stored as serialized JSON strings', async () => {
@@ -604,6 +582,12 @@ describe('DataNotification Component', () => {
     fireEvent.click(await screen.findByText('View'));
 
     expect(await screen.findByText('Serialized rejected comment')).toBeInTheDocument();
+
+    fireEvent.click(document.querySelector('.ant-modal-close') as HTMLElement);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Review Comment' })).not.toBeInTheDocument();
+    });
   });
 
   it('falls back for malformed serialized rejection comments and closes the modal', async () => {

--- a/tests/unit/pages/User/Login/index.test.tsx
+++ b/tests/unit/pages/User/Login/index.test.tsx
@@ -55,6 +55,11 @@ jest.mock('umi', () => {
   return {
     __esModule: true,
     Helmet: ({ children }: any) => <>{children}</>,
+    Link: ({ children, to, ...props }: any) => (
+      <a data-umi-to={to} href={to} {...props}>
+        {toText(children)}
+      </a>
+    ),
     history: mockHistory,
     useLocation: () => mockLocation,
     useIntl: () => ({
@@ -68,6 +73,11 @@ jest.mock('umi', () => {
 jest.mock('@umijs/max', () => ({
   __esModule: true,
   Helmet: ({ children }: any) => <>{children}</>,
+  Link: ({ children, to, ...props }: any) => (
+    <a data-umi-to={to} href={to} {...props}>
+      {toText(children)}
+    </a>
+  ),
   FormattedMessage: ({ defaultMessage, id, values }: any) => {
     const baseText = defaultMessage ?? id;
     if (!values) {
@@ -332,12 +342,12 @@ describe('Login page', () => {
     expect(mockHistory.push).not.toHaveBeenCalled();
   });
 
-  it('renders the forgot-password link with a hash-compatible app route', () => {
+  it('renders the forgot-password link as an Umi app route', () => {
     render(<LoginPage />);
 
     expect(screen.getByText('Forgot password').closest('a')).toHaveAttribute(
-      'href',
-      '/#/user/login/password_forgot',
+      'data-umi-to',
+      '/user/login/password_forgot',
     );
   });
 

--- a/tests/unit/utils/appUrl.test.ts
+++ b/tests/unit/utils/appUrl.test.ts
@@ -1,4 +1,4 @@
-import { buildAppAbsoluteUrl, getAppOrigin } from '@/utils/appUrl';
+import { buildExternalUrl, getAppOrigin } from '@/utils/appUrl';
 
 describe('appUrl helpers', () => {
   it('returns the browser origin when window is available', () => {
@@ -14,7 +14,7 @@ describe('appUrl helpers', () => {
 
     try {
       expect(getAppOrigin()).toBe('https://lca.tiangong.earth');
-      expect(buildAppAbsoluteUrl('/user/login/password_reset')).toBe(
+      expect(buildExternalUrl('/user/login/password_reset')).toBe(
         'https://lca.tiangong.earth/#/user/login/password_reset',
       );
     } finally {
@@ -26,23 +26,23 @@ describe('appUrl helpers', () => {
   });
 
   it('builds absolute app urls for off-app consumers and trims trailing slashes', () => {
-    expect(buildAppAbsoluteUrl('/user/login/password_reset', 'https://demo.example/')).toBe(
+    expect(buildExternalUrl('/user/login/password_reset', 'https://demo.example/')).toBe(
       'https://demo.example/#/user/login/password_reset',
     );
   });
 
   it('normalizes already-hashed route input before building absolute URLs', () => {
-    expect(buildAppAbsoluteUrl('/#/user/login/password_reset', 'https://demo.example')).toBe(
+    expect(buildExternalUrl('/#/user/login/password_reset', 'https://demo.example')).toBe(
       'https://demo.example/#/user/login/password_reset',
     );
-    expect(buildAppAbsoluteUrl('#/user/login/password_reset', 'https://demo.example')).toBe(
+    expect(buildExternalUrl('#/user/login/password_reset', 'https://demo.example')).toBe(
       'https://demo.example/#/user/login/password_reset',
     );
   });
 
   it('normalizes empty and relative route input for off-app URLs', () => {
-    expect(buildAppAbsoluteUrl('', 'https://demo.example')).toBe('https://demo.example/#/');
-    expect(buildAppAbsoluteUrl('user/login/password_reset', 'https://demo.example')).toBe(
+    expect(buildExternalUrl('', 'https://demo.example')).toBe('https://demo.example/#/');
+    expect(buildExternalUrl('user/login/password_reset', 'https://demo.example')).toBe(
       'https://demo.example/#/user/login/password_reset',
     );
   });

--- a/tests/unit/utils/appUrl.test.ts
+++ b/tests/unit/utils/appUrl.test.ts
@@ -1,14 +1,6 @@
-import { buildAppAbsoluteUrl, buildAppHashPath, getAppOrigin } from '@/utils/appUrl';
+import { buildAppAbsoluteUrl, getAppOrigin } from '@/utils/appUrl';
 
 describe('appUrl helpers', () => {
-  it('builds hash paths for empty, relative, and already-hashed app routes', () => {
-    expect(buildAppHashPath('')).toBe('/#/');
-    expect(buildAppHashPath('user/login')).toBe('/#/user/login');
-    expect(buildAppHashPath('/user/login')).toBe('/#/user/login');
-    expect(buildAppHashPath('/#/user/login')).toBe('/#/user/login');
-    expect(buildAppHashPath('#/user/login')).toBe('/#/user/login');
-  });
-
   it('returns the browser origin when window is available', () => {
     expect(getAppOrigin()).toBe('http://localhost:8000');
   });
@@ -33,8 +25,24 @@ describe('appUrl helpers', () => {
     }
   });
 
-  it('builds absolute app urls and trims trailing slashes from custom origins', () => {
+  it('builds absolute app urls for off-app consumers and trims trailing slashes', () => {
     expect(buildAppAbsoluteUrl('/user/login/password_reset', 'https://demo.example/')).toBe(
+      'https://demo.example/#/user/login/password_reset',
+    );
+  });
+
+  it('normalizes already-hashed route input before building absolute URLs', () => {
+    expect(buildAppAbsoluteUrl('/#/user/login/password_reset', 'https://demo.example')).toBe(
+      'https://demo.example/#/user/login/password_reset',
+    );
+    expect(buildAppAbsoluteUrl('#/user/login/password_reset', 'https://demo.example')).toBe(
+      'https://demo.example/#/user/login/password_reset',
+    );
+  });
+
+  it('normalizes empty and relative route input for off-app URLs', () => {
+    expect(buildAppAbsoluteUrl('', 'https://demo.example')).toBe('https://demo.example/#/');
+    expect(buildAppAbsoluteUrl('user/login/password_reset', 'https://demo.example')).toBe(
       'https://demo.example/#/user/login/password_reset',
     );
   });

--- a/tests/unit/utils/review.validation.test.ts
+++ b/tests/unit/utils/review.validation.test.ts
@@ -4,8 +4,8 @@ import {
   dealModel,
   dealProcress,
   enrichValidationIssuesWithOwner,
+  getDatasetDetailAbsoluteUrl,
   getDatasetDetailPath,
-  getDatasetDetailUrl,
   getDatasetPath,
   mapValidationIssuesToRefCheckData,
   normalizeSdkValidationResult,
@@ -127,10 +127,10 @@ describe('review helper coverage', () => {
     expect(getDatasetPath(ref, { required: true })).toBe(
       '/mydata/processes?id=process-1&version=01.00.000&required=1',
     );
-    expect(getDatasetDetailUrl(ref, 'https://demo.example')).toBe(
+    expect(getDatasetDetailAbsoluteUrl(ref, 'https://demo.example')).toBe(
       'https://demo.example/#/mydata/processes?id=process-1&version=01.00.000&required=1',
     );
-    expect(getDatasetDetailUrl(ref)).toBe(
+    expect(getDatasetDetailAbsoluteUrl(ref)).toBe(
       'http://localhost:8000/#/mydata/processes?id=process-1&version=01.00.000&required=1',
     );
 
@@ -140,7 +140,7 @@ describe('review helper coverage', () => {
       value: undefined,
     });
     try {
-      expect(getDatasetDetailUrl(ref)).toBe(
+      expect(getDatasetDetailAbsoluteUrl(ref)).toBe(
         'https://lca.tiangong.earth/#/mydata/processes?id=process-1&version=01.00.000&required=1',
       );
     } finally {
@@ -158,7 +158,7 @@ describe('review helper coverage', () => {
 
     expect(getDatasetDetailPath(unknownRef)).toBeNull();
     expect(getDatasetPath(unknownRef)).toBeNull();
-    expect(getDatasetDetailUrl(unknownRef)).toBe('');
+    expect(getDatasetDetailAbsoluteUrl(unknownRef)).toBe('');
   });
 
   it('maps combined validation issues into ref-check data flags', () => {


### PR DESCRIPTION
Closes #443

## Summary
- Route in-app Login and data notification navigation through Umi Link instead of serializing hash URLs in React UI.
- Keep absolute app URL construction scoped to off-app boundaries such as Supabase redirects and persisted/exported validation links.
- Document the Chinese implementation plan with the existing route/url inventory used for the migration review.

## Key Decisions
- Do not change Umi history mode; the app remains hash-history, with route paths as the UI source of truth.
- Make buildAppHashPath private so new UI code cannot depend on hash serialization directly.
- Keep rejected data notifications as modal-first actions, but render the fix action itself as a Umi Link with target=_blank.

## Validation
- npx jest tests/integration/user/LoginWorkflow.integration.test.tsx --runInBand --testTimeout=20000
- npm run test:ci
- npm run build
- npm run prepush:gate
- npm run docpact:gate
- ./scripts/docpact lint --root . --worktree --format json --output .docpact/runs/issue-443-lint.json

## Risks / Rollback
- Low runtime risk: changed UI links preserve the same route paths and target blank behavior; rollback is reverting this PR.

## Follow-ups
- No separate code follow-up identified; workspace integration remains tracked after merge.

## Workspace Integration
- Workspace integration is pending: after this PR merges, lca-workspace must deliberately bump the tiangong-lca-next submodule pointer when the child commit is eligible.