### PR TITLE
fix: show annual supply reference context hint

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-25"
-lastReviewedCommit: "7dcef870dab3ceb461d9646a7248da8ef87be684"
+lastReviewedAt: "2026-05-26"
+lastReviewedCommit: "1d82d1467b6a73f3a369d846db66f8183a5b5d27"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 7dcef870dab3ceb461d9646a7248da8ef87be684
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: 1d82d1467b6a73f3a369d846db66f8183a5b5d27
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 7dcef870dab3ceb461d9646a7248da8ef87be684
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: 1d82d1467b6a73f3a369d846db66f8183a5b5d27
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.js
   - .github/workflows/**
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 7dcef870dab3ceb461d9646a7248da8ef87be684
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: 1d82d1467b6a73f3a369d846db66f8183a5b5d27
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 7dcef870dab3ceb461d9646a7248da8ef87be684
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: 1d82d1467b6a73f3a369d846db66f8183a5b5d27
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 7dcef870dab3ceb461d9646a7248da8ef87be684
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: 1d82d1467b6a73f3a369d846db66f8183a5b5d27
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 7dcef870dab3ceb461d9646a7248da8ef87be684
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: 1d82d1467b6a73f3a369d846db66f8183a5b5d27
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 7dcef870dab3ceb461d9646a7248da8ef87be684
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: 1d82d1467b6a73f3a369d846db66f8183a5b5d27
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 7dcef870dab3ceb461d9646a7248da8ef87be684
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: 1d82d1467b6a73f3a369d846db66f8183a5b5d27
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 7dcef870dab3ceb461d9646a7248da8ef87be684
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: 1d82d1467b6a73f3a369d846db66f8183a5b5d27
 ---
 
 # Testing Troubleshooting

--- a/src/locales/en-US/pages_process.ts
+++ b/src/locales/en-US/pages_process.ts
@@ -645,6 +645,7 @@ export default {
   'pages.process.validator.referenceToDataSource.required': 'Please input data source(s) used for this data set',
   'pages.process.validator.annualSupplyOrProductionVolume.required': 'Please input annual supply or production volume',
   'pages.process.validator.annualSupplyOrProductionVolume.pattern': 'Please enter a number.',
+  'pages.process.validator.annualSupplyOrProductionVolume.referenceContext.required': 'Please select one input/output as the reference',
   'pages.process.validator.reviewType.required': 'Please input type of review',
   'pages.process.validator.scopeName.required': 'Please input scope name',
   'pages.process.validator.methodName.required': 'Please input method name',

--- a/src/locales/zh-CN/pages_process.ts
+++ b/src/locales/zh-CN/pages_process.ts
@@ -642,6 +642,7 @@ export default {
   'pages.process.validator.referenceToDataSource.required': '请输入使用的数据来源',
   'pages.process.validator.annualSupplyOrProductionVolume.required': '请输入年供应量或生产量',
   'pages.process.validator.annualSupplyOrProductionVolume.pattern': '请输入数值。',
+  'pages.process.validator.annualSupplyOrProductionVolume.referenceContext.required': '请选择一条输入/输出作为基准',
   'pages.process.validator.reviewType.required': '请输入审查类型',
   'pages.process.validator.scopeName.required': '请输入范围名称',
   'pages.process.validator.methodName.required': '请输入方法名称',

--- a/src/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.tsx
+++ b/src/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/services/processes/annualSupplyOrProductionVolume';
 import type { ProcessExchangeData } from '@/services/processes/data';
 import type { ProFormInstance } from '@ant-design/pro-components';
-import { Form, Input, InputNumber, Space } from 'antd';
+import { Form, Input, InputNumber, Space, theme } from 'antd';
 import type { FC, ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useIntl } from 'umi';
@@ -23,6 +23,7 @@ type Props = {
   lang: string;
   name: Array<string | number>;
   onData: () => void;
+  contextErrorMessage?: string;
   rules?: any[];
   setRuleErrorState?: (showError: boolean) => void;
 };
@@ -35,10 +36,12 @@ const AnnualSupplyOrProductionVolumeForm: FC<Props> = ({
   lang,
   name,
   onData,
+  contextErrorMessage,
   rules = [],
   setRuleErrorState,
 }) => {
   const intl = useIntl();
+  const { token } = theme.useToken();
   const [exchangeDataSourceWithUnits, setExchangeDataSourceWithUnits] =
     useState(exchangeDataSource);
   const form = formRef?.current;
@@ -183,10 +186,25 @@ const AnnualSupplyOrProductionVolumeForm: FC<Props> = ({
         <Input
           aria-label='annual-supply-volume-context'
           disabled
+          status={contextErrorMessage ? 'error' : undefined}
           style={{ width: '50%' }}
           value={currentSuffix}
         />
       </Space.Compact>
+      {contextErrorMessage ? (
+        <div
+          role='alert'
+          style={{
+            color: token.colorError,
+            fontSize: token.fontSizeSM ?? 12,
+            lineHeight: token.lineHeightSM ?? 1.5,
+            marginLeft: '50%',
+            marginTop: token.marginXXS ?? 4,
+          }}
+        >
+          {contextErrorMessage}
+        </div>
+      ) : null}
     </Form.Item>
   );
 };

--- a/src/pages/Processes/Components/form.tsx
+++ b/src/pages/Processes/Components/form.tsx
@@ -32,7 +32,11 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState, type FC } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 import schema from '../processes_schema.json';
-import { getSdkSuggestedFixMessage, resolveRequiredValidationMessage } from '../sdkValidationUi';
+import {
+  getSdkSuggestedFixMessage,
+  isAnnualSupplyVolumeReferenceContextSdkDetail,
+  resolveRequiredValidationMessage,
+} from '../sdkValidationUi';
 import AnnualSupplyOrProductionVolumeForm from './AnnualSupplyOrProductionVolume/form';
 import ComplianceItemForm from './Compliance/form';
 import { getExchangeColumns, PROCESS_EXCHANGE_TABLE_SCROLL } from './Exchange/column';
@@ -112,6 +116,9 @@ const isSdkHighlightOnlyDetail = (detail: ValidationIssueSdkDetail) =>
 const toReferenceValue = (reference?: ProcessExchangeData['referenceToFlowDataSet']) => {
   return Array.isArray(reference) ? reference[0] : reference;
 };
+
+const hasSelectedQuantitativeReferenceExchange = (exchangeDataSource: ProcessExchangeData[]) =>
+  exchangeDataSource.some((exchange) => exchange?.quantitativeReference === true);
 
 const parseSdkDetailFormName = (detail: ValidationIssueSdkDetail) => {
   if (Array.isArray(detail.formName) && detail.formName.length > 0) {
@@ -302,7 +309,7 @@ export const ProcessForm: FC<Props> = ({
     (detail: ValidationIssueSdkDetail) => getSdkSuggestedFixMessage(intlRef.current, detail),
     [],
   );
-  const fieldMessageSdkValidationDetails = useMemo(() => {
+  const visibleSdkValidationDetails = useMemo(() => {
     if (sdkValidationDismissedFieldKeys.size === 0) {
       return sdkValidationDetails;
     }
@@ -311,6 +318,27 @@ export const ProcessForm: FC<Props> = ({
       (detail) => !isDismissedRootSdkFieldDetail(detail, sdkValidationDismissedFieldKeys),
     );
   }, [sdkValidationDetails, sdkValidationDismissedFieldKeys]);
+  const hasAnnualSupplyVolumeReferenceContextError = useMemo(
+    () =>
+      !hasSelectedQuantitativeReferenceExchange(exchangeDataSource) &&
+      visibleSdkValidationDetails.some(isAnnualSupplyVolumeReferenceContextSdkDetail),
+    [exchangeDataSource, visibleSdkValidationDetails],
+  );
+  const annualSupplyVolumeReferenceContextErrorMessage = hasAnnualSupplyVolumeReferenceContextError
+    ? intl.formatMessage({
+        id: 'pages.process.validator.annualSupplyOrProductionVolume.referenceContext.required',
+        defaultMessage: '请选择一条输入/输出作为基准',
+      })
+    : undefined;
+  const fieldMessageSdkValidationDetails = useMemo(
+    () =>
+      hasAnnualSupplyVolumeReferenceContextError
+        ? visibleSdkValidationDetails.filter(
+            (detail) => !isAnnualSupplyVolumeReferenceContextSdkDetail(detail),
+          )
+        : visibleSdkValidationDetails,
+    [hasAnnualSupplyVolumeReferenceContextError, visibleSdkValidationDetails],
+  );
 
   const sdkVisibleSectionAnchorsByTab = sdkValidationDetails.reduce<Record<string, Set<string>>>(
     (accumulator, detail) => {
@@ -1877,6 +1905,7 @@ export const ProcessForm: FC<Props> = ({
             formRef={formRef}
             onData={onData}
             exchangeDataSource={exchangeDataSource}
+            contextErrorMessage={annualSupplyVolumeReferenceContextErrorMessage}
             rules={
               showRules
                 ? getRules(

--- a/src/pages/Processes/sdkValidationUi.ts
+++ b/src/pages/Processes/sdkValidationUi.ts
@@ -32,6 +32,10 @@ type RequiredValidationMessageResolution = {
 
 const SDK_MESSAGE_TRAILING_PUNCTUATION_PATTERN = /[。．.!！?？,，;；:：]+$/u;
 const PROCESS_REFERENCE_YEAR_FIELD_PATH = 'processInformation.time.common:referenceYear';
+const PROCESS_ANNUAL_SUPPLY_VOLUME_FIELD_PATH =
+  'modellingAndValidation.dataSourcesTreatmentAndRepresentativeness.annualSupplyOrProductionVolume';
+const LOCALIZED_TEXT_ZH_MUST_INCLUDE_CHINESE_CHARACTER =
+  'localized_text_zh_must_include_chinese_character';
 const DEFAULT_REQUIRED_MESSAGE = {
   defaultMessage: 'Please complete this field',
   id: 'validator.lang.required',
@@ -158,6 +162,21 @@ const getSdkFieldSpecificSuggestedFixMessage = (
   }
 
   return undefined;
+};
+
+export const isAnnualSupplyVolumeReferenceContextSdkDetail = (
+  detail?: SdkValidationDetailMessageLike,
+) => {
+  if (detail?.validationCode !== LOCALIZED_TEXT_ZH_MUST_INCLUDE_CHINESE_CHARACTER) {
+    return false;
+  }
+
+  const fieldPath = getSdkDetailFieldPath(detail);
+
+  return (
+    fieldPath.startsWith(`${PROCESS_ANNUAL_SUPPLY_VOLUME_FIELD_PATH}.`) &&
+    fieldPath.endsWith('.#text')
+  );
 };
 
 const isRequiredRule = (rule: unknown): rule is SchemaRuleLike =>

--- a/tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx
@@ -58,8 +58,14 @@ jest.mock('antd', () => {
       />
     </label>
   );
-  const Input = ({ 'aria-label': ariaLabel, disabled, style, value = '' }: any) => (
-    <input aria-label={ariaLabel} disabled={disabled} style={style} value={value} />
+  const Input = ({ 'aria-label': ariaLabel, disabled, status, style, value = '' }: any) => (
+    <input
+      aria-label={ariaLabel}
+      data-status={status}
+      disabled={disabled}
+      style={style}
+      value={value}
+    />
   );
   const Space = ({ children }: any) => <div>{children}</div>;
   Space.Compact = ({ children }: any) => <div data-testid='annual-volume-compact'>{children}</div>;
@@ -70,6 +76,16 @@ jest.mock('antd', () => {
     Input,
     InputNumber,
     Space,
+    theme: {
+      useToken: () => ({
+        token: {
+          colorError: '#ff4d4f',
+          fontSizeSM: 12,
+          lineHeightSM: 1.5,
+          marginXXS: 4,
+        },
+      }),
+    },
   };
 });
 
@@ -375,6 +391,30 @@ describe('AnnualSupplyOrProductionVolumeForm', () => {
       );
     });
     expect(screen.getByLabelText('annual-supply-volume-context')).toHaveValue('');
+  });
+
+  it('marks the derived context input and renders red help text when context is invalid', () => {
+    const form = buildForm(undefined);
+
+    render(
+      <AnnualSupplyOrProductionVolumeForm
+        contextErrorMessage='请选择一条输入/输出作为基准'
+        exchangeDataSource={[]}
+        formRef={{ current: form }}
+        label='Annual volume'
+        lang='zh'
+        name={['annualSupply']}
+        onData={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText('annual-supply-volume-context')).toHaveAttribute(
+      'data-status',
+      'error',
+    );
+    expect(screen.getByLabelText('annual-supply-volume-context')).toBeDisabled();
+    expect(screen.getByRole('alert')).toHaveTextContent('请选择一条输入/输出作为基准');
+    expect(screen.getByRole('alert')).toHaveStyle({ color: '#ff4d4f' });
   });
 
   it('normalizes single-object form values and uses default required validation copy', async () => {

--- a/tests/unit/pages/Processes/Components/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/form.test.tsx
@@ -378,10 +378,12 @@ jest.mock('antd', () => {
     'data-testid': dataTestId,
     'aria-label': ariaLabel,
     disabled,
+    status,
     style,
   }: any) => (
     <input
       aria-label={ariaLabel}
+      data-status={status}
       data-testid={dataTestId}
       disabled={disabled}
       style={style}
@@ -883,6 +885,99 @@ describe('ProcessForm component', () => {
     });
 
     expect(screen.queryByText('Fill in this field')).not.toBeInTheDocument();
+  });
+
+  it('renders annual supply reference-context sdk issues on the derived context input', async () => {
+    const sdkValidationDetail = {
+      key: 'sdk-annual-supply-zh-context',
+      tabName: 'modellingAndValidation',
+      fieldKey: 'annualSupplyOrProductionVolume',
+      fieldLabel: 'Annual supply or production volume',
+      fieldPath:
+        'modellingAndValidation.dataSourcesTreatmentAndRepresentativeness.annualSupplyOrProductionVolume.1.#text',
+      formName: [
+        'modellingAndValidation',
+        'dataSourcesTreatmentAndRepresentativeness',
+        'annualSupplyOrProductionVolume',
+        1,
+        '#text',
+      ],
+      reasonMessage:
+        "@xml:lang values starting with 'zh' must include at least one Chinese character",
+      suggestedFix: 'Chinese text must include at least one Chinese character',
+      validationCode: 'localized_text_zh_must_include_chinese_character',
+    };
+
+    render(
+      <ProcessForm
+        {...defaultProps}
+        activeTabKey='modellingAndValidation'
+        exchangeDataSource={[{ ...sampleExchange, quantitativeReference: false }]}
+        sdkValidationDetails={[sdkValidationDetail]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('annual-supply-volume-context')).toHaveAttribute(
+        'data-status',
+        'error',
+      );
+    });
+
+    expect(screen.getByRole('alert')).toHaveTextContent('请选择一条输入/输出作为基准');
+    expect(
+      screen.queryByText('Chinese text must include at least one Chinese character'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the generic annual supply localized-text sdk field error when a reference is selected', async () => {
+    const fieldName = [
+      'modellingAndValidation',
+      'dataSourcesTreatmentAndRepresentativeness',
+      'annualSupplyOrProductionVolume',
+      1,
+      '#text',
+    ];
+
+    render(
+      <ProcessForm
+        {...defaultProps}
+        activeTabKey='modellingAndValidation'
+        exchangeDataSource={[{ ...sampleExchange, quantitativeReference: true }]}
+        sdkValidationDetails={[
+          {
+            key: 'sdk-annual-supply-zh-context-with-reference',
+            tabName: 'modellingAndValidation',
+            fieldKey: 'annualSupplyOrProductionVolume',
+            fieldLabel: 'Annual supply or production volume',
+            fieldPath:
+              'modellingAndValidation.dataSourcesTreatmentAndRepresentativeness.annualSupplyOrProductionVolume.1.#text',
+            formName: fieldName,
+            reasonMessage:
+              "@xml:lang values starting with 'zh' must include at least one Chinese character",
+            suggestedFix: 'Chinese text must include at least one Chinese character',
+            validationCode: 'localized_text_zh_must_include_chinese_character',
+          },
+        ]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(defaultProps.formRef.current.setFields).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            errors: ['Chinese text must include at least one Chinese character'],
+            name: fieldName,
+          }),
+        ]),
+      );
+    });
+
+    expect(screen.queryByText('请选择一条输入/输出作为基准')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('annual-supply-volume-context')).not.toHaveAttribute(
+      'data-status',
+      'error',
+    );
   });
 
   it('clears dismissed root sdk messages instead of replaying them on rerender', async () => {

--- a/tests/unit/pages/Processes/sdkValidationUi.test.ts
+++ b/tests/unit/pages/Processes/sdkValidationUi.test.ts
@@ -1,6 +1,7 @@
 import schema from '@/pages/Processes/processes_schema.json';
 import {
   getSdkSuggestedFixMessage,
+  isAnnualSupplyVolumeReferenceContextSdkDetail,
   resolveRequiredValidationMessage,
   sdkValidationUiTestUtils,
   shouldSuppressRequiredSdkMessage,
@@ -50,6 +51,44 @@ describe('process sdk validation ui helpers', () => {
         '#text',
       ]),
     ).toBe(true);
+  });
+
+  it('detects only annual supply zh localized-text issues as reference-context candidates', () => {
+    expect(
+      isAnnualSupplyVolumeReferenceContextSdkDetail({
+        fieldPath:
+          'processDataSet.modellingAndValidation.dataSourcesTreatmentAndRepresentativeness.annualSupplyOrProductionVolume.1.#text',
+        validationCode: 'localized_text_zh_must_include_chinese_character',
+      }),
+    ).toBe(true);
+
+    expect(
+      isAnnualSupplyVolumeReferenceContextSdkDetail({
+        formName: [
+          'modellingAndValidation',
+          'dataSourcesTreatmentAndRepresentativeness',
+          'annualSupplyOrProductionVolume',
+          1,
+          '#text',
+        ],
+        validationCode: 'localized_text_zh_must_include_chinese_character',
+      }),
+    ).toBe(true);
+
+    expect(
+      isAnnualSupplyVolumeReferenceContextSdkDetail({
+        fieldPath: 'processInformation.time.common:timeRepresentativenessDescription.1.#text',
+        validationCode: 'localized_text_zh_must_include_chinese_character',
+      }),
+    ).toBe(false);
+
+    expect(
+      isAnnualSupplyVolumeReferenceContextSdkDetail({
+        fieldPath:
+          'modellingAndValidation.dataSourcesTreatmentAndRepresentativeness.annualSupplyOrProductionVolume.1.#text',
+        validationCode: 'localized_text_en_must_not_contain_chinese_character',
+      }),
+    ).toBe(false);
   });
 
   it('only treats exchange reference selectors as local required ui owners', () => {


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#445

## Summary
- Detect the annualSupplyOrProductionVolume zh localized-text SDK issue when no baseline exchange is selected and route it to the derived context input.
- Render the disabled annual-supply-volume-context input in Ant Design error state with the red help text 请选择一条输入/输出作为基准 below the input.
- Keep unrelated localized_text_zh_must_include_chinese_character details on their existing generic SDK-message path.

## Key Decisions
- Use a process-specific SDK UI helper so the generic localized-text validation code is not globally remapped.
- Keep the context input disabled; the actionable fix is selecting a quantitative-reference input/output, not editing generated annual supply text.

## Validation
- npm run lint
- npm run test:ci -- tests/unit/pages/Processes/Components/AnnualSupplyOrProductionVolume/form.test.tsx tests/unit/pages/Processes/Components/form.test.tsx tests/unit/pages/Processes/sdkValidationUi.test.ts --runInBand --testTimeout=30000
- npm run build
- npm run docpact:gate
- git push fork codex/fix-issue-445-annual-supply-context-hint ran the branch pre-push hook: docpact passed; full prepush:gate was skipped locally for this feature branch per repo policy.

## Risks / Rollback
- Low UI-risk: scoped to process annual supply SDK validation feedback and covered by focused component/helper tests.

## Follow-ups
- Run full PR checks in GitHub; no local npm run prepush:gate was run because feature-branch pre-push policy skips it and CI enforces full gates on PRs to dev/main.

## Workspace Integration
- After merge and promotion eligibility, lca-workspace may need a deliberate tiangong-lca-next submodule pointer bump.