### PR TITLE
fix: show public teams in join modal

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "49e0ba60e3742a27ff7d99d428a2fae537085060"
+lastReviewedCommit: "cff7da8c07c8ec0cc3476e277e46fff07ba514f2"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 49e0ba60e3742a27ff7d99d428a2fae537085060
+lastReviewedCommit: cff7da8c07c8ec0cc3476e277e46fff07ba514f2
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 49e0ba60e3742a27ff7d99d428a2fae537085060
+lastReviewedCommit: cff7da8c07c8ec0cc3476e277e46fff07ba514f2
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 49e0ba60e3742a27ff7d99d428a2fae537085060
+lastReviewedCommit: cff7da8c07c8ec0cc3476e277e46fff07ba514f2
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: cff7da8c07c8ec0cc3476e277e46fff07ba514f2
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 49e0ba60e3742a27ff7d99d428a2fae537085060
+lastReviewedCommit: cff7da8c07c8ec0cc3476e277e46fff07ba514f2
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -19,8 +19,8 @@ checkPaths:
   - config/supabaseEnv.ts
   - src/services/**
   - docker/**
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: cff7da8c07c8ec0cc3476e277e46fff07ba514f2
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 49e0ba60e3742a27ff7d99d428a2fae537085060
+lastReviewedCommit: cff7da8c07c8ec0cc3476e277e46fff07ba514f2
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 49e0ba60e3742a27ff7d99d428a2fae537085060
+lastReviewedCommit: cff7da8c07c8ec0cc3476e277e46fff07ba514f2
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 49e0ba60e3742a27ff7d99d428a2fae537085060
+lastReviewedCommit: cff7da8c07c8ec0cc3476e277e46fff07ba514f2
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 49e0ba60e3742a27ff7d99d428a2fae537085060
+lastReviewedCommit: cff7da8c07c8ec0cc3476e277e46fff07ba514f2
 ---
 
 # Testing Troubleshooting

--- a/src/components/AllTeams/index.tsx
+++ b/src/components/AllTeams/index.tsx
@@ -254,7 +254,7 @@ const TableList: FC<TableListProps> = ({ systemUserRole, tableType }) => {
                 };
               }
               if (keyWord.length > 0) {
-                const result = await getTeamsByKeyword(keyWord);
+                const result = await getTeamsByKeyword(keyWord, tableType);
                 setTableData(result.data || []);
                 return result;
               }
@@ -337,15 +337,8 @@ const TableList: FC<TableListProps> = ({ systemUserRole, tableType }) => {
             pageSize: 10,
           }}
           request={async (params: { pageSize: number; current: number }) => {
-            if (!systemUserRole) {
-              return {
-                data: [],
-                success: true,
-                total: 0,
-              };
-            }
             if (keyWord.length > 0) {
-              return getTeamsByKeyword(keyWord);
+              return getTeamsByKeyword(keyWord, tableType);
             }
             return getAllTableTeams(params, tableType);
           }}

--- a/src/services/teams/api.ts
+++ b/src/services/teams/api.ts
@@ -20,6 +20,8 @@ type TeamMemberRpcRow = {
   display_name?: string;
 };
 
+type TeamTableType = 'joinTeam' | 'manageSystem';
+
 async function invokeTeamCommand(command: string, body: Record<string, unknown>) {
   const session = await supabase.auth.getSession();
   if (!session.data.session) {
@@ -58,11 +60,19 @@ export async function getTeams() {
   });
 }
 
-export async function getTeamsByKeyword(keyword: string) {
-  const result = await supabase
+export async function getTeamsByKeyword(keyword: string, tableType?: TeamTableType) {
+  const query = supabase
     .from('teams')
     .select('*')
     .or(`json->title->0->>#text.ilike.%${keyword}%,json->title->1->>#text.ilike.%${keyword}%`);
+
+  if (tableType === 'joinTeam') {
+    query.eq('is_public', true);
+  } else if (tableType === 'manageSystem') {
+    query.gt('rank', 0);
+  }
+
+  const result = await query;
 
   if (result.error) {
     return Promise.resolve({
@@ -79,7 +89,7 @@ export async function getTeamsByKeyword(keyword: string) {
 
 export async function getAllTableTeams(
   params: { pageSize: number; current: number },
-  tableType: 'joinTeam' | 'manageSystem',
+  tableType: TeamTableType,
   // sort: Record<string, SortOrder>,
 ) {
   try {

--- a/tests/unit/components/AllTeams.test.tsx
+++ b/tests/unit/components/AllTeams.test.tsx
@@ -355,13 +355,11 @@ describe('AllTeams component', () => {
     expect(mockGetAllTableTeams).toHaveBeenCalledWith({ pageSize: 10, current: 1 }, 'joinTeam');
   });
 
-  it('returns an empty join-team table when the system role is missing', async () => {
+  it('loads join-team table for regular users without a system role', async () => {
     renderAllTeams({ tableType: 'joinTeam', systemUserRole: undefined });
 
-    await waitFor(() => {
-      expect(mockGetAllTableTeams).not.toHaveBeenCalled();
-    });
-    expect(screen.queryByTestId('row-t1')).not.toBeInTheDocument();
+    expect(await screen.findByText('Alpha Team')).toBeInTheDocument();
+    expect(mockGetAllTableTeams).toHaveBeenCalledWith({ pageSize: 10, current: 1 }, 'joinTeam');
   });
 
   it('searches by keyword in join-team view', async () => {
@@ -372,7 +370,7 @@ describe('AllTeams component', () => {
     fireEvent.click(screen.getByRole('button', { name: /search/i }));
 
     await waitFor(() => {
-      expect(mockGetTeamsByKeyword).toHaveBeenCalledWith('alpha');
+      expect(mockGetTeamsByKeyword).toHaveBeenCalledWith('alpha', 'joinTeam');
     });
   });
 
@@ -386,7 +384,7 @@ describe('AllTeams component', () => {
     fireEvent.click(searchButton);
 
     await waitFor(() => {
-      expect(mockGetTeamsByKeyword).toHaveBeenCalledWith('beta');
+      expect(mockGetTeamsByKeyword).toHaveBeenCalledWith('beta', 'manageSystem');
     });
   });
 
@@ -607,7 +605,7 @@ describe('AllTeams component', () => {
 
     await waitFor(() => {
       expect(actionRef.current.pageInfo.current).toBe(1);
-      expect(mockGetTeamsByKeyword).toHaveBeenCalledWith('gamma');
+      expect(mockGetTeamsByKeyword).toHaveBeenCalledWith('gamma', 'manageSystem');
     });
   });
 
@@ -662,7 +660,7 @@ describe('AllTeams component', () => {
     fireEvent.click(screen.getByRole('button', { name: /search/i }));
 
     await waitFor(() => {
-      expect(mockGetTeamsByKeyword).toHaveBeenCalledWith('missing');
+      expect(mockGetTeamsByKeyword).toHaveBeenCalledWith('missing', 'manageSystem');
     });
     expect(screen.queryByTestId('row-t1')).not.toBeInTheDocument();
   });

--- a/tests/unit/services/teams/api.test.ts
+++ b/tests/unit/services/teams/api.test.ts
@@ -140,6 +140,26 @@ describe('teams api task-4 boundaries', () => {
     });
   });
 
+  it('applies table visibility filters to keyword search when a table type is provided', async () => {
+    const joinTeamBuilder = createQueryBuilder({
+      data: [{ id: 'team-public' }],
+      error: null,
+    });
+    const manageSystemBuilder = createQueryBuilder({
+      data: [{ id: 'team-ranked' }],
+      error: null,
+    });
+    supabase.from.mockReturnValueOnce(joinTeamBuilder).mockReturnValueOnce(manageSystemBuilder);
+
+    await getTeamsByKeyword('public', 'joinTeam');
+    await getTeamsByKeyword('ranked', 'manageSystem');
+
+    expect(joinTeamBuilder.eq).toHaveBeenCalledWith('is_public', true);
+    expect(joinTeamBuilder.gt).not.toHaveBeenCalled();
+    expect(manageSystemBuilder.gt).toHaveBeenCalledWith('rank', 0);
+    expect(manageSystemBuilder.eq).not.toHaveBeenCalled();
+  });
+
   it('loads join-team table rows and enriches owner email', async () => {
     const teams = [
       { id: 'team-1', json: { title: 'Team One' }, rank: 1, is_public: true },


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#453

## Summary
- Allow the Join Team modal to load public teams for regular authenticated users without requiring a system role.
- Pass the AllTeams table type into keyword search so joinTeam search is also constrained to is_public teams.

## Key Decisions
- Keep system-role gating on manageSystem only; joinTeam visibility is governed by is_public = true.

## Validation
- npm run test:ci -- tests/unit/components/AllTeams.test.tsx tests/unit/services/teams/api.test.ts --runInBand
- npm run build
- npm run tsc
- npm run docpact:gate

## Risks / Rollback
- Low risk: change is scoped to team-list request routing and keyword filters.

## Follow-ups
- Workspace integration remains pending after this repo PR merges.

## Workspace Integration
- Requires a later lca-workspace submodule pointer bump after merge and promotion eligibility.