### PR TITLE
fix: repair v0.0.19 electron release

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-29"
-lastReviewedCommit: "d0fac07ab01d19d8ca82e925619928143f1c4eba"
+lastReviewedCommit: "95a711488dc2679f0307593865bce69b1b19996e"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,4 +185,4 @@ jobs:
         run: |
           npm run build
           npx tsc --project tsconfig.electron.json
-          npx electron-builder --config electron-builder.json --publish onTag --${{ matrix.arch }} -c.publish.provider=github -c.publish.releaseType=draft
+          npx electron-builder --config electron-builder.json --publish onTag --${{ matrix.arch }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: d0fac07ab01d19d8ca82e925619928143f1c4eba
+lastReviewedCommit: 5209b8678e0e942858f39919cbfd0a73c89cf60f
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 5de07dd8ffa76d39173b4a2c64ca6a4ddc548ec2
+lastReviewedCommit: 5209b8678e0e942858f39919cbfd0a73c89cf60f
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: d0fac07ab01d19d8ca82e925619928143f1c4eba
+lastReviewedCommit: 95a711488dc2679f0307593865bce69b1b19996e
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: d0fac07ab01d19d8ca82e925619928143f1c4eba
+lastReviewedCommit: 95a711488dc2679f0307593865bce69b1b19996e
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: d0fac07ab01d19d8ca82e925619928143f1c4eba
+lastReviewedCommit: 95a711488dc2679f0307593865bce69b1b19996e
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: d0fac07ab01d19d8ca82e925619928143f1c4eba
+lastReviewedCommit: 95a711488dc2679f0307593865bce69b1b19996e
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: d0fac07ab01d19d8ca82e925619928143f1c4eba
+lastReviewedCommit: 95a711488dc2679f0307593865bce69b1b19996e
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: d0fac07ab01d19d8ca82e925619928143f1c4eba
+lastReviewedCommit: 95a711488dc2679f0307593865bce69b1b19996e
 ---
 
 # Testing Troubleshooting

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -52,5 +52,9 @@
     "target": ["deb", "rpm"],
     "category": "Science",
     "icon": "./icons"
+  },
+  "publish": {
+    "provider": "github",
+    "releaseType": "draft"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
Closes #481

## Summary
- 修复 v0.0.19 发布流水线中 electron-builder publish 配置被误解析的问题。
- 将 package version 对齐到 0.0.19，避免 v0.0.19 Electron 资产仍显示 0.0.18。

## Key Decisions
- 把 publish.provider=github 和 publish.releaseType=draft 固化到 electron-builder.json，workflow 命令只保留 --config、--publish onTag 和架构参数。
- 本 PR 按生产 hotfix 流程直接回 main；合并后需要 main -> dev 回合并。

## Validation
- npm run build && npx tsc --project tsconfig.electron.json && npx electron-builder --config electron-builder.json --publish never --x64 --dir
- npm run docpact:gate
- git push fork hotfix/issue-481-release-v0.0.19 触发本地 pre-push gate 并通过：docpact、lint、test:coverage、test:coverage:assert-full；334 suites / 4084 tests passed，348/348 tracked source files 100% coverage。

## Risks / Rollback
- 当前远端 v0.0.19 tag 已存在并指向旧 main commit 0a108f07，旧 run 的 Web App deploy 成功但 Electron release 失败且未创建 GitHub Release。PR 合并后需要重新指向/重推 v0.0.19 tag 到新的 main commit，才能重新触发完整 release。

## Follow-ups
- PR 合并后重新触发 v0.0.19 发布，并确认 GitHub Release v0.0.19 draft 创建成功。
- 完成 main -> dev 回合并，保持 M2 hotfix 分支模型一致。

## Workspace Integration
- root workspace pointer 只有在需要记录 release snapshot 时再更新；本 hotfix 本身不直接改 root。