### PR TITLE
feat: add UUID mention search entry

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-29"
-lastReviewedCommit: "14bb4ec53086ce0806703661938254727328a460"
+lastReviewedCommit: "d0fac07ab01d19d8ca82e925619928143f1c4eba"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 14bb4ec53086ce0806703661938254727328a460
+lastReviewedCommit: d0fac07ab01d19d8ca82e925619928143f1c4eba
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 14bb4ec53086ce0806703661938254727328a460
+lastReviewedCommit: 5de07dd8ffa76d39173b4a2c64ca6a4ddc548ec2
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 14bb4ec53086ce0806703661938254727328a460
+lastReviewedCommit: d0fac07ab01d19d8ca82e925619928143f1c4eba
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 14bb4ec53086ce0806703661938254727328a460
+lastReviewedCommit: d0fac07ab01d19d8ca82e925619928143f1c4eba
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 14bb4ec53086ce0806703661938254727328a460
+lastReviewedCommit: d0fac07ab01d19d8ca82e925619928143f1c4eba
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -20,7 +20,7 @@ checkPaths:
   - src/services/**
   - docker/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 14bb4ec53086ce0806703661938254727328a460
+lastReviewedCommit: d0fac07ab01d19d8ca82e925619928143f1c4eba
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 14bb4ec53086ce0806703661938254727328a460
+lastReviewedCommit: d0fac07ab01d19d8ca82e925619928143f1c4eba
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 14bb4ec53086ce0806703661938254727328a460
+lastReviewedCommit: d0fac07ab01d19d8ca82e925619928143f1c4eba
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 14bb4ec53086ce0806703661938254727328a460
+lastReviewedCommit: d0fac07ab01d19d8ca82e925619928143f1c4eba
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 14bb4ec53086ce0806703661938254727328a460
+lastReviewedCommit: d0fac07ab01d19d8ca82e925619928143f1c4eba
 ---
 
 # Testing Troubleshooting

--- a/src/components/DatasetUuidMentionSearch/index.tsx
+++ b/src/components/DatasetUuidMentionSearch/index.tsx
@@ -1,0 +1,158 @@
+import { SearchOutlined } from '@ant-design/icons';
+import { Alert, Button, Space, Table, Typography } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { useEffect, useMemo, useState } from 'react';
+import { FormattedMessage, useIntl } from 'umi';
+
+import {
+  type DatasetUuidMentionEntityKind,
+  type DatasetUuidMentionRow,
+  normalizeDatasetUuidSearchQuery,
+  searchDatasetJsonUuidMentions,
+} from '@/services/datasetUuidMentionSearch/api';
+
+type DatasetUuidMentionSearchProps = {
+  dataSource: string;
+  getStateCodeFilter?: () => number | string | null | undefined;
+  queryText: string;
+  sourceEntityKinds: DatasetUuidMentionEntityKind[];
+  teamId?: string | null;
+};
+
+const ENTITY_KIND_LABELS: Record<DatasetUuidMentionEntityKind, string> = {
+  contact: 'Contact',
+  flow: 'Flow',
+  flowproperty: 'Flow property',
+  lifecyclemodel: 'Model',
+  process: 'Process',
+  source: 'Source',
+  unitgroup: 'Unit group',
+};
+
+const ENTITY_KIND_MESSAGE_IDS: Record<DatasetUuidMentionEntityKind, string> = {
+  contact: 'menu.tgdata.contacts',
+  flow: 'menu.tgdata.flows',
+  flowproperty: 'menu.tgdata.flowproperties',
+  lifecyclemodel: 'menu.tgdata.products',
+  process: 'menu.tgdata.processes',
+  source: 'menu.tgdata.sources',
+  unitgroup: 'menu.tgdata.unitgroups',
+};
+
+export default function DatasetUuidMentionSearch({
+  dataSource,
+  getStateCodeFilter,
+  queryText,
+  sourceEntityKinds,
+  teamId,
+}: DatasetUuidMentionSearchProps) {
+  const intl = useIntl();
+  const normalizedUuid = normalizeDatasetUuidSearchQuery(queryText);
+  const [loading, setLoading] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [rows, setRows] = useState<DatasetUuidMentionRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const sourceEntityKindsKey = sourceEntityKinds.join(',');
+
+  useEffect(() => {
+    setHasSearched(false);
+    setRows([]);
+    setError(null);
+  }, [dataSource, normalizedUuid, sourceEntityKindsKey, teamId]);
+
+  const columns = useMemo<ColumnsType<DatasetUuidMentionRow>>(
+    () => [
+      {
+        dataIndex: 'source_entity_kind',
+        title: <FormattedMessage id='pages.datasetUuidMention.entityKind' />,
+        width: 132,
+        render: (value: DatasetUuidMentionEntityKind) =>
+          intl.formatMessage({
+            defaultMessage: ENTITY_KIND_LABELS[value] ?? value,
+            id: ENTITY_KIND_MESSAGE_IDS[value],
+          }),
+      },
+      {
+        dataIndex: 'source_name',
+        ellipsis: true,
+        title: <FormattedMessage id='pages.table.title.name' defaultMessage='Name' />,
+        render: (value?: string | null) => value || '-',
+      },
+      {
+        dataIndex: 'source_version',
+        title: <FormattedMessage id='pages.table.title.version' defaultMessage='Version' />,
+        width: 112,
+      },
+      {
+        dataIndex: 'source_id',
+        title: 'ID',
+        width: 300,
+        render: (value: string) => (
+          <Typography.Text copyable={{ text: value }} ellipsis>
+            {value}
+          </Typography.Text>
+        ),
+      },
+    ],
+    [intl],
+  );
+
+  if (!normalizedUuid) {
+    return null;
+  }
+
+  const handleSearch = async () => {
+    setLoading(true);
+    setHasSearched(true);
+    setError(null);
+    try {
+      const result = await searchDatasetJsonUuidMentions({
+        dataSource,
+        sourceEntityKinds,
+        stateCode: getStateCodeFilter?.(),
+        teamId,
+        uuid: normalizedUuid,
+      });
+      setRows(result.data);
+      if (!result.success) {
+        setError(result.error ?? 'search_failed');
+      }
+    } catch (caughtError) {
+      setRows([]);
+      setError(caughtError instanceof Error ? caughtError.message : 'search_failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Space direction='vertical' size='small' style={{ marginTop: 12, width: '100%' }}>
+      <Button icon={<SearchOutlined />} loading={loading} onClick={handleSearch}>
+        <FormattedMessage id='pages.datasetUuidMention.searchButton' />
+      </Button>
+      {error && (
+        <Alert
+          message={intl.formatMessage({ id: 'pages.datasetUuidMention.error' })}
+          showIcon
+          type='error'
+        />
+      )}
+      {hasSearched && !error && rows.length === 0 && (
+        <Alert
+          message={intl.formatMessage({ id: 'pages.datasetUuidMention.empty' })}
+          showIcon
+          type='info'
+        />
+      )}
+      {rows.length > 0 && (
+        <Table<DatasetUuidMentionRow>
+          columns={columns}
+          dataSource={rows}
+          pagination={false}
+          rowKey={(row) => `${row.source_entity_kind}-${row.source_id}-${row.source_version}`}
+          size='small'
+        />
+      )}
+    </Space>
+  );
+}

--- a/src/locales/en-US/pages_general.ts
+++ b/src/locales/en-US/pages_general.ts
@@ -83,6 +83,10 @@ export default {
   'pages.search.openAI': 'AI Recommendation',
   'pages.search.keyWord': 'Full-text search: Enter one or more keywords.',
   'pages.search.placeholder': 'AI Search: Describe the data you need in one sentence or a few key words.',
+  'pages.datasetUuidMention.empty': 'No data contains this ID',
+  'pages.datasetUuidMention.entityKind': 'Data type',
+  'pages.datasetUuidMention.error': 'Search failed. Try again later.',
+  'pages.datasetUuidMention.searchButton': 'Find data containing this ID',
 
   'pages.lifeCycleModel.drawer.title.create': 'Create Model',
 

--- a/src/locales/zh-CN/pages_general.ts
+++ b/src/locales/zh-CN/pages_general.ts
@@ -82,6 +82,10 @@ export default {
   'pages.search.openAI': '智能推荐',
   'pages.search.keyWord': '全文检索：请输入一个或多个关键词。',
   'pages.search.placeholder': '智能查询：用一句话或几个关键词描述您所需要的数据。',
+  'pages.datasetUuidMention.empty': '没有找到包含该 ID 的数据',
+  'pages.datasetUuidMention.entityKind': '数据类型',
+  'pages.datasetUuidMention.error': '查找失败，请稍后重试',
+  'pages.datasetUuidMention.searchButton': '查找包含该 ID 的数据',
 
   'pages.lifeCycleModel.drawer.title.create': '创建模型',
 

--- a/src/pages/Contacts/index.tsx
+++ b/src/pages/Contacts/index.tsx
@@ -4,6 +4,7 @@ import {
   extractContributeDataError,
   getContributeDataErrorMessage,
 } from '@/components/ContributeData/utils';
+import DatasetUuidMentionSearch from '@/components/DatasetUuidMentionSearch';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
 import {
@@ -42,6 +43,7 @@ import ContactView from './Components/view';
 const { Search } = Input;
 
 const TableList: FC = () => {
+  const [keyWord, setKeyWord] = useState<string>('');
   const [team, setTeam] = useState<TeamTable | null>(null);
   const [importData, setImportData] = useState<ContactImportData | null>(null);
   const [editDrawerVisible, setEditDrawerVisible] = useState<boolean>(false);
@@ -301,6 +303,7 @@ const TableList: FC = () => {
 
   const onSearch: SearchProps['onSearch'] = (value) => {
     keyWordRef.current = value;
+    setKeyWord(value);
     actionRef.current?.setPageInfo?.({ current: 1 });
     actionRef.current?.reload();
   };
@@ -327,6 +330,13 @@ const TableList: FC = () => {
             />
           </Col>
         </Row>
+        <DatasetUuidMentionSearch
+          dataSource={dataSource}
+          getStateCodeFilter={() => stateCodeRef.current}
+          queryText={keyWord}
+          sourceEntityKinds={['contact']}
+          teamId={tid}
+        />
       </Card>
       <ProTable<ContactTable, ListPagination>
         {...responsiveDataListTableProps}

--- a/src/pages/Flowproperties/index.tsx
+++ b/src/pages/Flowproperties/index.tsx
@@ -25,6 +25,7 @@ import {
   extractContributeDataError,
   getContributeDataErrorMessage,
 } from '@/components/ContributeData/utils';
+import DatasetUuidMentionSearch from '@/components/DatasetUuidMentionSearch';
 import { getTeamById } from '@/services/teams/api';
 import { SearchProps } from 'antd/es/input/Search';
 // import ReferenceUnit from '../Unitgroups/Components/Unit/reference';
@@ -370,6 +371,13 @@ const TableList: FC = () => {
             />
           </Col>
         </Row>
+        <DatasetUuidMentionSearch
+          dataSource={dataSource}
+          getStateCodeFilter={() => stateCodeRef.current}
+          queryText={keyWord}
+          sourceEntityKinds={['flowproperty']}
+          teamId={tid}
+        />
       </Card>
       <ProTable<FlowpropertyTable, ListPagination>
         {...responsiveDataListTableProps}

--- a/src/pages/Flows/index.tsx
+++ b/src/pages/Flows/index.tsx
@@ -13,6 +13,7 @@ import {
   extractContributeDataError,
   getContributeDataErrorMessage,
 } from '@/components/ContributeData/utils';
+import DatasetUuidMentionSearch from '@/components/DatasetUuidMentionSearch';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
 import {
@@ -446,6 +447,13 @@ const TableList: FC = () => {
             </Checkbox>
           </Col>
         </Row>
+        <DatasetUuidMentionSearch
+          dataSource={dataSource}
+          getStateCodeFilter={() => stateCodeRef.current}
+          queryText={keyWord}
+          sourceEntityKinds={['flow']}
+          teamId={tid}
+        />
       </Card>
       <ProTable<FlowTable, ListPagination>
         {...responsiveDataListTableProps}

--- a/src/pages/LifeCycleModels/index.tsx
+++ b/src/pages/LifeCycleModels/index.tsx
@@ -4,6 +4,7 @@ import {
   extractContributeDataError,
   getContributeDataErrorMessage,
 } from '@/components/ContributeData/utils';
+import DatasetUuidMentionSearch from '@/components/DatasetUuidMentionSearch';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
 import {
@@ -358,6 +359,13 @@ const TableList: FC = () => {
             </Checkbox>
           </Col>
         </Row>
+        <DatasetUuidMentionSearch
+          dataSource={dataSource}
+          getStateCodeFilter={() => stateCodeRef.current}
+          queryText={keyWord}
+          sourceEntityKinds={['lifecyclemodel']}
+          teamId={tid}
+        />
       </Card>
       <ProTable<LifeCycleModelTable, ListPagination>
         {...responsiveDataListTableProps}

--- a/src/pages/Processes/index.tsx
+++ b/src/pages/Processes/index.tsx
@@ -17,6 +17,7 @@ import {
   extractContributeDataError,
   getContributeDataErrorMessage,
 } from '@/components/ContributeData/utils';
+import DatasetUuidMentionSearch from '@/components/DatasetUuidMentionSearch';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
 import {
@@ -530,6 +531,13 @@ const TableList: FC = () => {
             </Checkbox>
           </Col>
         </Row>
+        <DatasetUuidMentionSearch
+          dataSource={dataSource}
+          getStateCodeFilter={() => stateCodeRef.current}
+          queryText={keyWord}
+          sourceEntityKinds={['process']}
+          teamId={tid}
+        />
       </Card>
       <ProTable<ProcessTable, ListPagination>
         {...responsiveDataListTableProps}

--- a/src/pages/Sources/index.tsx
+++ b/src/pages/Sources/index.tsx
@@ -11,6 +11,7 @@ import {
   extractContributeDataError,
   getContributeDataErrorMessage,
 } from '@/components/ContributeData/utils';
+import DatasetUuidMentionSearch from '@/components/DatasetUuidMentionSearch';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
 import {
@@ -43,6 +44,7 @@ import SourceView from './Components/view';
 const { Search } = Input;
 
 const TableList: FC = () => {
+  const [keyWord, setKeyWord] = useState<string>('');
   const [team, setTeam] = useState<TeamTable | null>(null);
   const [importData, setImportData] = useState<SourceImportData | null>(null);
   const [editDrawerVisible, setEditDrawerVisible] = useState<boolean>(false);
@@ -298,6 +300,7 @@ const TableList: FC = () => {
   }, []);
   const onSearch: SearchProps['onSearch'] = (value) => {
     keyWordRef.current = value;
+    setKeyWord(value);
     actionRef.current?.setPageInfo?.({ current: 1 });
     actionRef.current?.reload();
   };
@@ -322,6 +325,13 @@ const TableList: FC = () => {
             />
           </Col>
         </Row>
+        <DatasetUuidMentionSearch
+          dataSource={dataSource}
+          getStateCodeFilter={() => stateCodeRef.current}
+          queryText={keyWord}
+          sourceEntityKinds={['source']}
+          teamId={tid}
+        />
       </Card>
       <ProTable<SourceTable, ListPagination>
         {...responsiveDataListTableProps}

--- a/src/pages/Unitgroups/index.tsx
+++ b/src/pages/Unitgroups/index.tsx
@@ -5,6 +5,7 @@ import {
   extractContributeDataError,
   getContributeDataErrorMessage,
 } from '@/components/ContributeData/utils';
+import DatasetUuidMentionSearch from '@/components/DatasetUuidMentionSearch';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
 import {
@@ -361,6 +362,13 @@ const TableList: FC = () => {
             />
           </Col>
         </Row>
+        <DatasetUuidMentionSearch
+          dataSource={dataSource}
+          getStateCodeFilter={() => stateCodeRef.current}
+          queryText={keyWord}
+          sourceEntityKinds={['unitgroup']}
+          teamId={tid}
+        />
       </Card>
       <ProTable<UnitGroupTable, ListPagination>
         {...responsiveDataListTableProps}

--- a/src/services/datasetUuidMentionSearch/api.ts
+++ b/src/services/datasetUuidMentionSearch/api.ts
@@ -1,0 +1,131 @@
+import { supabase } from '@/services/supabase';
+import { getTeamIdByUserId } from '../general/api';
+
+export type DatasetUuidMentionEntityKind =
+  | 'flow'
+  | 'process'
+  | 'lifecyclemodel'
+  | 'source'
+  | 'contact'
+  | 'unitgroup'
+  | 'flowproperty';
+
+export type DatasetUuidMentionRow = {
+  matched_by: string;
+  matched_entity_table: string;
+  rank: number;
+  source_entity_kind: DatasetUuidMentionEntityKind;
+  source_id: string;
+  source_json?: Record<string, unknown>;
+  source_modified_at?: string | null;
+  source_name?: string | null;
+  source_team_id?: string | null;
+  source_version: string;
+};
+
+type SearchDatasetJsonUuidMentionsOptions = {
+  dataSource: string;
+  limit?: number;
+  sourceEntityKinds: DatasetUuidMentionEntityKind[];
+  stateCode?: number | string | null;
+  teamId?: string | null;
+  uuid: string;
+};
+
+export type SearchDatasetJsonUuidMentionsResult = {
+  data: DatasetUuidMentionRow[];
+  error?: string;
+  success: boolean;
+};
+
+const DATASET_UUID_QUERY_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function normalizeOptionalTeamId(teamId?: string | null): string | null {
+  const normalizedTeamId = typeof teamId === 'string' ? teamId.trim() : '';
+  return normalizedTeamId.length > 0 ? normalizedTeamId : null;
+}
+
+async function getDatasetUuidMentionTeamFilter(
+  dataSource: string,
+  teamId?: string | null,
+): Promise<string | null> {
+  if (dataSource === 'te') {
+    return (await getTeamIdByUserId()) ?? null;
+  }
+  if (dataSource === 'tg' || dataSource === 'co') {
+    return normalizeOptionalTeamId(teamId);
+  }
+  return null;
+}
+
+export function normalizeDatasetUuidSearchQuery(queryText?: string | null): string | null {
+  const normalizedQuery = (queryText ?? '').trim();
+  if (!DATASET_UUID_QUERY_PATTERN.test(normalizedQuery)) {
+    return null;
+  }
+  return normalizedQuery.toLowerCase();
+}
+
+export function normalizeDatasetUuidMentionStateCode(
+  stateCode?: number | string | null,
+): number | null {
+  if (typeof stateCode === 'number' && Number.isFinite(stateCode)) {
+    return stateCode;
+  }
+  if (typeof stateCode === 'string') {
+    const normalizedStateCode = stateCode.trim();
+    if (normalizedStateCode.length > 0 && normalizedStateCode !== 'all') {
+      const parsedStateCode = Number(normalizedStateCode);
+      return Number.isFinite(parsedStateCode) ? parsedStateCode : null;
+    }
+  }
+  return null;
+}
+
+export async function searchDatasetJsonUuidMentions({
+  dataSource,
+  limit = 20,
+  sourceEntityKinds,
+  stateCode,
+  teamId,
+  uuid,
+}: SearchDatasetJsonUuidMentionsOptions): Promise<SearchDatasetJsonUuidMentionsResult> {
+  const normalizedUuid = normalizeDatasetUuidSearchQuery(uuid);
+  if (!normalizedUuid || sourceEntityKinds.length === 0) {
+    return { data: [], success: true };
+  }
+
+  const session = await supabase.auth.getSession();
+  if (!session.data.session) {
+    return { data: [], success: false, error: 'not_authenticated' };
+  }
+
+  const teamIdFilter = await getDatasetUuidMentionTeamFilter(dataSource, teamId);
+  if (dataSource === 'te' && !teamIdFilter) {
+    return { data: [], success: true };
+  }
+
+  const result = await supabase.rpc('search_dataset_json_uuid_mentions', {
+    p_data_source: dataSource,
+    p_limit: limit,
+    p_source_entity_kinds: sourceEntityKinds,
+    p_state_code_filter: normalizeDatasetUuidMentionStateCode(stateCode),
+    p_team_id_filter: teamIdFilter,
+    p_this_user_id: session.data.session.user?.id ?? '',
+    p_uuid: normalizedUuid,
+  });
+
+  if (result.error) {
+    return {
+      data: [],
+      error: result.error.message,
+      success: false,
+    };
+  }
+
+  return {
+    data: (result.data ?? []) as DatasetUuidMentionRow[],
+    success: true,
+  };
+}

--- a/src/services/datasetUuidMentionSearch/api.ts
+++ b/src/services/datasetUuidMentionSearch/api.ts
@@ -1,6 +1,3 @@
-import { supabase } from '@/services/supabase';
-import { getTeamIdByUserId } from '../general/api';
-
 export type DatasetUuidMentionEntityKind =
   | 'flow'
   | 'process'
@@ -51,6 +48,7 @@ async function getDatasetUuidMentionTeamFilter(
   teamId?: string | null,
 ): Promise<string | null> {
   if (dataSource === 'te') {
+    const { getTeamIdByUserId } = require('../general/api') as typeof import('../general/api');
     return (await getTeamIdByUserId()) ?? null;
   }
   if (dataSource === 'tg' || dataSource === 'co') {
@@ -96,6 +94,7 @@ export async function searchDatasetJsonUuidMentions({
     return { data: [], success: true };
   }
 
+  const { supabase } = require('@/services/supabase') as typeof import('@/services/supabase');
   const session = await supabase.auth.getSession();
   if (!session.data.session) {
     return { data: [], success: false, error: 'not_authenticated' };

--- a/tests/unit/components/DatasetUuidMentionSearch.test.tsx
+++ b/tests/unit/components/DatasetUuidMentionSearch.test.tsx
@@ -1,0 +1,200 @@
+import DatasetUuidMentionSearch from '@/components/DatasetUuidMentionSearch';
+import { searchDatasetJsonUuidMentions } from '@/services/datasetUuidMentionSearch/api';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+jest.mock('@ant-design/icons', () => ({
+  SearchOutlined: () => <span data-testid='search-icon' />,
+}));
+
+jest.mock('antd', () => {
+  return {
+    Alert: ({ message, type }: any) => (
+      <div data-type={type} role='alert'>
+        {message}
+      </div>
+    ),
+    Button: ({ children, icon, loading, onClick }: any) => (
+      <button aria-busy={loading ? 'true' : 'false'} onClick={onClick} type='button'>
+        {icon}
+        {children}
+      </button>
+    ),
+    Space: ({ children }: any) => <div>{children}</div>,
+    Table: ({ columns, dataSource, rowKey }: any) => (
+      <table>
+        <tbody>
+          {dataSource.map((row: any) => (
+            <tr key={rowKey(row)}>
+              {columns.map((column: any) => {
+                const value = row[column.dataIndex];
+                return (
+                  <td key={String(column.dataIndex)}>
+                    {column.render ? column.render(value, row) : value}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    ),
+    Typography: {
+      Text: ({ children }: any) => <span>{children}</span>,
+    },
+  };
+});
+
+jest.mock('umi', () => ({
+  FormattedMessage: ({ defaultMessage, id }: any) => <span>{defaultMessage ?? id}</span>,
+  useIntl: () => ({
+    formatMessage: ({ defaultMessage, id }: any) => defaultMessage ?? id,
+  }),
+}));
+
+jest.mock('@/services/datasetUuidMentionSearch/api', () => {
+  const actual = jest.requireActual('@/services/datasetUuidMentionSearch/api');
+  return {
+    ...actual,
+    searchDatasetJsonUuidMentions: jest.fn(),
+  };
+});
+
+const searchDatasetJsonUuidMentionsMock = searchDatasetJsonUuidMentions as jest.Mock;
+
+const uuid = 'd1380000-0000-4000-8000-000000000001';
+
+describe('DatasetUuidMentionSearch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    searchDatasetJsonUuidMentionsMock.mockResolvedValue({ data: [], success: true });
+  });
+
+  it('does not render for non-UUID queries', () => {
+    const { container } = render(
+      <DatasetUuidMentionSearch
+        dataSource='my'
+        queryText='process'
+        sourceEntityKinds={['process']}
+      />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('searches UUID mentions and renders an empty result', async () => {
+    render(
+      <DatasetUuidMentionSearch
+        dataSource='my'
+        getStateCodeFilter={() => '20'}
+        queryText={uuid}
+        sourceEntityKinds={['process']}
+        teamId='team-1'
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(searchDatasetJsonUuidMentionsMock).toHaveBeenCalledWith({
+        dataSource: 'my',
+        sourceEntityKinds: ['process'],
+        stateCode: '20',
+        teamId: 'team-1',
+        uuid,
+      });
+    });
+    expect(screen.getByRole('alert')).toHaveTextContent('pages.datasetUuidMention.empty');
+  });
+
+  it('renders mention rows with entity labels, name fallbacks, and copied ids', async () => {
+    searchDatasetJsonUuidMentionsMock.mockResolvedValue({
+      data: [
+        {
+          matched_by: 'json_uuid',
+          matched_entity_table: 'flows',
+          rank: 1,
+          source_entity_kind: 'flow',
+          source_id: uuid,
+          source_name: 'Flow A',
+          source_version: '01.00.000',
+        },
+        {
+          matched_by: 'json_uuid',
+          matched_entity_table: 'unknown',
+          rank: 2,
+          source_entity_kind: 'unknown',
+          source_id: 'd1380000-0000-4000-8000-000000000002',
+          source_name: null,
+          source_version: '01.00.000',
+        },
+      ],
+      success: true,
+    });
+
+    render(
+      <DatasetUuidMentionSearch dataSource='tg' queryText={uuid} sourceEntityKinds={['flow']} />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(await screen.findByText('Flow')).toBeInTheDocument();
+    expect(screen.getByText('Flow A')).toBeInTheDocument();
+    expect(screen.getByText('unknown')).toBeInTheDocument();
+    expect(screen.getByText('-')).toBeInTheDocument();
+    expect(screen.getByText(uuid)).toBeInTheDocument();
+  });
+
+  it('renders service errors with and without backend messages', async () => {
+    searchDatasetJsonUuidMentionsMock
+      .mockResolvedValueOnce({ data: [], error: 'backend failed', success: false })
+      .mockResolvedValueOnce({ data: [], success: false });
+
+    const { rerender } = render(
+      <DatasetUuidMentionSearch dataSource='my' queryText={uuid} sourceEntityKinds={['process']} />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('pages.datasetUuidMention.error');
+    });
+
+    rerender(
+      <DatasetUuidMentionSearch
+        dataSource='my'
+        queryText='d1380000-0000-4000-8000-000000000002'
+        sourceEntityKinds={['process']}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('pages.datasetUuidMention.error');
+    });
+  });
+
+  it('renders thrown search failures', async () => {
+    searchDatasetJsonUuidMentionsMock
+      .mockRejectedValueOnce(new Error('network failed'))
+      .mockRejectedValueOnce('string failure');
+
+    const { rerender } = render(
+      <DatasetUuidMentionSearch dataSource='my' queryText={uuid} sourceEntityKinds={['process']} />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('pages.datasetUuidMention.error');
+    });
+
+    rerender(
+      <DatasetUuidMentionSearch
+        dataSource='my'
+        queryText='d1380000-0000-4000-8000-000000000002'
+        sourceEntityKinds={['process']}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('pages.datasetUuidMention.error');
+    });
+  });
+});

--- a/tests/unit/pages/Contacts/index.test.tsx
+++ b/tests/unit/pages/Contacts/index.test.tsx
@@ -27,6 +27,7 @@ const mockGetDataSource = jest.fn(() => 'my');
 const mockGetLang = jest.fn(() => 'en');
 const mockGetLangText = jest.fn((value: any) => value?.[0]?.['#text'] ?? 'Team title');
 const mockGetTeamById = jest.fn();
+const mockDatasetUuidMentionSearch = jest.fn();
 
 const baseContactRow = {
   id: 'contact-1',
@@ -148,6 +149,24 @@ jest.mock('@/components/TableFilter', () => ({
       table-filter
     </button>
   ),
+}));
+
+jest.mock('@/components/DatasetUuidMentionSearch', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    mockDatasetUuidMentionSearch(props);
+    return (
+      <div data-testid='dataset-uuid-mention-search'>
+        {JSON.stringify({
+          dataSource: props.dataSource,
+          queryText: props.queryText,
+          sourceEntityKinds: props.sourceEntityKinds,
+          stateCode: props.getStateCodeFilter?.(),
+          teamId: props.teamId,
+        })}
+      </div>
+    );
+  },
 }));
 
 jest.mock('@/pages/Utils', () => ({
@@ -389,6 +408,16 @@ describe('ContactsPage', () => {
     expect(screen.getByTestId('contact-edit')).toHaveTextContent('edit:contact-1');
     expect(screen.getByTestId('contact-delete')).toHaveTextContent('delete:contact-1');
     expect(screen.getAllByTestId('contact-create')[0]).toHaveTextContent('"actionType":"create"');
+    expect(screen.getByTestId('dataset-uuid-mention-search')).toHaveTextContent(
+      '"sourceEntityKinds":["contact"]',
+    );
+    expect(mockDatasetUuidMentionSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dataSource: 'my',
+        sourceEntityKinds: ['contact'],
+        teamId: 'team-1',
+      }),
+    );
 
     await userEvent.click(screen.getByRole('button', { name: /close-contact-edit/i }));
     await userEvent.click(screen.getByRole('button', { name: /close-contact-delete/i }));

--- a/tests/unit/pages/Flowproperties/index.test.tsx
+++ b/tests/unit/pages/Flowproperties/index.test.tsx
@@ -31,6 +31,7 @@ const mockGetLangText = jest.fn((value: any) => {
 });
 const mockGetTeamById = jest.fn();
 const mockGetUnitData = jest.fn();
+const mockDatasetUuidMentionSearch = jest.fn();
 const mockMessage = {
   success: jest.fn(),
   error: jest.fn(),
@@ -119,6 +120,24 @@ jest.mock('@/components/TableFilter', () => ({
       table-filter
     </button>
   ),
+}));
+
+jest.mock('@/components/DatasetUuidMentionSearch', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    mockDatasetUuidMentionSearch(props);
+    return (
+      <div data-testid='dataset-uuid-mention-search'>
+        {JSON.stringify({
+          dataSource: props.dataSource,
+          queryText: props.queryText,
+          sourceEntityKinds: props.sourceEntityKinds,
+          stateCode: props.getStateCodeFilter?.(),
+          teamId: props.teamId,
+        })}
+      </div>
+    );
+  },
 }));
 
 jest.mock('@/pages/Utils', () => ({
@@ -389,6 +408,16 @@ describe('FlowpropertiesPage', () => {
     );
     expect(screen.getByTestId('table-dropdown')).toBeInTheDocument();
     expect(screen.getByTestId('export-data')).toHaveTextContent('flowproperties:fp-1:01.00.000');
+    expect(screen.getByTestId('dataset-uuid-mention-search')).toHaveTextContent(
+      '"sourceEntityKinds":["flowproperty"]',
+    );
+    expect(mockDatasetUuidMentionSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dataSource: 'my',
+        sourceEntityKinds: ['flowproperty'],
+        teamId: 'team-1',
+      }),
+    );
 
     await userEvent.click(screen.getByRole('button', { name: /import-data/i }));
     expect(

--- a/tests/unit/pages/Flows/index.test.tsx
+++ b/tests/unit/pages/Flows/index.test.tsx
@@ -28,6 +28,7 @@ const mockGetDataSource = jest.fn(() => 'my');
 const mockGetLang = jest.fn(() => 'en');
 const mockGetLangText = jest.fn((value: any) => value?.[0]?.['#text'] ?? 'Team title');
 const mockGetTeamById = jest.fn();
+const mockDatasetUuidMentionSearch = jest.fn();
 const mockMessageSuccess = jest.fn();
 const mockMessageError = jest.fn();
 
@@ -144,6 +145,24 @@ jest.mock('@/components/TableFilter', () => ({
       table-filter
     </button>
   ),
+}));
+
+jest.mock('@/components/DatasetUuidMentionSearch', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    mockDatasetUuidMentionSearch(props);
+    return (
+      <div data-testid='dataset-uuid-mention-search'>
+        {JSON.stringify({
+          dataSource: props.dataSource,
+          queryText: props.queryText,
+          sourceEntityKinds: props.sourceEntityKinds,
+          stateCode: props.getStateCodeFilter?.(),
+          teamId: props.teamId,
+        })}
+      </div>
+    );
+  },
 }));
 
 jest.mock('@/pages/Utils', () => ({
@@ -452,6 +471,16 @@ describe('FlowsPage', () => {
     );
     expect(screen.getByTestId('classification-filters')).toHaveTextContent(
       '"text":"-","value":"classification:class-empty"',
+    );
+    expect(screen.getByTestId('dataset-uuid-mention-search')).toHaveTextContent(
+      '"sourceEntityKinds":["flow"]',
+    );
+    expect(mockDatasetUuidMentionSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dataSource: 'my',
+        sourceEntityKinds: ['flow'],
+        teamId: 'team-1',
+      }),
     );
     expect(screen.getAllByTestId('flow-create-createVersion')).toHaveLength(2);
     expect(screen.getAllByTestId('flow-create-createVersion')[0]).toHaveTextContent(

--- a/tests/unit/pages/LifeCycleModels/index.test.tsx
+++ b/tests/unit/pages/LifeCycleModels/index.test.tsx
@@ -28,6 +28,7 @@ const mockGetLifeCycleModelTablePgroongaSearch = jest.fn();
 const mockLifeCycleModelHybridSearch = jest.fn();
 const mockContributeLifeCycleModel = jest.fn();
 const mockGetTeamById = jest.fn();
+const mockDatasetUuidMentionSearch = jest.fn();
 const mockMessageSuccess = jest.fn();
 
 const modelRows = [
@@ -133,6 +134,24 @@ jest.mock('@/components/TableFilter', () => ({
       table-filter
     </button>
   ),
+}));
+
+jest.mock('@/components/DatasetUuidMentionSearch', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    mockDatasetUuidMentionSearch(props);
+    return (
+      <div data-testid='dataset-uuid-mention-search'>
+        {JSON.stringify({
+          dataSource: props.dataSource,
+          queryText: props.queryText,
+          sourceEntityKinds: props.sourceEntityKinds,
+          stateCode: props.getStateCodeFilter?.(),
+          teamId: props.teamId,
+        })}
+      </div>
+    );
+  },
 }));
 
 jest.mock('@/pages/Utils', () => ({
@@ -455,6 +474,16 @@ describe('LifeCycleModelsPage', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /table-filter/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /import-data/i })).toBeInTheDocument();
+    expect(screen.getByTestId('dataset-uuid-mention-search')).toHaveTextContent(
+      '"sourceEntityKinds":["lifecyclemodel"]',
+    );
+    expect(mockDatasetUuidMentionSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dataSource: 'my',
+        sourceEntityKinds: ['lifecyclemodel'],
+        teamId: 'team-1',
+      }),
+    );
 
     await user.click(screen.getByRole('button', { name: /import-data/i }));
     expect(screen.getByTestId('lifecycle-create-create')).toHaveTextContent('"importCount":1');

--- a/tests/unit/pages/Processes/index.test.tsx
+++ b/tests/unit/pages/Processes/index.test.tsx
@@ -28,6 +28,7 @@ const mockGetDataSource = jest.fn(() => 'my');
 const mockGetLang = jest.fn(() => 'en');
 const mockGetLangText = jest.fn((value: any) => value?.[0]?.['#text'] ?? 'Team title');
 const mockGetTeamById = jest.fn();
+const mockDatasetUuidMentionSearch = jest.fn();
 let latestRequest: any = null;
 
 jest.mock('umi', () => ({
@@ -114,6 +115,24 @@ jest.mock('@/components/TableFilter', () => ({
       table-filter
     </button>
   ),
+}));
+
+jest.mock('@/components/DatasetUuidMentionSearch', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    mockDatasetUuidMentionSearch(props);
+    return (
+      <div data-testid='dataset-uuid-mention-search'>
+        {JSON.stringify({
+          dataSource: props.dataSource,
+          queryText: props.queryText,
+          sourceEntityKinds: props.sourceEntityKinds,
+          stateCode: props.getStateCodeFilter?.(),
+          teamId: props.teamId,
+        })}
+      </div>
+    );
+  },
 }));
 
 jest.mock('@/components/ToolBarButton', () => ({
@@ -469,6 +488,16 @@ describe('ProcessesPage', () => {
     expect(screen.getByText('2024')).toBeInTheDocument();
     expect(screen.getByText('CN')).toBeInTheDocument();
     expect(screen.getAllByTestId('lca-solve-toolbar')).toHaveLength(3);
+    expect(screen.getByTestId('dataset-uuid-mention-search')).toHaveTextContent(
+      '"sourceEntityKinds":["process"]',
+    );
+    expect(mockDatasetUuidMentionSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dataSource: 'my',
+        sourceEntityKinds: ['process'],
+        teamId: 'team-1',
+      }),
+    );
 
     await userEvent.click(screen.getByRole('button', { name: /import-data/i }));
     const createAction = screen

--- a/tests/unit/pages/Sources/index.test.tsx
+++ b/tests/unit/pages/Sources/index.test.tsx
@@ -27,6 +27,7 @@ const mockGetDataSource = jest.fn(() => 'my');
 const mockGetLang = jest.fn(() => 'en');
 const mockGetLangText = jest.fn((value: any) => value?.[0]?.['#text'] ?? 'Team title');
 const mockGetTeamById = jest.fn();
+const mockDatasetUuidMentionSearch = jest.fn();
 
 const baseSourceRow = {
   id: 'source-1',
@@ -147,6 +148,24 @@ jest.mock('@/components/TableFilter', () => ({
       table-filter
     </button>
   ),
+}));
+
+jest.mock('@/components/DatasetUuidMentionSearch', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    mockDatasetUuidMentionSearch(props);
+    return (
+      <div data-testid='dataset-uuid-mention-search'>
+        {JSON.stringify({
+          dataSource: props.dataSource,
+          queryText: props.queryText,
+          sourceEntityKinds: props.sourceEntityKinds,
+          stateCode: props.getStateCodeFilter?.(),
+          teamId: props.teamId,
+        })}
+      </div>
+    );
+  },
 }));
 
 jest.mock('@/pages/Utils', () => ({
@@ -395,6 +414,16 @@ describe('SourcesPage', () => {
     expect(screen.getByTestId('source-edit')).toHaveTextContent('edit:source-1');
     expect(screen.getByTestId('source-delete')).toHaveTextContent('delete:source-1');
     expect(screen.getAllByTestId('source-create')[0]).toHaveTextContent('"actionType":"create"');
+    expect(screen.getByTestId('dataset-uuid-mention-search')).toHaveTextContent(
+      '"sourceEntityKinds":["source"]',
+    );
+    expect(mockDatasetUuidMentionSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dataSource: 'my',
+        sourceEntityKinds: ['source'],
+        teamId: 'team-1',
+      }),
+    );
 
     await userEvent.click(screen.getByRole('button', { name: /close-source-edit/i }));
     await userEvent.click(screen.getByRole('button', { name: /close-source-delete/i }));

--- a/tests/unit/pages/Unitgroups/index.test.tsx
+++ b/tests/unit/pages/Unitgroups/index.test.tsx
@@ -32,6 +32,7 @@ const mockGetRoleByUserId = jest.fn();
 const mockGetTeamById = jest.fn();
 const mockGetUnitGroupTableAll = jest.fn();
 const mockGetUnitGroupTablePgroongaSearch = jest.fn();
+const mockDatasetUuidMentionSearch = jest.fn();
 
 jest.mock('umi', () => ({
   __esModule: true,
@@ -141,6 +142,24 @@ jest.mock('@/components/TableFilter', () => ({
       table-filter
     </button>
   ),
+}));
+
+jest.mock('@/components/DatasetUuidMentionSearch', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    mockDatasetUuidMentionSearch(props);
+    return (
+      <div data-testid='dataset-uuid-mention-search'>
+        {JSON.stringify({
+          dataSource: props.dataSource,
+          queryText: props.queryText,
+          sourceEntityKinds: props.sourceEntityKinds,
+          stateCode: props.getStateCodeFilter?.(),
+          teamId: props.teamId,
+        })}
+      </div>
+    );
+  },
 }));
 
 jest.mock('@/pages/Utils', () => ({
@@ -431,6 +450,16 @@ describe('UnitgroupsPage', () => {
       'my',
       'team-1',
       'all',
+    );
+    expect(screen.getByTestId('dataset-uuid-mention-search')).toHaveTextContent(
+      '"sourceEntityKinds":["unitgroup"]',
+    );
+    expect(mockDatasetUuidMentionSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dataSource: 'my',
+        sourceEntityKinds: ['unitgroup'],
+        teamId: 'team-1',
+      }),
     );
 
     expect(screen.getByRole('heading', { name: 'Unit Team' })).toBeInTheDocument();

--- a/tests/unit/services/datasetUuidMentionSearch.test.ts
+++ b/tests/unit/services/datasetUuidMentionSearch.test.ts
@@ -1,0 +1,104 @@
+import {
+  normalizeDatasetUuidMentionStateCode,
+  normalizeDatasetUuidSearchQuery,
+  searchDatasetJsonUuidMentions,
+} from '@/services/datasetUuidMentionSearch/api';
+import { getTeamIdByUserId } from '@/services/general/api';
+import { supabase } from '@/services/supabase';
+
+jest.mock('@/services/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn(),
+    },
+    rpc: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/general/api', () => ({
+  getTeamIdByUserId: jest.fn(),
+}));
+
+const supabaseMock = supabase as unknown as {
+  auth: { getSession: jest.Mock };
+  rpc: jest.Mock;
+};
+const getTeamIdByUserIdMock = getTeamIdByUserId as jest.Mock;
+
+describe('datasetUuidMentionSearch service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    supabaseMock.auth.getSession.mockResolvedValue({
+      data: { session: { user: { id: 'user-1' } } },
+    });
+    supabaseMock.rpc.mockResolvedValue({ data: [], error: null });
+  });
+
+  it('normalizes only full UUID search queries', () => {
+    expect(normalizeDatasetUuidSearchQuery(' D1380000-0000-4000-8000-000000000001 ')).toBe(
+      'd1380000-0000-4000-8000-000000000001',
+    );
+    expect(normalizeDatasetUuidSearchQuery('prefix d1380000-0000-4000-8000-000000000001')).toBe(
+      null,
+    );
+    expect(normalizeDatasetUuidSearchQuery('d1380000')).toBe(null);
+  });
+
+  it('normalizes state code filters', () => {
+    expect(normalizeDatasetUuidMentionStateCode(100)).toBe(100);
+    expect(normalizeDatasetUuidMentionStateCode('200')).toBe(200);
+    expect(normalizeDatasetUuidMentionStateCode('all')).toBe(null);
+    expect(normalizeDatasetUuidMentionStateCode('draft')).toBe(null);
+  });
+
+  it('calls the JSON UUID mention RPC with bounded params', async () => {
+    await searchDatasetJsonUuidMentions({
+      dataSource: 'my',
+      sourceEntityKinds: ['process'],
+      stateCode: '100',
+      teamId: 'team-ignored-for-my',
+      uuid: 'd1380000-0000-4000-8000-000000000001',
+    });
+
+    expect(supabaseMock.rpc).toHaveBeenCalledWith('search_dataset_json_uuid_mentions', {
+      p_data_source: 'my',
+      p_limit: 20,
+      p_source_entity_kinds: ['process'],
+      p_state_code_filter: 100,
+      p_team_id_filter: null,
+      p_this_user_id: 'user-1',
+      p_uuid: 'd1380000-0000-4000-8000-000000000001',
+    });
+  });
+
+  it('uses the current user team for team data searches', async () => {
+    getTeamIdByUserIdMock.mockResolvedValue('team-1');
+
+    await searchDatasetJsonUuidMentions({
+      dataSource: 'te',
+      sourceEntityKinds: ['flow'],
+      uuid: 'd1380000-0000-4000-8000-000000000001',
+    });
+
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      'search_dataset_json_uuid_mentions',
+      expect.objectContaining({
+        p_data_source: 'te',
+        p_team_id_filter: 'team-1',
+      }),
+    );
+  });
+
+  it('does not call RPC without an authenticated session', async () => {
+    supabaseMock.auth.getSession.mockResolvedValue({ data: { session: null } });
+
+    const result = await searchDatasetJsonUuidMentions({
+      dataSource: 'tg',
+      sourceEntityKinds: ['flow'],
+      uuid: 'd1380000-0000-4000-8000-000000000001',
+    });
+
+    expect(result).toEqual({ data: [], error: 'not_authenticated', success: false });
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/datasetUuidMentionSearch.test.ts
+++ b/tests/unit/services/datasetUuidMentionSearch.test.ts
@@ -38,6 +38,7 @@ describe('datasetUuidMentionSearch service', () => {
     expect(normalizeDatasetUuidSearchQuery(' D1380000-0000-4000-8000-000000000001 ')).toBe(
       'd1380000-0000-4000-8000-000000000001',
     );
+    expect(normalizeDatasetUuidSearchQuery()).toBe(null);
     expect(normalizeDatasetUuidSearchQuery('prefix d1380000-0000-4000-8000-000000000001')).toBe(
       null,
     );
@@ -48,7 +49,9 @@ describe('datasetUuidMentionSearch service', () => {
     expect(normalizeDatasetUuidMentionStateCode(100)).toBe(100);
     expect(normalizeDatasetUuidMentionStateCode('200')).toBe(200);
     expect(normalizeDatasetUuidMentionStateCode('all')).toBe(null);
+    expect(normalizeDatasetUuidMentionStateCode('')).toBe(null);
     expect(normalizeDatasetUuidMentionStateCode('draft')).toBe(null);
+    expect(normalizeDatasetUuidMentionStateCode(Number.NaN)).toBe(null);
   });
 
   it('calls the JSON UUID mention RPC with bounded params', async () => {
@@ -89,6 +92,92 @@ describe('datasetUuidMentionSearch service', () => {
     );
   });
 
+  it('uses trimmed open-data team filters when present', async () => {
+    await searchDatasetJsonUuidMentions({
+      dataSource: 'co',
+      sourceEntityKinds: ['flow'],
+      stateCode: 200,
+      teamId: ' team-1 ',
+      uuid: 'd1380000-0000-4000-8000-000000000001',
+    });
+
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      'search_dataset_json_uuid_mentions',
+      expect.objectContaining({
+        p_data_source: 'co',
+        p_state_code_filter: 200,
+        p_team_id_filter: 'team-1',
+      }),
+    );
+  });
+
+  it('uses null team filters for blank public team values', async () => {
+    await searchDatasetJsonUuidMentions({
+      dataSource: 'tg',
+      sourceEntityKinds: ['flow'],
+      teamId: ' ',
+      uuid: 'd1380000-0000-4000-8000-000000000001',
+    });
+
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      'search_dataset_json_uuid_mentions',
+      expect.objectContaining({
+        p_data_source: 'tg',
+        p_team_id_filter: null,
+      }),
+    );
+  });
+
+  it('uses null team filters when public team values are omitted', async () => {
+    await searchDatasetJsonUuidMentions({
+      dataSource: 'tg',
+      sourceEntityKinds: ['flow'],
+      uuid: 'd1380000-0000-4000-8000-000000000001',
+    });
+
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      'search_dataset_json_uuid_mentions',
+      expect.objectContaining({
+        p_data_source: 'tg',
+        p_team_id_filter: null,
+      }),
+    );
+  });
+
+  it('returns early for invalid UUID or empty source kinds', async () => {
+    await expect(
+      searchDatasetJsonUuidMentions({
+        dataSource: 'my',
+        sourceEntityKinds: ['process'],
+        uuid: 'not-a-uuid',
+      }),
+    ).resolves.toEqual({ data: [], success: true });
+
+    await expect(
+      searchDatasetJsonUuidMentions({
+        dataSource: 'my',
+        sourceEntityKinds: [],
+        uuid: 'd1380000-0000-4000-8000-000000000001',
+      }),
+    ).resolves.toEqual({ data: [], success: true });
+
+    expect(supabaseMock.auth.getSession).not.toHaveBeenCalled();
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
+  it('skips team-data search when no current team can be resolved', async () => {
+    getTeamIdByUserIdMock.mockResolvedValue(null);
+
+    const result = await searchDatasetJsonUuidMentions({
+      dataSource: 'te',
+      sourceEntityKinds: ['flow'],
+      uuid: 'd1380000-0000-4000-8000-000000000001',
+    });
+
+    expect(result).toEqual({ data: [], success: true });
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
   it('does not call RPC without an authenticated session', async () => {
     supabaseMock.auth.getSession.mockResolvedValue({ data: { session: null } });
 
@@ -100,5 +189,49 @@ describe('datasetUuidMentionSearch service', () => {
 
     expect(result).toEqual({ data: [], error: 'not_authenticated', success: false });
     expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
+  it('uses an empty user id when the session user is missing', async () => {
+    supabaseMock.auth.getSession.mockResolvedValue({
+      data: { session: {} },
+    });
+
+    await searchDatasetJsonUuidMentions({
+      dataSource: 'my',
+      sourceEntityKinds: ['process'],
+      uuid: 'd1380000-0000-4000-8000-000000000001',
+    });
+
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      'search_dataset_json_uuid_mentions',
+      expect.objectContaining({
+        p_this_user_id: '',
+      }),
+    );
+  });
+
+  it('returns RPC errors and falls back to empty data when needed', async () => {
+    supabaseMock.rpc.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'rpc failed' },
+    });
+
+    await expect(
+      searchDatasetJsonUuidMentions({
+        dataSource: 'my',
+        sourceEntityKinds: ['process'],
+        uuid: 'd1380000-0000-4000-8000-000000000001',
+      }),
+    ).resolves.toEqual({ data: [], error: 'rpc failed', success: false });
+
+    supabaseMock.rpc.mockResolvedValueOnce({ data: undefined, error: null });
+
+    await expect(
+      searchDatasetJsonUuidMentions({
+        dataSource: 'my',
+        sourceEntityKinds: ['process'],
+        uuid: 'd1380000-0000-4000-8000-000000000001',
+      }),
+    ).resolves.toEqual({ data: [], success: true });
   });
 });


### PR DESCRIPTION
## Summary
- add a UUID-only “find data containing this ID” entry on dataset list pages
- call `search_dataset_json_uuid_mentions` with the current data source, team/state filters, and page entity kind
- keep ordinary keyword and hybrid searches unchanged; UUID deep JSON search only runs after the explicit action
- defer Supabase access until the action runs so list pages still render in test/bootstrap contexts

Closes #478

Depends on tiangong-lca/database-engine#139 for the RPC.

## Validation
- `npm run tsc`
- `npm run lint:js`
- `npm run jest -- tests/unit/services/datasetUuidMentionSearch.test.ts tests/unit/components/DatasetUuidMentionSearch.test.tsx --runInBand`
- `npm run jest -- tests/integration/sources/SourcesWorkflow.integration.test.tsx --runInBand`
- `npm run jest -- tests/unit/pages/Contacts/index.test.tsx tests/unit/pages/Flowproperties/index.test.tsx tests/unit/pages/Flows/index.test.tsx tests/unit/pages/LifeCycleModels/index.test.tsx tests/unit/pages/Processes/index.test.tsx --runInBand`
- pre-push gate via `git push -u fork feature/issue-478-json-uuid-deep-search`: `npm run docpact:gate`, `npm run lint`, `npm run test:coverage`, `npm run test:coverage:assert-full` (334 suites / 4084 tests, 100% coverage)