### PR TITLE
fix: guard manual web deploy ref

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-27"
-lastReviewedCommit: "2a3cd23e643952abcec65813e67d1a417178954d"
+lastReviewedAt: "2026-05-28"
+lastReviewedCommit: "67294f4f6e49d4267ab9bfba5c0d3554da23ef20"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   build-and-deploy:
     name: Build and Deploy Web App
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     env:
       EDGEONE_OUTPUT_DIR: dist
@@ -15,6 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: main
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: 67294f4f6e49d4267ab9bfba5c0d3554da23ef20
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 2a3cd23e643952abcec65813e67d1a417178954d
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: 67294f4f6e49d4267ab9bfba5c0d3554da23ef20
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.js
   - .github/workflows/**
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: 67294f4f6e49d4267ab9bfba5c0d3554da23ef20
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -73,7 +73,7 @@ The local `pre-push` hook always runs `npm run docpact:gate` first, then runs th
 
 If the change touches `scripts/test-runner.cjs` or protected-branch gate reproduction, run `npm run test:ci` and `npm run prepush:gate` serially locally because both commands regenerate `.umi-test`.
 
-For deployment-only workflow changes under `.github/workflows/build.yml` or the manual `.github/workflows/ci.yml` fallback, validate the workflow shape directly with YAML parsing, formatter checks, and shell syntax checks for edited deploy scripts. Do not run production deploy commands locally or from PR validation unless the task explicitly requires exercising live deploy credentials; the automatic EdgeOne Pages deploy step runs only from a `v*` release tag whose target commit is already on `main`, while ordinary branch pushes belong to the local pre-push gate.
+For deployment-only workflow changes under `.github/workflows/build.yml` or the manual `.github/workflows/ci.yml` fallback, validate the workflow shape directly with YAML parsing, formatter checks, and shell syntax checks for edited deploy scripts. Do not run production deploy commands locally or from PR validation unless the task explicitly requires exercising live deploy credentials; the automatic EdgeOne Pages deploy step runs only from a `v*` release tag whose target commit is already on `main`, the manual deploy fallback is guarded to `refs/heads/main`, and ordinary branch pushes belong to the local pre-push gate.
 
 Treat dataset-validation work under `src/pages/*/sdkValidation.ts`, `src/pages/Utils/validation/**`, `src/components/ValidationIssueModal/index.tsx`, and localized validator copy under `src/locales/**` as shipped runtime work even when most of the change looks like error-message plumbing.
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 2a3cd23e643952abcec65813e67d1a417178954d
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: 67294f4f6e49d4267ab9bfba5c0d3554da23ef20
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 2a3cd23e643952abcec65813e67d1a417178954d
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: 67294f4f6e49d4267ab9bfba5c0d3554da23ef20
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: 67294f4f6e49d4267ab9bfba5c0d3554da23ef20
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 2a3cd23e643952abcec65813e67d1a417178954d
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: 67294f4f6e49d4267ab9bfba5c0d3554da23ef20
 ---
 
 # Testing Troubleshooting


### PR DESCRIPTION
## Summary
- Guard the manual web deploy job so it only runs from refs/heads/main.
- Explicitly check out main for the manual deploy fallback.
- Refresh docpact review evidence and validation guidance for the deploy fallback guard.

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml')"
- scripts/docpact lint --root . --staged --format text
- push hook: npm run prepush:gate (4046 tests, 100% coverage gate)

Closes #462