### PR TITLE
Promote dev to main for search RPC contract

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-26"
-lastReviewedCommit: "f4b7ed09ebf1ec8cbace8c623f8f17a5a5b8d298"
+lastReviewedCommit: "9366a0891e16f64b5054c1f5e7bc76c37cb949a6"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: f4b7ed09ebf1ec8cbace8c623f8f17a5a5b8d298
+lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: 7b03374bc518370dcd9ef7ad7b5b51ce7ceb809b
+lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
 ---
 
 # Development Bootstrap

--- a/docs/agents/contribution-path-analysis-design.md
+++ b/docs/agents/contribution-path-analysis-design.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: ca4280853d06d12dd6566df5ba0e48cbc3466719
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
 ---
 
 # Contribution Path Analysis Design

--- a/docs/agents/lca-analysis-visualization-plan.md
+++ b/docs/agents/lca-analysis-visualization-plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: ca4280853d06d12dd6566df5ba0e48cbc3466719
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
 ---
 
 # LCA Analysis And Visualization Plan

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: f4b7ed09ebf1ec8cbace8c623f8f17a5a5b8d298
+lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: f4b7ed09ebf1ec8cbace8c623f8f17a5a5b8d298
+lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: f4b7ed09ebf1ec8cbace8c623f8f17a5a5b8d298
+lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -20,7 +20,7 @@ checkPaths:
   - src/services/**
   - docker/**
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: f4b7ed09ebf1ec8cbace8c623f8f17a5a5b8d298
+lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: f4b7ed09ebf1ec8cbace8c623f8f17a5a5b8d298
+lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: f4b7ed09ebf1ec8cbace8c623f8f17a5a5b8d298
+lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: f4b7ed09ebf1ec8cbace8c623f8f17a5a5b8d298
+lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: f4b7ed09ebf1ec8cbace8c623f8f17a5a5b8d298
+lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/util_calculate.md
+++ b/docs/agents/util_calculate.md
@@ -20,8 +20,8 @@ checkPaths:
   - src/services/lca/**
   - src/components/LcaTaskCenter/**
   - src/pages/Processes/Analysis/**
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: ca4280853d06d12dd6566df5ba0e48cbc3466719
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
 ---
 
 # Lifecycle Model Calculation Reference

--- a/src/services/contacts/api.ts
+++ b/src/services/contacts/api.ts
@@ -326,7 +326,7 @@ export async function getContactTablePgroongaSearch(
       });
     }
 
-    result = await supabase.rpc('pgroonga_search_contacts_latest', {
+    result = await supabase.rpc('search_contacts_latest', {
       query_text: queryText,
       filter_condition: filterCondition,
       page_size: params.pageSize ?? 10,

--- a/src/services/flowproperties/api.ts
+++ b/src/services/flowproperties/api.ts
@@ -344,7 +344,7 @@ export async function getFlowpropertyTablePgroongaSearch(
     }
 
     result = await supabase.rpc(
-      'pgroonga_search_flowproperties_latest',
+      'search_flowproperties_latest',
       typeof stateCode === 'number'
         ? {
             query_text: queryText,

--- a/src/services/flows/api.ts
+++ b/src/services/flows/api.ts
@@ -457,7 +457,7 @@ export async function getFlowTablePgroongaSearch(
     }
 
     result = await supabase.rpc(
-      'pgroonga_search_flows_latest',
+      'search_flows_latest',
       typeof stateCode === 'number'
         ? {
             query_text: queryText,
@@ -619,16 +619,23 @@ export async function flow_hybrid_search(
   stateCode?: string | number,
 ) {
   let result: any = {};
+  const bodyParams: Record<string, any> = {
+    query,
+    filter_condition: filter,
+    data_source: dataSource,
+    page_size: params.pageSize ?? 10,
+    page_current: params.current ?? 1,
+  };
+  if (typeof stateCode === 'number') {
+    bodyParams.state_code = stateCode;
+  }
   const session = await supabase.auth.getSession();
   if (session.data.session) {
     result = await supabase.functions.invoke('flow_hybrid_search', {
       headers: {
         Authorization: `Bearer ${session.data.session?.access_token ?? ''}`,
       },
-      body:
-        typeof stateCode === 'number'
-          ? { query: query, filter: filter, state_code: stateCode }
-          : { query: query, filter: filter },
+      body: bodyParams,
       region: FunctionRegion.UsEast1,
     });
   }

--- a/src/services/lifeCycleModels/api.ts
+++ b/src/services/lifeCycleModels/api.ts
@@ -660,7 +660,7 @@ export async function getLifeCycleModelTablePgroongaSearch(
     }
 
     result = await supabase.rpc(
-      'pgroonga_search_lifecyclemodels_latest',
+      'search_lifecyclemodels_latest',
       typeof stateCode === 'number'
         ? {
             query_text: queryText,
@@ -787,16 +787,23 @@ export async function lifeCycleModel_hybrid_search(
   stateCode?: string | number,
 ) {
   let result: any = {};
+  const bodyParams: Record<string, any> = {
+    query: queryText,
+    filter_condition: filterCondition,
+    data_source: dataSource,
+    page_size: params.pageSize ?? 10,
+    page_current: params.current ?? 1,
+  };
+  if (typeof stateCode === 'number') {
+    bodyParams.state_code = stateCode;
+  }
   const session = await supabase.auth.getSession();
   if (session.data.session) {
     result = await supabase.functions.invoke('lifecyclemodel_hybrid_search', {
       headers: {
         Authorization: `Bearer ${session.data.session?.access_token ?? ''}`,
       },
-      body:
-        typeof stateCode === 'number'
-          ? { query: queryText, filter: filterCondition, state_code: stateCode }
-          : { query: queryText, filter: filterCondition },
+      body: bodyParams,
       region: FunctionRegion.UsEast1,
     });
   }

--- a/src/services/processes/api.ts
+++ b/src/services/processes/api.ts
@@ -838,7 +838,7 @@ export async function getProcessTablePgroongaSearch(
     state_code_filter: typeof stateCode === 'number' ? stateCode : null,
     type_of_data_set_filter: typeOfDataSet ?? 'all',
   };
-  const result = await supabase.rpc('pgroonga_search_processes_latest', requestParams);
+  const result = await supabase.rpc('search_processes_latest', requestParams);
   if (result.error) {
     console.log('error', result.error);
   }
@@ -1211,7 +1211,13 @@ export async function process_hybrid_search(
   typeOfDataSet?: string,
 ) {
   let result: any = {};
-  const bodyParams: { [key: string]: any } = { query: queryText, filter: filterCondition };
+  const bodyParams: { [key: string]: any } = {
+    query: queryText,
+    filter_condition: filterCondition,
+    data_source: dataSource,
+    page_size: params.pageSize ?? 10,
+    page_current: params.current ?? 1,
+  };
   if (typeof stateCode === 'number') {
     bodyParams['state_code'] = stateCode;
   }

--- a/src/services/sources/api.ts
+++ b/src/services/sources/api.ts
@@ -325,7 +325,7 @@ export async function getSourceTablePgroongaSearch(
     }
 
     result = await supabase.rpc(
-      'pgroonga_search_sources_latest',
+      'search_sources_latest',
       typeof stateCode === 'number'
         ? {
             query_text: queryText,

--- a/src/services/unitgroups/api.ts
+++ b/src/services/unitgroups/api.ts
@@ -342,7 +342,7 @@ export async function getUnitGroupTablePgroongaSearch(
     }
 
     result = await supabase.rpc(
-      'pgroonga_search_unitgroups_latest',
+      'search_unitgroups_latest',
       typeof stateCode === 'number'
         ? {
             query_text: queryText,

--- a/tests/data-workflows/unit/processes/processes-full-text-search-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/processes/processes-full-text-search-workflow-lib.test.ts
@@ -215,7 +215,7 @@ describe('processes-full-text-search-workflow-lib', () => {
       );
       expect(rpc).toHaveBeenNthCalledWith(
         1,
-        'pgroonga_search_processes_v1',
+        'search_processes_latest',
         expect.objectContaining({
           data_source: 'my',
           page_current: 1,

--- a/tests/data-workflows/workflows/contacts/contacts-full-text-search-workflow-lib.ts
+++ b/tests/data-workflows/workflows/contacts/contacts-full-text-search-workflow-lib.ts
@@ -44,7 +44,7 @@ const CONTACT_FULL_TEXT_SEARCH_CONFIG: FullTextSearchWorkflowConfig = {
   prepareRuntimeFixture,
   probeFrontendUrl,
   resolveRuntimeRecordFilePath,
-  rpcName: 'pgroonga_search_contacts',
+  rpcName: 'search_contacts_latest',
   table: 'contacts',
   workflowName: 'Contact full-text search',
 };

--- a/tests/data-workflows/workflows/flowproperties/flowproperties-full-text-search-workflow-lib.ts
+++ b/tests/data-workflows/workflows/flowproperties/flowproperties-full-text-search-workflow-lib.ts
@@ -44,7 +44,7 @@ const FLOWPROPERTY_FULL_TEXT_SEARCH_CONFIG: FullTextSearchWorkflowConfig = {
   prepareRuntimeFixture,
   probeFrontendUrl,
   resolveRuntimeRecordFilePath,
-  rpcName: 'pgroonga_search_flowproperties',
+  rpcName: 'search_flowproperties_latest',
   table: 'flowproperties',
   workflowName: 'Flow property full-text search',
 };

--- a/tests/data-workflows/workflows/flows/flows-full-text-search-workflow-lib.ts
+++ b/tests/data-workflows/workflows/flows/flows-full-text-search-workflow-lib.ts
@@ -43,7 +43,7 @@ const FLOW_FULL_TEXT_SEARCH_CONFIG: FullTextSearchWorkflowConfig = {
   prepareRuntimeFixture,
   probeFrontendUrl,
   resolveRuntimeRecordFilePath,
-  rpcName: 'pgroonga_search_flows_v1',
+  rpcName: 'search_flows_latest',
   table: 'flows',
   workflowName: 'Flow full-text search',
 };

--- a/tests/data-workflows/workflows/full-text-search-shared.ts
+++ b/tests/data-workflows/workflows/full-text-search-shared.ts
@@ -457,7 +457,7 @@ export async function runFullTextSearchSmoke(
     for (const query of searchFixture.queries) {
       const summary = await pollUntil(
         () =>
-          runPgroongaSearch({
+          runFullTextSearchQuery({
             config,
             currentUserId: signInResult.data.user.id,
             query,
@@ -557,7 +557,7 @@ export async function runFullTextSearchSmoke(
   };
 }
 
-async function runPgroongaSearch(input: {
+async function runFullTextSearchQuery(input: {
   config: FullTextSearchWorkflowConfig;
   currentUserId: string;
   query: FullTextSearchQueryFixture;
@@ -577,11 +577,11 @@ async function runPgroongaSearch(input: {
   }
 
   if (typeof input.query.stateCode === 'number') {
-    requestParams.state_code = input.query.stateCode;
+    requestParams.state_code_filter = input.query.stateCode;
   }
 
   if (input.query.typeOfDataSet && input.query.typeOfDataSet !== 'all') {
-    requestParams.type_of_data_set = input.query.typeOfDataSet;
+    requestParams.type_of_data_set_filter = input.query.typeOfDataSet;
   }
 
   const result = await input.supabase.rpc(input.config.rpcName, requestParams);

--- a/tests/data-workflows/workflows/processes/processes-full-text-search-workflow-lib.ts
+++ b/tests/data-workflows/workflows/processes/processes-full-text-search-workflow-lib.ts
@@ -437,7 +437,7 @@ export async function runProcessFullTextSearchSmoke(
     for (const query of searchFixture.queries) {
       const summary = await pollUntil(
         () =>
-          runPgroongaProcessSearch({
+          runProcessFullTextSearchQuery({
             query,
             runtimeId: runtimeFixture.runtimeId,
             supabase,
@@ -539,7 +539,7 @@ export function buildProcessFullTextSearchHelpText() {
   return buildDataWorkflowHelpText(PROCESS_FULL_TEXT_SEARCH_DATA_WORKFLOW_HELP);
 }
 
-async function runPgroongaProcessSearch(input: {
+async function runProcessFullTextSearchQuery(input: {
   query: FullTextSearchQueryFixture;
   runtimeId: string;
   supabase: SupabaseLike;
@@ -553,14 +553,14 @@ async function runPgroongaProcessSearch(input: {
   };
 
   if (typeof input.query.stateCode === 'number') {
-    requestParams.state_code = input.query.stateCode;
+    requestParams.state_code_filter = input.query.stateCode;
   }
 
   if (input.query.typeOfDataSet && input.query.typeOfDataSet !== 'all') {
-    requestParams.type_of_data_set = input.query.typeOfDataSet;
+    requestParams.type_of_data_set_filter = input.query.typeOfDataSet;
   }
 
-  const result = await input.supabase.rpc('pgroonga_search_processes_v1', requestParams);
+  const result = await input.supabase.rpc('search_processes_latest', requestParams);
   if (result.error) {
     throw new Error(
       `Process full-text search failed for "${input.query.label}": ${result.error.message}`,

--- a/tests/data-workflows/workflows/sources/sources-full-text-search-workflow-lib.ts
+++ b/tests/data-workflows/workflows/sources/sources-full-text-search-workflow-lib.ts
@@ -44,7 +44,7 @@ const SOURCE_FULL_TEXT_SEARCH_CONFIG: FullTextSearchWorkflowConfig = {
   prepareRuntimeFixture,
   probeFrontendUrl,
   resolveRuntimeRecordFilePath,
-  rpcName: 'pgroonga_search_sources',
+  rpcName: 'search_sources_latest',
   table: 'sources',
   workflowName: 'Source full-text search',
 };

--- a/tests/data-workflows/workflows/unitgroups/unitgroups-full-text-search-workflow-lib.ts
+++ b/tests/data-workflows/workflows/unitgroups/unitgroups-full-text-search-workflow-lib.ts
@@ -44,7 +44,7 @@ const UNITGROUP_FULL_TEXT_SEARCH_CONFIG: FullTextSearchWorkflowConfig = {
   prepareRuntimeFixture,
   probeFrontendUrl,
   resolveRuntimeRecordFilePath,
-  rpcName: 'pgroonga_search_unitgroups',
+  rpcName: 'search_unitgroups_latest',
   table: 'unitgroups',
   workflowName: 'Unit group full-text search',
 };

--- a/tests/unit/services/contacts/api.test.ts
+++ b/tests/unit/services/contacts/api.test.ts
@@ -736,7 +736,7 @@ describe('Contacts API Service', () => {
       );
 
       expect(mockAuth).toHaveBeenCalled();
-      expect(mockRpc).toHaveBeenCalledWith('pgroonga_search_contacts_latest', {
+      expect(mockRpc).toHaveBeenCalledWith('search_contacts_latest', {
         query_text: 'test query',
         filter_condition: {},
         page_size: 10,
@@ -782,7 +782,7 @@ describe('Contacts API Service', () => {
 
       await getContactTablePgroongaSearch({ current: 1, pageSize: 10 }, 'en', 'tg', 'query', {});
 
-      expect(mockRpc).toHaveBeenCalledWith('pgroonga_search_contacts_latest', {
+      expect(mockRpc).toHaveBeenCalledWith('search_contacts_latest', {
         query_text: 'query',
         filter_condition: {},
         page_size: 10,
@@ -908,7 +908,7 @@ describe('Contacts API Service', () => {
         0,
       );
 
-      expect(mockRpc).toHaveBeenCalledWith('pgroonga_search_contacts_latest', {
+      expect(mockRpc).toHaveBeenCalledWith('search_contacts_latest', {
         query_text: 'defaults',
         filter_condition: { status: 'active' },
         page_size: 10,
@@ -947,7 +947,7 @@ describe('Contacts API Service', () => {
 
       await getContactTablePgroongaSearch({}, 'en', 'tg', 'defaults', { level: 1 });
 
-      expect(mockRpc).toHaveBeenCalledWith('pgroonga_search_contacts_latest', {
+      expect(mockRpc).toHaveBeenCalledWith('search_contacts_latest', {
         query_text: 'defaults',
         filter_condition: { level: 1 },
         page_size: 10,

--- a/tests/unit/services/flowproperties/api.test.ts
+++ b/tests/unit/services/flowproperties/api.test.ts
@@ -852,7 +852,7 @@ describe('FlowProperties API Service (src/services/flowproperties/api.ts)', () =
         undefined,
       );
 
-      expect(supabase.rpc).toHaveBeenCalledWith('pgroonga_search_flowproperties_latest', {
+      expect(supabase.rpc).toHaveBeenCalledWith('search_flowproperties_latest', {
         query_text: 'mass',
         filter_condition: {},
         page_size: 10,
@@ -933,7 +933,7 @@ describe('FlowProperties API Service (src/services/flowproperties/api.ts)', () =
       );
 
       expect(supabase.rpc).toHaveBeenCalledWith(
-        'pgroonga_search_flowproperties_latest',
+        'search_flowproperties_latest',
         expect.objectContaining({
           state_code_filter: 100,
         }),
@@ -946,7 +946,7 @@ describe('FlowProperties API Service (src/services/flowproperties/api.ts)', () =
       await getFlowpropertyTablePgroongaSearch({}, 'en', 'my', 'test', {}, 100);
 
       expect(supabase.rpc).toHaveBeenCalledWith(
-        'pgroonga_search_flowproperties_latest',
+        'search_flowproperties_latest',
         expect.objectContaining({
           page_size: 10,
           page_current: 1,
@@ -1173,7 +1173,7 @@ describe('FlowProperties API Service (src/services/flowproperties/api.ts)', () =
         undefined,
       );
 
-      expect(supabase.rpc).toHaveBeenCalledWith('pgroonga_search_flowproperties_latest', {
+      expect(supabase.rpc).toHaveBeenCalledWith('search_flowproperties_latest', {
         query_text: '质量',
         filter_condition: {},
         page_size: 10,

--- a/tests/unit/services/flows/api.test.ts
+++ b/tests/unit/services/flows/api.test.ts
@@ -1178,7 +1178,7 @@ describe('getFlowTablePgroongaSearch', () => {
     );
 
     expect(mockRpc).toHaveBeenCalledWith(
-      'pgroonga_search_flows_latest',
+      'search_flows_latest',
       expect.objectContaining({
         query_text: 'water',
         data_source: 'tg',
@@ -1344,7 +1344,7 @@ describe('getFlowTablePgroongaSearch', () => {
       { key: 'baseName', lang: 'zh', order: 'asc' },
     );
 
-    expect(mockRpc).toHaveBeenCalledWith('pgroonga_search_flows_latest', {
+    expect(mockRpc).toHaveBeenCalledWith('search_flows_latest', {
       query_text: 'steel',
       filter_condition: { flowType: 'Product flow' },
       page_size: 15,
@@ -1601,7 +1601,7 @@ describe('getFlowTablePgroongaSearch', () => {
     });
 
     expect(mockRpc).toHaveBeenCalledWith(
-      'pgroonga_search_flows_latest',
+      'search_flows_latest',
       expect.objectContaining({
         filter_condition: {
           flowType: 'Product flow',
@@ -1643,7 +1643,7 @@ describe('getFlowTablePgroongaSearch', () => {
 
     const result = await getFlowTablePgroongaSearch({}, 'zh', 'my', 'steel', {}, 300);
 
-    expect(mockRpc).toHaveBeenCalledWith('pgroonga_search_flows_latest', {
+    expect(mockRpc).toHaveBeenCalledWith('search_flows_latest', {
       query_text: 'steel',
       filter_condition: {},
       page_size: 10,
@@ -1681,7 +1681,7 @@ describe('getFlowTablePgroongaSearch', () => {
 
     await getFlowTablePgroongaSearch({}, 'en', 'tg', 'default-query', {});
 
-    expect(mockRpc).toHaveBeenCalledWith('pgroonga_search_flows_latest', {
+    expect(mockRpc).toHaveBeenCalledWith('search_flows_latest', {
       query_text: 'default-query',
       filter_condition: {},
       page_size: 10,
@@ -1798,7 +1798,13 @@ describe('flow_hybrid_search', () => {
     expect(mockFunctionsInvoke).toHaveBeenCalledWith(
       'flow_hybrid_search',
       expect.objectContaining({
-        body: { query: 'nitrogen', filter: { flowType: '' } },
+        body: {
+          query: 'nitrogen',
+          filter_condition: { flowType: '' },
+          data_source: 'tg',
+          page_size: 10,
+          page_current: 1,
+        },
         headers: { Authorization: 'Bearer token' },
         region: FunctionRegion.UsEast1,
       }),
@@ -1909,7 +1915,13 @@ describe('flow_hybrid_search', () => {
       'flow_hybrid_search',
       expect.objectContaining({
         headers: { Authorization: 'Bearer ' },
-        body: { query: 'steam', filter: {} },
+        body: {
+          query: 'steam',
+          filter_condition: {},
+          data_source: 'tg',
+          page_size: 10,
+          page_current: 1,
+        },
       }),
     );
     expect(result).toEqual({
@@ -1938,10 +1950,13 @@ describe('flow_hybrid_search', () => {
       expect.objectContaining({
         body: {
           query: 'steam',
-          filter: {
+          filter_condition: {
             flowType: 'Product flow',
             classification: [{ scope: 'classification', code: '01' }],
           },
+          data_source: 'tg',
+          page_size: 10,
+          page_current: 1,
         },
       }),
     );
@@ -2024,7 +2039,14 @@ describe('flow_hybrid_search', () => {
     expect(mockFunctionsInvoke).toHaveBeenCalledWith(
       'flow_hybrid_search',
       expect.objectContaining({
-        body: { query: '电力', filter: {}, state_code: 200 },
+        body: {
+          query: '电力',
+          filter_condition: {},
+          data_source: 'my',
+          page_size: 10,
+          page_current: 2,
+          state_code: 200,
+        },
       }),
     );
     expect(result).toEqual({

--- a/tests/unit/services/lifeCycleModels/api.test.ts
+++ b/tests/unit/services/lifeCycleModels/api.test.ts
@@ -2121,7 +2121,7 @@ describe('table/search helpers', () => {
       { key: 'baseName', lang: 'en', order: 'desc' },
     );
 
-    expect(mockRpc).toHaveBeenCalledWith('pgroonga_search_lifecyclemodels_latest', {
+    expect(mockRpc).toHaveBeenCalledWith('search_lifecyclemodels_latest', {
       query_text: 'keyword',
       filter_condition: { filter: true },
       page_size: 5,
@@ -2153,7 +2153,7 @@ describe('table/search helpers', () => {
       20,
     );
 
-    expect(mockRpc).toHaveBeenCalledWith('pgroonga_search_lifecyclemodels_latest', {
+    expect(mockRpc).toHaveBeenCalledWith('search_lifecyclemodels_latest', {
       query_text: 'keyword',
       filter_condition: {},
       page_size: 10,
@@ -2527,7 +2527,13 @@ describe('table/search helpers', () => {
       headers: {
         Authorization: 'Bearer ',
       },
-      body: { query: 'keyword', filter: {} },
+      body: {
+        query: 'keyword',
+        filter_condition: {},
+        data_source: 'my',
+        page_size: 10,
+        page_current: 1,
+      },
       region: expect.any(String),
     });
   });
@@ -2552,7 +2558,14 @@ describe('table/search helpers', () => {
       headers: {
         Authorization: `Bearer ${sampleAccessToken}`,
       },
-      body: { query: 'keyword', filter: { filter: true }, state_code: 100 },
+      body: {
+        query: 'keyword',
+        filter_condition: { filter: true },
+        data_source: 'tg',
+        page_size: 10,
+        page_current: 1,
+        state_code: 100,
+      },
       region: expect.any(String),
     });
     expect(result).toEqual({

--- a/tests/unit/services/processes/api.test.ts
+++ b/tests/unit/services/processes/api.test.ts
@@ -1482,7 +1482,7 @@ describe('listProcessesForLcaAnalysis', () => {
 
     expect(mockRpc).toHaveBeenNthCalledWith(
       1,
-      'pgroonga_search_processes_latest',
+      'search_processes_latest',
       expect.objectContaining({
         query_text: 'battery',
         data_source: 'my',
@@ -1492,7 +1492,7 @@ describe('listProcessesForLcaAnalysis', () => {
     );
     expect(mockRpc).toHaveBeenNthCalledWith(
       2,
-      'pgroonga_search_processes_latest',
+      'search_processes_latest',
       expect.objectContaining({
         query_text: 'battery',
         data_source: 'tg',
@@ -1502,7 +1502,7 @@ describe('listProcessesForLcaAnalysis', () => {
     );
     expect(mockRpc).toHaveBeenNthCalledWith(
       3,
-      'pgroonga_search_processes_latest',
+      'search_processes_latest',
       expect.objectContaining({
         query_text: 'battery',
         data_source: 'my',
@@ -1512,7 +1512,7 @@ describe('listProcessesForLcaAnalysis', () => {
     );
     expect(mockRpc).toHaveBeenNthCalledWith(
       4,
-      'pgroonga_search_processes_latest',
+      'search_processes_latest',
       expect.objectContaining({
         query_text: 'battery',
         data_source: 'tg',
@@ -2093,7 +2093,7 @@ describe('listProcessesForLcaAnalysis', () => {
     );
 
     expect(mockRpc).toHaveBeenCalledWith(
-      'pgroonga_search_processes_latest',
+      'search_processes_latest',
       expect.objectContaining({
         query_text: 'battery',
         data_source: 'tg',
@@ -2242,7 +2242,13 @@ describe('process_hybrid_search', () => {
 
     expect(mockFunctionsInvoke).toHaveBeenCalledWith('process_hybrid_search', {
       headers: { Authorization: 'Bearer token-xyz' },
-      body: { query: 'steel', filter: {} },
+      body: {
+        query: 'steel',
+        filter_condition: {},
+        data_source: 'tg',
+        page_size: 5,
+        page_current: 3,
+      },
       region: FunctionRegion.UsEast1,
     });
     expect(mockJsonToList).toHaveBeenCalledWith({ '#text': 'class-h' });
@@ -2298,7 +2304,10 @@ describe('process_hybrid_search', () => {
       headers: { Authorization: 'Bearer ' },
       body: {
         query: 'steel',
-        filter: { status: 'active' },
+        filter_condition: { status: 'active' },
+        data_source: 'my',
+        page_size: 10,
+        page_current: 1,
         state_code: 300,
         type_of_data_set: 'foreground',
       },
@@ -3614,7 +3623,7 @@ describe('getProcessTablePgroongaSearch', () => {
     );
 
     expect(mockRpc).toHaveBeenCalledWith(
-      'pgroonga_search_processes_latest',
+      'search_processes_latest',
       expect.objectContaining({
         query_text: 'search term',
         order_by: {},
@@ -3662,7 +3671,7 @@ describe('getProcessTablePgroongaSearch', () => {
       'foreground',
     );
 
-    expect(mockRpc).toHaveBeenCalledWith('pgroonga_search_processes_latest', {
+    expect(mockRpc).toHaveBeenCalledWith('search_processes_latest', {
       query_text: 'keyword',
       filter_condition: { processType: 'target' },
       page_size: 10,

--- a/tests/unit/services/sources/api.test.ts
+++ b/tests/unit/services/sources/api.test.ts
@@ -753,7 +753,7 @@ describe('Sources API Service (src/services/sources/api.ts)', () => {
       );
 
       expect(supabase.auth.getSession).toHaveBeenCalled();
-      expect(supabase.rpc).toHaveBeenCalledWith('pgroonga_search_sources_latest', {
+      expect(supabase.rpc).toHaveBeenCalledWith('search_sources_latest', {
         query_text: 'test query',
         filter_condition: mockFilterCondition,
         page_size: 10,
@@ -788,7 +788,7 @@ describe('Sources API Service (src/services/sources/api.ts)', () => {
       );
 
       expect(supabase.rpc).toHaveBeenCalledWith(
-        'pgroonga_search_sources_latest',
+        'search_sources_latest',
         expect.objectContaining({
           state_code_filter: 100,
         }),
@@ -812,7 +812,7 @@ describe('Sources API Service (src/services/sources/api.ts)', () => {
       );
 
       expect(supabase.rpc).toHaveBeenCalledWith(
-        'pgroonga_search_sources_latest',
+        'search_sources_latest',
         expect.objectContaining({
           data_source: 'tg',
           team_id_filter: 'team-123',
@@ -871,7 +871,7 @@ describe('Sources API Service (src/services/sources/api.ts)', () => {
 
       const result = await getSourceTablePgroongaSearch({}, 'zh', 'tg', '出版物', {});
 
-      expect(supabase.rpc).toHaveBeenCalledWith('pgroonga_search_sources_latest', {
+      expect(supabase.rpc).toHaveBeenCalledWith('search_sources_latest', {
         query_text: '出版物',
         filter_condition: {},
         page_size: 10,
@@ -996,7 +996,7 @@ describe('Sources API Service (src/services/sources/api.ts)', () => {
 
       const result = await getSourceTablePgroongaSearch({}, 'en', 'my', 'sparse', {}, 100);
 
-      expect(supabase.rpc).toHaveBeenCalledWith('pgroonga_search_sources_latest', {
+      expect(supabase.rpc).toHaveBeenCalledWith('search_sources_latest', {
         query_text: 'sparse',
         filter_condition: {},
         page_size: 10,

--- a/tests/unit/services/unitgroups/api.test.ts
+++ b/tests/unit/services/unitgroups/api.test.ts
@@ -983,7 +983,7 @@ describe('getUnitGroupTablePgroongaSearch', () => {
     );
 
     expect(mockRpc).toHaveBeenCalledWith(
-      'pgroonga_search_unitgroups_latest',
+      'search_unitgroups_latest',
       expect.objectContaining({
         query_text: 'energy',
         filter_condition: {},
@@ -1021,7 +1021,7 @@ describe('getUnitGroupTablePgroongaSearch', () => {
 
     await getUnitGroupTablePgroongaSearch({} as any, 'en', 'tg', 'energy', { k: 1 }, undefined);
 
-    expect(mockRpc).toHaveBeenCalledWith('pgroonga_search_unitgroups_latest', {
+    expect(mockRpc).toHaveBeenCalledWith('search_unitgroups_latest', {
       query_text: 'energy',
       filter_condition: { k: 1 },
       page_size: 10,
@@ -1252,7 +1252,7 @@ describe('getUnitGroupTablePgroongaSearch', () => {
 
     const result = await getUnitGroupTablePgroongaSearch({}, 'zh', 'tg', 'defaults', {}, 500);
 
-    expect(mockRpc).toHaveBeenCalledWith('pgroonga_search_unitgroups_latest', {
+    expect(mockRpc).toHaveBeenCalledWith('search_unitgroups_latest', {
       query_text: 'defaults',
       filter_condition: {},
       page_size: 10,


### PR DESCRIPTION
## Summary
- Promote `dev` to `main` for the dataset search RPC contract alignment.
- Includes linancn/tiangong-lca-next#457 (`fix: 对齐数据集搜索 RPC 契约`).
- Aligns the frontend service calls with the database search RPC contract already promoted through tiangong-lca/database-engine#87 and the Edge contract promote in linancn/tiangong-lca-edge-functions#130.

## Validation
- `npm run lint`
- `npx jest tests/unit/services/flows/api.test.ts tests/unit/services/processes/api.test.ts tests/unit/services/lifeCycleModels/api.test.ts tests/unit/services/contacts/api.test.ts tests/unit/services/sources/api.test.ts tests/unit/services/unitgroups/api.test.ts tests/unit/services/flowproperties/api.test.ts --runInBand --testTimeout=20000`：7 suites / 447 tests PASS
- fork pre-push docpact gate passed against `origin/main`

## Rollout Notes
- This is the M2 promote path `dev -> main`.
- This PR intentionally does not include unrelated open main PR #412.
- After merge, root workspace should bump `tiangong-lca-next` to the promoted main commit.

Refs linancn/tiangong-lca-next#457
Refs tiangong-lca/database-engine#87
Refs linancn/tiangong-lca-edge-functions#130
Refs tiangong-lca/workspace#168