### PR TITLE
Gate release builds with local doc checks

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "d65dd52e116ae22440b09002a69191a933061b96"
+lastReviewedCommit: "d31886638063f1555fc3fa645007aefe303e56c4"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,7 +1,7 @@
 name: ai-doc-lint
 
 on:
-  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,19 +16,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch main
+        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
         run: cargo install docpact --version 0.1.9 --force
 
-      - name: Validate docpact config
-        run: scripts/docpact validate-config --root . --strict
-
-      - name: Run docpact lint
-        run: >
-          scripts/docpact lint
-          --root .
-          --base "${{ github.event.pull_request.base.sha }}"
-          --head "${{ github.event.pull_request.head.sha }}"
-          --mode enforce
+      - name: Run local docpact gate
+        run: npm run docpact:gate -- --base origin/main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,11 +50,21 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.release-context.outputs.tag_commit }}
+          fetch-depth: 0
 
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 24
+
+      - name: Fetch main
+        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install docpact
+        run: cargo install docpact --version 0.1.9 --force
 
       - name: Cache npm
         uses: actions/cache@v5
@@ -66,6 +76,9 @@ jobs:
 
       - name: Install dependencies
         run: npm install
+
+      - name: Run docpact release gate
+        run: npm run docpact:gate -- --base origin/main
 
       - name: Run CI tests
         run: npm run test:ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ Do not start from additional governed source docs, proposal docs, or README-leve
 - minimum proof and protected-branch gate expectations live in `docs/agents/repo-validation.md`
 - path-level ownership, routing intents, governed-doc inventory, and lint rules live in `.docpact/config.yaml`
 - app-shell support, branding/package surfaces, and local-stack path mapping live in `docs/agents/repo-architecture.md`
-- repo-local documentation maintenance is enforced by `.github/workflows/ai-doc-lint.yml` with `docpact lint`
+- repo-local documentation maintenance is enforced locally by the pre-push docpact gate; `.github/workflows/ai-doc-lint.yml` is manual-dispatch fallback
 - dataset-validation adapters live in `src/pages/*/sdkValidation.ts`; shared localized validation helpers live in `src/pages/Utils/validation/**`
 - data workflow result fixture relationships live in `tests/data-workflows/fixtures/result/README.md`; proof selection stays in `docs/agents/repo-validation.md`
 - when reproducing the local and release gates, run `npm run test:ci` and `npm run prepush:gate` serially because both regenerate Umi test artifacts

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: d65dd52e116ae22440b09002a69191a933061b96
+lastReviewedCommit: d31886638063f1555fc3fa645007aefe303e56c4
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: d65dd52e116ae22440b09002a69191a933061b96
+lastReviewedCommit: d31886638063f1555fc3fa645007aefe303e56c4
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: d31886638063f1555fc3fa645007aefe303e56c4
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: d65dd52e116ae22440b09002a69191a933061b96
+lastReviewedCommit: d31886638063f1555fc3fa645007aefe303e56c4
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: d65dd52e116ae22440b09002a69191a933061b96
+lastReviewedCommit: d31886638063f1555fc3fa645007aefe303e56c4
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: d65dd52e116ae22440b09002a69191a933061b96
+lastReviewedCommit: d31886638063f1555fc3fa645007aefe303e56c4
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -49,7 +49,7 @@ Canonical baseline and proof ownership stays with `DEV.md` and `docs/agents/repo
 | provider or context error | missing wrapper or wrong test utility | use the repo helper that already provides the required wrapper |
 | data workflow smoke assertion mismatch | `fixtures/data/**`, `fixtures/result/**`, workflow default path, or last-run artifact drifted apart | compare the case in `tests/data-workflows/fixtures/result/README.md`, then update the paired input fixture, expected-result Markdown, workflow lib default, and unit proof together |
 | one gate fails only while another heavy gate is running locally | shared `.umi-test` regeneration from concurrent commands | rerun `npm run test:ci` and `npm run prepush:gate` serially |
-| local `docpact:gate` or remote `ai-doc-lint` fails with `missing-review` after runtime, service, or test changes | required governed docs were not reviewed in the same PR | rerun `npm run docpact:gate`, inspect the required docs from `.docpact/config.yaml`, and touch the owning docs with a real review/update |
+| local `docpact:gate` or manual `ai-doc-lint` fails with `missing-review` after runtime, service, or test changes | required governed docs were not reviewed in the same PR | rerun `npm run docpact:gate`, inspect the required docs from `.docpact/config.yaml`, and touch the owning docs with a real review/update |
 
 ## Open-Handle Playbook
 


### PR DESCRIPTION
## Summary
- move ai-doc-lint off ordinary PR/push execution and keep it as manual fallback
- keep documentation governance in the local pre-push gate
- add docpact into the v* release gate before web deploy and Electron release

## Validation
- parsed changed GitHub workflow YAML locally
- ran repo docpact/AI-doc gate against origin/main..HEAD
- ran local test gate where the repo pre-push hook required it

Closes #468
