### PR TITLE
chore: promote dev to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-29"
-lastReviewedCommit: "e70ba456089ed8d36560eccf6804bf2fc273133d"
+lastReviewedCommit: "224fca96a652a087ef851787967628014f17e9d7"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-29"
-lastReviewedCommit: "224fca96a652a087ef851787967628014f17e9d7"
+lastReviewedAt: "2026-05-30"
+lastReviewedCommit: "ab4c20721106b32cb8a6cee77762278dd5a55dce"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-29"
-lastReviewedCommit: "95a711488dc2679f0307593865bce69b1b19996e"
+lastReviewedCommit: "e70ba456089ed8d36560eccf6804bf2fc273133d"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
+lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-29
-lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
+lastReviewedAt: 2026-05-30
+lastReviewedCommit: ab4c20721106b32cb8a6cee77762278dd5a55dce
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 5209b8678e0e942858f39919cbfd0a73c89cf60f
+lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-05-29
-lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
+lastReviewedAt: 2026-05-30
+lastReviewedCommit: ab4c20721106b32cb8a6cee77762278dd5a55dce
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 5209b8678e0e942858f39919cbfd0a73c89cf60f
+lastReviewedCommit: c90f5c23745b6d5ca58c2047bf4194987224d26c
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: c90f5c23745b6d5ca58c2047bf4194987224d26c
+lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
 ---
 
 # Development Bootstrap

--- a/docs/agents/contribution-path-analysis-design.md
+++ b/docs/agents/contribution-path-analysis-design.md
@@ -21,7 +21,7 @@ checkPaths:
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
+lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
 ---
 
 # Contribution Path Analysis Design

--- a/docs/agents/contribution-path-analysis-design.md
+++ b/docs/agents/contribution-path-analysis-design.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
+lastReviewedAt: 2026-05-29
+lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
 ---
 
 # Contribution Path Analysis Design

--- a/docs/agents/lca-analysis-visualization-plan.md
+++ b/docs/agents/lca-analysis-visualization-plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
+lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
 ---
 
 # LCA Analysis And Visualization Plan

--- a/docs/agents/lca-analysis-visualization-plan.md
+++ b/docs/agents/lca-analysis-visualization-plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
+lastReviewedAt: 2026-05-29
+lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
 ---
 
 # LCA Analysis And Visualization Plan

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
+lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.js
   - .github/workflows/**
-lastReviewedAt: 2026-05-29
-lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
+lastReviewedAt: 2026-05-30
+lastReviewedCommit: ab4c20721106b32cb8a6cee77762278dd5a55dce
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 95a711488dc2679f0307593865bce69b1b19996e
+lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-05-29
-lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
+lastReviewedAt: 2026-05-30
+lastReviewedCommit: ab4c20721106b32cb8a6cee77762278dd5a55dce
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: d0fac07ab01d19d8ca82e925619928143f1c4eba
+lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
+lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 95a711488dc2679f0307593865bce69b1b19996e
+lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-05-29
-lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
+lastReviewedAt: 2026-05-30
+lastReviewedCommit: ab4c20721106b32cb8a6cee77762278dd5a55dce
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
+lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -20,7 +20,7 @@ checkPaths:
   - src/services/**
   - docker/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
+lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -20,7 +20,7 @@ checkPaths:
   - src/services/**
   - docker/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: d0fac07ab01d19d8ca82e925619928143f1c4eba
+lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-05-29
-lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
+lastReviewedAt: 2026-05-30
+lastReviewedCommit: ab4c20721106b32cb8a6cee77762278dd5a55dce
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
+lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 95a711488dc2679f0307593865bce69b1b19996e
+lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-05-29
-lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
+lastReviewedAt: 2026-05-30
+lastReviewedCommit: ab4c20721106b32cb8a6cee77762278dd5a55dce
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
+lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 95a711488dc2679f0307593865bce69b1b19996e
+lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-05-29
-lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
+lastReviewedAt: 2026-05-30
+lastReviewedCommit: ab4c20721106b32cb8a6cee77762278dd5a55dce
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
+lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 95a711488dc2679f0307593865bce69b1b19996e
+lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-05-29
-lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
+lastReviewedAt: 2026-05-30
+lastReviewedCommit: ab4c20721106b32cb8a6cee77762278dd5a55dce
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
+lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 95a711488dc2679f0307593865bce69b1b19996e
+lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/util_calculate.md
+++ b/docs/agents/util_calculate.md
@@ -20,8 +20,8 @@ checkPaths:
   - src/services/lca/**
   - src/components/LcaTaskCenter/**
   - src/pages/Processes/Analysis/**
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: 9366a0891e16f64b5054c1f5e7bc76c37cb949a6
+lastReviewedAt: 2026-05-29
+lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
 ---
 
 # Lifecycle Model Calculation Reference

--- a/docs/agents/util_calculate.md
+++ b/docs/agents/util_calculate.md
@@ -21,7 +21,7 @@ checkPaths:
   - src/components/LcaTaskCenter/**
   - src/pages/Processes/Analysis/**
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: e70ba456089ed8d36560eccf6804bf2fc273133d
+lastReviewedCommit: 224fca96a652a087ef851787967628014f17e9d7
 ---
 
 # Lifecycle Model Calculation Reference

--- a/src/locales/en-US/pages_general.ts
+++ b/src/locales/en-US/pages_general.ts
@@ -81,11 +81,15 @@ export default {
   'pages.tab.title.co': 'Business Data',
 
   'pages.search.openAI': 'AI Recommendation',
+  'pages.search.referenceLookup': 'Reference Lookup',
   'pages.search.keyWord': 'Full-text search: Enter one or more keywords.',
   'pages.search.placeholder': 'AI Search: Describe the data you need in one sentence or a few key words.',
+  'pages.search.referenceLookup.placeholder': 'Reference Lookup: Enter a complete dataset UUID.',
   'pages.datasetUuidMention.empty': 'No data contains this ID',
   'pages.datasetUuidMention.entityKind': 'Data type',
   'pages.datasetUuidMention.error': 'Search failed. Try again later.',
+  'pages.datasetUuidMention.invalidUuid': 'Enter a complete dataset UUID before running Reference Lookup.',
+  'pages.datasetUuidMention.maxResults': 'Showing up to the first 50 reference lookup results.',
   'pages.datasetUuidMention.searchButton': 'Find data containing this ID',
 
   'pages.lifeCycleModel.drawer.title.create': 'Create Model',

--- a/src/locales/zh-CN/pages_general.ts
+++ b/src/locales/zh-CN/pages_general.ts
@@ -80,11 +80,15 @@ export default {
   'pages.tab.title.co': '商业数据',
 
   'pages.search.openAI': '智能推荐',
+  'pages.search.referenceLookup': '引用查找',
   'pages.search.keyWord': '全文检索：请输入一个或多个关键词。',
   'pages.search.placeholder': '智能查询：用一句话或几个关键词描述您所需要的数据。',
+  'pages.search.referenceLookup.placeholder': '引用查找：请输入完整的数据集 UUID。',
   'pages.datasetUuidMention.empty': '没有找到包含该 ID 的数据',
   'pages.datasetUuidMention.entityKind': '数据类型',
   'pages.datasetUuidMention.error': '查找失败，请稍后重试',
+  'pages.datasetUuidMention.invalidUuid': '请输入完整的数据集 UUID 后再进行引用查找。',
+  'pages.datasetUuidMention.maxResults': '最多展示前 50 条引用查找结果。',
   'pages.datasetUuidMention.searchButton': '查找包含该 ID 的数据',
 
   'pages.lifeCycleModel.drawer.title.create': '创建模型',

--- a/src/pages/Contacts/index.tsx
+++ b/src/pages/Contacts/index.tsx
@@ -4,7 +4,6 @@ import {
   extractContributeDataError,
   getContributeDataErrorMessage,
 } from '@/components/ContributeData/utils';
-import DatasetUuidMentionSearch from '@/components/DatasetUuidMentionSearch';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
 import {
@@ -16,12 +15,17 @@ import {
   dataListTextColumn,
   responsiveDataListTableProps,
   responsiveSearchCardClassName,
+  responsiveSearchExtraColProps,
   responsiveSearchPrimaryColProps,
   responsiveSearchRowProps,
   useResponsiveDataListMobile,
 } from '@/components/ResponsiveDataList';
 import TableFilter from '@/components/TableFilter';
-import { getContactTableAll, getContactTablePgroongaSearch } from '@/services/contacts/api';
+import {
+  getContactTableAll,
+  getContactTablePgroongaSearch,
+  getContactTableUuidMentionSearch,
+} from '@/services/contacts/api';
 import { ContactImportData, ContactTable } from '@/services/contacts/data';
 import { attachStateCodesToRows, contributeSource } from '@/services/general/api';
 import { ListPagination } from '@/services/general/data';
@@ -29,12 +33,18 @@ import { getDataSource, getLang, getLangText, isDataUnderReview } from '@/servic
 import { getTeamById } from '@/services/teams/api';
 import { TeamTable } from '@/services/teams/data';
 import { ActionType, PageContainer, ProColumns, ProTable } from '@ant-design/pro-components';
-import { Card, Col, Input, Row, Space, message } from 'antd';
+import { Card, Checkbox, Col, Input, Row, Space, message } from 'antd';
 import { SearchProps } from 'antd/es/input/Search';
 import type { FC, MutableRefObject } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl, useLocation } from 'umi';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
+import {
+  getReferenceLookupEmptyResult,
+  getReferenceLookupUuid,
+  showInvalidReferenceLookupUuidMessage,
+  showReferenceLookupLimitMessage,
+} from '../Utils/referenceLookup';
 import ContactCreate from './Components/create';
 import ContactDelete from './Components/delete';
 import ContactEdit from './Components/edit';
@@ -46,6 +56,7 @@ const TableList: FC = () => {
   const [keyWord, setKeyWord] = useState<string>('');
   const [team, setTeam] = useState<TeamTable | null>(null);
   const [importData, setImportData] = useState<ContactImportData | null>(null);
+  const [referenceLookup, setReferenceLookup] = useState<boolean>(false);
   const [editDrawerVisible, setEditDrawerVisible] = useState<boolean>(false);
   const [editId, setEditId] = useState<string>('');
   const [editVersion, setEditVersion] = useState<string>('');
@@ -66,6 +77,7 @@ const TableList: FC = () => {
   const actionRef = useRef<ActionType>();
   const stateCodeRef = useRef<string | number>('all');
   const keyWordRef = useRef<string>('');
+  const referenceLookupLimitNoticeRef = useRef<string>('');
   const attachReviewState = async (result: {
     data?: ContactTable[];
     page?: number;
@@ -305,6 +317,9 @@ const TableList: FC = () => {
     keyWordRef.current = value;
     setKeyWord(value);
     actionRef.current?.setPageInfo?.({ current: 1 });
+    if (referenceLookup && !getReferenceLookupUuid(value)) {
+      showInvalidReferenceLookupUuidMessage(intl);
+    }
     actionRef.current?.reload();
   };
 
@@ -324,19 +339,27 @@ const TableList: FC = () => {
           <Col {...responsiveSearchPrimaryColProps}>
             <Search
               size={'large'}
-              placeholder={intl.formatMessage({ id: 'pages.search.keyWord' })}
+              placeholder={intl.formatMessage({
+                id: referenceLookup
+                  ? 'pages.search.referenceLookup.placeholder'
+                  : 'pages.search.keyWord',
+              })}
               onSearch={onSearch}
               enterButton
             />
           </Col>
+          <Col {...responsiveSearchExtraColProps}>
+            <Checkbox
+              checked={referenceLookup}
+              onChange={(e) => setReferenceLookup(e.target.checked)}
+            >
+              <FormattedMessage
+                id='pages.search.referenceLookup'
+                defaultMessage='Reference Lookup'
+              />
+            </Checkbox>
+          </Col>
         </Row>
-        <DatasetUuidMentionSearch
-          dataSource={dataSource}
-          getStateCodeFilter={() => stateCodeRef.current}
-          queryText={keyWord}
-          sourceEntityKinds={['contact']}
-          teamId={tid}
-        />
       </Card>
       <ProTable<ContactTable, ListPagination>
         {...responsiveDataListTableProps}
@@ -387,8 +410,31 @@ const TableList: FC = () => {
           },
           sort,
         ) => {
-          const currentKeyWord = keyWordRef.current;
+          const currentKeyWord = keyWordRef.current || keyWord;
           const currentStateCode = stateCodeRef.current;
+          if (referenceLookup) {
+            const referenceLookupUuid = getReferenceLookupUuid(currentKeyWord);
+            if (!referenceLookupUuid) {
+              return attachReviewState(getReferenceLookupEmptyResult(params.current));
+            }
+
+            const result = await getContactTableUuidMentionSearch(
+              params,
+              lang,
+              dataSource,
+              referenceLookupUuid,
+              currentStateCode,
+              tid ?? '',
+            );
+            const noticeKey = [dataSource, referenceLookupUuid, currentStateCode, tid ?? ''].join(
+              ':',
+            );
+            if (result.capped && referenceLookupLimitNoticeRef.current !== noticeKey) {
+              referenceLookupLimitNoticeRef.current = noticeKey;
+              showReferenceLookupLimitMessage(intl);
+            }
+            return attachReviewState(result);
+          }
           if (currentKeyWord.length > 0) {
             return attachReviewState(
               await getContactTablePgroongaSearch(

--- a/src/pages/Contacts/index.tsx
+++ b/src/pages/Contacts/index.tsx
@@ -41,6 +41,7 @@ import { FormattedMessage, useIntl, useLocation } from 'umi';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
 import {
   getReferenceLookupEmptyResult,
+  getReferenceLookupPaginationProps,
   getReferenceLookupTeamId,
   getReferenceLookupUuid,
   showInvalidReferenceLookupUuidMessage,
@@ -377,6 +378,7 @@ const TableList: FC = () => {
         pagination={{
           showSizeChanger: false,
           pageSize: 10,
+          ...getReferenceLookupPaginationProps(referenceLookup),
         }}
         toolBarRender={() => {
           if (dataSource === 'my') {

--- a/src/pages/Contacts/index.tsx
+++ b/src/pages/Contacts/index.tsx
@@ -41,6 +41,7 @@ import { FormattedMessage, useIntl, useLocation } from 'umi';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
 import {
   getReferenceLookupEmptyResult,
+  getReferenceLookupTeamId,
   getReferenceLookupUuid,
   showInvalidReferenceLookupUuidMessage,
   showReferenceLookupLimitMessage,
@@ -417,6 +418,7 @@ const TableList: FC = () => {
             if (!referenceLookupUuid) {
               return attachReviewState(getReferenceLookupEmptyResult(params.current));
             }
+            const referenceLookupTeamId = getReferenceLookupTeamId(tid);
 
             const result = await getContactTableUuidMentionSearch(
               params,
@@ -424,11 +426,14 @@ const TableList: FC = () => {
               dataSource,
               referenceLookupUuid,
               currentStateCode,
-              tid ?? '',
+              referenceLookupTeamId,
             );
-            const noticeKey = [dataSource, referenceLookupUuid, currentStateCode, tid ?? ''].join(
-              ':',
-            );
+            const noticeKey = [
+              dataSource,
+              referenceLookupUuid,
+              currentStateCode,
+              referenceLookupTeamId,
+            ].join(':');
             if (result.capped && referenceLookupLimitNoticeRef.current !== noticeKey) {
               referenceLookupLimitNoticeRef.current = noticeKey;
               showReferenceLookupLimitMessage(intl);

--- a/src/pages/Flowproperties/index.tsx
+++ b/src/pages/Flowproperties/index.tsx
@@ -1,6 +1,7 @@
 import {
   getFlowpropertyTableAll,
   getFlowpropertyTablePgroongaSearch,
+  getFlowpropertyTableUuidMentionSearch,
 } from '@/services/flowproperties/api';
 import { FlowpropertyImportData, FlowpropertyTable } from '@/services/flowproperties/data';
 import { attachStateCodesToRows, contributeSource } from '@/services/general/api';
@@ -14,7 +15,7 @@ import {
 } from '@/services/general/util';
 import { TeamTable } from '@/services/teams/data';
 import { ActionType, PageContainer, ProColumns, ProTable } from '@ant-design/pro-components';
-import { Card, Col, Input, Row, Space, Tooltip, message } from 'antd';
+import { Card, Checkbox, Col, Input, Row, Space, Tooltip, message } from 'antd';
 import type { FC, MutableRefObject } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl, useLocation } from 'umi';
@@ -25,7 +26,6 @@ import {
   extractContributeDataError,
   getContributeDataErrorMessage,
 } from '@/components/ContributeData/utils';
-import DatasetUuidMentionSearch from '@/components/DatasetUuidMentionSearch';
 import { getTeamById } from '@/services/teams/api';
 import { SearchProps } from 'antd/es/input/Search';
 // import ReferenceUnit from '../Unitgroups/Components/Unit/reference';
@@ -41,12 +41,19 @@ import {
   dataListTextColumn,
   responsiveDataListTableProps,
   responsiveSearchCardClassName,
+  responsiveSearchExtraColProps,
   responsiveSearchPrimaryColProps,
   responsiveSearchRowProps,
   useResponsiveDataListMobile,
 } from '@/components/ResponsiveDataList';
 import TableFilter from '@/components/TableFilter';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
+import {
+  getReferenceLookupEmptyResult,
+  getReferenceLookupUuid,
+  showInvalidReferenceLookupUuidMessage,
+  showReferenceLookupLimitMessage,
+} from '../Utils/referenceLookup';
 import FlowpropertiesCreate from './Components/create';
 import FlowpropertiesDelete from './Components/delete';
 import FlowpropertiesEdit from './Components/edit';
@@ -59,6 +66,7 @@ const TableList: FC = () => {
   const [, setStateCode] = useState<string | number>('all');
   const [team, setTeam] = useState<TeamTable | null>(null);
   const [importData, setImportData] = useState<FlowpropertyImportData | null>(null);
+  const [referenceLookup, setReferenceLookup] = useState<boolean>(false);
   const [editDrawerVisible, setEditDrawerVisible] = useState<boolean>(false);
   const [editId, setEditId] = useState<string>('');
   const [editVersion, setEditVersion] = useState<string>('');
@@ -79,6 +87,7 @@ const TableList: FC = () => {
   const actionRef = useRef<ActionType>();
   const keyWordRef = useRef<string>('');
   const stateCodeRef = useRef<string | number>('all');
+  const referenceLookupLimitNoticeRef = useRef<string>('');
   const attachReviewState = async (result: {
     data?: FlowpropertyTable[];
     page?: number;
@@ -348,6 +357,9 @@ const TableList: FC = () => {
     keyWordRef.current = value;
     setKeyWord(value);
     actionRef.current?.setPageInfo?.({ current: 1 });
+    if (referenceLookup && !getReferenceLookupUuid(value)) {
+      showInvalidReferenceLookupUuidMessage(intl);
+    }
     actionRef.current?.reload();
   };
   const handleImportData = (jsonData: FlowpropertyImportData) => {
@@ -365,19 +377,27 @@ const TableList: FC = () => {
           <Col {...responsiveSearchPrimaryColProps}>
             <Search
               size={'large'}
-              placeholder={intl.formatMessage({ id: 'pages.search.keyWord' })}
+              placeholder={intl.formatMessage({
+                id: referenceLookup
+                  ? 'pages.search.referenceLookup.placeholder'
+                  : 'pages.search.keyWord',
+              })}
               onSearch={onSearch}
               enterButton
             />
           </Col>
+          <Col {...responsiveSearchExtraColProps}>
+            <Checkbox
+              checked={referenceLookup}
+              onChange={(e) => setReferenceLookup(e.target.checked)}
+            >
+              <FormattedMessage
+                id='pages.search.referenceLookup'
+                defaultMessage='Reference Lookup'
+              />
+            </Checkbox>
+          </Col>
         </Row>
-        <DatasetUuidMentionSearch
-          dataSource={dataSource}
-          getStateCodeFilter={() => stateCodeRef.current}
-          queryText={keyWord}
-          sourceEntityKinds={['flowproperty']}
-          teamId={tid}
-        />
       </Card>
       <ProTable<FlowpropertyTable, ListPagination>
         {...responsiveDataListTableProps}
@@ -431,6 +451,29 @@ const TableList: FC = () => {
         ) => {
           const currentKeyWord = keyWordRef.current || keyWord;
           const currentStateCode = stateCodeRef.current;
+          if (referenceLookup) {
+            const referenceLookupUuid = getReferenceLookupUuid(currentKeyWord);
+            if (!referenceLookupUuid) {
+              return attachRefUnitData(getReferenceLookupEmptyResult(params.current));
+            }
+
+            const result = await getFlowpropertyTableUuidMentionSearch(
+              params,
+              lang,
+              dataSource,
+              referenceLookupUuid,
+              currentStateCode,
+              tid ?? '',
+            );
+            const noticeKey = [dataSource, referenceLookupUuid, currentStateCode, tid ?? ''].join(
+              ':',
+            );
+            if (result.capped && referenceLookupLimitNoticeRef.current !== noticeKey) {
+              referenceLookupLimitNoticeRef.current = noticeKey;
+              showReferenceLookupLimitMessage(intl);
+            }
+            return attachRefUnitData(result);
+          }
           if (currentKeyWord.length > 0) {
             return attachRefUnitData(
               await getFlowpropertyTablePgroongaSearch(

--- a/src/pages/Flowproperties/index.tsx
+++ b/src/pages/Flowproperties/index.tsx
@@ -50,6 +50,7 @@ import TableFilter from '@/components/TableFilter';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
 import {
   getReferenceLookupEmptyResult,
+  getReferenceLookupTeamId,
   getReferenceLookupUuid,
   showInvalidReferenceLookupUuidMessage,
   showReferenceLookupLimitMessage,
@@ -456,6 +457,7 @@ const TableList: FC = () => {
             if (!referenceLookupUuid) {
               return attachRefUnitData(getReferenceLookupEmptyResult(params.current));
             }
+            const referenceLookupTeamId = getReferenceLookupTeamId(tid);
 
             const result = await getFlowpropertyTableUuidMentionSearch(
               params,
@@ -463,11 +465,14 @@ const TableList: FC = () => {
               dataSource,
               referenceLookupUuid,
               currentStateCode,
-              tid ?? '',
+              referenceLookupTeamId,
             );
-            const noticeKey = [dataSource, referenceLookupUuid, currentStateCode, tid ?? ''].join(
-              ':',
-            );
+            const noticeKey = [
+              dataSource,
+              referenceLookupUuid,
+              currentStateCode,
+              referenceLookupTeamId,
+            ].join(':');
             if (result.capped && referenceLookupLimitNoticeRef.current !== noticeKey) {
               referenceLookupLimitNoticeRef.current = noticeKey;
               showReferenceLookupLimitMessage(intl);

--- a/src/pages/Flowproperties/index.tsx
+++ b/src/pages/Flowproperties/index.tsx
@@ -50,6 +50,7 @@ import TableFilter from '@/components/TableFilter';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
 import {
   getReferenceLookupEmptyResult,
+  getReferenceLookupPaginationProps,
   getReferenceLookupTeamId,
   getReferenceLookupUuid,
   showInvalidReferenceLookupUuidMessage,
@@ -415,6 +416,7 @@ const TableList: FC = () => {
         pagination={{
           showSizeChanger: false,
           pageSize: 10,
+          ...getReferenceLookupPaginationProps(referenceLookup),
         }}
         toolBarRender={() => {
           if (dataSource === 'my') {

--- a/src/pages/Flows/index.tsx
+++ b/src/pages/Flows/index.tsx
@@ -45,6 +45,7 @@ import type { FC, ReactNode } from 'react';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
 import {
   getReferenceLookupEmptyResult,
+  getReferenceLookupPaginationProps,
   getReferenceLookupTeamId,
   getReferenceLookupUuid,
   showInvalidReferenceLookupUuidMessage,
@@ -495,6 +496,7 @@ const TableList: FC = () => {
         pagination={{
           showSizeChanger: false,
           pageSize: 10,
+          ...getReferenceLookupPaginationProps(referenceLookup),
         }}
         toolBarRender={() => {
           if (dataSource === 'my') {

--- a/src/pages/Flows/index.tsx
+++ b/src/pages/Flows/index.tsx
@@ -2,6 +2,7 @@ import {
   flow_hybrid_search,
   getFlowTableAll,
   getFlowTablePgroongaSearch,
+  getFlowTableUuidMentionSearch,
 } from '@/services/flows/api';
 import { Card, Checkbox, Col, Input, Row, Space, message } from 'antd';
 import { useEffect, useRef, useState } from 'react';
@@ -13,7 +14,6 @@ import {
   extractContributeDataError,
   getContributeDataErrorMessage,
 } from '@/components/ContributeData/utils';
-import DatasetUuidMentionSearch from '@/components/DatasetUuidMentionSearch';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
 import {
@@ -43,6 +43,12 @@ import { SearchProps } from 'antd/es/input/Search';
 import type { SortOrder } from 'antd/lib/table/interface';
 import type { FC, ReactNode } from 'react';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
+import {
+  getReferenceLookupEmptyResult,
+  getReferenceLookupUuid,
+  showInvalidReferenceLookupUuidMessage,
+  showReferenceLookupLimitMessage,
+} from '../Utils/referenceLookup';
 import FlowsCreate from './Components/create';
 import FlowsDelete from './Components/delete';
 import FlowsEdit from './Components/edit';
@@ -60,6 +66,7 @@ const TableList: FC = () => {
   const [team, setTeam] = useState<TeamTable | null>(null);
   const [importData, setImportData] = useState<FlowImportData | null>(null);
   const [openAI, setOpenAI] = useState<boolean>(false);
+  const [referenceLookup, setReferenceLookup] = useState<boolean>(false);
   const [editDrawerVisible, setEditDrawerVisible] = useState<boolean>(false);
   const [editId, setEditId] = useState<string>('');
   const [editVersion, setEditVersion] = useState<string>('');
@@ -81,6 +88,7 @@ const TableList: FC = () => {
   const lang = getLang(intl.locale);
   const keyWordRef = useRef<string>('');
   const stateCodeRef = useRef<string | number>('all');
+  const referenceLookupLimitNoticeRef = useRef<string>('');
 
   const parseClassificationFilter = (
     values?: (string | number | boolean)[] | null,
@@ -411,6 +419,9 @@ const TableList: FC = () => {
     keyWordRef.current = value;
     setKeyWord(value);
     actionRef.current?.setPageInfo?.({ current: 1 });
+    if (referenceLookup && !getReferenceLookupUuid(value)) {
+      showInvalidReferenceLookupUuidMessage(intl);
+    }
     actionRef.current?.reload();
   };
   const handleImportData = (jsonData: FlowImportData) => {
@@ -429,9 +440,11 @@ const TableList: FC = () => {
             <Search
               size={'large'}
               placeholder={
-                openAI
-                  ? intl.formatMessage({ id: 'pages.search.placeholder' })
-                  : intl.formatMessage({ id: 'pages.search.keyWord' })
+                referenceLookup
+                  ? intl.formatMessage({ id: 'pages.search.referenceLookup.placeholder' })
+                  : openAI
+                    ? intl.formatMessage({ id: 'pages.search.placeholder' })
+                    : intl.formatMessage({ id: 'pages.search.keyWord' })
               }
               onSearch={onSearch}
               enterButton
@@ -439,21 +452,32 @@ const TableList: FC = () => {
           </Col>
           <Col {...responsiveSearchExtraColProps}>
             <Checkbox
+              checked={openAI}
               onChange={(e) => {
                 setOpenAI(e.target.checked);
+                if (e.target.checked) {
+                  setReferenceLookup(false);
+                }
               }}
             >
               <FormattedMessage id='pages.search.openAI' defaultMessage='AI Search' />
             </Checkbox>
+            <Checkbox
+              checked={referenceLookup}
+              onChange={(e) => {
+                setReferenceLookup(e.target.checked);
+                if (e.target.checked) {
+                  setOpenAI(false);
+                }
+              }}
+            >
+              <FormattedMessage
+                id='pages.search.referenceLookup'
+                defaultMessage='Reference Lookup'
+              />
+            </Checkbox>
           </Col>
         </Row>
-        <DatasetUuidMentionSearch
-          dataSource={dataSource}
-          getStateCodeFilter={() => stateCodeRef.current}
-          queryText={keyWord}
-          sourceEntityKinds={['flow']}
-          teamId={tid}
-        />
       </Card>
       <ProTable<FlowTable, ListPagination>
         {...responsiveDataListTableProps}
@@ -514,6 +538,33 @@ const TableList: FC = () => {
             flowType: flowTypeFilter,
             ...(classificationFilter.length > 0 ? { classification: classificationFilter } : {}),
           };
+          if (referenceLookup) {
+            const referenceLookupUuid = getReferenceLookupUuid(currentKeyWord);
+            if (!referenceLookupUuid) {
+              return attachReviewState(getReferenceLookupEmptyResult(params.current));
+            }
+
+            const result = await getFlowTableUuidMentionSearch(
+              params,
+              lang,
+              dataSource,
+              referenceLookupUuid,
+              currentStateCode,
+              tid ?? '',
+            );
+            const noticeKey = [
+              dataSource,
+              referenceLookupUuid,
+              currentStateCode,
+              JSON.stringify(searchFilters),
+              tid ?? '',
+            ].join(':');
+            if (result.capped && referenceLookupLimitNoticeRef.current !== noticeKey) {
+              referenceLookupLimitNoticeRef.current = noticeKey;
+              showReferenceLookupLimitMessage(intl);
+            }
+            return attachReviewState(result);
+          }
           if (currentKeyWord.length > 0) {
             let orderBy:
               | { key: 'common:class' | 'baseName'; lang?: 'en' | 'zh'; order: 'asc' | 'desc' }

--- a/src/pages/Flows/index.tsx
+++ b/src/pages/Flows/index.tsx
@@ -45,6 +45,7 @@ import type { FC, ReactNode } from 'react';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
 import {
   getReferenceLookupEmptyResult,
+  getReferenceLookupTeamId,
   getReferenceLookupUuid,
   showInvalidReferenceLookupUuidMessage,
   showReferenceLookupLimitMessage,
@@ -543,6 +544,7 @@ const TableList: FC = () => {
             if (!referenceLookupUuid) {
               return attachReviewState(getReferenceLookupEmptyResult(params.current));
             }
+            const referenceLookupTeamId = getReferenceLookupTeamId(tid);
 
             const result = await getFlowTableUuidMentionSearch(
               params,
@@ -550,14 +552,14 @@ const TableList: FC = () => {
               dataSource,
               referenceLookupUuid,
               currentStateCode,
-              tid ?? '',
+              referenceLookupTeamId,
             );
             const noticeKey = [
               dataSource,
               referenceLookupUuid,
               currentStateCode,
               JSON.stringify(searchFilters),
-              tid ?? '',
+              referenceLookupTeamId,
             ].join(':');
             if (result.capped && referenceLookupLimitNoticeRef.current !== noticeKey) {
               referenceLookupLimitNoticeRef.current = noticeKey;

--- a/src/pages/LifeCycleModels/index.tsx
+++ b/src/pages/LifeCycleModels/index.tsx
@@ -46,6 +46,7 @@ import { FormattedMessage, useIntl, useLocation } from 'umi';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
 import {
   getReferenceLookupEmptyResult,
+  getReferenceLookupPaginationProps,
   getReferenceLookupTeamId,
   getReferenceLookupUuid,
   showInvalidReferenceLookupUuidMessage,
@@ -407,6 +408,7 @@ const TableList: FC = () => {
         pagination={{
           showSizeChanger: false,
           pageSize: 10,
+          ...getReferenceLookupPaginationProps(referenceLookup),
         }}
         toolBarRender={() => {
           if (dataSource === 'my') {

--- a/src/pages/LifeCycleModels/index.tsx
+++ b/src/pages/LifeCycleModels/index.tsx
@@ -4,7 +4,6 @@ import {
   extractContributeDataError,
   getContributeDataErrorMessage,
 } from '@/components/ContributeData/utils';
-import DatasetUuidMentionSearch from '@/components/DatasetUuidMentionSearch';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
 import {
@@ -29,6 +28,7 @@ import {
   contributeLifeCycleModel,
   getLifeCycleModelTableAll,
   getLifeCycleModelTablePgroongaSearch,
+  getLifeCycleModelTableUuidMentionSearch,
   lifeCycleModel_hybrid_search,
 } from '@/services/lifeCycleModels/api';
 import type {
@@ -44,6 +44,12 @@ import type { FC } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl, useLocation } from 'umi';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
+import {
+  getReferenceLookupEmptyResult,
+  getReferenceLookupUuid,
+  showInvalidReferenceLookupUuidMessage,
+  showReferenceLookupLimitMessage,
+} from '../Utils/referenceLookup';
 import LifeCycleModelCreate from './Components/create';
 import LifeCycleModelDelete from './Components/delete';
 import LifeCycleModelEdit from './Components/edit';
@@ -56,6 +62,7 @@ const TableList: FC = () => {
   const [team, setTeam] = useState<TeamTable | null>(null);
   const [importData, setImportData] = useState<LifeCycleModelImportData | null>(null);
   const [openAI, setOpenAI] = useState<boolean>(false);
+  const [referenceLookup, setReferenceLookup] = useState<boolean>(false);
   const [editDrawerVisible, setEditDrawerVisible] = useState<boolean>(false);
   const [viewDrawerVisible, setViewDrawerVisible] = useState<boolean>(false);
   const [editId, setEditId] = useState<string>('');
@@ -78,6 +85,7 @@ const TableList: FC = () => {
   const actionRef = useRef<ActionType>();
   const keyWordRef = useRef('');
   const stateCodeRef = useRef<string | number>('all');
+  const referenceLookupLimitNoticeRef = useRef<string>('');
   const attachReviewState = async (result: {
     data?: LifeCycleModelTable[];
     page?: number;
@@ -314,6 +322,9 @@ const TableList: FC = () => {
     keyWordRef.current = value;
     setKeyWord(value);
     actionRef.current?.setPageInfo?.({ current: 1 });
+    if (referenceLookup && !getReferenceLookupUuid(value)) {
+      showInvalidReferenceLookupUuidMessage(intl);
+    }
     actionRef.current?.reload();
   };
 
@@ -341,9 +352,11 @@ const TableList: FC = () => {
             <Search
               size={'large'}
               placeholder={
-                openAI
-                  ? intl.formatMessage({ id: 'pages.search.placeholder' })
-                  : intl.formatMessage({ id: 'pages.search.keyWord' })
+                referenceLookup
+                  ? intl.formatMessage({ id: 'pages.search.referenceLookup.placeholder' })
+                  : openAI
+                    ? intl.formatMessage({ id: 'pages.search.placeholder' })
+                    : intl.formatMessage({ id: 'pages.search.keyWord' })
               }
               onSearch={onSearch}
               enterButton
@@ -351,21 +364,32 @@ const TableList: FC = () => {
           </Col>
           <Col {...responsiveSearchExtraColProps}>
             <Checkbox
+              checked={openAI}
               onChange={(e) => {
                 setOpenAI(e.target.checked);
+                if (e.target.checked) {
+                  setReferenceLookup(false);
+                }
               }}
             >
               <FormattedMessage id='pages.search.openAI' defaultMessage='AI Search' />
             </Checkbox>
+            <Checkbox
+              checked={referenceLookup}
+              onChange={(e) => {
+                setReferenceLookup(e.target.checked);
+                if (e.target.checked) {
+                  setOpenAI(false);
+                }
+              }}
+            >
+              <FormattedMessage
+                id='pages.search.referenceLookup'
+                defaultMessage='Reference Lookup'
+              />
+            </Checkbox>
           </Col>
         </Row>
-        <DatasetUuidMentionSearch
-          dataSource={dataSource}
-          getStateCodeFilter={() => stateCodeRef.current}
-          queryText={keyWord}
-          sourceEntityKinds={['lifecyclemodel']}
-          teamId={tid}
-        />
       </Card>
       <ProTable<LifeCycleModelTable, ListPagination>
         {...responsiveDataListTableProps}
@@ -420,6 +444,29 @@ const TableList: FC = () => {
         ) => {
           const currentKeyWord = keyWordRef.current || keyWord;
           const currentStateCode = stateCodeRef.current;
+          if (referenceLookup) {
+            const referenceLookupUuid = getReferenceLookupUuid(currentKeyWord);
+            if (!referenceLookupUuid) {
+              return attachReviewState(getReferenceLookupEmptyResult(params.current));
+            }
+
+            const result = await getLifeCycleModelTableUuidMentionSearch(
+              params,
+              lang,
+              dataSource,
+              referenceLookupUuid,
+              currentStateCode,
+              tid ?? '',
+            );
+            const noticeKey = [dataSource, referenceLookupUuid, currentStateCode, tid ?? ''].join(
+              ':',
+            );
+            if (result.capped && referenceLookupLimitNoticeRef.current !== noticeKey) {
+              referenceLookupLimitNoticeRef.current = noticeKey;
+              showReferenceLookupLimitMessage(intl);
+            }
+            return attachReviewState(result);
+          }
           if (currentKeyWord.length > 0) {
             let orderBy:
               | { key: 'common:class' | 'baseName'; lang?: 'en' | 'zh'; order: 'asc' | 'desc' }

--- a/src/pages/LifeCycleModels/index.tsx
+++ b/src/pages/LifeCycleModels/index.tsx
@@ -46,6 +46,7 @@ import { FormattedMessage, useIntl, useLocation } from 'umi';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
 import {
   getReferenceLookupEmptyResult,
+  getReferenceLookupTeamId,
   getReferenceLookupUuid,
   showInvalidReferenceLookupUuidMessage,
   showReferenceLookupLimitMessage,
@@ -449,6 +450,7 @@ const TableList: FC = () => {
             if (!referenceLookupUuid) {
               return attachReviewState(getReferenceLookupEmptyResult(params.current));
             }
+            const referenceLookupTeamId = getReferenceLookupTeamId(tid);
 
             const result = await getLifeCycleModelTableUuidMentionSearch(
               params,
@@ -456,11 +458,14 @@ const TableList: FC = () => {
               dataSource,
               referenceLookupUuid,
               currentStateCode,
-              tid ?? '',
+              referenceLookupTeamId,
             );
-            const noticeKey = [dataSource, referenceLookupUuid, currentStateCode, tid ?? ''].join(
-              ':',
-            );
+            const noticeKey = [
+              dataSource,
+              referenceLookupUuid,
+              currentStateCode,
+              referenceLookupTeamId,
+            ].join(':');
             if (result.capped && referenceLookupLimitNoticeRef.current !== noticeKey) {
               referenceLookupLimitNoticeRef.current = noticeKey;
               showReferenceLookupLimitMessage(intl);

--- a/src/pages/Processes/index.tsx
+++ b/src/pages/Processes/index.tsx
@@ -3,6 +3,7 @@ import {
   contributeProcess,
   getProcessTableAll,
   getProcessTablePgroongaSearch,
+  getProcessTableUuidMentionSearch,
   process_hybrid_search,
 } from '@/services/processes/api';
 import { BarChartOutlined } from '@ant-design/icons';
@@ -17,7 +18,6 @@ import {
   extractContributeDataError,
   getContributeDataErrorMessage,
 } from '@/components/ContributeData/utils';
-import DatasetUuidMentionSearch from '@/components/DatasetUuidMentionSearch';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
 import {
@@ -51,6 +51,12 @@ import { SearchProps } from 'antd/es/input/Search';
 import type { SortOrder } from 'antd/es/table/interface';
 import type { FC, ReactElement } from 'react';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
+import {
+  getReferenceLookupEmptyResult,
+  getReferenceLookupUuid,
+  showInvalidReferenceLookupUuidMessage,
+  showReferenceLookupLimitMessage,
+} from '../Utils/referenceLookup';
 import ProcessCreate from './Components/create';
 import ProcessDelete from './Components/delete';
 import ProcessEdit from './Components/edit';
@@ -73,6 +79,7 @@ const TableList: FC = () => {
   const [team, setTeam] = useState<TeamTable | null>(null);
   const [importData, setImportData] = useState<ProcessImportData | null>(null);
   const [openAI, setOpenAI] = useState<boolean>(false);
+  const [referenceLookup, setReferenceLookup] = useState<boolean>(false);
   const [editDrawerVisible, setEditDrawerVisible] = useState<boolean>(false);
   const [viewDrawerVisible, setViewDrawerVisible] = useState<boolean>(false);
   const [editId, setEditId] = useState<string>('');
@@ -111,6 +118,7 @@ const TableList: FC = () => {
   const keyWordRef = useRef('');
   const stateCodeRef = useRef<string | number>('all');
   const typeOfDataSetRef = useRef<string>('all');
+  const referenceLookupLimitNoticeRef = useRef<string>('');
   const typeOfDataSetFilter = (width: number) => {
     const onChange = (value: string) => {
       typeOfDataSetRef.current = value;
@@ -485,6 +493,9 @@ const TableList: FC = () => {
     keyWordRef.current = value;
     setKeyWord(value);
     actionRef.current?.setPageInfo?.({ current: 1 });
+    if (referenceLookup && !getReferenceLookupUuid(value)) {
+      showInvalidReferenceLookupUuidMessage(intl);
+    }
     actionRef.current?.reload();
   };
   const handleImportData = (jsonData: ProcessImportData) => {
@@ -513,9 +524,11 @@ const TableList: FC = () => {
             <Search
               size={'large'}
               placeholder={
-                openAI
-                  ? intl.formatMessage({ id: 'pages.search.placeholder' })
-                  : intl.formatMessage({ id: 'pages.search.keyWord' })
+                referenceLookup
+                  ? intl.formatMessage({ id: 'pages.search.referenceLookup.placeholder' })
+                  : openAI
+                    ? intl.formatMessage({ id: 'pages.search.placeholder' })
+                    : intl.formatMessage({ id: 'pages.search.keyWord' })
               }
               onSearch={onSearch}
               enterButton
@@ -523,21 +536,32 @@ const TableList: FC = () => {
           </Col>
           <Col {...responsiveSearchExtraColProps}>
             <Checkbox
+              checked={openAI}
               onChange={(e) => {
                 setOpenAI(e.target.checked);
+                if (e.target.checked) {
+                  setReferenceLookup(false);
+                }
               }}
             >
               <FormattedMessage id='pages.search.openAI' defaultMessage='AI Search' />
             </Checkbox>
+            <Checkbox
+              checked={referenceLookup}
+              onChange={(e) => {
+                setReferenceLookup(e.target.checked);
+                if (e.target.checked) {
+                  setOpenAI(false);
+                }
+              }}
+            >
+              <FormattedMessage
+                id='pages.search.referenceLookup'
+                defaultMessage='Reference Lookup'
+              />
+            </Checkbox>
           </Col>
         </Row>
-        <DatasetUuidMentionSearch
-          dataSource={dataSource}
-          getStateCodeFilter={() => stateCodeRef.current}
-          queryText={keyWord}
-          sourceEntityKinds={['process']}
-          teamId={tid}
-        />
       </Card>
       <ProTable<ProcessTable, ListPagination>
         {...responsiveDataListTableProps}
@@ -656,6 +680,34 @@ const TableList: FC = () => {
             const currentKeyWord = keyWordRef.current || keyWord;
             const currentStateCode = stateCodeRef.current;
             const currentTypeOfDataSet = typeOfDataSetRef.current;
+            if (referenceLookup) {
+              const referenceLookupUuid = getReferenceLookupUuid(currentKeyWord);
+              if (!referenceLookupUuid) {
+                return applyProcessTableResult(getReferenceLookupEmptyResult(params.current));
+              }
+
+              const result = await getProcessTableUuidMentionSearch(
+                params,
+                lang,
+                dataSource,
+                referenceLookupUuid,
+                currentStateCode,
+                currentTypeOfDataSet,
+                tid ?? '',
+              );
+              const noticeKey = [
+                dataSource,
+                referenceLookupUuid,
+                currentStateCode,
+                currentTypeOfDataSet,
+                tid ?? '',
+              ].join(':');
+              if (result.capped && referenceLookupLimitNoticeRef.current !== noticeKey) {
+                referenceLookupLimitNoticeRef.current = noticeKey;
+                showReferenceLookupLimitMessage(intl);
+              }
+              return applyProcessTableResult(result);
+            }
             if (currentKeyWord.length > 0) {
               let orderBy:
                 | { key: 'common:class' | 'baseName'; lang?: 'en' | 'zh'; order: 'asc' | 'desc' }

--- a/src/pages/Processes/index.tsx
+++ b/src/pages/Processes/index.tsx
@@ -53,6 +53,7 @@ import type { FC, ReactElement } from 'react';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
 import {
   getReferenceLookupEmptyResult,
+  getReferenceLookupPaginationProps,
   getReferenceLookupTeamId,
   getReferenceLookupUuid,
   showInvalidReferenceLookupUuidMessage,
@@ -613,6 +614,7 @@ const TableList: FC = () => {
         pagination={{
           showSizeChanger: false,
           pageSize: 10,
+          ...getReferenceLookupPaginationProps(referenceLookup),
         }}
         toolBarRender={() => {
           if (dataSource === 'my') {

--- a/src/pages/Processes/index.tsx
+++ b/src/pages/Processes/index.tsx
@@ -53,6 +53,7 @@ import type { FC, ReactElement } from 'react';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
 import {
   getReferenceLookupEmptyResult,
+  getReferenceLookupTeamId,
   getReferenceLookupUuid,
   showInvalidReferenceLookupUuidMessage,
   showReferenceLookupLimitMessage,
@@ -685,6 +686,7 @@ const TableList: FC = () => {
               if (!referenceLookupUuid) {
                 return applyProcessTableResult(getReferenceLookupEmptyResult(params.current));
               }
+              const referenceLookupTeamId = getReferenceLookupTeamId(tid);
 
               const result = await getProcessTableUuidMentionSearch(
                 params,
@@ -693,14 +695,14 @@ const TableList: FC = () => {
                 referenceLookupUuid,
                 currentStateCode,
                 currentTypeOfDataSet,
-                tid ?? '',
+                referenceLookupTeamId,
               );
               const noticeKey = [
                 dataSource,
                 referenceLookupUuid,
                 currentStateCode,
                 currentTypeOfDataSet,
-                tid ?? '',
+                referenceLookupTeamId,
               ].join(':');
               if (result.capped && referenceLookupLimitNoticeRef.current !== noticeKey) {
                 referenceLookupLimitNoticeRef.current = noticeKey;

--- a/src/pages/Sources/index.tsx
+++ b/src/pages/Sources/index.tsx
@@ -43,6 +43,7 @@ import type { FC, MutableRefObject } from 'react';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
 import {
   getReferenceLookupEmptyResult,
+  getReferenceLookupTeamId,
   getReferenceLookupUuid,
   showInvalidReferenceLookupUuidMessage,
   showReferenceLookupLimitMessage,
@@ -412,6 +413,7 @@ const TableList: FC = () => {
             if (!referenceLookupUuid) {
               return attachReviewState(getReferenceLookupEmptyResult(params.current));
             }
+            const referenceLookupTeamId = getReferenceLookupTeamId(tid);
 
             const result = await getSourceTableUuidMentionSearch(
               params,
@@ -419,11 +421,14 @@ const TableList: FC = () => {
               dataSource,
               referenceLookupUuid,
               currentStateCode,
-              tid ?? '',
+              referenceLookupTeamId,
             );
-            const noticeKey = [dataSource, referenceLookupUuid, currentStateCode, tid ?? ''].join(
-              ':',
-            );
+            const noticeKey = [
+              dataSource,
+              referenceLookupUuid,
+              currentStateCode,
+              referenceLookupTeamId,
+            ].join(':');
             if (result.capped && referenceLookupLimitNoticeRef.current !== noticeKey) {
               referenceLookupLimitNoticeRef.current = noticeKey;
               showReferenceLookupLimitMessage(intl);

--- a/src/pages/Sources/index.tsx
+++ b/src/pages/Sources/index.tsx
@@ -43,6 +43,7 @@ import type { FC, MutableRefObject } from 'react';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
 import {
   getReferenceLookupEmptyResult,
+  getReferenceLookupPaginationProps,
   getReferenceLookupTeamId,
   getReferenceLookupUuid,
   showInvalidReferenceLookupUuidMessage,
@@ -372,6 +373,7 @@ const TableList: FC = () => {
         pagination={{
           showSizeChanger: false,
           pageSize: 10,
+          ...getReferenceLookupPaginationProps(referenceLookup),
         }}
         toolBarRender={() => {
           if (dataSource === 'my') {

--- a/src/pages/Sources/index.tsx
+++ b/src/pages/Sources/index.tsx
@@ -1,6 +1,10 @@
 import { attachStateCodesToRows, contributeSource } from '@/services/general/api';
-import { getSourceTableAll, getSourceTablePgroongaSearch } from '@/services/sources/api';
-import { Card, Col, Input, Row, Space, message } from 'antd';
+import {
+  getSourceTableAll,
+  getSourceTablePgroongaSearch,
+  getSourceTableUuidMentionSearch,
+} from '@/services/sources/api';
+import { Card, Checkbox, Col, Input, Row, Space, message } from 'antd';
 import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl, useLocation } from 'umi';
 import { getPublicationTypeLabel } from './Components/optiondata';
@@ -11,7 +15,6 @@ import {
   extractContributeDataError,
   getContributeDataErrorMessage,
 } from '@/components/ContributeData/utils';
-import DatasetUuidMentionSearch from '@/components/DatasetUuidMentionSearch';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
 import {
@@ -23,6 +26,7 @@ import {
   dataListTextColumn,
   responsiveDataListTableProps,
   responsiveSearchCardClassName,
+  responsiveSearchExtraColProps,
   responsiveSearchPrimaryColProps,
   responsiveSearchRowProps,
   useResponsiveDataListMobile,
@@ -37,6 +41,12 @@ import { ActionType, PageContainer, ProColumns, ProTable } from '@ant-design/pro
 import { SearchProps } from 'antd/es/input/Search';
 import type { FC, MutableRefObject } from 'react';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
+import {
+  getReferenceLookupEmptyResult,
+  getReferenceLookupUuid,
+  showInvalidReferenceLookupUuidMessage,
+  showReferenceLookupLimitMessage,
+} from '../Utils/referenceLookup';
 import SourceCreate from './Components/create';
 import SourceDelete from './Components/delete';
 import SourceEdit from './Components/edit';
@@ -47,6 +57,7 @@ const TableList: FC = () => {
   const [keyWord, setKeyWord] = useState<string>('');
   const [team, setTeam] = useState<TeamTable | null>(null);
   const [importData, setImportData] = useState<SourceImportData | null>(null);
+  const [referenceLookup, setReferenceLookup] = useState<boolean>(false);
   const [editDrawerVisible, setEditDrawerVisible] = useState<boolean>(false);
   const [editId, setEditId] = useState<string>('');
   const [editVersion, setEditVersion] = useState<string>('');
@@ -67,6 +78,7 @@ const TableList: FC = () => {
   const actionRef = useRef<ActionType>();
   const stateCodeRef = useRef<string | number>('all');
   const keyWordRef = useRef<string>('');
+  const referenceLookupLimitNoticeRef = useRef<string>('');
   const attachReviewState = async (result: {
     data?: SourceTable[];
     page?: number;
@@ -302,6 +314,9 @@ const TableList: FC = () => {
     keyWordRef.current = value;
     setKeyWord(value);
     actionRef.current?.setPageInfo?.({ current: 1 });
+    if (referenceLookup && !getReferenceLookupUuid(value)) {
+      showInvalidReferenceLookupUuidMessage(intl);
+    }
     actionRef.current?.reload();
   };
   const handleImportData = (jsonData: SourceImportData) => {
@@ -319,19 +334,27 @@ const TableList: FC = () => {
           <Col {...responsiveSearchPrimaryColProps}>
             <Search
               size={'large'}
-              placeholder={intl.formatMessage({ id: 'pages.search.keyWord' })}
+              placeholder={intl.formatMessage({
+                id: referenceLookup
+                  ? 'pages.search.referenceLookup.placeholder'
+                  : 'pages.search.keyWord',
+              })}
               onSearch={onSearch}
               enterButton
             />
           </Col>
+          <Col {...responsiveSearchExtraColProps}>
+            <Checkbox
+              checked={referenceLookup}
+              onChange={(e) => setReferenceLookup(e.target.checked)}
+            >
+              <FormattedMessage
+                id='pages.search.referenceLookup'
+                defaultMessage='Reference Lookup'
+              />
+            </Checkbox>
+          </Col>
         </Row>
-        <DatasetUuidMentionSearch
-          dataSource={dataSource}
-          getStateCodeFilter={() => stateCodeRef.current}
-          queryText={keyWord}
-          sourceEntityKinds={['source']}
-          teamId={tid}
-        />
       </Card>
       <ProTable<SourceTable, ListPagination>
         {...responsiveDataListTableProps}
@@ -382,8 +405,31 @@ const TableList: FC = () => {
           },
           sort,
         ) => {
-          const currentKeyWord = keyWordRef.current;
+          const currentKeyWord = keyWordRef.current || keyWord;
           const currentStateCode = stateCodeRef.current;
+          if (referenceLookup) {
+            const referenceLookupUuid = getReferenceLookupUuid(currentKeyWord);
+            if (!referenceLookupUuid) {
+              return attachReviewState(getReferenceLookupEmptyResult(params.current));
+            }
+
+            const result = await getSourceTableUuidMentionSearch(
+              params,
+              lang,
+              dataSource,
+              referenceLookupUuid,
+              currentStateCode,
+              tid ?? '',
+            );
+            const noticeKey = [dataSource, referenceLookupUuid, currentStateCode, tid ?? ''].join(
+              ':',
+            );
+            if (result.capped && referenceLookupLimitNoticeRef.current !== noticeKey) {
+              referenceLookupLimitNoticeRef.current = noticeKey;
+              showReferenceLookupLimitMessage(intl);
+            }
+            return attachReviewState(result);
+          }
           if (currentKeyWord.length > 0) {
             return attachReviewState(
               await getSourceTablePgroongaSearch(

--- a/src/pages/Unitgroups/index.tsx
+++ b/src/pages/Unitgroups/index.tsx
@@ -43,6 +43,7 @@ import { FormattedMessage, useIntl, useLocation } from 'umi';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
 import {
   getReferenceLookupEmptyResult,
+  getReferenceLookupPaginationProps,
   getReferenceLookupTeamId,
   getReferenceLookupUuid,
   showInvalidReferenceLookupUuidMessage,
@@ -418,6 +419,7 @@ const TableList: FC = () => {
         pagination={{
           showSizeChanger: false,
           pageSize: 10,
+          ...getReferenceLookupPaginationProps(referenceLookup),
         }}
         toolBarRender={() => {
           if (dataSource === 'my') {

--- a/src/pages/Unitgroups/index.tsx
+++ b/src/pages/Unitgroups/index.tsx
@@ -5,7 +5,6 @@ import {
   extractContributeDataError,
   getContributeDataErrorMessage,
 } from '@/components/ContributeData/utils';
-import DatasetUuidMentionSearch from '@/components/DatasetUuidMentionSearch';
 import ExportData from '@/components/ExportData';
 import ImportData from '@/components/ImportData';
 import {
@@ -17,6 +16,7 @@ import {
   dataListTextColumn,
   responsiveDataListTableProps,
   responsiveSearchCardClassName,
+  responsiveSearchExtraColProps,
   responsiveSearchPrimaryColProps,
   responsiveSearchRowProps,
   useResponsiveDataListMobile,
@@ -28,15 +28,25 @@ import { getDataSource, getLang, getLangText, isDataUnderReview } from '@/servic
 import { getRoleByUserId } from '@/services/roles/api';
 import { getTeamById } from '@/services/teams/api';
 import { TeamTable } from '@/services/teams/data';
-import { getUnitGroupTableAll, getUnitGroupTablePgroongaSearch } from '@/services/unitgroups/api';
+import {
+  getUnitGroupTableAll,
+  getUnitGroupTablePgroongaSearch,
+  getUnitGroupTableUuidMentionSearch,
+} from '@/services/unitgroups/api';
 import { UnitGroupImportItem, UnitGroupTable } from '@/services/unitgroups/data';
 import { ActionType, PageContainer, ProColumns, ProTable } from '@ant-design/pro-components';
-import { Card, Col, Input, Row, Space, message, theme } from 'antd';
+import { Card, Checkbox, Col, Input, Row, Space, message, theme } from 'antd';
 import { SearchProps } from 'antd/es/input/Search';
 import type { FC, MutableRefObject } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl, useLocation } from 'umi';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
+import {
+  getReferenceLookupEmptyResult,
+  getReferenceLookupUuid,
+  showInvalidReferenceLookupUuidMessage,
+  showReferenceLookupLimitMessage,
+} from '../Utils/referenceLookup';
 import UnitGroupCreate from './Components/create';
 import UnitGroupDelete from './Components/delete';
 import UnitGroupEdit from './Components/edit';
@@ -49,6 +59,7 @@ const TableList: FC = () => {
   const [, setStateCode] = useState<string | number>('all');
   const [team, setTeam] = useState<TeamTable | null>(null);
   const [importData, setImportData] = useState<UnitGroupImportItem[] | null>(null);
+  const [referenceLookup, setReferenceLookup] = useState<boolean>(false);
   const [isSystemAdmin, setIsSystemAdmin] = useState<boolean>(false);
   const [editDrawerVisible, setEditDrawerVisible] = useState<boolean>(false);
   const [editId, setEditId] = useState<string>('');
@@ -71,6 +82,7 @@ const TableList: FC = () => {
   const actionRef = useRef<ActionType>();
   const keyWordRef = useRef<string>('');
   const stateCodeRef = useRef<string | number>('all');
+  const referenceLookupLimitNoticeRef = useRef<string>('');
   const attachReviewState = async (result: {
     data?: UnitGroupTable[];
     page?: number;
@@ -336,6 +348,9 @@ const TableList: FC = () => {
     keyWordRef.current = value;
     setKeyWord(value);
     actionRef.current?.setPageInfo?.({ current: 1 });
+    if (referenceLookup && !getReferenceLookupUuid(value)) {
+      showInvalidReferenceLookupUuidMessage(intl);
+    }
     actionRef.current?.reload();
   };
 
@@ -356,19 +371,28 @@ const TableList: FC = () => {
             <Search
               disabled={dataSource === 'my' && !isSystemAdmin}
               size={'large'}
-              placeholder={intl.formatMessage({ id: 'pages.search.keyWord' })}
+              placeholder={intl.formatMessage({
+                id: referenceLookup
+                  ? 'pages.search.referenceLookup.placeholder'
+                  : 'pages.search.keyWord',
+              })}
               onSearch={onSearch}
               enterButton
             />
           </Col>
+          <Col {...responsiveSearchExtraColProps}>
+            <Checkbox
+              checked={referenceLookup}
+              disabled={dataSource === 'my' && !isSystemAdmin}
+              onChange={(e) => setReferenceLookup(e.target.checked)}
+            >
+              <FormattedMessage
+                id='pages.search.referenceLookup'
+                defaultMessage='Reference Lookup'
+              />
+            </Checkbox>
+          </Col>
         </Row>
-        <DatasetUuidMentionSearch
-          dataSource={dataSource}
-          getStateCodeFilter={() => stateCodeRef.current}
-          queryText={keyWord}
-          sourceEntityKinds={['unitgroup']}
-          teamId={tid}
-        />
       </Card>
       <ProTable<UnitGroupTable, ListPagination>
         {...responsiveDataListTableProps}
@@ -439,6 +463,29 @@ const TableList: FC = () => {
           }
           const currentKeyWord = keyWordRef.current || keyWord;
           const currentStateCode = stateCodeRef.current;
+          if (referenceLookup) {
+            const referenceLookupUuid = getReferenceLookupUuid(currentKeyWord);
+            if (!referenceLookupUuid) {
+              return attachReviewState(getReferenceLookupEmptyResult(params.current));
+            }
+
+            const result = await getUnitGroupTableUuidMentionSearch(
+              params,
+              lang,
+              dataSource,
+              referenceLookupUuid,
+              currentStateCode,
+              tid ?? '',
+            );
+            const noticeKey = [dataSource, referenceLookupUuid, currentStateCode, tid ?? ''].join(
+              ':',
+            );
+            if (result.capped && referenceLookupLimitNoticeRef.current !== noticeKey) {
+              referenceLookupLimitNoticeRef.current = noticeKey;
+              showReferenceLookupLimitMessage(intl);
+            }
+            return attachReviewState(result);
+          }
           if (currentKeyWord.length > 0) {
             return attachReviewState(
               await getUnitGroupTablePgroongaSearch(

--- a/src/pages/Unitgroups/index.tsx
+++ b/src/pages/Unitgroups/index.tsx
@@ -43,6 +43,7 @@ import { FormattedMessage, useIntl, useLocation } from 'umi';
 import { getAllVersionsColumns, getDataTitle } from '../Utils';
 import {
   getReferenceLookupEmptyResult,
+  getReferenceLookupTeamId,
   getReferenceLookupUuid,
   showInvalidReferenceLookupUuidMessage,
   showReferenceLookupLimitMessage,
@@ -468,6 +469,7 @@ const TableList: FC = () => {
             if (!referenceLookupUuid) {
               return attachReviewState(getReferenceLookupEmptyResult(params.current));
             }
+            const referenceLookupTeamId = getReferenceLookupTeamId(tid);
 
             const result = await getUnitGroupTableUuidMentionSearch(
               params,
@@ -475,11 +477,14 @@ const TableList: FC = () => {
               dataSource,
               referenceLookupUuid,
               currentStateCode,
-              tid ?? '',
+              referenceLookupTeamId,
             );
-            const noticeKey = [dataSource, referenceLookupUuid, currentStateCode, tid ?? ''].join(
-              ':',
-            );
+            const noticeKey = [
+              dataSource,
+              referenceLookupUuid,
+              currentStateCode,
+              referenceLookupTeamId,
+            ].join(':');
             if (result.capped && referenceLookupLimitNoticeRef.current !== noticeKey) {
               referenceLookupLimitNoticeRef.current = noticeKey;
               showReferenceLookupLimitMessage(intl);

--- a/src/pages/Utils/referenceLookup.ts
+++ b/src/pages/Utils/referenceLookup.ts
@@ -5,6 +5,10 @@ type IntlLike = {
   formatMessage: (descriptor: { defaultMessage?: string; id: string }) => string;
 };
 
+type ReferenceLookupPaginationProps = {
+  showTotal?: (total: number, range: [number, number]) => null;
+};
+
 export function getReferenceLookupUuid(queryText: string): string | null {
   return normalizeDatasetUuidSearchQuery(queryText);
 }
@@ -16,6 +20,16 @@ export function getReferenceLookupEmptyResult(current = 1) {
     success: true,
     total: 0,
   };
+}
+
+export function getReferenceLookupPaginationProps(
+  enabled: boolean,
+): ReferenceLookupPaginationProps {
+  return enabled
+    ? {
+        showTotal: () => null,
+      }
+    : {};
 }
 
 export function getReferenceLookupTeamId(tid?: string | null): string {

--- a/src/pages/Utils/referenceLookup.ts
+++ b/src/pages/Utils/referenceLookup.ts
@@ -1,0 +1,35 @@
+import { normalizeDatasetUuidSearchQuery } from '@/services/datasetUuidMentionSearch/api';
+import { message } from 'antd';
+
+type IntlLike = {
+  formatMessage: (descriptor: { defaultMessage?: string; id: string }) => string;
+};
+
+export function getReferenceLookupUuid(queryText: string): string | null {
+  return normalizeDatasetUuidSearchQuery(queryText);
+}
+
+export function getReferenceLookupEmptyResult(current = 1) {
+  return {
+    data: [],
+    page: current,
+    success: true,
+    total: 0,
+  };
+}
+
+export function showInvalidReferenceLookupUuidMessage(intl: IntlLike) {
+  const text = intl.formatMessage({
+    defaultMessage: 'Enter a complete dataset UUID before running Reference Lookup.',
+    id: 'pages.datasetUuidMention.invalidUuid',
+  });
+  (message.warning ?? message.error)?.(text);
+}
+
+export function showReferenceLookupLimitMessage(intl: IntlLike) {
+  const text = intl.formatMessage({
+    defaultMessage: 'Showing up to the first 50 reference lookup results.',
+    id: 'pages.datasetUuidMention.maxResults',
+  });
+  (message.info ?? message.warning ?? message.error)?.(text);
+}

--- a/src/pages/Utils/referenceLookup.ts
+++ b/src/pages/Utils/referenceLookup.ts
@@ -18,6 +18,10 @@ export function getReferenceLookupEmptyResult(current = 1) {
   };
 }
 
+export function getReferenceLookupTeamId(tid?: string | null): string {
+  return tid ?? '';
+}
+
 export function showInvalidReferenceLookupUuidMessage(intl: IntlLike) {
   const text = intl.formatMessage({
     defaultMessage: 'Enter a complete dataset UUID before running Reference Lookup.',

--- a/src/services/contacts/api.ts
+++ b/src/services/contacts/api.ts
@@ -12,6 +12,7 @@ import { SortOrder } from 'antd/lib/table/interface';
 import { getCachedClassificationData } from '../classifications/cache';
 import {
   mapDatasetUuidMentionRowsToListRows,
+  normalizeDatasetUuidMentionTeamId,
   searchDatasetJsonUuidMentionPage,
 } from '../datasetUuidMentionSearch/api';
 import {
@@ -373,7 +374,7 @@ export async function getContactTableUuidMentionSearch(
   dataSource: string,
   uuid: string,
   stateCode?: string | number,
-  tid: string | [] = [],
+  tid?: string | [],
 ) {
   const result = await searchDatasetJsonUuidMentionPage({
     dataSource,
@@ -381,7 +382,7 @@ export async function getContactTableUuidMentionSearch(
     pageSize: params.pageSize,
     sourceEntityKinds: ['contact'],
     stateCode,
-    teamId: typeof tid === 'string' ? tid : null,
+    teamId: normalizeDatasetUuidMentionTeamId(tid),
     uuid,
   });
   if (!result.success) {

--- a/src/services/contacts/api.ts
+++ b/src/services/contacts/api.ts
@@ -11,6 +11,10 @@ import { normalizeDeleteCommandResult } from '@/services/supabase/data';
 import { SortOrder } from 'antd/lib/table/interface';
 import { getCachedClassificationData } from '../classifications/cache';
 import {
+  mapDatasetUuidMentionRowsToListRows,
+  searchDatasetJsonUuidMentionPage,
+} from '../datasetUuidMentionSearch/api';
+import {
   attachLangNormalizationMetadata,
   buildLangNormalizationMetadata,
   getDataDetail,
@@ -358,6 +362,36 @@ export async function getContactTablePgroongaSearch(
     });
   }
   return result;
+}
+
+export async function getContactTableUuidMentionSearch(
+  params: {
+    current?: number;
+    pageSize?: number;
+  },
+  lang: string,
+  dataSource: string,
+  uuid: string,
+  stateCode?: string | number,
+  tid: string | [] = [],
+) {
+  const result = await searchDatasetJsonUuidMentionPage({
+    dataSource,
+    pageCurrent: params.current,
+    pageSize: params.pageSize,
+    sourceEntityKinds: ['contact'],
+    stateCode,
+    teamId: typeof tid === 'string' ? tid : null,
+    uuid,
+  });
+  if (!result.success) {
+    return { ...result, data: [] };
+  }
+
+  return {
+    ...result,
+    data: await mapContactListRows(mapDatasetUuidMentionRowsToListRows(result.data), lang),
+  };
 }
 
 export async function getContactDetail(id: string, version: string) {

--- a/src/services/datasetUuidMentionSearch/api.ts
+++ b/src/services/datasetUuidMentionSearch/api.ts
@@ -99,6 +99,11 @@ export function normalizeDatasetUuidMentionStateCode(
   return null;
 }
 
+export function normalizeDatasetUuidMentionTeamId(tid?: string | [] | null): string | null {
+  const normalizedTeamId = typeof tid === 'string' ? tid.trim() : '';
+  return normalizedTeamId.length > 0 ? normalizedTeamId : null;
+}
+
 export async function searchDatasetJsonUuidMentions({
   dataSource,
   limit = 20,

--- a/src/services/datasetUuidMentionSearch/api.ts
+++ b/src/services/datasetUuidMentionSearch/api.ts
@@ -35,6 +35,24 @@ export type SearchDatasetJsonUuidMentionsResult = {
   success: boolean;
 };
 
+export type SearchDatasetJsonUuidMentionPageOptions = Omit<
+  SearchDatasetJsonUuidMentionsOptions,
+  'limit'
+> & {
+  maxResults?: number;
+  pageCurrent?: number;
+  pageSize?: number;
+};
+
+export type SearchDatasetJsonUuidMentionPageResult = SearchDatasetJsonUuidMentionsResult & {
+  capped: boolean;
+  page: number;
+  total: number;
+};
+
+export const DATASET_UUID_MENTION_PAGE_SIZE = 10;
+export const DATASET_UUID_MENTION_MAX_RESULTS = 50;
+
 const DATASET_UUID_QUERY_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -127,4 +145,70 @@ export async function searchDatasetJsonUuidMentions({
     data: (result.data ?? []) as DatasetUuidMentionRow[],
     success: true,
   };
+}
+
+export async function searchDatasetJsonUuidMentionPage({
+  maxResults = DATASET_UUID_MENTION_MAX_RESULTS,
+  pageCurrent = 1,
+  pageSize = DATASET_UUID_MENTION_PAGE_SIZE,
+  ...options
+}: SearchDatasetJsonUuidMentionPageOptions): Promise<SearchDatasetJsonUuidMentionPageResult> {
+  const normalizedPageSize = Math.max(1, Math.floor(pageSize));
+  const normalizedPage = Math.max(1, Math.floor(pageCurrent));
+  const normalizedMaxResults = Math.min(
+    DATASET_UUID_MENTION_MAX_RESULTS,
+    Math.max(1, Math.floor(maxResults)),
+  );
+  const pageStart = (normalizedPage - 1) * normalizedPageSize;
+
+  if (pageStart >= normalizedMaxResults) {
+    return {
+      capped: true,
+      data: [],
+      page: normalizedPage,
+      success: true,
+      total: normalizedMaxResults,
+    };
+  }
+
+  const fetchLimit = Math.min(normalizedMaxResults, pageStart + normalizedPageSize + 1);
+  const result = await searchDatasetJsonUuidMentions({
+    ...options,
+    limit: fetchLimit,
+  });
+
+  if (!result.success) {
+    return {
+      ...result,
+      capped: false,
+      page: normalizedPage,
+      total: 0,
+    };
+  }
+
+  const pageRows = result.data.slice(pageStart, pageStart + normalizedPageSize);
+  const hasNextPage = result.data.length > pageStart + normalizedPageSize;
+  const capped = fetchLimit >= normalizedMaxResults && result.data.length >= normalizedMaxResults;
+  const total = Math.min(
+    normalizedMaxResults,
+    hasNextPage ? pageStart + pageRows.length + 1 : pageStart + pageRows.length,
+  );
+
+  return {
+    ...result,
+    capped,
+    data: pageRows,
+    page: normalizedPage,
+    total,
+  };
+}
+
+export function mapDatasetUuidMentionRowsToListRows(rows: DatasetUuidMentionRow[]) {
+  return rows.map((row) => ({
+    id: row.source_id,
+    json: row.source_json,
+    modified_at: row.source_modified_at ?? undefined,
+    team_id: row.source_team_id ?? undefined,
+    version: row.source_version,
+  }));
 }

--- a/src/services/flowproperties/api.ts
+++ b/src/services/flowproperties/api.ts
@@ -12,6 +12,7 @@ import { SortOrder } from 'antd/lib/table/interface';
 import { getCachedClassificationData } from '../classifications/cache';
 import {
   mapDatasetUuidMentionRowsToListRows,
+  normalizeDatasetUuidMentionTeamId,
   searchDatasetJsonUuidMentionPage,
 } from '../datasetUuidMentionSearch/api';
 import {
@@ -404,7 +405,7 @@ export async function getFlowpropertyTableUuidMentionSearch(
   dataSource: string,
   uuid: string,
   stateCode?: string | number,
-  tid: string | [] = [],
+  tid?: string | [],
 ) {
   const result = await searchDatasetJsonUuidMentionPage({
     dataSource,
@@ -412,7 +413,7 @@ export async function getFlowpropertyTableUuidMentionSearch(
     pageSize: params.pageSize,
     sourceEntityKinds: ['flowproperty'],
     stateCode,
-    teamId: typeof tid === 'string' ? tid : null,
+    teamId: normalizeDatasetUuidMentionTeamId(tid),
     uuid,
   });
   if (!result.success) {

--- a/src/services/flowproperties/api.ts
+++ b/src/services/flowproperties/api.ts
@@ -11,6 +11,10 @@ import { normalizeDeleteCommandResult } from '@/services/supabase/data';
 import { SortOrder } from 'antd/lib/table/interface';
 import { getCachedClassificationData } from '../classifications/cache';
 import {
+  mapDatasetUuidMentionRowsToListRows,
+  searchDatasetJsonUuidMentionPage,
+} from '../datasetUuidMentionSearch/api';
+import {
   attachLangNormalizationMetadata,
   buildLangNormalizationMetadata,
   getDataDetail,
@@ -389,6 +393,36 @@ export async function getFlowpropertyTablePgroongaSearch(
   }
 
   return result;
+}
+
+export async function getFlowpropertyTableUuidMentionSearch(
+  params: {
+    current?: number;
+    pageSize?: number;
+  },
+  lang: string,
+  dataSource: string,
+  uuid: string,
+  stateCode?: string | number,
+  tid: string | [] = [],
+) {
+  const result = await searchDatasetJsonUuidMentionPage({
+    dataSource,
+    pageCurrent: params.current,
+    pageSize: params.pageSize,
+    sourceEntityKinds: ['flowproperty'],
+    stateCode,
+    teamId: typeof tid === 'string' ? tid : null,
+    uuid,
+  });
+  if (!result.success) {
+    return { ...result, data: [] };
+  }
+
+  return {
+    ...result,
+    data: await mapFlowpropertyListRows(mapDatasetUuidMentionRowsToListRows(result.data), lang),
+  };
 }
 
 export async function getFlowpropertyDetail(id: string, version: string) {

--- a/src/services/flows/api.ts
+++ b/src/services/flows/api.ts
@@ -13,6 +13,7 @@ import { SortOrder } from 'antd/lib/table/interface';
 import { getCachedFlowCategorizationAll } from '../classifications/cache';
 import {
   mapDatasetUuidMentionRowsToListRows,
+  normalizeDatasetUuidMentionTeamId,
   searchDatasetJsonUuidMentionPage,
 } from '../datasetUuidMentionSearch/api';
 import {
@@ -691,7 +692,7 @@ export async function getFlowTableUuidMentionSearch(
   dataSource: string,
   uuid: string,
   stateCode?: string | number,
-  tid: string | [] = [],
+  tid?: string | [],
 ) {
   const result = await searchDatasetJsonUuidMentionPage({
     dataSource,
@@ -699,7 +700,7 @@ export async function getFlowTableUuidMentionSearch(
     pageSize: params.pageSize,
     sourceEntityKinds: ['flow'],
     stateCode,
-    teamId: typeof tid === 'string' ? tid : null,
+    teamId: normalizeDatasetUuidMentionTeamId(tid),
     uuid,
   });
   if (!result.success) {

--- a/src/services/flows/api.ts
+++ b/src/services/flows/api.ts
@@ -12,6 +12,10 @@ import { FunctionRegion } from '@supabase/supabase-js';
 import { SortOrder } from 'antd/lib/table/interface';
 import { getCachedFlowCategorizationAll } from '../classifications/cache';
 import {
+  mapDatasetUuidMentionRowsToListRows,
+  searchDatasetJsonUuidMentionPage,
+} from '../datasetUuidMentionSearch/api';
+import {
   attachLangNormalizationMetadata,
   buildLangNormalizationMetadata,
   getDataDetail,
@@ -22,6 +26,7 @@ import {
 } from '../general/api';
 import { getILCDLocationByValues } from '../locations/api';
 import { getCachedLocationData } from '../locations/cache';
+import type { FlowTable } from './data';
 import { genFlowJsonOrdered, genFlowName } from './util';
 function normalizeLocationData(response: any): any[] {
   if (Array.isArray(response)) {
@@ -604,6 +609,107 @@ export async function getFlowTablePgroongaSearch(
     data: [],
     success: false,
   });
+}
+
+async function mapFlowMentionRows(rows: FlowListRpcRow[], lang: string): Promise<FlowTable[]> {
+  const [locationData, categorizationData] = await Promise.all([
+    fetchLocationLookup(
+      lang,
+      rows.map((i: any) => i.json?.flowDataSet?.flowInformation?.geography?.locationOfSupply),
+    ),
+    lang === 'zh' ? getCachedFlowCategorizationAll(lang) : Promise.resolve(null),
+  ]);
+
+  return rows.map((i: any) => {
+    try {
+      const typeOfDataSet = i.json?.flowDataSet?.modellingAndValidation?.LCIMethod?.typeOfDataSet;
+      const dataInfo = i.json?.flowDataSet?.flowInformation?.dataSetInformation;
+      let classificationData: any = {};
+      let thisClass: any[] = [];
+      if (typeOfDataSet === 'Elementary flow') {
+        classificationData =
+          dataInfo?.classificationInformation?.['common:elementaryFlowCategorization']?.[
+            'common:category'
+          ];
+        thisClass = categorizationData?.categoryElementaryFlow ?? [];
+      } else {
+        classificationData =
+          dataInfo?.classificationInformation?.['common:classification']?.['common:class'];
+        thisClass = categorizationData?.category ?? [];
+      }
+      const classifications = jsonToList(classificationData);
+      const classification =
+        lang === 'zh' && categorizationData
+          ? classificationToString(genClassificationZH(classifications, thisClass))
+          : classificationToString(classifications);
+
+      return {
+        key: i.id + ':' + i.version,
+        id: i.id,
+        name: genFlowName(dataInfo?.name ?? {}, lang) ?? '-',
+        flowType: typeOfDataSet ?? '-',
+        classification,
+        synonyms: getLangText(dataInfo?.['common:synonyms'], lang),
+        CASNumber: dataInfo?.CASNumber ?? '-',
+        refFlowPropertyId:
+          i.json?.flowDataSet?.flowProperties?.flowProperty?.referenceToFlowPropertyDataSet?.[
+            '@refObjectId'
+          ] ?? '-',
+        locationOfSupply: resolveLocationOfSupply(
+          i.json?.flowDataSet?.flowInformation?.geography?.locationOfSupply,
+          locationData,
+        ),
+        version: i.version ?? '',
+        modifiedAt: new Date(i.modified_at ?? 0),
+        teamId: i.team_id ?? '',
+      };
+    } catch (e) {
+      console.error(e);
+      return {
+        id: i.id,
+        version: i.version ?? '',
+        modifiedAt: new Date(i.modified_at ?? 0),
+        teamId: i.team_id ?? '',
+        name: '-',
+        synonyms: '',
+        classification: '',
+        flowType: '-',
+        CASNumber: '-',
+        locationOfSupply: '-',
+        refFlowPropertyId: '-',
+      };
+    }
+  });
+}
+
+export async function getFlowTableUuidMentionSearch(
+  params: {
+    current?: number;
+    pageSize?: number;
+  },
+  lang: string,
+  dataSource: string,
+  uuid: string,
+  stateCode?: string | number,
+  tid: string | [] = [],
+) {
+  const result = await searchDatasetJsonUuidMentionPage({
+    dataSource,
+    pageCurrent: params.current,
+    pageSize: params.pageSize,
+    sourceEntityKinds: ['flow'],
+    stateCode,
+    teamId: typeof tid === 'string' ? tid : null,
+    uuid,
+  });
+  if (!result.success) {
+    return { ...result, data: [] };
+  }
+
+  return {
+    ...result,
+    data: await mapFlowMentionRows(mapDatasetUuidMentionRowsToListRows(result.data), lang),
+  };
 }
 
 export async function flow_hybrid_search(

--- a/src/services/lifeCycleModels/api.ts
+++ b/src/services/lifeCycleModels/api.ts
@@ -17,6 +17,10 @@ import { isRuleVerificationPassed } from '@/utils/ruleVerification';
 import { FunctionRegion } from '@supabase/supabase-js';
 import { SortOrder } from 'antd/lib/table/interface';
 import { getILCDClassification } from '../classifications/api';
+import {
+  mapDatasetUuidMentionRowsToListRows,
+  searchDatasetJsonUuidMentionPage,
+} from '../datasetUuidMentionSearch/api';
 import { getTeamIdByUserId } from '../general/api';
 import {
   classificationToString,
@@ -30,6 +34,7 @@ import type {
   LifeCycleModelJsonTg,
   LifeCycleModelMutationResult,
   LifeCycleModelPersistencePlan,
+  LifeCycleModelTable,
 } from './data';
 import {
   buildDeleteLifeCycleModelBundlePayload,
@@ -773,6 +778,119 @@ export async function getLifeCycleModelTablePgroongaSearch(
   }
 
   return result;
+}
+
+async function mapLifeCycleModelMentionRows(
+  rows: LifeCycleModelListRpcRow[],
+  lang: string,
+): Promise<LifeCycleModelTable[]> {
+  if (lang === 'zh') {
+    const classificationData = await getILCDClassification('LifeCycleModel', lang, ['all']);
+    return rows.map((i: any) => {
+      try {
+        const dataInfo = i.json?.lifeCycleModelDataSet?.lifeCycleModelInformation;
+        const classifications = jsonToList(
+          dataInfo?.dataSetInformation?.classificationInformation?.['common:classification']?.[
+            'common:class'
+          ],
+        );
+        const classificationZH = genClassificationZH(classifications, classificationData?.data);
+
+        return {
+          key: i.id,
+          id: i.id,
+          name: genProcessName(dataInfo?.dataSetInformation?.name ?? {}, lang),
+          generalComment: getLangText(
+            dataInfo?.dataSetInformation?.['common:generalComment'] ?? {},
+            lang,
+          ),
+          classification: classificationToString(classificationZH),
+          version: i?.version ?? '',
+          modifiedAt: new Date(i?.modified_at ?? 0),
+          teamId: i?.team_id ?? '',
+        };
+      } catch (e) {
+        console.error(e);
+        return {
+          id: i.id,
+          version: i.version ?? '',
+          modifiedAt: new Date(i.modified_at ?? 0),
+          teamId: i.team_id ?? '',
+          name: '-',
+          generalComment: '',
+          classification: '',
+        };
+      }
+    });
+  }
+
+  return rows.map((i: any) => {
+    try {
+      const dataInfo = i.json?.lifeCycleModelDataSet?.lifeCycleModelInformation;
+      const classifications = jsonToList(
+        dataInfo?.dataSetInformation?.classificationInformation?.['common:classification']?.[
+          'common:class'
+        ],
+      );
+      return {
+        key: i.id,
+        id: i.id,
+        name: genProcessName(dataInfo?.dataSetInformation?.name ?? {}, lang),
+        generalComment: getLangText(
+          dataInfo?.dataSetInformation?.['common:generalComment'] ?? {},
+          lang,
+        ),
+        classification: classificationToString(classifications),
+        version: i?.version ?? '',
+        modifiedAt: new Date(i?.modified_at ?? 0),
+        teamId: i?.team_id ?? '',
+      };
+    } catch (e) {
+      console.error(e);
+      return {
+        id: i.id,
+        version: i.version ?? '',
+        modifiedAt: new Date(i.modified_at ?? 0),
+        teamId: i.team_id ?? '',
+        name: '-',
+        generalComment: '',
+        classification: '',
+      };
+    }
+  });
+}
+
+export async function getLifeCycleModelTableUuidMentionSearch(
+  params: {
+    current?: number;
+    pageSize?: number;
+  },
+  lang: string,
+  dataSource: string,
+  uuid: string,
+  stateCode?: string | number,
+  tid: string = '',
+) {
+  const result = await searchDatasetJsonUuidMentionPage({
+    dataSource,
+    pageCurrent: params.current,
+    pageSize: params.pageSize,
+    sourceEntityKinds: ['lifecyclemodel'],
+    stateCode,
+    teamId: tid,
+    uuid,
+  });
+  if (!result.success) {
+    return { ...result, data: [] };
+  }
+
+  return {
+    ...result,
+    data: await mapLifeCycleModelMentionRows(
+      mapDatasetUuidMentionRowsToListRows(result.data),
+      lang,
+    ),
+  };
 }
 export async function lifeCycleModel_hybrid_search(
   params: {

--- a/src/services/lifeCycleModels/api.ts
+++ b/src/services/lifeCycleModels/api.ts
@@ -19,6 +19,7 @@ import { SortOrder } from 'antd/lib/table/interface';
 import { getILCDClassification } from '../classifications/api';
 import {
   mapDatasetUuidMentionRowsToListRows,
+  normalizeDatasetUuidMentionTeamId,
   searchDatasetJsonUuidMentionPage,
 } from '../datasetUuidMentionSearch/api';
 import { getTeamIdByUserId } from '../general/api';
@@ -85,12 +86,12 @@ function normalizeLifeCycleModelSortDirection(orderBy: SortOrder): 'asc' | 'desc
 
 async function getLifeCycleModelTeamFilter(
   dataSource: string,
-  tid: string,
+  tid?: string | [],
 ): Promise<string | null> {
   if (dataSource === 'te') {
     return (await getTeamIdByUserId()) ?? null;
   }
-  return tid.length > 0 ? tid : null;
+  return normalizeDatasetUuidMentionTeamId(tid);
 }
 
 function buildMutationError(
@@ -651,7 +652,7 @@ export async function getLifeCycleModelTablePgroongaSearch(
   filterCondition: any,
   stateCode?: string | number,
   orderBy?: { key: 'common:class' | 'baseName'; lang?: 'en' | 'zh'; order: 'asc' | 'desc' },
-  tid: string = '',
+  tid?: string | [],
 ) {
   let result: any = {};
   const session = await supabase.auth.getSession();
@@ -869,7 +870,7 @@ export async function getLifeCycleModelTableUuidMentionSearch(
   dataSource: string,
   uuid: string,
   stateCode?: string | number,
-  tid: string = '',
+  tid?: string | [],
 ) {
   const result = await searchDatasetJsonUuidMentionPage({
     dataSource,
@@ -877,7 +878,7 @@ export async function getLifeCycleModelTableUuidMentionSearch(
     pageSize: params.pageSize,
     sourceEntityKinds: ['lifecyclemodel'],
     stateCode,
-    teamId: tid,
+    teamId: normalizeDatasetUuidMentionTeamId(tid),
     uuid,
   });
   if (!result.success) {

--- a/src/services/processes/api.ts
+++ b/src/services/processes/api.ts
@@ -26,6 +26,7 @@ import { SortOrder } from 'antd/es/table/interface';
 import { getCachedClassificationData } from '../classifications/cache';
 import {
   mapDatasetUuidMentionRowsToListRows,
+  normalizeDatasetUuidMentionTeamId,
   searchDatasetJsonUuidMentionPage,
 } from '../datasetUuidMentionSearch/api';
 import { getTeamIdByUserId } from '../general/api';
@@ -896,7 +897,6 @@ export async function getProcessTablePgroongaSearch(
             return {
               key: i.id + ':' + i.version,
               id: i.id,
-              lang,
               name: genProcessName(dataInfo?.dataSetInformation?.name ?? {}, lang),
               generalComment: getLangText(
                 dataInfo?.dataSetInformation?.['common:generalComment'] ?? {},
@@ -1087,7 +1087,7 @@ export async function getProcessTableUuidMentionSearch(
   uuid: string,
   stateCode?: string | number,
   typeOfDataSet?: string,
-  tid: string | [] = [],
+  tid?: string | [],
 ): Promise<ProcessTableResponse & { capped?: boolean }> {
   const result = await searchDatasetJsonUuidMentionPage({
     dataSource,
@@ -1095,7 +1095,7 @@ export async function getProcessTableUuidMentionSearch(
     pageSize: params.pageSize,
     sourceEntityKinds: ['process'],
     stateCode,
-    teamId: typeof tid === 'string' ? tid : null,
+    teamId: normalizeDatasetUuidMentionTeamId(tid),
     uuid,
   });
   if (!result.success) {

--- a/src/services/processes/api.ts
+++ b/src/services/processes/api.ts
@@ -24,6 +24,10 @@ import {
 import { FunctionRegion } from '@supabase/supabase-js';
 import { SortOrder } from 'antd/es/table/interface';
 import { getCachedClassificationData } from '../classifications/cache';
+import {
+  mapDatasetUuidMentionRowsToListRows,
+  searchDatasetJsonUuidMentionPage,
+} from '../datasetUuidMentionSearch/api';
 import { getTeamIdByUserId } from '../general/api';
 import {
   classificationToString,
@@ -892,6 +896,7 @@ export async function getProcessTablePgroongaSearch(
             return {
               key: i.id + ':' + i.version,
               id: i.id,
+              lang,
               name: genProcessName(dataInfo?.dataSetInformation?.name ?? {}, lang),
               generalComment: getLangText(
                 dataInfo?.dataSetInformation?.['common:generalComment'] ?? {},
@@ -1007,6 +1012,111 @@ function mergeUniqueProcessTableRows(responses: ProcessTableResponse[]): Process
   });
 
   return merged;
+}
+
+async function mapProcessListRows(
+  rows: ProcessListRpcRow[],
+  lang: string,
+): Promise<ProcessTable[]> {
+  const locations: string[] = Array.from(
+    new Set(
+      rows.map(
+        (i: any) =>
+          i.json?.processDataSet?.processInformation?.geography
+            ?.locationOfOperationSupplyOrProduction?.['@location'],
+      ),
+    ),
+  );
+  const locationData = await getCachedLocationData(lang, locations);
+  const classificationData =
+    lang === 'zh' ? await getCachedClassificationData('Process', lang, ['all']) : [];
+
+  return rows.map((i: any) => {
+    try {
+      const dataInfo = i.json?.processDataSet?.processInformation;
+      const classifications = jsonToList(
+        dataInfo?.dataSetInformation?.classificationInformation?.['common:classification']?.[
+          'common:class'
+        ],
+      );
+      const thisLocation = locationData.find(
+        (l: any) =>
+          l['@value'] === dataInfo?.geography?.locationOfOperationSupplyOrProduction?.['@location'],
+      );
+      const location =
+        thisLocation?.['#text'] ??
+        dataInfo?.geography?.locationOfOperationSupplyOrProduction?.['@location'];
+      const classification =
+        lang === 'zh'
+          ? classificationToString(genClassificationZH(classifications, classificationData))
+          : classificationToString(classifications);
+
+      return {
+        key: i.id + ':' + i.version,
+        id: i.id,
+        lang,
+        name: genProcessName(dataInfo?.dataSetInformation?.name ?? {}, lang),
+        generalComment: getLangText(
+          dataInfo?.dataSetInformation?.['common:generalComment'] ?? {},
+          lang,
+        ),
+        classification,
+        referenceYear: dataInfo?.time?.['common:referenceYear'] ?? '-',
+        location: location ?? '-',
+        version: i.version,
+        typeOfDataSet:
+          i?.json?.processDataSet?.modellingAndValidation?.LCIMethodAndAllocation?.typeOfDataSet ??
+          '-',
+        modifiedAt: new Date(i.modified_at ?? 0),
+        teamId: i.team_id ?? '',
+        modelId: i.model_id ?? '',
+      };
+    } catch (e) {
+      console.error(e);
+      return {
+        id: i.id,
+      } as ProcessTable;
+    }
+  });
+}
+
+export async function getProcessTableUuidMentionSearch(
+  params: ProcessTableQueryParams,
+  lang: string,
+  dataSource: string,
+  uuid: string,
+  stateCode?: string | number,
+  typeOfDataSet?: string,
+  tid: string | [] = [],
+): Promise<ProcessTableResponse & { capped?: boolean }> {
+  const result = await searchDatasetJsonUuidMentionPage({
+    dataSource,
+    pageCurrent: params.current,
+    pageSize: params.pageSize,
+    sourceEntityKinds: ['process'],
+    stateCode,
+    teamId: typeof tid === 'string' ? tid : null,
+    uuid,
+  });
+  if (!result.success) {
+    return { ...result, data: [] };
+  }
+
+  const rows = mapDatasetUuidMentionRowsToListRows(result.data).filter((row) => {
+    if (!typeOfDataSet || typeOfDataSet === 'all') {
+      return true;
+    }
+    const sourceJson = row.json as any;
+    return (
+      sourceJson?.processDataSet?.modellingAndValidation?.LCIMethodAndAllocation?.typeOfDataSet ===
+      typeOfDataSet
+    );
+  }) as ProcessListRpcRow[];
+
+  return {
+    ...result,
+    data: await mapProcessListRows(rows, lang),
+  };
 }
 
 async function listAllDataSearchProcessPage(

--- a/src/services/sources/api.ts
+++ b/src/services/sources/api.ts
@@ -11,6 +11,10 @@ import { normalizeDeleteCommandResult } from '@/services/supabase/data';
 import { SortOrder } from 'antd/lib/table/interface';
 import { getCachedClassificationData } from '../classifications/cache';
 import {
+  mapDatasetUuidMentionRowsToListRows,
+  searchDatasetJsonUuidMentionPage,
+} from '../datasetUuidMentionSearch/api';
+import {
   attachLangNormalizationMetadata,
   buildLangNormalizationMetadata,
   getDataDetail,
@@ -371,6 +375,36 @@ export async function getSourceTablePgroongaSearch(
   }
 
   return result;
+}
+
+export async function getSourceTableUuidMentionSearch(
+  params: {
+    current?: number;
+    pageSize?: number;
+  },
+  lang: string,
+  dataSource: string,
+  uuid: string,
+  stateCode?: string | number,
+  tid: string | [] = [],
+) {
+  const result = await searchDatasetJsonUuidMentionPage({
+    dataSource,
+    pageCurrent: params.current,
+    pageSize: params.pageSize,
+    sourceEntityKinds: ['source'],
+    stateCode,
+    teamId: typeof tid === 'string' ? tid : null,
+    uuid,
+  });
+  if (!result.success) {
+    return { ...result, data: [] };
+  }
+
+  return {
+    ...result,
+    data: await mapSourceListRows(mapDatasetUuidMentionRowsToListRows(result.data), lang),
+  };
 }
 
 export async function getSourceDetail(id: string, version: string) {

--- a/src/services/sources/api.ts
+++ b/src/services/sources/api.ts
@@ -12,6 +12,7 @@ import { SortOrder } from 'antd/lib/table/interface';
 import { getCachedClassificationData } from '../classifications/cache';
 import {
   mapDatasetUuidMentionRowsToListRows,
+  normalizeDatasetUuidMentionTeamId,
   searchDatasetJsonUuidMentionPage,
 } from '../datasetUuidMentionSearch/api';
 import {
@@ -386,7 +387,7 @@ export async function getSourceTableUuidMentionSearch(
   dataSource: string,
   uuid: string,
   stateCode?: string | number,
-  tid: string | [] = [],
+  tid?: string | [],
 ) {
   const result = await searchDatasetJsonUuidMentionPage({
     dataSource,
@@ -394,7 +395,7 @@ export async function getSourceTableUuidMentionSearch(
     pageSize: params.pageSize,
     sourceEntityKinds: ['source'],
     stateCode,
-    teamId: typeof tid === 'string' ? tid : null,
+    teamId: normalizeDatasetUuidMentionTeamId(tid),
     uuid,
   });
   if (!result.success) {

--- a/src/services/unitgroups/api.ts
+++ b/src/services/unitgroups/api.ts
@@ -11,6 +11,10 @@ import { normalizeDeleteCommandResult } from '@/services/supabase/data';
 import { SortOrder } from 'antd/lib/table/interface';
 import { getCachedClassificationData } from '../classifications/cache';
 import {
+  mapDatasetUuidMentionRowsToListRows,
+  searchDatasetJsonUuidMentionPage,
+} from '../datasetUuidMentionSearch/api';
+import {
   attachLangNormalizationMetadata,
   buildLangNormalizationMetadata,
   getDataDetail,
@@ -387,6 +391,36 @@ export async function getUnitGroupTablePgroongaSearch(
   }
 
   return result;
+}
+
+export async function getUnitGroupTableUuidMentionSearch(
+  params: {
+    current?: number;
+    pageSize?: number;
+  },
+  lang: string,
+  dataSource: string,
+  uuid: string,
+  stateCode?: string | number,
+  tid: string | [] = [],
+) {
+  const result = await searchDatasetJsonUuidMentionPage({
+    dataSource,
+    pageCurrent: params.current,
+    pageSize: params.pageSize,
+    sourceEntityKinds: ['unitgroup'],
+    stateCode,
+    teamId: typeof tid === 'string' ? tid : null,
+    uuid,
+  });
+  if (!result.success) {
+    return { ...result, data: [] };
+  }
+
+  return {
+    ...result,
+    data: await mapUnitGroupListRows(mapDatasetUuidMentionRowsToListRows(result.data), lang),
+  };
 }
 export async function getUnitGroupDetail(id: string, version: string) {
   return getDataDetail(id, version, 'unitgroups');

--- a/src/services/unitgroups/api.ts
+++ b/src/services/unitgroups/api.ts
@@ -12,6 +12,7 @@ import { SortOrder } from 'antd/lib/table/interface';
 import { getCachedClassificationData } from '../classifications/cache';
 import {
   mapDatasetUuidMentionRowsToListRows,
+  normalizeDatasetUuidMentionTeamId,
   searchDatasetJsonUuidMentionPage,
 } from '../datasetUuidMentionSearch/api';
 import {
@@ -402,7 +403,7 @@ export async function getUnitGroupTableUuidMentionSearch(
   dataSource: string,
   uuid: string,
   stateCode?: string | number,
-  tid: string | [] = [],
+  tid?: string | [],
 ) {
   const result = await searchDatasetJsonUuidMentionPage({
     dataSource,
@@ -410,7 +411,7 @@ export async function getUnitGroupTableUuidMentionSearch(
     pageSize: params.pageSize,
     sourceEntityKinds: ['unitgroup'],
     stateCode,
-    teamId: typeof tid === 'string' ? tid : null,
+    teamId: normalizeDatasetUuidMentionTeamId(tid),
     uuid,
   });
   if (!result.success) {

--- a/tests/unit/pages/Contacts/index.test.tsx
+++ b/tests/unit/pages/Contacts/index.test.tsx
@@ -23,6 +23,7 @@ let mockBreakpointScreens: Record<string, boolean | undefined> = {};
 const mockContributeSource = jest.fn();
 const mockGetContactTableAll = jest.fn();
 const mockGetContactTablePgroongaSearch = jest.fn();
+const mockGetContactTableUuidMentionSearch = jest.fn();
 const mockGetDataSource = jest.fn(() => 'my');
 const mockGetLang = jest.fn(() => 'en');
 const mockGetLangText = jest.fn((value: any) => value?.[0]?.['#text'] ?? 'Team title');
@@ -54,6 +55,8 @@ jest.mock('@/services/contacts/api', () => ({
   __esModule: true,
   getContactTableAll: (...args: any[]) => mockGetContactTableAll(...args),
   getContactTablePgroongaSearch: (...args: any[]) => mockGetContactTablePgroongaSearch(...args),
+  getContactTableUuidMentionSearch: (...args: any[]) =>
+    mockGetContactTableUuidMentionSearch(...args),
 }));
 
 jest.mock('@/services/general/api', () => ({
@@ -381,6 +384,7 @@ describe('ContactsPage', () => {
     });
     mockGetContactTableAll.mockResolvedValue({ data: [baseContactRow], success: true });
     mockGetContactTablePgroongaSearch.mockResolvedValue({ data: [baseContactRow], success: true });
+    mockGetContactTableUuidMentionSearch.mockResolvedValue({ data: [], success: true, total: 0 });
     mockContributeSource.mockResolvedValue({ error: null });
   });
 
@@ -408,16 +412,7 @@ describe('ContactsPage', () => {
     expect(screen.getByTestId('contact-edit')).toHaveTextContent('edit:contact-1');
     expect(screen.getByTestId('contact-delete')).toHaveTextContent('delete:contact-1');
     expect(screen.getAllByTestId('contact-create')[0]).toHaveTextContent('"actionType":"create"');
-    expect(screen.getByTestId('dataset-uuid-mention-search')).toHaveTextContent(
-      '"sourceEntityKinds":["contact"]',
-    );
-    expect(mockDatasetUuidMentionSearch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        dataSource: 'my',
-        sourceEntityKinds: ['contact'],
-        teamId: 'team-1',
-      }),
-    );
+    expect(screen.getByRole('checkbox', { name: 'Reference Lookup' })).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: /close-contact-edit/i }));
     await userEvent.click(screen.getByRole('button', { name: /close-contact-delete/i }));

--- a/tests/unit/pages/Contacts/index.test.tsx
+++ b/tests/unit/pages/Contacts/index.test.tsx
@@ -258,6 +258,9 @@ jest.mock('antd', () => {
       <button type='button' onClick={() => onSearch?.('alice')}>
         search
       </button>
+      <button type='button' onClick={() => onSearch?.('D1380000-0000-4000-8000-000000000001')}>
+        uuid-lookup
+      </button>
     </div>
   );
   const Input = { Search };
@@ -566,6 +569,67 @@ describe('ContactsPage', () => {
     expect(message.success).not.toHaveBeenCalled();
     expect(consoleLogSpy).toHaveBeenCalledWith({ message: 'contribute failed' });
     consoleLogSpy.mockRestore();
+  });
+
+  it('uses the main table for reference lookup and clears rows for incomplete UUIDs', async () => {
+    const { message } = jest.requireMock('antd');
+    const referenceRows = [
+      { ...baseContactRow, id: 'contact-ref', shortName: 'Referenced contact' },
+    ];
+    mockGetContactTableUuidMentionSearch.mockResolvedValue({
+      data: referenceRows,
+      success: true,
+      total: 1,
+      capped: true,
+    });
+
+    renderWithProviders(<ContactsPage />);
+
+    await screen.findByTestId('contact-view');
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Reference Lookup' }));
+    expect(screen.getByRole('textbox', { name: /search-input/i })).toHaveAttribute(
+      'placeholder',
+      'pages.search.referenceLookup.placeholder',
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'search' }));
+    await waitFor(() =>
+      expect(message.error).toHaveBeenCalledWith(
+        'Enter a complete dataset UUID before running Reference Lookup.',
+      ),
+    );
+    await waitFor(() => expect(screen.queryByTestId('contact-view')).not.toBeInTheDocument());
+    expect(mockGetContactTableUuidMentionSearch).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', { name: 'uuid-lookup' }));
+    await waitFor(() =>
+      expect(mockGetContactTableUuidMentionSearch).toHaveBeenCalledWith(
+        { pageSize: 10, current: 1 },
+        'en',
+        'my',
+        'd1380000-0000-4000-8000-000000000001',
+        'all',
+        'team-1',
+      ),
+    );
+    expect(await screen.findByText('Referenced contact')).toBeInTheDocument();
+    expect(message.error).toHaveBeenCalledWith(
+      'Showing up to the first 50 reference lookup results.',
+    );
+
+    const callCountBeforeUncappedLookup = mockGetContactTableUuidMentionSearch.mock.calls.length;
+    mockGetContactTableUuidMentionSearch.mockResolvedValue({
+      data: referenceRows,
+      success: true,
+      total: 1,
+      capped: false,
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'uuid-lookup' }));
+    await waitFor(() =>
+      expect(mockGetContactTableUuidMentionSearch.mock.calls.length).toBeGreaterThan(
+        callCountBeforeUncappedLookup,
+      ),
+    );
   });
 
   it('renders a dash when classification is missing or invalid', async () => {

--- a/tests/unit/pages/Flowproperties/index.test.tsx
+++ b/tests/unit/pages/Flowproperties/index.test.tsx
@@ -22,6 +22,7 @@ let mockBreakpointScreens: Record<string, boolean | undefined> = {};
 const mockContributeSource = jest.fn();
 const mockGetFlowpropertyTableAll = jest.fn();
 const mockGetFlowpropertyTablePgroongaSearch = jest.fn();
+const mockGetFlowpropertyTableUuidMentionSearch = jest.fn();
 const mockGetDataSource = jest.fn(() => 'my');
 const mockGetLang = jest.fn(() => 'en');
 const mockGetLangText = jest.fn((value: any) => {
@@ -52,6 +53,8 @@ jest.mock('@/services/flowproperties/api', () => ({
   getFlowpropertyTableAll: (...args: any[]) => mockGetFlowpropertyTableAll(...args),
   getFlowpropertyTablePgroongaSearch: (...args: any[]) =>
     mockGetFlowpropertyTablePgroongaSearch(...args),
+  getFlowpropertyTableUuidMentionSearch: (...args: any[]) =>
+    mockGetFlowpropertyTableUuidMentionSearch(...args),
 }));
 
 jest.mock('@/services/general/util', () => ({
@@ -372,6 +375,11 @@ describe('FlowpropertiesPage', () => {
     mockContributeSource.mockResolvedValue({ error: null });
     mockGetFlowpropertyTableAll.mockResolvedValue({ data: [row], success: true });
     mockGetFlowpropertyTablePgroongaSearch.mockResolvedValue({ data: [row], success: true });
+    mockGetFlowpropertyTableUuidMentionSearch.mockResolvedValue({
+      data: [],
+      success: true,
+      total: 0,
+    });
     mockGetUnitData.mockImplementation(async (_table: string, rows: any[]) => rows ?? []);
   });
 
@@ -408,16 +416,7 @@ describe('FlowpropertiesPage', () => {
     );
     expect(screen.getByTestId('table-dropdown')).toBeInTheDocument();
     expect(screen.getByTestId('export-data')).toHaveTextContent('flowproperties:fp-1:01.00.000');
-    expect(screen.getByTestId('dataset-uuid-mention-search')).toHaveTextContent(
-      '"sourceEntityKinds":["flowproperty"]',
-    );
-    expect(mockDatasetUuidMentionSearch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        dataSource: 'my',
-        sourceEntityKinds: ['flowproperty'],
-        teamId: 'team-1',
-      }),
-    );
+    expect(screen.getByRole('checkbox', { name: 'Reference Lookup' })).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: /import-data/i }));
     expect(

--- a/tests/unit/pages/Flowproperties/index.test.tsx
+++ b/tests/unit/pages/Flowproperties/index.test.tsx
@@ -241,6 +241,9 @@ jest.mock('antd', () => {
       <button type='button' onClick={() => onSearch?.('climate')}>
         search
       </button>
+      <button type='button' onClick={() => onSearch?.('D1380000-0000-4000-8000-000000000001')}>
+        uuid-lookup
+      </button>
     </div>
   );
   const Input = { Search };
@@ -623,6 +626,80 @@ describe('FlowpropertiesPage', () => {
         'unitgroup',
         [],
       ]),
+    );
+  });
+
+  it('uses the main table for reference lookup and clears rows for incomplete UUIDs', async () => {
+    const referenceRows = [
+      {
+        id: 'fp-ref',
+        version: '01.00.000',
+        name: 'Referenced flow property',
+        generalComment: 'Referenced comment',
+        classification: 'Impact',
+        refUnitRes: {
+          name: [{ '@xml:lang': 'en', '#text': 'Mass' }],
+          refUnitGeneralComment: [{ '@xml:lang': 'en', '#text': 'Reference unit comment' }],
+          refUnitName: 'kg',
+        },
+        modifiedAt: '2024-01-01T00:00:00.000Z',
+        teamId: null,
+      },
+    ];
+    mockGetFlowpropertyTableUuidMentionSearch.mockResolvedValue({
+      data: referenceRows,
+      success: true,
+      total: 1,
+      capped: true,
+    });
+
+    renderWithProviders(<FlowpropertiesPage />);
+
+    await screen.findByTestId('flowproperty-view');
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Reference Lookup' }));
+    expect(screen.getByRole('textbox', { name: /search-input/i })).toHaveAttribute(
+      'placeholder',
+      'pages.search.referenceLookup.placeholder',
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'search' }));
+    await waitFor(() =>
+      expect(mockMessage.error).toHaveBeenCalledWith(
+        'Enter a complete dataset UUID before running Reference Lookup.',
+      ),
+    );
+    await waitFor(() => expect(screen.queryByTestId('flowproperty-view')).not.toBeInTheDocument());
+    expect(mockGetFlowpropertyTableUuidMentionSearch).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', { name: 'uuid-lookup' }));
+    await waitFor(() =>
+      expect(mockGetFlowpropertyTableUuidMentionSearch).toHaveBeenCalledWith(
+        { pageSize: 10, current: 1 },
+        'en',
+        'my',
+        'd1380000-0000-4000-8000-000000000001',
+        'all',
+        'team-1',
+      ),
+    );
+    expect(await screen.findByText('Referenced flow property')).toBeInTheDocument();
+    expect(mockMessage.error).toHaveBeenCalledWith(
+      'Showing up to the first 50 reference lookup results.',
+    );
+
+    const callCountBeforeUncappedLookup =
+      mockGetFlowpropertyTableUuidMentionSearch.mock.calls.length;
+    mockGetFlowpropertyTableUuidMentionSearch.mockResolvedValue({
+      data: referenceRows,
+      success: true,
+      total: 1,
+      capped: false,
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'uuid-lookup' }));
+    await waitFor(() =>
+      expect(mockGetFlowpropertyTableUuidMentionSearch.mock.calls.length).toBeGreaterThan(
+        callCountBeforeUncappedLookup,
+      ),
     );
   });
 

--- a/tests/unit/pages/Flows/index.test.tsx
+++ b/tests/unit/pages/Flows/index.test.tsx
@@ -255,6 +255,9 @@ jest.mock('antd', () => {
       <button type='button' onClick={() => onSearch?.('steel')}>
         search
       </button>
+      <button type='button' onClick={() => onSearch?.('D1380000-0000-4000-8000-000000000001')}>
+        uuid-lookup
+      </button>
     </div>
   );
   const Input = { Search };
@@ -819,6 +822,64 @@ describe('FlowsPage', () => {
         'all',
         undefined,
         '',
+      ),
+    );
+  });
+
+  it('uses the main table for reference lookup and clears rows for incomplete UUIDs', async () => {
+    const referenceRows = [{ ...flowRows[0], id: 'flow-ref', name: 'Referenced flow' }];
+    mockGetFlowTableUuidMentionSearch.mockResolvedValue({
+      data: referenceRows,
+      success: true,
+      total: 1,
+      capped: true,
+    });
+
+    renderWithProviders(<FlowsPage />);
+
+    await screen.findByText('Flow One');
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Reference Lookup' }));
+    expect(screen.getByRole('textbox', { name: /search-input/i })).toHaveAttribute(
+      'placeholder',
+      'pages.search.referenceLookup.placeholder',
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'search' }));
+    await waitFor(() =>
+      expect(mockMessageError).toHaveBeenCalledWith(
+        'Enter a complete dataset UUID before running Reference Lookup.',
+      ),
+    );
+    await waitFor(() => expect(screen.queryByText('Flow One')).not.toBeInTheDocument());
+    expect(mockGetFlowTableUuidMentionSearch).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', { name: 'uuid-lookup' }));
+    await waitFor(() =>
+      expect(mockGetFlowTableUuidMentionSearch).toHaveBeenCalledWith(
+        { pageSize: 10, current: 1 },
+        'en',
+        'my',
+        'd1380000-0000-4000-8000-000000000001',
+        'all',
+        'team-1',
+      ),
+    );
+    expect(await screen.findByText('Referenced flow')).toBeInTheDocument();
+    expect(mockMessageError).toHaveBeenCalledWith(
+      'Showing up to the first 50 reference lookup results.',
+    );
+
+    const callCountBeforeUncappedLookup = mockGetFlowTableUuidMentionSearch.mock.calls.length;
+    mockGetFlowTableUuidMentionSearch.mockResolvedValue({
+      data: referenceRows,
+      success: true,
+      total: 1,
+      capped: false,
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'uuid-lookup' }));
+    await waitFor(() =>
+      expect(mockGetFlowTableUuidMentionSearch.mock.calls.length).toBeGreaterThan(
+        callCountBeforeUncappedLookup,
       ),
     );
   });

--- a/tests/unit/pages/Flows/index.test.tsx
+++ b/tests/unit/pages/Flows/index.test.tsx
@@ -22,6 +22,7 @@ let mockBreakpointScreens: Record<string, boolean | undefined> = {};
 const mockContributeSource = jest.fn();
 const mockGetFlowTableAll = jest.fn();
 const mockGetFlowTablePgroongaSearch = jest.fn();
+const mockGetFlowTableUuidMentionSearch = jest.fn();
 const mockFlowHybridSearch = jest.fn();
 const mockGetCachedFlowCategorizationAll = jest.fn();
 const mockGetDataSource = jest.fn(() => 'my');
@@ -74,6 +75,7 @@ jest.mock('@/services/flows/api', () => ({
   flow_hybrid_search: (...args: any[]) => mockFlowHybridSearch(...args),
   getFlowTableAll: (...args: any[]) => mockGetFlowTableAll(...args),
   getFlowTablePgroongaSearch: (...args: any[]) => mockGetFlowTablePgroongaSearch(...args),
+  getFlowTableUuidMentionSearch: (...args: any[]) => mockGetFlowTableUuidMentionSearch(...args),
 }));
 
 jest.mock('@/services/classifications/cache', () => ({
@@ -437,6 +439,7 @@ describe('FlowsPage', () => {
     });
     mockGetFlowTableAll.mockResolvedValue({ data: flowRows, success: true });
     mockGetFlowTablePgroongaSearch.mockResolvedValue({ data: [], success: true });
+    mockGetFlowTableUuidMentionSearch.mockResolvedValue({ data: [], success: true, total: 0 });
     mockFlowHybridSearch.mockResolvedValue({ data: [], success: true });
     mockContributeSource.mockResolvedValue({ error: null });
   });
@@ -472,16 +475,7 @@ describe('FlowsPage', () => {
     expect(screen.getByTestId('classification-filters')).toHaveTextContent(
       '"text":"-","value":"classification:class-empty"',
     );
-    expect(screen.getByTestId('dataset-uuid-mention-search')).toHaveTextContent(
-      '"sourceEntityKinds":["flow"]',
-    );
-    expect(mockDatasetUuidMentionSearch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        dataSource: 'my',
-        sourceEntityKinds: ['flow'],
-        teamId: 'team-1',
-      }),
-    );
+    expect(screen.getByRole('checkbox', { name: 'Reference Lookup' })).toBeInTheDocument();
     expect(screen.getAllByTestId('flow-create-createVersion')).toHaveLength(2);
     expect(screen.getAllByTestId('flow-create-createVersion')[0]).toHaveTextContent(
       '"newVersion":"02.00.000"',

--- a/tests/unit/pages/LifeCycleModels/index.test.tsx
+++ b/tests/unit/pages/LifeCycleModels/index.test.tsx
@@ -258,6 +258,9 @@ jest.mock('antd', () => {
       <button type='button' onClick={() => onSearch?.('steel')}>
         search
       </button>
+      <button type='button' onClick={() => onSearch?.('D1380000-0000-4000-8000-000000000001')}>
+        uuid-lookup
+      </button>
     </div>
   );
 
@@ -801,6 +804,66 @@ describe('LifeCycleModelsPage', () => {
         'all',
         undefined,
         '',
+      ),
+    );
+  });
+
+  it('uses the main table for reference lookup and clears rows for incomplete UUIDs', async () => {
+    const { message } = jest.requireMock('antd');
+    const referenceRows = [{ ...modelRows[0], id: 'model-ref', name: 'Referenced model' }];
+    mockGetLifeCycleModelTableUuidMentionSearch.mockResolvedValue({
+      data: referenceRows,
+      success: true,
+      total: 1,
+      capped: true,
+    });
+
+    renderWithProviders(<LifeCycleModelsPage />);
+
+    await screen.findByText('Lifecycle model 1');
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Reference Lookup' }));
+    expect(screen.getByRole('textbox', { name: /search-input/i })).toHaveAttribute(
+      'placeholder',
+      'pages.search.referenceLookup.placeholder',
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'search' }));
+    await waitFor(() =>
+      expect(message.error).toHaveBeenCalledWith(
+        'Enter a complete dataset UUID before running Reference Lookup.',
+      ),
+    );
+    await waitFor(() => expect(screen.queryByText('Lifecycle model 1')).not.toBeInTheDocument());
+    expect(mockGetLifeCycleModelTableUuidMentionSearch).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', { name: 'uuid-lookup' }));
+    await waitFor(() =>
+      expect(mockGetLifeCycleModelTableUuidMentionSearch).toHaveBeenCalledWith(
+        { pageSize: 10, current: 1 },
+        'en',
+        'my',
+        'd1380000-0000-4000-8000-000000000001',
+        'all',
+        'team-1',
+      ),
+    );
+    expect(await screen.findByText('Referenced model')).toBeInTheDocument();
+    expect(message.error).toHaveBeenCalledWith(
+      'Showing up to the first 50 reference lookup results.',
+    );
+
+    const callCountBeforeUncappedLookup =
+      mockGetLifeCycleModelTableUuidMentionSearch.mock.calls.length;
+    mockGetLifeCycleModelTableUuidMentionSearch.mockResolvedValue({
+      data: referenceRows,
+      success: true,
+      total: 1,
+      capped: false,
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'uuid-lookup' }));
+    await waitFor(() =>
+      expect(mockGetLifeCycleModelTableUuidMentionSearch.mock.calls.length).toBeGreaterThan(
+        callCountBeforeUncappedLookup,
       ),
     );
   });

--- a/tests/unit/pages/LifeCycleModels/index.test.tsx
+++ b/tests/unit/pages/LifeCycleModels/index.test.tsx
@@ -25,6 +25,7 @@ const mockGetLang = jest.fn(() => 'en');
 const mockGetLangText = jest.fn((value: any) => value?.[0]?.['#text'] ?? 'Team title');
 const mockGetLifeCycleModelTableAll = jest.fn();
 const mockGetLifeCycleModelTablePgroongaSearch = jest.fn();
+const mockGetLifeCycleModelTableUuidMentionSearch = jest.fn();
 const mockLifeCycleModelHybridSearch = jest.fn();
 const mockContributeLifeCycleModel = jest.fn();
 const mockGetTeamById = jest.fn();
@@ -81,6 +82,8 @@ jest.mock('@/services/lifeCycleModels/api', () => ({
   getLifeCycleModelTableAll: (...args: any[]) => mockGetLifeCycleModelTableAll(...args),
   getLifeCycleModelTablePgroongaSearch: (...args: any[]) =>
     mockGetLifeCycleModelTablePgroongaSearch(...args),
+  getLifeCycleModelTableUuidMentionSearch: (...args: any[]) =>
+    mockGetLifeCycleModelTableUuidMentionSearch(...args),
   lifeCycleModel_hybrid_search: (...args: any[]) => mockLifeCycleModelHybridSearch(...args),
 }));
 
@@ -423,6 +426,11 @@ describe('LifeCycleModelsPage', () => {
       data: [],
       success: true,
     });
+    mockGetLifeCycleModelTableUuidMentionSearch.mockResolvedValue({
+      data: [],
+      success: true,
+      total: 0,
+    });
     mockLifeCycleModelHybridSearch.mockResolvedValue({
       data: [],
       success: true,
@@ -474,16 +482,7 @@ describe('LifeCycleModelsPage', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /table-filter/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /import-data/i })).toBeInTheDocument();
-    expect(screen.getByTestId('dataset-uuid-mention-search')).toHaveTextContent(
-      '"sourceEntityKinds":["lifecyclemodel"]',
-    );
-    expect(mockDatasetUuidMentionSearch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        dataSource: 'my',
-        sourceEntityKinds: ['lifecyclemodel'],
-        teamId: 'team-1',
-      }),
-    );
+    expect(screen.getByRole('checkbox', { name: 'Reference Lookup' })).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: /import-data/i }));
     expect(screen.getByTestId('lifecycle-create-create')).toHaveTextContent('"importCount":1');

--- a/tests/unit/pages/Processes/index.test.tsx
+++ b/tests/unit/pages/Processes/index.test.tsx
@@ -282,6 +282,9 @@ jest.mock('antd', () => {
       <button type='button' onClick={() => onSearch?.('cement')}>
         search
       </button>
+      <button type='button' onClick={() => onSearch?.('D1380000-0000-4000-8000-000000000001')}>
+        uuid-lookup
+      </button>
     </div>
   );
   const Input = { Search };
@@ -1029,6 +1032,79 @@ describe('ProcessesPage', () => {
     await waitFor(() => expect(mockGetProcessTableAll).toHaveBeenCalled());
     expect(screen.getByRole('heading', { name: 'Process Team' })).toBeInTheDocument();
     expect(screen.queryAllByTestId('process-view')).toHaveLength(0);
+  });
+
+  it('uses the main table for reference lookup and clears rows for incomplete UUIDs', async () => {
+    const referenceRows = [
+      {
+        id: 'proc-ref',
+        version: '1.0.0',
+        name: 'Referenced process',
+        generalComment: 'Referenced comment',
+        classification: 'Materials',
+        typeOfDataSet: 'gate to gate',
+        referenceYear: '2024',
+        location: 'CN',
+        modifiedAt: '2024-01-01T00:00:00Z',
+        modelId: '',
+        teamId: '',
+      },
+    ];
+    mockGetProcessTableUuidMentionSearch.mockResolvedValue({
+      data: referenceRows,
+      success: true,
+      total: 1,
+      capped: true,
+    });
+
+    renderWithProviders(<ProcessesPage />);
+
+    await screen.findByTestId('process-view');
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Reference Lookup' }));
+    expect(screen.getByRole('textbox', { name: /search-input/i })).toHaveAttribute(
+      'placeholder',
+      'pages.search.referenceLookup.placeholder',
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'search' }));
+    await waitFor(() =>
+      expect(message.error).toHaveBeenCalledWith(
+        'Enter a complete dataset UUID before running Reference Lookup.',
+      ),
+    );
+    await waitFor(() => expect(screen.queryByTestId('process-view')).not.toBeInTheDocument());
+    expect(mockGetProcessTableUuidMentionSearch).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', { name: 'uuid-lookup' }));
+    await waitFor(() =>
+      expect(mockGetProcessTableUuidMentionSearch).toHaveBeenCalledWith(
+        { pageSize: 10, current: 1 },
+        'en',
+        'my',
+        'd1380000-0000-4000-8000-000000000001',
+        'all',
+        'all',
+        'team-1',
+      ),
+    );
+    expect((await screen.findAllByText('Referenced process')).length).toBeGreaterThan(0);
+    expect(message.error).toHaveBeenCalledWith(
+      'Showing up to the first 50 reference lookup results.',
+    );
+
+    const callCountBeforeUncappedLookup = mockGetProcessTableUuidMentionSearch.mock.calls.length;
+    mockGetProcessTableUuidMentionSearch.mockResolvedValue({
+      data: referenceRows,
+      success: true,
+      total: 1,
+      capped: false,
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'uuid-lookup' }));
+    await waitFor(() =>
+      expect(mockGetProcessTableUuidMentionSearch.mock.calls.length).toBeGreaterThan(
+        callCountBeforeUncappedLookup,
+      ),
+    );
   });
 
   it('falls back to an empty table and shows a toast when loading the process list throws', async () => {

--- a/tests/unit/pages/Processes/index.test.tsx
+++ b/tests/unit/pages/Processes/index.test.tsx
@@ -21,6 +21,7 @@ let mockBreakpointScreens: Record<string, boolean | undefined> = {};
 
 const mockGetProcessTableAll = jest.fn();
 const mockGetProcessTablePgroongaSearch = jest.fn();
+const mockGetProcessTableUuidMentionSearch = jest.fn();
 const mockProcessHybridSearch = jest.fn();
 const mockContributeProcess = jest.fn();
 const mockContributeLifeCycleModel = jest.fn();
@@ -49,6 +50,8 @@ jest.mock('@/services/processes/api', () => ({
   contributeProcess: (...args: any[]) => mockContributeProcess(...args),
   getProcessTableAll: (...args: any[]) => mockGetProcessTableAll(...args),
   getProcessTablePgroongaSearch: (...args: any[]) => mockGetProcessTablePgroongaSearch(...args),
+  getProcessTableUuidMentionSearch: (...args: any[]) =>
+    mockGetProcessTableUuidMentionSearch(...args),
   process_hybrid_search: (...args: any[]) => mockProcessHybridSearch(...args),
 }));
 
@@ -453,6 +456,7 @@ describe('ProcessesPage', () => {
       success: true,
     });
     mockGetProcessTablePgroongaSearch.mockResolvedValue({ data: [], success: true });
+    mockGetProcessTableUuidMentionSearch.mockResolvedValue({ data: [], success: true, total: 0 });
     mockProcessHybridSearch.mockResolvedValue({ data: [], success: true });
     message.success.mockReset();
     message.error.mockReset();
@@ -488,16 +492,7 @@ describe('ProcessesPage', () => {
     expect(screen.getByText('2024')).toBeInTheDocument();
     expect(screen.getByText('CN')).toBeInTheDocument();
     expect(screen.getAllByTestId('lca-solve-toolbar')).toHaveLength(3);
-    expect(screen.getByTestId('dataset-uuid-mention-search')).toHaveTextContent(
-      '"sourceEntityKinds":["process"]',
-    );
-    expect(mockDatasetUuidMentionSearch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        dataSource: 'my',
-        sourceEntityKinds: ['process'],
-        teamId: 'team-1',
-      }),
-    );
+    expect(screen.getByRole('checkbox', { name: 'Reference Lookup' })).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: /import-data/i }));
     const createAction = screen

--- a/tests/unit/pages/Sources/index.test.tsx
+++ b/tests/unit/pages/Sources/index.test.tsx
@@ -23,6 +23,7 @@ let mockBreakpointScreens: Record<string, boolean | undefined> = {};
 const mockContributeSource = jest.fn();
 const mockGetSourceTableAll = jest.fn();
 const mockGetSourceTablePgroongaSearch = jest.fn();
+const mockGetSourceTableUuidMentionSearch = jest.fn();
 const mockGetDataSource = jest.fn(() => 'my');
 const mockGetLang = jest.fn(() => 'en');
 const mockGetLangText = jest.fn((value: any) => value?.[0]?.['#text'] ?? 'Team title');
@@ -53,6 +54,7 @@ jest.mock('@/services/sources/api', () => ({
   __esModule: true,
   getSourceTableAll: (...args: any[]) => mockGetSourceTableAll(...args),
   getSourceTablePgroongaSearch: (...args: any[]) => mockGetSourceTablePgroongaSearch(...args),
+  getSourceTableUuidMentionSearch: (...args: any[]) => mockGetSourceTableUuidMentionSearch(...args),
 }));
 
 jest.mock('@/services/general/api', () => ({
@@ -387,6 +389,7 @@ describe('SourcesPage', () => {
     });
     mockGetSourceTableAll.mockResolvedValue({ data: [baseSourceRow], success: true });
     mockGetSourceTablePgroongaSearch.mockResolvedValue({ data: [baseSourceRow], success: true });
+    mockGetSourceTableUuidMentionSearch.mockResolvedValue({ data: [], success: true, total: 0 });
     mockContributeSource.mockResolvedValue({ error: null });
   });
 
@@ -414,16 +417,7 @@ describe('SourcesPage', () => {
     expect(screen.getByTestId('source-edit')).toHaveTextContent('edit:source-1');
     expect(screen.getByTestId('source-delete')).toHaveTextContent('delete:source-1');
     expect(screen.getAllByTestId('source-create')[0]).toHaveTextContent('"actionType":"create"');
-    expect(screen.getByTestId('dataset-uuid-mention-search')).toHaveTextContent(
-      '"sourceEntityKinds":["source"]',
-    );
-    expect(mockDatasetUuidMentionSearch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        dataSource: 'my',
-        sourceEntityKinds: ['source'],
-        teamId: 'team-1',
-      }),
-    );
+    expect(screen.getByRole('checkbox', { name: 'Reference Lookup' })).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: /close-source-edit/i }));
     await userEvent.click(screen.getByRole('button', { name: /close-source-delete/i }));

--- a/tests/unit/pages/Sources/index.test.tsx
+++ b/tests/unit/pages/Sources/index.test.tsx
@@ -263,6 +263,9 @@ jest.mock('antd', () => {
       <button type='button' onClick={() => onSearch?.('iso')}>
         search
       </button>
+      <button type='button' onClick={() => onSearch?.('D1380000-0000-4000-8000-000000000001')}>
+        uuid-lookup
+      </button>
     </div>
   );
   const Input = { Search };
@@ -571,6 +574,65 @@ describe('SourcesPage', () => {
     expect(message.success).not.toHaveBeenCalled();
     expect(consoleLogSpy).toHaveBeenCalledWith({ message: 'contribute failed' });
     consoleLogSpy.mockRestore();
+  });
+
+  it('uses the main table for reference lookup and clears rows for incomplete UUIDs', async () => {
+    const { message } = jest.requireMock('antd');
+    const referenceRows = [{ ...baseSourceRow, id: 'source-ref', shortName: 'Referenced source' }];
+    mockGetSourceTableUuidMentionSearch.mockResolvedValue({
+      data: referenceRows,
+      success: true,
+      total: 1,
+      capped: true,
+    });
+
+    renderWithProviders(<SourcesPage />);
+
+    await screen.findByTestId('source-view');
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Reference Lookup' }));
+    expect(screen.getByRole('textbox', { name: /search-input/i })).toHaveAttribute(
+      'placeholder',
+      'pages.search.referenceLookup.placeholder',
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'search' }));
+    await waitFor(() =>
+      expect(message.error).toHaveBeenCalledWith(
+        'Enter a complete dataset UUID before running Reference Lookup.',
+      ),
+    );
+    await waitFor(() => expect(screen.queryByTestId('source-view')).not.toBeInTheDocument());
+    expect(mockGetSourceTableUuidMentionSearch).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', { name: 'uuid-lookup' }));
+    await waitFor(() =>
+      expect(mockGetSourceTableUuidMentionSearch).toHaveBeenCalledWith(
+        { pageSize: 10, current: 1 },
+        'en',
+        'my',
+        'd1380000-0000-4000-8000-000000000001',
+        'all',
+        'team-1',
+      ),
+    );
+    expect(await screen.findByText('Referenced source')).toBeInTheDocument();
+    expect(message.error).toHaveBeenCalledWith(
+      'Showing up to the first 50 reference lookup results.',
+    );
+
+    const callCountBeforeUncappedLookup = mockGetSourceTableUuidMentionSearch.mock.calls.length;
+    mockGetSourceTableUuidMentionSearch.mockResolvedValue({
+      data: referenceRows,
+      success: true,
+      total: 1,
+      capped: false,
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'uuid-lookup' }));
+    await waitFor(() =>
+      expect(mockGetSourceTableUuidMentionSearch.mock.calls.length).toBeGreaterThan(
+        callCountBeforeUncappedLookup,
+      ),
+    );
   });
 
   it('renders a dash when classification is missing or invalid', async () => {

--- a/tests/unit/pages/Unitgroups/index.test.tsx
+++ b/tests/unit/pages/Unitgroups/index.test.tsx
@@ -32,6 +32,7 @@ const mockGetRoleByUserId = jest.fn();
 const mockGetTeamById = jest.fn();
 const mockGetUnitGroupTableAll = jest.fn();
 const mockGetUnitGroupTablePgroongaSearch = jest.fn();
+const mockGetUnitGroupTableUuidMentionSearch = jest.fn();
 const mockDatasetUuidMentionSearch = jest.fn();
 
 jest.mock('umi', () => ({
@@ -72,6 +73,8 @@ jest.mock('@/services/unitgroups/api', () => ({
   __esModule: true,
   getUnitGroupTableAll: (...args: any[]) => mockGetUnitGroupTableAll(...args),
   getUnitGroupTablePgroongaSearch: (...args: any[]) => mockGetUnitGroupTablePgroongaSearch(...args),
+  getUnitGroupTableUuidMentionSearch: (...args: any[]) =>
+    mockGetUnitGroupTableUuidMentionSearch(...args),
 }));
 
 jest.mock('@/components/AlignedNumber', () => ({
@@ -414,6 +417,11 @@ describe('UnitgroupsPage', () => {
       ],
       success: true,
     });
+    mockGetUnitGroupTableUuidMentionSearch.mockResolvedValue({
+      data: [],
+      success: true,
+      total: 0,
+    });
     mockContributeSource.mockResolvedValue({ error: null });
   });
 
@@ -451,16 +459,7 @@ describe('UnitgroupsPage', () => {
       'team-1',
       'all',
     );
-    expect(screen.getByTestId('dataset-uuid-mention-search')).toHaveTextContent(
-      '"sourceEntityKinds":["unitgroup"]',
-    );
-    expect(mockDatasetUuidMentionSearch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        dataSource: 'my',
-        sourceEntityKinds: ['unitgroup'],
-        teamId: 'team-1',
-      }),
-    );
+    expect(screen.getByRole('checkbox', { name: 'Reference Lookup' })).toBeInTheDocument();
 
     expect(screen.getByRole('heading', { name: 'Unit Team' })).toBeInTheDocument();
     await waitFor(() =>

--- a/tests/unit/pages/Unitgroups/index.test.tsx
+++ b/tests/unit/pages/Unitgroups/index.test.tsx
@@ -248,6 +248,13 @@ jest.mock('antd', () => {
       <button type='button' disabled={disabled} onClick={() => onSearch?.('density')}>
         search
       </button>
+      <button
+        type='button'
+        disabled={disabled}
+        onClick={() => onSearch?.('D1380000-0000-4000-8000-000000000001')}
+      >
+        uuid-lookup
+      </button>
     </div>
   );
   const Input = { Search };
@@ -505,6 +512,82 @@ describe('UnitgroupsPage', () => {
     const { message } = jest.requireMock('antd');
     expect(message.success).toHaveBeenCalledWith('Contribute successfully');
     expect(latestReloadMock).toHaveBeenCalled();
+  });
+
+  it('uses the main table for reference lookup and clears rows for incomplete UUIDs', async () => {
+    const { message } = jest.requireMock('antd');
+    mockGetRoleByUserId.mockResolvedValue([
+      {
+        team_id: '00000000-0000-0000-0000-000000000000',
+        role: 'admin',
+      },
+    ]);
+    const referenceRows = [
+      {
+        id: 'ug-ref',
+        version: '1.0.0',
+        name: 'Referenced unit group',
+        refUnitName: 'kg',
+        refUnitGeneralComment: 'Mass unit',
+        classification: 'Physical',
+        modifiedAt: '2024-01-01',
+        teamId: '',
+      },
+    ];
+    mockGetUnitGroupTableUuidMentionSearch.mockResolvedValue({
+      data: referenceRows,
+      success: true,
+      total: 1,
+      capped: true,
+    });
+
+    renderWithProviders(<UnitgroupsPage />);
+
+    await screen.findByTestId('unitgroup-view');
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Reference Lookup' }));
+    expect(screen.getByRole('textbox', { name: /search-input/i })).toHaveAttribute(
+      'placeholder',
+      'pages.search.referenceLookup.placeholder',
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'search' }));
+    await waitFor(() =>
+      expect(message.error).toHaveBeenCalledWith(
+        'Enter a complete dataset UUID before running Reference Lookup.',
+      ),
+    );
+    await waitFor(() => expect(screen.queryByTestId('unitgroup-view')).not.toBeInTheDocument());
+    expect(mockGetUnitGroupTableUuidMentionSearch).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', { name: 'uuid-lookup' }));
+    await waitFor(() =>
+      expect(mockGetUnitGroupTableUuidMentionSearch).toHaveBeenCalledWith(
+        { pageSize: 10, current: 1 },
+        'en',
+        'my',
+        'd1380000-0000-4000-8000-000000000001',
+        'all',
+        'team-1',
+      ),
+    );
+    expect(await screen.findByText('Referenced unit group')).toBeInTheDocument();
+    expect(message.error).toHaveBeenCalledWith(
+      'Showing up to the first 50 reference lookup results.',
+    );
+
+    const callCountBeforeUncappedLookup = mockGetUnitGroupTableUuidMentionSearch.mock.calls.length;
+    mockGetUnitGroupTableUuidMentionSearch.mockResolvedValue({
+      data: referenceRows,
+      success: true,
+      total: 1,
+      capped: false,
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'uuid-lookup' }));
+    await waitFor(() =>
+      expect(mockGetUnitGroupTableUuidMentionSearch.mock.calls.length).toBeGreaterThan(
+        callCountBeforeUncappedLookup,
+      ),
+    );
   });
 
   it('uses compact mobile controls for admin my data rows', async () => {

--- a/tests/unit/pages/Utils/referenceLookup.test.ts
+++ b/tests/unit/pages/Utils/referenceLookup.test.ts
@@ -1,0 +1,84 @@
+import {
+  getReferenceLookupEmptyResult,
+  getReferenceLookupTeamId,
+  getReferenceLookupUuid,
+  showInvalidReferenceLookupUuidMessage,
+  showReferenceLookupLimitMessage,
+} from '@/pages/Utils/referenceLookup';
+import { message } from 'antd';
+
+jest.mock('antd', () => ({
+  message: {
+    error: jest.fn(),
+    warning: jest.fn(),
+  },
+}));
+
+describe('reference lookup page helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('normalizes complete UUIDs and rejects partial values', () => {
+    expect(getReferenceLookupUuid(' D1380000-0000-4000-8000-000000000001 ')).toBe(
+      'd1380000-0000-4000-8000-000000000001',
+    );
+    expect(getReferenceLookupUuid('D1380000')).toBe(null);
+  });
+
+  it('builds an empty table result for invalid reference lookup input', () => {
+    expect(getReferenceLookupEmptyResult()).toEqual({
+      data: [],
+      page: 1,
+      success: true,
+      total: 0,
+    });
+    expect(getReferenceLookupEmptyResult(3)).toEqual({
+      data: [],
+      page: 3,
+      success: true,
+      total: 0,
+    });
+  });
+
+  it('normalizes optional team ids for reference lookup requests', () => {
+    expect(getReferenceLookupTeamId('team-1')).toBe('team-1');
+    expect(getReferenceLookupTeamId()).toBe('');
+  });
+
+  it('shows localized reference lookup messages', () => {
+    const intl = {
+      formatMessage: jest.fn(({ defaultMessage }) => defaultMessage),
+    };
+
+    showInvalidReferenceLookupUuidMessage(intl as any);
+    showReferenceLookupLimitMessage(intl as any);
+
+    expect(message.warning).toHaveBeenCalledWith(
+      'Enter a complete dataset UUID before running Reference Lookup.',
+    );
+    expect(message.warning).toHaveBeenCalledWith(
+      'Showing up to the first 50 reference lookup results.',
+    );
+  });
+
+  it('falls back to error messages when warning is unavailable', () => {
+    const intl = {
+      formatMessage: jest.fn(({ defaultMessage }) => defaultMessage),
+    };
+    const originalWarning = message.warning;
+    (message as any).warning = undefined;
+
+    showInvalidReferenceLookupUuidMessage(intl as any);
+    showReferenceLookupLimitMessage(intl as any);
+
+    expect(message.error).toHaveBeenCalledWith(
+      'Enter a complete dataset UUID before running Reference Lookup.',
+    );
+    expect(message.error).toHaveBeenCalledWith(
+      'Showing up to the first 50 reference lookup results.',
+    );
+
+    (message as any).warning = originalWarning;
+  });
+});

--- a/tests/unit/pages/Utils/referenceLookup.test.ts
+++ b/tests/unit/pages/Utils/referenceLookup.test.ts
@@ -1,5 +1,6 @@
 import {
   getReferenceLookupEmptyResult,
+  getReferenceLookupPaginationProps,
   getReferenceLookupTeamId,
   getReferenceLookupUuid,
   showInvalidReferenceLookupUuidMessage,
@@ -44,6 +45,14 @@ describe('reference lookup page helpers', () => {
   it('normalizes optional team ids for reference lookup requests', () => {
     expect(getReferenceLookupTeamId('team-1')).toBe('team-1');
     expect(getReferenceLookupTeamId()).toBe('');
+  });
+
+  it('hides total text only while reference lookup pagination is active', () => {
+    expect(getReferenceLookupPaginationProps(false)).toEqual({});
+
+    const paginationProps = getReferenceLookupPaginationProps(true);
+
+    expect(paginationProps.showTotal?.(24, [1, 10])).toBeNull();
   });
 
   it('shows localized reference lookup messages', () => {

--- a/tests/unit/services/contacts/api.test.ts
+++ b/tests/unit/services/contacts/api.test.ts
@@ -987,6 +987,114 @@ describe('Contacts API Service', () => {
     });
   });
 
+  describe('getContactTableUuidMentionSearch', () => {
+    const mentionRow = (overrides: any = {}) => ({
+      matched_by: 'json',
+      matched_entity_table: 'contacts',
+      rank: 1,
+      source_entity_kind: 'contact',
+      source_id: 'contact-ref',
+      source_json: {
+        contactDataSet: {
+          contactInformation: {
+            dataSetInformation: {
+              'common:shortName': [{ '@xml:lang': 'en', '#text': 'Referenced contact' }],
+              'common:name': [{ '@xml:lang': 'en', '#text': 'Reference Contact Full Name' }],
+              classificationInformation: {
+                'common:classification': {
+                  'common:class': [{ '@level': '0', '#text': 'People' }],
+                },
+              },
+              email: 'ref@example.com',
+            },
+          },
+        },
+      },
+      source_modified_at: '2024-01-01T00:00:00Z',
+      source_team_id: 'team-ref',
+      source_version: '01.00.000',
+      ...overrides,
+    });
+
+    it('maps reference lookup rows into contact table rows', async () => {
+      const { getContactTableUuidMentionSearch } = require('@/services/contacts/api');
+      mockRpc.mockResolvedValue({
+        data: [mentionRow()],
+        error: null,
+      });
+      getLangText.mockImplementation((value: any) => value?.[0]?.['#text'] ?? '-');
+      jsonToList.mockReturnValue([{ '@level': '0', '#text': 'People' }]);
+      classificationToString.mockReturnValue('People');
+
+      const result = await getContactTableUuidMentionSearch(
+        { current: 1, pageSize: 10 },
+        'en',
+        'tg',
+        'd1380000-0000-4000-8000-000000000001',
+        '100',
+        'team-1',
+      );
+
+      expect(mockRpc).toHaveBeenCalledWith('search_dataset_json_uuid_mentions', {
+        p_data_source: 'tg',
+        p_limit: 11,
+        p_source_entity_kinds: ['contact'],
+        p_state_code_filter: 100,
+        p_team_id_filter: 'team-1',
+        p_this_user_id: 'user-123',
+        p_uuid: 'd1380000-0000-4000-8000-000000000001',
+      });
+      expect(result).toMatchObject({
+        data: [
+          expect.objectContaining({
+            id: 'contact-ref',
+            shortName: 'Referenced contact',
+            name: 'Reference Contact Full Name',
+            classification: 'People',
+            email: 'ref@example.com',
+            teamId: 'team-ref',
+            version: '01.00.000',
+          }),
+        ],
+        success: true,
+        total: 1,
+      });
+    });
+
+    it('returns empty table data when reference lookup fails', async () => {
+      const { getContactTableUuidMentionSearch } = require('@/services/contacts/api');
+      mockRpc.mockResolvedValue({
+        data: null,
+        error: { message: 'lookup failed' },
+      });
+
+      const result = await getContactTableUuidMentionSearch(
+        { current: 1, pageSize: 10 },
+        'en',
+        'tg',
+        'd1380000-0000-4000-8000-000000000001',
+        undefined,
+        [],
+      );
+
+      expect(mockRpc).toHaveBeenCalledWith(
+        'search_dataset_json_uuid_mentions',
+        expect.objectContaining({
+          p_source_entity_kinds: ['contact'],
+          p_team_id_filter: null,
+        }),
+      );
+      expect(result).toEqual({
+        capped: false,
+        data: [],
+        error: 'lookup failed',
+        page: 1,
+        success: false,
+        total: 0,
+      });
+    });
+  });
+
   describe('getContactDetail', () => {
     it('should delegate to getDataDetail with contacts table', async () => {
       const { getContactDetail } = require('@/services/contacts/api');

--- a/tests/unit/services/datasetUuidMentionSearch.test.ts
+++ b/tests/unit/services/datasetUuidMentionSearch.test.ts
@@ -3,6 +3,7 @@ import {
   DATASET_UUID_MENTION_PAGE_SIZE,
   mapDatasetUuidMentionRowsToListRows,
   normalizeDatasetUuidMentionStateCode,
+  normalizeDatasetUuidMentionTeamId,
   normalizeDatasetUuidSearchQuery,
   searchDatasetJsonUuidMentionPage,
   searchDatasetJsonUuidMentions,
@@ -56,6 +57,13 @@ describe('datasetUuidMentionSearch service', () => {
     expect(normalizeDatasetUuidMentionStateCode('')).toBe(null);
     expect(normalizeDatasetUuidMentionStateCode('draft')).toBe(null);
     expect(normalizeDatasetUuidMentionStateCode(Number.NaN)).toBe(null);
+  });
+
+  it('normalizes optional route team ids', () => {
+    expect(normalizeDatasetUuidMentionTeamId(' team-1 ')).toBe('team-1');
+    expect(normalizeDatasetUuidMentionTeamId('')).toBe(null);
+    expect(normalizeDatasetUuidMentionTeamId([])).toBe(null);
+    expect(normalizeDatasetUuidMentionTeamId()).toBe(null);
   });
 
   it('calls the JSON UUID mention RPC with bounded params', async () => {
@@ -293,6 +301,68 @@ describe('datasetUuidMentionSearch service', () => {
       'search_dataset_json_uuid_mentions',
       expect.objectContaining({ p_limit: 21 }),
     );
+  });
+
+  it('uses default synthetic pagination when page inputs are omitted', async () => {
+    const rows = Array.from({ length: 11 }, (_, index) => ({
+      matched_by: 'json',
+      matched_entity_table: 'processes',
+      rank: index + 1,
+      source_entity_kind: 'process' as const,
+      source_id: `process-${index + 1}`,
+      source_json: { value: index + 1 },
+      source_version: '01.00.000',
+    }));
+
+    supabaseMock.rpc.mockResolvedValueOnce({ data: rows, error: null });
+
+    await expect(
+      searchDatasetJsonUuidMentionPage({
+        dataSource: 'my',
+        sourceEntityKinds: ['process'],
+        uuid: 'd1380000-0000-4000-8000-000000000001',
+      }),
+    ).resolves.toMatchObject({
+      capped: false,
+      data: rows.slice(0, 10),
+      page: 1,
+      success: true,
+      total: 11,
+    });
+
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      'search_dataset_json_uuid_mentions',
+      expect.objectContaining({ p_limit: 11 }),
+    );
+  });
+
+  it('marks the last fetchable synthetic page as capped when 50 rows are reached', async () => {
+    const rows = Array.from({ length: DATASET_UUID_MENTION_MAX_RESULTS }, (_, index) => ({
+      matched_by: 'json',
+      matched_entity_table: 'processes',
+      rank: index + 1,
+      source_entity_kind: 'process' as const,
+      source_id: `process-${index + 1}`,
+      source_json: { value: index + 1 },
+      source_version: '01.00.000',
+    }));
+
+    supabaseMock.rpc.mockResolvedValueOnce({ data: rows, error: null });
+
+    await expect(
+      searchDatasetJsonUuidMentionPage({
+        dataSource: 'my',
+        pageCurrent: 5,
+        sourceEntityKinds: ['process'],
+        uuid: 'd1380000-0000-4000-8000-000000000001',
+      }),
+    ).resolves.toMatchObject({
+      capped: true,
+      data: rows.slice(40, 50),
+      page: 5,
+      success: true,
+      total: DATASET_UUID_MENTION_MAX_RESULTS,
+    });
   });
 
   it('caps synthetic reference lookup pages at the first 50 rows', async () => {

--- a/tests/unit/services/datasetUuidMentionSearch.test.ts
+++ b/tests/unit/services/datasetUuidMentionSearch.test.ts
@@ -1,6 +1,10 @@
 import {
+  DATASET_UUID_MENTION_MAX_RESULTS,
+  DATASET_UUID_MENTION_PAGE_SIZE,
+  mapDatasetUuidMentionRowsToListRows,
   normalizeDatasetUuidMentionStateCode,
   normalizeDatasetUuidSearchQuery,
+  searchDatasetJsonUuidMentionPage,
   searchDatasetJsonUuidMentions,
 } from '@/services/datasetUuidMentionSearch/api';
 import { getTeamIdByUserId } from '@/services/general/api';
@@ -233,5 +237,106 @@ describe('datasetUuidMentionSearch service', () => {
         uuid: 'd1380000-0000-4000-8000-000000000001',
       }),
     ).resolves.toEqual({ data: [], success: true });
+  });
+
+  it('builds bounded synthetic pages from the existing limit-only RPC', async () => {
+    const rows = Array.from({ length: 12 }, (_, index) => ({
+      matched_by: 'json',
+      matched_entity_table: 'processes',
+      rank: index + 1,
+      source_entity_kind: 'process' as const,
+      source_id: `process-${index + 1}`,
+      source_json: { value: index + 1 },
+      source_version: '01.00.000',
+    }));
+
+    supabaseMock.rpc.mockResolvedValueOnce({ data: rows.slice(0, 11), error: null });
+    await expect(
+      searchDatasetJsonUuidMentionPage({
+        dataSource: 'my',
+        pageCurrent: 1,
+        pageSize: DATASET_UUID_MENTION_PAGE_SIZE,
+        sourceEntityKinds: ['process'],
+        uuid: 'd1380000-0000-4000-8000-000000000001',
+      }),
+    ).resolves.toMatchObject({
+      capped: false,
+      data: rows.slice(0, 10),
+      page: 1,
+      success: true,
+      total: 11,
+    });
+
+    expect(supabaseMock.rpc).toHaveBeenLastCalledWith(
+      'search_dataset_json_uuid_mentions',
+      expect.objectContaining({ p_limit: 11 }),
+    );
+
+    supabaseMock.rpc.mockResolvedValueOnce({ data: rows, error: null });
+    await expect(
+      searchDatasetJsonUuidMentionPage({
+        dataSource: 'my',
+        pageCurrent: 2,
+        pageSize: DATASET_UUID_MENTION_PAGE_SIZE,
+        sourceEntityKinds: ['process'],
+        uuid: 'd1380000-0000-4000-8000-000000000001',
+      }),
+    ).resolves.toMatchObject({
+      capped: false,
+      data: rows.slice(10, 12),
+      page: 2,
+      success: true,
+      total: 12,
+    });
+
+    expect(supabaseMock.rpc).toHaveBeenLastCalledWith(
+      'search_dataset_json_uuid_mentions',
+      expect.objectContaining({ p_limit: 21 }),
+    );
+  });
+
+  it('caps synthetic reference lookup pages at the first 50 rows', async () => {
+    const result = await searchDatasetJsonUuidMentionPage({
+      dataSource: 'my',
+      pageCurrent: 6,
+      pageSize: DATASET_UUID_MENTION_PAGE_SIZE,
+      sourceEntityKinds: ['process'],
+      uuid: 'd1380000-0000-4000-8000-000000000001',
+    });
+
+    expect(result).toEqual({
+      capped: true,
+      data: [],
+      page: 6,
+      success: true,
+      total: DATASET_UUID_MENTION_MAX_RESULTS,
+    });
+    expect(supabaseMock.rpc).not.toHaveBeenCalled();
+  });
+
+  it('maps reference lookup RPC rows into list-row inputs', () => {
+    expect(
+      mapDatasetUuidMentionRowsToListRows([
+        {
+          matched_by: 'json',
+          matched_entity_table: 'flows',
+          rank: 1,
+          source_entity_kind: 'flow',
+          source_id: 'flow-1',
+          source_json: { flowDataSet: {} },
+          source_modified_at: null,
+          source_team_id: null,
+          source_version: '01.00.000',
+        },
+      ]),
+    ).toEqual([
+      {
+        id: 'flow-1',
+        json: { flowDataSet: {} },
+        modified_at: undefined,
+        team_id: undefined,
+        version: '01.00.000',
+      },
+    ]);
   });
 });

--- a/tests/unit/services/flowproperties/api.test.ts
+++ b/tests/unit/services/flowproperties/api.test.ts
@@ -21,6 +21,7 @@ import {
   getFlowpropertyDetail,
   getFlowpropertyTableAll,
   getFlowpropertyTablePgroongaSearch,
+  getFlowpropertyTableUuidMentionSearch,
   getReferenceUnitGroup,
   getReferenceUnitGroups,
   updateFlowproperties,
@@ -807,6 +808,95 @@ describe('FlowProperties API Service (src/services/flowproperties/api.ts)', () =
         page: 1,
         success: true,
         total: 0,
+      });
+    });
+
+    describe('getFlowpropertyTableUuidMentionSearch', () => {
+      const mentionRow = (overrides: any = {}) => ({
+        matched_by: 'json',
+        matched_entity_table: 'flowproperties',
+        rank: 1,
+        source_entity_kind: 'flowproperty',
+        source_id: 'fp-ref',
+        source_json: latestFlowpropertyRow().json,
+        source_modified_at: '2024-01-01T00:00:00Z',
+        source_team_id: 'team-ref',
+        source_version: '01.00.000',
+        ...overrides,
+      });
+
+      it('maps reference lookup rows into flow property table rows', async () => {
+        supabase.rpc.mockResolvedValueOnce({
+          data: [mentionRow()],
+          error: null,
+        });
+        classificationToString.mockReturnValue('Impact category');
+
+        const result = await getFlowpropertyTableUuidMentionSearch(
+          { current: 1, pageSize: 10 },
+          'en',
+          'tg',
+          'd1380000-0000-4000-8000-000000000001',
+          '100',
+          'team-1',
+        );
+
+        expect(supabase.rpc).toHaveBeenCalledWith('search_dataset_json_uuid_mentions', {
+          p_data_source: 'tg',
+          p_limit: 11,
+          p_source_entity_kinds: ['flowproperty'],
+          p_state_code_filter: 100,
+          p_team_id_filter: 'team-1',
+          p_this_user_id: 'user-123',
+          p_uuid: 'd1380000-0000-4000-8000-000000000001',
+        });
+        expect(result).toMatchObject({
+          data: [
+            expect.objectContaining({
+              id: 'fp-ref',
+              name: 'Mass',
+              classification: 'Impact category',
+              refUnitGroupId: 'ug-1',
+              refUnitGroup: 'Reference unit group',
+              teamId: 'team-ref',
+              version: '01.00.000',
+            }),
+          ],
+          success: true,
+          total: 1,
+        });
+      });
+
+      it('returns empty table data when reference lookup fails', async () => {
+        supabase.rpc.mockResolvedValueOnce({
+          data: null,
+          error: { message: 'lookup failed' },
+        });
+
+        const result = await getFlowpropertyTableUuidMentionSearch(
+          { current: 1, pageSize: 10 },
+          'en',
+          'tg',
+          'd1380000-0000-4000-8000-000000000001',
+          undefined,
+          [],
+        );
+
+        expect(supabase.rpc).toHaveBeenCalledWith(
+          'search_dataset_json_uuid_mentions',
+          expect.objectContaining({
+            p_source_entity_kinds: ['flowproperty'],
+            p_team_id_filter: null,
+          }),
+        );
+        expect(result).toEqual({
+          capped: false,
+          data: [],
+          error: 'lookup failed',
+          page: 1,
+          success: false,
+          total: 0,
+        });
       });
     });
   });

--- a/tests/unit/services/flows/api.test.ts
+++ b/tests/unit/services/flows/api.test.ts
@@ -12,6 +12,7 @@ import {
   getFlowStateCodeByIdsAndVersions,
   getFlowTableAll,
   getFlowTablePgroongaSearch,
+  getFlowTableUuidMentionSearch,
   getReferenceProperty,
   updateFlows,
 } from '@/services/flows/api';
@@ -1740,6 +1741,310 @@ describe('getFlowTablePgroongaSearch', () => {
       version: '01.00.019',
       modifiedAt: new Date('2024-01-19T00:00:00Z'),
       teamId: undefined,
+    });
+  });
+});
+
+describe('getFlowTableUuidMentionSearch', () => {
+  const mentionRow = (overrides: any = {}) => ({
+    matched_by: 'json',
+    matched_entity_table: 'flows',
+    rank: 1,
+    source_entity_kind: 'flow',
+    source_id: 'flow-ref',
+    source_json: {
+      flowDataSet: {
+        flowInformation: {
+          dataSetInformation: {
+            name: {
+              baseName: [{ '@xml:lang': 'en', '#text': 'Referenced flow' }],
+            },
+            classificationInformation: {
+              'common:classification': {
+                'common:class': [{ '@value': 'Products', '#text': 'Products' }],
+              },
+            },
+            'common:synonyms': [{ '@xml:lang': 'en', '#text': 'Ref flow synonym' }],
+            CASNumber: '50-00-0',
+          },
+          geography: {
+            locationOfSupply: 'CN',
+          },
+        },
+        modellingAndValidation: {
+          LCIMethod: {
+            typeOfDataSet: 'Product flow',
+          },
+        },
+        flowProperties: {
+          flowProperty: {
+            referenceToFlowPropertyDataSet: {
+              '@refObjectId': 'fp-ref',
+            },
+          },
+        },
+      },
+    },
+    source_modified_at: '2024-01-01T00:00:00Z',
+    source_team_id: 'team-ref',
+    source_version: '01.00.000',
+    ...overrides,
+  });
+
+  it('maps English reference lookup rows and sparse fallbacks into flow table rows', async () => {
+    mockRpc.mockResolvedValueOnce({
+      data: [
+        mentionRow(),
+        mentionRow({
+          source_id: 'flow-sparse',
+          source_json: { flowDataSet: { flowInformation: { dataSetInformation: {} } } },
+          source_modified_at: undefined,
+          source_team_id: undefined,
+          source_version: undefined,
+        }),
+      ],
+      error: null,
+    });
+    mockGetCachedLocationData.mockResolvedValueOnce([{ '@value': 'CN', '#text': 'China' }]);
+
+    const result = await getFlowTableUuidMentionSearch(
+      { current: 1, pageSize: 10 },
+      'en',
+      'tg',
+      'd1380000-0000-4000-8000-000000000001',
+      '100',
+      'team-1',
+    );
+
+    expect(mockRpc).toHaveBeenCalledWith('search_dataset_json_uuid_mentions', {
+      p_data_source: 'tg',
+      p_limit: 11,
+      p_source_entity_kinds: ['flow'],
+      p_state_code_filter: 100,
+      p_team_id_filter: 'team-1',
+      p_this_user_id: 'user-id',
+      p_uuid: 'd1380000-0000-4000-8000-000000000001',
+    });
+    expect(result.data[0]).toEqual({
+      key: 'flow-ref:01.00.000',
+      id: 'flow-ref',
+      name: 'Referenced flow',
+      synonyms: 'Ref flow synonym',
+      flowType: 'Product flow',
+      classification: 'Products',
+      CASNumber: '50-00-0',
+      locationOfSupply: 'China',
+      refFlowPropertyId: 'fp-ref',
+      version: '01.00.000',
+      modifiedAt: new Date('2024-01-01T00:00:00Z'),
+      teamId: 'team-ref',
+    });
+    expect(result.data[1]).toEqual({
+      key: 'flow-sparse:undefined',
+      id: 'flow-sparse',
+      name: '-',
+      synonyms: '-',
+      flowType: '-',
+      classification: '',
+      CASNumber: '-',
+      locationOfSupply: '-',
+      refFlowPropertyId: '-',
+      version: '',
+      modifiedAt: new Date(0),
+      teamId: '',
+    });
+  });
+
+  it('localizes Chinese elementary flow reference lookup rows', async () => {
+    mockRpc.mockResolvedValueOnce({
+      data: [
+        mentionRow({
+          source_id: 'flow-zh',
+          source_json: {
+            flowDataSet: {
+              flowInformation: {
+                dataSetInformation: {
+                  name: {
+                    baseName: [{ '@xml:lang': 'zh', '#text': '参考流' }],
+                  },
+                  classificationInformation: {
+                    'common:elementaryFlowCategorization': {
+                      'common:category': [{ '@value': 'Air', '#text': 'Air' }],
+                    },
+                  },
+                  'common:synonyms': [{ '@xml:lang': 'zh', '#text': '别名' }],
+                },
+                geography: {
+                  locationOfSupply: 'GLO',
+                },
+              },
+              modellingAndValidation: {
+                LCIMethod: {
+                  typeOfDataSet: 'Elementary flow',
+                },
+              },
+            },
+          },
+        }),
+      ],
+      error: null,
+    });
+    mockGetCachedLocationData.mockResolvedValueOnce([{ '@value': 'GLO', '#text': '全球' }]);
+    mockGetCachedFlowCategorizationAll.mockResolvedValueOnce({
+      categoryElementaryFlow: [{ '@value': 'Air', '#text': '空气' }],
+      category: [],
+    });
+
+    const result = await getFlowTableUuidMentionSearch(
+      { current: 1, pageSize: 10 },
+      'zh',
+      'tg',
+      'd1380000-0000-4000-8000-000000000001',
+    );
+
+    expect(result.data[0]).toMatchObject({
+      id: 'flow-zh',
+      name: '参考流',
+      synonyms: '别名',
+      classification: '空气',
+      flowType: 'Elementary flow',
+      locationOfSupply: '全球',
+    });
+  });
+
+  it('uses raw classifications when Chinese categorization data is unavailable', async () => {
+    mockRpc.mockResolvedValueOnce({
+      data: [
+        mentionRow({
+          source_id: 'flow-zh-no-category',
+          source_json: {
+            flowDataSet: {
+              flowInformation: {
+                dataSetInformation: {
+                  classificationInformation: {
+                    'common:elementaryFlowCategorization': {
+                      'common:category': [{ '@value': 'Air', '#text': 'Air' }],
+                    },
+                  },
+                },
+              },
+              modellingAndValidation: {
+                LCIMethod: {
+                  typeOfDataSet: 'Elementary flow',
+                },
+              },
+            },
+          },
+        }),
+      ],
+      error: null,
+    });
+    mockGetCachedFlowCategorizationAll.mockResolvedValueOnce(null);
+
+    const result = await getFlowTableUuidMentionSearch(
+      { current: 1, pageSize: 10 },
+      'zh',
+      'tg',
+      'd1380000-0000-4000-8000-000000000001',
+    );
+
+    expect(result.data[0]).toMatchObject({
+      id: 'flow-zh-no-category',
+      classification: 'Air',
+    });
+  });
+
+  it('falls back when the reference lookup flow name formatter returns undefined', async () => {
+    mockRpc.mockResolvedValueOnce({
+      data: [mentionRow({ source_id: 'flow-unnamed' })],
+      error: null,
+    });
+    mockGetCachedLocationData.mockResolvedValueOnce([{ '@value': 'CN', '#text': 'China' }]);
+    mockGenFlowName.mockReturnValueOnce(undefined);
+
+    const result = await getFlowTableUuidMentionSearch(
+      { current: 1, pageSize: 10 },
+      'en',
+      'tg',
+      'd1380000-0000-4000-8000-000000000001',
+    );
+
+    expect(result.data[0]).toMatchObject({
+      id: 'flow-unnamed',
+      name: '-',
+    });
+  });
+
+  it('returns fallback rows when reference lookup flow mapping throws', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+    mockRpc.mockResolvedValueOnce({
+      data: [
+        mentionRow({
+          source_id: 'flow-bad',
+          source_modified_at: undefined,
+          source_team_id: undefined,
+          source_version: undefined,
+        }),
+      ],
+      error: null,
+    });
+    mockJsonToList.mockImplementationOnce(() => {
+      throw new Error('bad flow mapping');
+    });
+
+    const result = await getFlowTableUuidMentionSearch(
+      { current: 1, pageSize: 10 },
+      'en',
+      'tg',
+      'd1380000-0000-4000-8000-000000000001',
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(result.data[0]).toEqual({
+      id: 'flow-bad',
+      version: '',
+      modifiedAt: new Date(0),
+      teamId: '',
+      name: '-',
+      synonyms: '',
+      classification: '',
+      flowType: '-',
+      CASNumber: '-',
+      locationOfSupply: '-',
+      refFlowPropertyId: '-',
+    });
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('returns empty table data when reference lookup fails', async () => {
+    mockRpc.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'lookup failed' },
+    });
+
+    const result = await getFlowTableUuidMentionSearch(
+      { current: 1, pageSize: 10 },
+      'en',
+      'tg',
+      'd1380000-0000-4000-8000-000000000001',
+      undefined,
+      [],
+    );
+
+    expect(mockRpc).toHaveBeenCalledWith(
+      'search_dataset_json_uuid_mentions',
+      expect.objectContaining({
+        p_source_entity_kinds: ['flow'],
+        p_team_id_filter: null,
+      }),
+    );
+    expect(result).toEqual({
+      capped: false,
+      data: [],
+      error: 'lookup failed',
+      page: 1,
+      success: false,
+      total: 0,
     });
   });
 });

--- a/tests/unit/services/lifeCycleModels/api.test.ts
+++ b/tests/unit/services/lifeCycleModels/api.test.ts
@@ -2496,6 +2496,242 @@ describe('table/search helpers', () => {
     expect(result).toEqual({});
   });
 
+  describe('getLifeCycleModelTableUuidMentionSearch', () => {
+    const mentionRow = (overrides: any = {}) => ({
+      matched_by: 'json',
+      matched_entity_table: 'lifecyclemodels',
+      rank: 1,
+      source_entity_kind: 'lifecyclemodel',
+      source_id: sampleModelId,
+      source_json: {
+        lifeCycleModelDataSet: {
+          lifeCycleModelInformation: {
+            dataSetInformation: {
+              name: {},
+              'common:generalComment': {},
+              classificationInformation: {
+                'common:classification': {
+                  'common:class': [{ id: 'class-1' }],
+                },
+              },
+            },
+          },
+        },
+      },
+      source_modified_at: '2026-03-17T10:00:00.000Z',
+      source_team_id: 'team-1',
+      source_version: sampleVersion,
+      ...overrides,
+    });
+
+    it('maps English reference lookup rows and sparse fallbacks into lifecycle model table rows', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: [
+          mentionRow(),
+          mentionRow({
+            source_id: 'model-sparse',
+            source_json: {},
+            source_modified_at: undefined,
+            source_team_id: undefined,
+            source_version: undefined,
+          }),
+        ],
+        error: null,
+      });
+
+      const result = await lifeCycleModelsApi.getLifeCycleModelTableUuidMentionSearch(
+        { current: 1, pageSize: 10 },
+        'en',
+        'tg',
+        'd1380000-0000-4000-8000-000000000001',
+        '100',
+        'team-1',
+      );
+
+      expect(mockRpc).toHaveBeenCalledWith('search_dataset_json_uuid_mentions', {
+        p_data_source: 'tg',
+        p_limit: 11,
+        p_source_entity_kinds: ['lifecyclemodel'],
+        p_state_code_filter: 100,
+        p_team_id_filter: 'team-1',
+        p_this_user_id: sampleUserId,
+        p_uuid: 'd1380000-0000-4000-8000-000000000001',
+      });
+      expect(result.data).toEqual([
+        {
+          key: sampleModelId,
+          id: sampleModelId,
+          name: 'Life Cycle Model Name',
+          generalComment: 'localized-text',
+          classification: 'classification-string',
+          version: sampleVersion,
+          modifiedAt: new Date('2026-03-17T10:00:00.000Z'),
+          teamId: 'team-1',
+        },
+        {
+          key: 'model-sparse',
+          id: 'model-sparse',
+          name: 'Life Cycle Model Name',
+          generalComment: 'localized-text',
+          classification: 'classification-string',
+          version: '',
+          modifiedAt: new Date(0),
+          teamId: '',
+        },
+      ]);
+    });
+
+    it('maps Chinese reference lookup rows with classification localization', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: [
+          mentionRow({ source_id: 'model-zh' }),
+          mentionRow({
+            source_id: 'model-zh-sparse',
+            source_json: {},
+            source_modified_at: undefined,
+            source_team_id: undefined,
+            source_version: undefined,
+          }),
+        ],
+        error: null,
+      });
+      mockGenClassificationZH.mockReturnValueOnce(['zh-classification']);
+
+      const result = await lifeCycleModelsApi.getLifeCycleModelTableUuidMentionSearch(
+        { current: 1, pageSize: 10 },
+        'zh',
+        'tg',
+        'd1380000-0000-4000-8000-000000000001',
+      );
+
+      expect(mockGetILCDClassification).toHaveBeenCalledWith('LifeCycleModel', 'zh', ['all']);
+      expect(result.data[0]).toEqual({
+        key: 'model-zh',
+        id: 'model-zh',
+        name: 'Life Cycle Model Name',
+        generalComment: 'localized-text',
+        classification: 'classification-string',
+        version: sampleVersion,
+        modifiedAt: new Date('2026-03-17T10:00:00.000Z'),
+        teamId: 'team-1',
+      });
+      expect(result.data[1]).toEqual({
+        key: 'model-zh-sparse',
+        id: 'model-zh-sparse',
+        name: 'Life Cycle Model Name',
+        generalComment: 'localized-text',
+        classification: 'classification-string',
+        version: '',
+        modifiedAt: new Date(0),
+        teamId: '',
+      });
+    });
+
+    it('returns fallback rows when Chinese reference lookup mapping throws', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      mockRpc.mockResolvedValueOnce({
+        data: [
+          mentionRow({
+            source_id: 'model-bad-zh',
+            source_modified_at: undefined,
+            source_team_id: undefined,
+            source_version: undefined,
+          }),
+        ],
+        error: null,
+      });
+      mockJsonToList.mockImplementationOnce(() => {
+        throw new Error('bad zh lifecycle mention');
+      });
+
+      const result = await lifeCycleModelsApi.getLifeCycleModelTableUuidMentionSearch(
+        { current: 1, pageSize: 10 },
+        'zh',
+        'tg',
+        'd1380000-0000-4000-8000-000000000001',
+      );
+
+      expect(result.data[0]).toEqual({
+        id: 'model-bad-zh',
+        version: '',
+        modifiedAt: new Date(0),
+        teamId: '',
+        name: '-',
+        generalComment: '',
+        classification: '',
+      });
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('returns fallback rows when English reference lookup mapping throws', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      mockRpc.mockResolvedValueOnce({
+        data: [
+          mentionRow({
+            source_id: 'model-bad-en',
+            source_modified_at: undefined,
+            source_team_id: undefined,
+            source_version: undefined,
+          }),
+        ],
+        error: null,
+      });
+      mockJsonToList.mockImplementationOnce(() => {
+        throw new Error('bad en lifecycle mention');
+      });
+
+      const result = await lifeCycleModelsApi.getLifeCycleModelTableUuidMentionSearch(
+        { current: 1, pageSize: 10 },
+        'en',
+        'tg',
+        'd1380000-0000-4000-8000-000000000001',
+      );
+
+      expect(result.data[0]).toEqual({
+        id: 'model-bad-en',
+        version: '',
+        modifiedAt: new Date(0),
+        teamId: '',
+        name: '-',
+        generalComment: '',
+        classification: '',
+      });
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('returns empty table data when reference lookup fails', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: null,
+        error: { message: 'lookup failed' },
+      });
+
+      const result = await lifeCycleModelsApi.getLifeCycleModelTableUuidMentionSearch(
+        { current: 1, pageSize: 10 },
+        'en',
+        'tg',
+        'd1380000-0000-4000-8000-000000000001',
+      );
+
+      expect(mockRpc).toHaveBeenCalledWith(
+        'search_dataset_json_uuid_mentions',
+        expect.objectContaining({
+          p_source_entity_kinds: ['lifecyclemodel'],
+          p_team_id_filter: null,
+        }),
+      );
+      expect(result).toEqual({
+        capped: false,
+        data: [],
+        error: 'lookup failed',
+        page: 1,
+        success: false,
+        total: 0,
+      });
+    });
+  });
+
   it('returns the raw hybrid-search result when there is no session', async () => {
     mockAuthGetSession.mockResolvedValueOnce(createMockNoSession());
 

--- a/tests/unit/services/processes/api.test.ts
+++ b/tests/unit/services/processes/api.test.ts
@@ -3961,6 +3961,243 @@ describe('getProcessTablePgroongaSearch', () => {
   });
 });
 
+describe('getProcessTableUuidMentionSearch', () => {
+  beforeEach(() => {
+    mockAuthGetSession.mockResolvedValue({
+      data: {
+        session: {
+          user: { id: 'user-id' },
+        },
+      },
+    });
+  });
+
+  const mentionRow = (overrides: any = {}) => ({
+    matched_by: 'json',
+    matched_entity_table: 'processes',
+    rank: 1,
+    source_entity_kind: 'process',
+    source_id: 'process-ref',
+    source_json: {
+      processDataSet: {
+        processInformation: {
+          dataSetInformation: {
+            name: {},
+            'common:generalComment': {},
+            classificationInformation: {
+              'common:classification': {
+                'common:class': [{ '@value': 'process-class', '#text': 'Process Class' }],
+              },
+            },
+          },
+          geography: {
+            locationOfOperationSupplyOrProduction: {
+              '@location': 'CN',
+            },
+          },
+          time: {
+            'common:referenceYear': '2024',
+          },
+        },
+        modellingAndValidation: {
+          LCIMethodAndAllocation: {
+            typeOfDataSet: 'LCI result',
+          },
+        },
+      },
+    },
+    source_modified_at: '2024-01-01T00:00:00Z',
+    source_model_id: 'model-ref',
+    source_team_id: 'team-ref',
+    source_version: sampleVersion,
+    ...overrides,
+  });
+
+  it('maps and filters English reference lookup rows into process table rows', async () => {
+    mockRpc.mockResolvedValueOnce({
+      data: [
+        mentionRow(),
+        mentionRow({
+          source_id: 'process-filtered-out',
+          source_json: {
+            processDataSet: {
+              processInformation: {
+                dataSetInformation: {},
+              },
+              modellingAndValidation: {
+                LCIMethodAndAllocation: {
+                  typeOfDataSet: 'gate to gate',
+                },
+              },
+            },
+          },
+        }),
+      ],
+      error: null,
+    });
+    mockGetCachedLocationData.mockResolvedValueOnce([{ '@value': 'CN', '#text': 'China' }]);
+
+    const result = await processesApi.getProcessTableUuidMentionSearch(
+      { current: 1, pageSize: 10 },
+      'en',
+      'tg',
+      'd1380000-0000-4000-8000-000000000001',
+      '100',
+      'LCI result',
+      'team-1',
+    );
+
+    expect(mockRpc).toHaveBeenCalledWith('search_dataset_json_uuid_mentions', {
+      p_data_source: 'tg',
+      p_limit: 11,
+      p_source_entity_kinds: ['process'],
+      p_state_code_filter: 100,
+      p_team_id_filter: 'team-1',
+      p_this_user_id: 'user-id',
+      p_uuid: 'd1380000-0000-4000-8000-000000000001',
+    });
+    expect(result.data).toEqual([
+      {
+        key: `process-ref:${sampleVersion}`,
+        id: 'process-ref',
+        lang: 'en',
+        name: 'Process Name',
+        generalComment: 'General comment',
+        classification: 'classification-string',
+        referenceYear: '2024',
+        location: 'China',
+        version: sampleVersion,
+        typeOfDataSet: 'LCI result',
+        modifiedAt: new Date('2024-01-01T00:00:00Z'),
+        teamId: 'team-ref',
+        modelId: '',
+      },
+    ]);
+  });
+
+  it('maps Chinese reference lookup rows and all dataset types with fallbacks', async () => {
+    mockRpc.mockResolvedValueOnce({
+      data: [
+        mentionRow({
+          source_id: 'process-zh',
+          source_json: {
+            processDataSet: {
+              processInformation: {
+                dataSetInformation: {},
+                geography: {
+                  locationOfOperationSupplyOrProduction: {
+                    '@location': 'US',
+                  },
+                },
+              },
+            },
+          },
+          source_modified_at: undefined,
+          source_model_id: undefined,
+          source_team_id: undefined,
+        }),
+        mentionRow({
+          source_id: 'process-no-location',
+          source_json: {
+            processDataSet: {
+              processInformation: {
+                dataSetInformation: {},
+              },
+            },
+          },
+        }),
+      ],
+      error: null,
+    });
+    mockGetCachedLocationData.mockResolvedValueOnce([]);
+
+    const result = await processesApi.getProcessTableUuidMentionSearch(
+      { current: 1, pageSize: 10 },
+      'zh',
+      'tg',
+      'd1380000-0000-4000-8000-000000000001',
+      undefined,
+      'all',
+    );
+
+    expect(mockGetCachedClassificationData).toHaveBeenCalledWith('Process', 'zh', ['all']);
+    expect(result.data[0]).toEqual({
+      key: `process-zh:${sampleVersion}`,
+      id: 'process-zh',
+      lang: 'zh',
+      name: 'Process Name',
+      generalComment: 'General comment',
+      classification: 'classification-string',
+      referenceYear: '-',
+      location: 'US',
+      version: sampleVersion,
+      typeOfDataSet: '-',
+      modifiedAt: new Date(0),
+      teamId: '',
+      modelId: '',
+    });
+    expect(result.data[1]).toMatchObject({
+      id: 'process-no-location',
+      location: '-',
+    });
+  });
+
+  it('returns fallback rows when reference lookup process mapping throws', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    mockRpc.mockResolvedValueOnce({
+      data: [mentionRow({ source_id: 'process-bad' })],
+      error: null,
+    });
+    mockJsonToList.mockImplementationOnce(() => {
+      throw new Error('bad process mention');
+    });
+
+    const result = await processesApi.getProcessTableUuidMentionSearch(
+      { current: 1, pageSize: 10 },
+      'en',
+      'tg',
+      'd1380000-0000-4000-8000-000000000001',
+    );
+
+    expect(result.data).toEqual([{ id: 'process-bad' }]);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it('returns empty table data when reference lookup fails', async () => {
+    mockRpc.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'lookup failed' },
+    });
+
+    const result = await processesApi.getProcessTableUuidMentionSearch(
+      { current: 1, pageSize: 10 },
+      'en',
+      'tg',
+      'd1380000-0000-4000-8000-000000000001',
+      undefined,
+      undefined,
+      [],
+    );
+
+    expect(mockRpc).toHaveBeenCalledWith(
+      'search_dataset_json_uuid_mentions',
+      expect.objectContaining({
+        p_source_entity_kinds: ['process'],
+        p_team_id_filter: null,
+      }),
+    );
+    expect(result).toEqual({
+      capped: false,
+      data: [],
+      error: 'lookup failed',
+      page: 1,
+      success: false,
+      total: 0,
+    });
+  });
+});
+
 describe('contributeProcess', () => {
   const testId = 'process-123';
   const testVersion = '01.00.000';

--- a/tests/unit/services/sources/api.test.ts
+++ b/tests/unit/services/sources/api.test.ts
@@ -24,6 +24,7 @@ import {
   getSourcesByIdsAndVersions,
   getSourceTableAll,
   getSourceTablePgroongaSearch,
+  getSourceTableUuidMentionSearch,
   updateSource,
 } from '@/services/sources/api';
 import {
@@ -1051,6 +1052,95 @@ describe('Sources API Service (src/services/sources/api.ts)', () => {
         id: 'source-sparse-zh',
         sourceCitation: '-',
         publicationType: '-',
+      });
+    });
+  });
+
+  describe('getSourceTableUuidMentionSearch', () => {
+    const mentionRow = (overrides: any = {}) => ({
+      matched_by: 'json',
+      matched_entity_table: 'sources',
+      rank: 1,
+      source_entity_kind: 'source',
+      source_id: 'source-ref',
+      source_json: mockSource.json,
+      source_modified_at: '2024-01-01T00:00:00Z',
+      source_team_id: 'team-ref',
+      source_version: '01.00.000',
+      ...overrides,
+    });
+
+    it('maps reference lookup rows into source table rows', async () => {
+      supabase.rpc.mockResolvedValue({
+        data: [mentionRow()],
+        error: null,
+      });
+      getLangText.mockReturnValue('Referenced source');
+      jsonToList.mockReturnValue([]);
+      classificationToString.mockReturnValue('Reference');
+
+      const result = await getSourceTableUuidMentionSearch(
+        { current: 1, pageSize: 10 },
+        'en',
+        'tg',
+        'd1380000-0000-4000-8000-000000000001',
+        '100',
+        'team-1',
+      );
+
+      expect(supabase.rpc).toHaveBeenCalledWith('search_dataset_json_uuid_mentions', {
+        p_data_source: 'tg',
+        p_limit: 11,
+        p_source_entity_kinds: ['source'],
+        p_state_code_filter: 100,
+        p_team_id_filter: 'team-1',
+        p_this_user_id: 'user-123',
+        p_uuid: 'd1380000-0000-4000-8000-000000000001',
+      });
+      expect(result).toMatchObject({
+        data: [
+          expect.objectContaining({
+            id: 'source-ref',
+            shortName: 'Referenced source',
+            classification: 'Reference',
+            teamId: 'team-ref',
+            version: '01.00.000',
+          }),
+        ],
+        success: true,
+        total: 1,
+      });
+    });
+
+    it('returns empty table data when reference lookup fails', async () => {
+      supabase.rpc.mockResolvedValue({
+        data: null,
+        error: { message: 'lookup failed' },
+      });
+
+      const result = await getSourceTableUuidMentionSearch(
+        { current: 1, pageSize: 10 },
+        'en',
+        'tg',
+        'd1380000-0000-4000-8000-000000000001',
+        undefined,
+        [],
+      );
+
+      expect(supabase.rpc).toHaveBeenCalledWith(
+        'search_dataset_json_uuid_mentions',
+        expect.objectContaining({
+          p_source_entity_kinds: ['source'],
+          p_team_id_filter: null,
+        }),
+      );
+      expect(result).toEqual({
+        capped: false,
+        data: [],
+        error: 'lookup failed',
+        page: 1,
+        success: false,
+        total: 0,
       });
     });
   });

--- a/tests/unit/services/unitgroups/api.test.ts
+++ b/tests/unit/services/unitgroups/api.test.ts
@@ -11,6 +11,7 @@ import {
   getUnitGroupDetail,
   getUnitGroupTableAll,
   getUnitGroupTablePgroongaSearch,
+  getUnitGroupTableUuidMentionSearch,
   updateUnitGroup,
 } from '@/services/unitgroups/api';
 
@@ -925,6 +926,92 @@ describe('getUnitGroupTableAll', () => {
       total: 1,
     });
     expect(Number.isNaN(result.data[0].modifiedAt.getTime())).toBe(true);
+  });
+
+  describe('getUnitGroupTableUuidMentionSearch', () => {
+    const mentionRow = (overrides: any = {}) => ({
+      matched_by: 'json',
+      matched_entity_table: 'unitgroups',
+      rank: 1,
+      source_entity_kind: 'unitgroup',
+      source_id: 'ug-ref',
+      source_json: latestUnitGroupRow().json,
+      source_modified_at: '2024-01-01T00:00:00Z',
+      source_team_id: 'team-ref',
+      source_version: '01.00.000',
+      ...overrides,
+    });
+
+    it('maps reference lookup rows into unit group table rows', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: [mentionRow()],
+        error: null,
+      });
+
+      const result = await getUnitGroupTableUuidMentionSearch(
+        { current: 1, pageSize: 10 },
+        'en',
+        'tg',
+        'd1380000-0000-4000-8000-000000000001',
+        '100',
+        'team-1',
+      );
+
+      expect(mockRpc).toHaveBeenCalledWith('search_dataset_json_uuid_mentions', {
+        p_data_source: 'tg',
+        p_limit: 11,
+        p_source_entity_kinds: ['unitgroup'],
+        p_state_code_filter: 100,
+        p_team_id_filter: 'team-1',
+        p_this_user_id: 'user-id',
+        p_uuid: 'd1380000-0000-4000-8000-000000000001',
+      });
+      expect(result).toMatchObject({
+        data: [
+          expect.objectContaining({
+            id: 'ug-ref',
+            name: 'Unit Group One',
+            refUnitName: 'Kilogram',
+            teamId: 'team-ref',
+            version: '01.00.000',
+          }),
+        ],
+        success: true,
+        total: 1,
+      });
+    });
+
+    it('returns empty table data when reference lookup fails', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: null,
+        error: { message: 'lookup failed' },
+      });
+
+      const result = await getUnitGroupTableUuidMentionSearch(
+        { current: 1, pageSize: 10 },
+        'en',
+        'tg',
+        'd1380000-0000-4000-8000-000000000001',
+        undefined,
+        [],
+      );
+
+      expect(mockRpc).toHaveBeenCalledWith(
+        'search_dataset_json_uuid_mentions',
+        expect.objectContaining({
+          p_source_entity_kinds: ['unitgroup'],
+          p_team_id_filter: null,
+        }),
+      );
+      expect(result).toEqual({
+        capped: false,
+        data: [],
+        error: 'lookup failed',
+        page: 1,
+        success: false,
+        total: 0,
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## 概要
- 将最新 dev 分支提升到 main
- 包含已合入 dev 的 #485：优化“查找包含该 ID 的数据”并复用全文检索表格展示

## 校验
- npm run lint
- npm run test:coverage -- --silent
- npm run test:coverage:assert-full

## 说明
- 使用 fork 分支 ForeverYoung5:promote/dev-to-main-20260531 发起，避免依赖上游仓库推送权限。