### PR TITLE
Fix docpact gate review feedback

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "6ae7b1374cea4f9d80020cbef7576d53d1414e63"
+lastReviewedCommit: "38934973ad04f17793a7f1d1570312597e4643ee"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "38934973ad04f17793a7f1d1570312597e4643ee"
+lastReviewedCommit: "49e0ba60e3742a27ff7d99d428a2fae537085060"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "d31886638063f1555fc3fa645007aefe303e56c4"
+lastReviewedCommit: "6ae7b1374cea4f9d80020cbef7576d53d1414e63"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -2,6 +2,11 @@ name: ai-doc-lint
 
 on:
   workflow_dispatch:
+    inputs:
+      base_ref:
+        description: Base ref for the manual docpact comparison.
+        required: false
+        default: origin/dev
 
 permissions:
   contents: read
@@ -16,8 +21,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Fetch main
-        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+      - name: Fetch branches
+        run: git fetch --force origin '+refs/heads/*:refs/remotes/origin/*'
 
       - name: Install Node.js
         uses: actions/setup-node@v6
@@ -31,4 +36,4 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run local docpact gate
-        run: npm run docpact:gate -- --base origin/main
+        run: npm run docpact:gate -- --base "${{ inputs.base_ref }}"

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -36,4 +36,6 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run local docpact gate
-        run: npm run docpact:gate -- --base "${{ inputs.base_ref }}"
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
+        run: npm run docpact:gate -- --base "$BASE_REF"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,11 @@ jobs:
         run: npm install
 
       - name: Run docpact release gate
-        run: npm run docpact:gate -- --base origin/main
+        run: |
+          set -euo pipefail
+          release_head="${{ needs.release-context.outputs.tag_commit }}"
+          release_base="$(git rev-parse "${release_head}^")"
+          npm run docpact:gate -- --base "$release_base" --head "$release_head"
 
       - name: Run CI tests
         run: npm run test:ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: d65dd52e116ae22440b09002a69191a933061b96
+lastReviewedCommit: 6ae7b1374cea4f9d80020cbef7576d53d1414e63
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 6ae7b1374cea4f9d80020cbef7576d53d1414e63
+lastReviewedCommit: 38934973ad04f17793a7f1d1570312597e4643ee
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 38934973ad04f17793a7f1d1570312597e4643ee
+lastReviewedCommit: 49e0ba60e3742a27ff7d99d428a2fae537085060
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 38934973ad04f17793a7f1d1570312597e4643ee
+lastReviewedCommit: 49e0ba60e3742a27ff7d99d428a2fae537085060
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: d31886638063f1555fc3fa645007aefe303e56c4
+lastReviewedCommit: 38934973ad04f17793a7f1d1570312597e4643ee
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 38934973ad04f17793a7f1d1570312597e4643ee
+lastReviewedCommit: 49e0ba60e3742a27ff7d99d428a2fae537085060
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: d31886638063f1555fc3fa645007aefe303e56c4
+lastReviewedCommit: 6ae7b1374cea4f9d80020cbef7576d53d1414e63
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 6ae7b1374cea4f9d80020cbef7576d53d1414e63
+lastReviewedCommit: 38934973ad04f17793a7f1d1570312597e4643ee
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: d31886638063f1555fc3fa645007aefe303e56c4
+lastReviewedCommit: 6ae7b1374cea4f9d80020cbef7576d53d1414e63
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 6ae7b1374cea4f9d80020cbef7576d53d1414e63
+lastReviewedCommit: 38934973ad04f17793a7f1d1570312597e4643ee
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 38934973ad04f17793a7f1d1570312597e4643ee
+lastReviewedCommit: 49e0ba60e3742a27ff7d99d428a2fae537085060
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: d31886638063f1555fc3fa645007aefe303e56c4
+lastReviewedCommit: 6ae7b1374cea4f9d80020cbef7576d53d1414e63
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 38934973ad04f17793a7f1d1570312597e4643ee
+lastReviewedCommit: 49e0ba60e3742a27ff7d99d428a2fae537085060
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 6ae7b1374cea4f9d80020cbef7576d53d1414e63
+lastReviewedCommit: 38934973ad04f17793a7f1d1570312597e4643ee
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 6ae7b1374cea4f9d80020cbef7576d53d1414e63
+lastReviewedCommit: 38934973ad04f17793a7f1d1570312597e4643ee
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 38934973ad04f17793a7f1d1570312597e4643ee
+lastReviewedCommit: 49e0ba60e3742a27ff7d99d428a2fae537085060
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: d31886638063f1555fc3fa645007aefe303e56c4
+lastReviewedCommit: 6ae7b1374cea4f9d80020cbef7576d53d1414e63
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 6ae7b1374cea4f9d80020cbef7576d53d1414e63
+lastReviewedCommit: 38934973ad04f17793a7f1d1570312597e4643ee
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: d31886638063f1555fc3fa645007aefe303e56c4
+lastReviewedCommit: 6ae7b1374cea4f9d80020cbef7576d53d1414e63
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 38934973ad04f17793a7f1d1570312597e4643ee
+lastReviewedCommit: 49e0ba60e3742a27ff7d99d428a2fae537085060
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 38934973ad04f17793a7f1d1570312597e4643ee
+lastReviewedCommit: 49e0ba60e3742a27ff7d99d428a2fae537085060
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: d65dd52e116ae22440b09002a69191a933061b96
+lastReviewedCommit: 6ae7b1374cea4f9d80020cbef7576d53d1414e63
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 6ae7b1374cea4f9d80020cbef7576d53d1414e63
+lastReviewedCommit: 38934973ad04f17793a7f1d1570312597e4643ee
 ---
 
 # Testing Troubleshooting


### PR DESCRIPTION
## Summary
- address Codex review feedback from the ai-doc local-gate rollout
- make manual ai-doc/docpact fallback workflows accept an explicit base_ref and fetch remote branches
- make release tag docpact gates compare the tag commit against its parent instead of a base that can collapse to the tag commit
- refresh governance review evidence for the touched workflow guidance docs

## Validation
- YAML workflow parse passed from the workspace root
- local docpact/ai-doc gate passed for this branch

Refs tiangong-lca/workspace#183