### PR TITLE
Release: pin EdgeOne deploy dependencies

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-06-01'
-lastReviewedCommit: '5f291096792e8e67770fd03a29826a3ec21a2dcd'
+lastReviewedCommit: 'e8aa2619aaf2332e8f7cb61130e163a2ab1ed795'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,14 @@ name: Build/release
 
 # Releases normally start from a main push whose package.json version is new.
 # The workflow creates the matching v* tag and runs the release in the same run.
-# Manual v* tag pushes remain supported for recovery/backfill releases.
+# Manual v* tag pushes and workflow_dispatch runs remain supported for recovery/backfill releases.
 on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Existing v* tag to release with the current workflow definition.
+        required: true
+        type: string
   push:
     branches:
       - main
@@ -41,6 +47,9 @@ jobs:
 
       - name: Resolve release target
         id: release
+        env:
+          PUSH_BEFORE_SHA: ${{ github.event.before || '' }}
+          REQUESTED_TAG_NAME: ${{ github.event.inputs.tag_name || '' }}
         run: |
           set -euo pipefail
 
@@ -54,26 +63,68 @@ jobs:
             exit 0
           fi
 
-          package_version="$(node -p "require('./package.json').version")"
-          expected_tag="v${package_version}"
+          read_package_version() {
+            git show "${1}:package.json" | node -e "const fs = require('fs'); const pkg = JSON.parse(fs.readFileSync(0, 'utf8')); console.log(pkg.version);"
+          }
+
           tag_created=false
 
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            tag_name="${REQUESTED_TAG_NAME}"
+            if [ -z "${tag_name}" ] || [[ "${tag_name}" != v* ]]; then
+              echo "::error::workflow_dispatch tag_name must be an existing v* tag."
+              exit 1
+            fi
+
+            if ! release_head="$(git rev-list -n 1 "${tag_name}" 2>/dev/null)"; then
+              echo "::error::Release tag ${tag_name} does not exist."
+              exit 1
+            fi
+
+            package_version="$(read_package_version "${release_head}")"
+            expected_tag="v${package_version}"
+            if [ "${tag_name}" != "${expected_tag}" ]; then
+              echo "::error::Release tag ${tag_name} does not match package.json version ${package_version} at ${release_head}."
+              exit 1
+            fi
+
+            echo "::notice::Releasing existing ${tag_name} at ${release_head} with the current workflow definition."
+          elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             tag_name="${GITHUB_REF_NAME}"
             release_head="$(git rev-list -n 1 "${tag_name}")"
+            package_version="$(read_package_version "${release_head}")"
+            expected_tag="v${package_version}"
             if [ "${tag_name}" != "${expected_tag}" ]; then
-              echo "::error::Release tag ${tag_name} does not match package.json version ${package_version}."
+              echo "::error::Release tag ${tag_name} does not match package.json version ${package_version} at ${release_head}."
               exit 1
             fi
           else
-            tag_name="${expected_tag}"
             release_head="${GITHUB_SHA}"
+            package_version="$(read_package_version "${release_head}")"
+            expected_tag="v${package_version}"
+            tag_name="${expected_tag}"
+            package_changed=true
+
+            if [ -n "${PUSH_BEFORE_SHA}" ] && [ "${PUSH_BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]; then
+              if git diff --quiet "${PUSH_BEFORE_SHA}" "${release_head}" -- package.json; then
+                package_changed=false
+              fi
+            fi
 
             existing_tag_sha="$(git ls-remote --tags origin "refs/tags/${tag_name}" | awk '{print $1}')"
             if [ -n "${existing_tag_sha}" ]; then
               git fetch --force origin "refs/tags/${tag_name}:refs/tags/${tag_name}"
               existing_tag_commit="$(git rev-list -n 1 "${tag_name}")"
               if [ "${existing_tag_commit}" != "${release_head}" ]; then
+                if [ "${package_changed}" = "false" ]; then
+                  echo "should_release=false" >> "$GITHUB_OUTPUT"
+                  echo "tag_created=false" >> "$GITHUB_OUTPUT"
+                  echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+                  echo "release_head=${release_head}" >> "$GITHUB_OUTPUT"
+                  echo "::notice::${tag_name} already points to ${existing_tag_commit}; package.json was unchanged in this main push, so this workflow hotfix is not a new release."
+                  exit 0
+                fi
+
                 echo "::error::${tag_name} already points to ${existing_tag_commit}, not current main commit ${release_head}. Bump package.json before releasing another main commit."
                 exit 1
               fi
@@ -174,6 +225,8 @@ jobs:
       EDGEONE_OUTPUT_DIR: dist
       EDGEONE_PROJECT_NAME: tiangong-lca-next-upload
       EDGEONE_CLI_VERSION: 1.4.6
+      EDGEONE_VITEST_VERSION: 3.2.4
+      EDGEONE_VITE_NODE_VERSION: 3.2.4
 
     steps:
       - name: Check out Git repository
@@ -211,11 +264,34 @@ jobs:
             exit 1
           fi
 
+          edgeone_cli_dir="$(mktemp -d)"
+          cleanup_edgeone_cli() {
+            rm -rf "$edgeone_cli_dir"
+          }
+          trap cleanup_edgeone_cli EXIT
+
+          npm --prefix "$edgeone_cli_dir" install \
+            --prefer-offline \
+            --no-save \
+            --ignore-scripts \
+            --package-lock=false \
+            --no-audit \
+            --no-fund \
+            "edgeone@${EDGEONE_CLI_VERSION}" \
+            "vitest@${EDGEONE_VITEST_VERSION}" \
+            "vite-node@${EDGEONE_VITE_NODE_VERSION}"
+
+          edgeone_bin="$edgeone_cli_dir/node_modules/.bin/edgeone"
+          if [ ! -x "$edgeone_bin" ]; then
+            echo "::error::EdgeOne CLI binary was not installed at ${edgeone_bin}."
+            exit 1
+          fi
+
           max_attempts=3
           for attempt in $(seq 1 "$max_attempts"); do
             echo "Deploying to EdgeOne Pages, attempt ${attempt}/${max_attempts}."
 
-            if timeout 300s npx --yes "edgeone@${EDGEONE_CLI_VERSION}" pages deploy "$EDGEONE_OUTPUT_DIR" -n "$EDGEONE_PROJECT_NAME" -t "$EDGEONE_API_TOKEN"; then
+            if timeout 300s "$edgeone_bin" pages deploy "$EDGEONE_OUTPUT_DIR" -n "$EDGEONE_PROJECT_NAME" -t "$EDGEONE_API_TOKEN"; then
               exit 0
             fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 710b7e5f82205c4f1509dbbcbc5f3480d341669f
+lastReviewedCommit: e8aa2619aaf2332e8f7cb61130e163a2ab1ed795
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -152,7 +152,8 @@ Route those tasks to:
 - routine PR base: `dev`
 - promote path: `dev -> main`
 - canonical `main` branch pushes read `package.json.version`, create the matching `v*` tag when missing, run the release gate, deploy the web app, and build draft Electron releases in the same workflow run
-- manual `v*` tag pushes whose target commit is already on `main` remain supported for recovery/backfill releases
+- canonical `main` branch pushes whose `package.json` is unchanged and whose matching `v*` tag already points to an older `main` commit skip release instead of requiring a version bump
+- manual `v*` tag pushes and `workflow_dispatch` runs for an existing `v*` tag whose target commit is already on `main` remain supported for recovery/backfill releases
 
 Do not infer daily workflow from GitHub default-branch UI alone.
 

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 5f291096792e8e67770fd03a29826a3ec21a2dcd
+lastReviewedCommit: e8aa2619aaf2332e8f7cb61130e163a2ab1ed795
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 710b7e5f82205c4f1509dbbcbc5f3480d341669f
+lastReviewedCommit: e8aa2619aaf2332e8f7cb61130e163a2ab1ed795
 ---
 
 # Pre-Push Gate Policy
@@ -64,7 +64,8 @@ It does not own:
 | ordinary GitHub branch pushes | do not run standalone remote test jobs |
 | PRs into `dev` or `main` | rely on local test-gate evidence and docpact PR governance |
 | canonical post-merge `main` pushes | read `package.json.version`, create the matching `v*` tag when missing, then run release-gate tests before web deploy and draft Electron release |
-| manual release tags on `main` commits | remain supported for recovery/backfill releases and run the same release gate before deploy/release |
+| unchanged-version `main` workflow hotfix pushes | skip release when the matching `v*` tag already points to an older `main` commit |
+| manual release tags or `workflow_dispatch` recovery on `main` commits | remain supported for recovery/backfill releases and run the same release gate before deploy/release |
 
 ## Adoption Conditions
 
@@ -81,5 +82,6 @@ It does not own:
 - protect the actual local and release gates
 - avoid spending GitHub Actions minutes on ordinary push-triggered test jobs
 - keep release automation in the same `main` push workflow after the tag is created; do not rely on a second tag-push workflow run from `GITHUB_TOKEN`
+- use `workflow_dispatch` with an existing `v*` tag when a release needs to be recovered with newer workflow code
 - reproduce `npm run test:ci` and `npm run prepush:gate` serially on one workstation when both are needed
 - keep `100%` coverage on every tracked file, and treat any direct-collection exclusions as a reviewed exception rather than a default pattern

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 710b7e5f82205c4f1509dbbcbc5f3480d341669f
+lastReviewedCommit: e8aa2619aaf2332e8f7cb61130e163a2ab1ed795
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -73,7 +73,7 @@ The local `pre-push` hook always runs `npm run docpact:gate` first, then runs th
 
 If the change touches `scripts/test-runner.cjs` or protected-branch gate reproduction, run `npm run test:ci` and `npm run prepush:gate` serially locally because both commands regenerate `.umi-test`.
 
-For deployment-only workflow changes under `.github/workflows/build.yml` or the manual `.github/workflows/ci.yml` fallback, validate the workflow shape directly with YAML parsing, formatter checks, and shell syntax checks for edited deploy scripts. Do not run production deploy commands locally or from PR validation unless the task explicitly requires exercising live deploy credentials; the automatic EdgeOne Pages deploy step runs from canonical `main` pushes by creating the matching `v*` tag from `package.json.version` and continuing release in the same workflow run, manual `v*` tag pushes remain supported when the target commit is already on `main`, the manual deploy fallback is guarded to `refs/heads/main` and checks out `github.sha`, and ordinary non-release branch pushes belong to the local pre-push gate.
+For deployment-only workflow changes under `.github/workflows/build.yml` or the manual `.github/workflows/ci.yml` fallback, validate the workflow shape directly with YAML parsing, formatter checks, and shell syntax checks for edited deploy scripts. For EdgeOne CLI dependency changes, also validate the pinned temporary install path locally without calling the live deploy command. Do not run production deploy commands locally or from PR validation unless the task explicitly requires exercising live deploy credentials; the automatic EdgeOne Pages deploy step runs from canonical `main` pushes by creating the matching `v*` tag from `package.json.version` and continuing release in the same workflow run, unchanged-version `main` workflow hotfix pushes skip release when the matching tag already belongs to an older `main` commit, manual `v*` tag pushes and `workflow_dispatch` recovery runs remain supported when the target commit is already on `main`, the manual deploy fallback is guarded to `refs/heads/main` and checks out `github.sha`, and ordinary non-release branch pushes belong to the local pre-push gate.
 
 Treat dataset-validation work under `src/pages/*/sdkValidation.ts`, `src/pages/Utils/validation/**`, `src/components/ValidationIssueModal/index.tsx`, and localized validator copy under `src/locales/**` as shipped runtime work even when most of the change looks like error-message plumbing.
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 5f291096792e8e67770fd03a29826a3ec21a2dcd
+lastReviewedCommit: e8aa2619aaf2332e8f7cb61130e163a2ab1ed795
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 5f291096792e8e67770fd03a29826a3ec21a2dcd
+lastReviewedCommit: e8aa2619aaf2332e8f7cb61130e163a2ab1ed795
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 5f291096792e8e67770fd03a29826a3ec21a2dcd
+lastReviewedCommit: e8aa2619aaf2332e8f7cb61130e163a2ab1ed795
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 5f291096792e8e67770fd03a29826a3ec21a2dcd
+lastReviewedCommit: e8aa2619aaf2332e8f7cb61130e163a2ab1ed795
 ---
 
 # Testing Troubleshooting


### PR DESCRIPTION
Closes #494

## Summary
- Pins EdgeOne deploy's transient Vitest/vite-node dependency set and installs the CLI into a temporary directory before deploy retries.
- Adds workflow_dispatch recovery for existing v* tags so v0.0.20 can be redeployed with the fixed workflow.
- Makes unchanged-version main workflow hotfix pushes skip release when the matching tag already points to an older main commit.

## Key Decisions
- Keep package.json version unchanged; this is a release workflow hotfix, not a new product release.
- Use workflow_dispatch tag_name for recovering an already-created tag with current workflow code.

## Validation
- YAML parse for .github/workflows/build.yml.
- Extracted 12 workflow run blocks and passed bash -n after normalizing GitHub expressions.
- Temporary EdgeOne install succeeded with edgeone@1.4.6, vitest@3.2.4, and vite-node@3.2.4; binary existed.
- Simulated main hotfix push release-context: should_release=false for existing v0.0.20 on older main commit.
- Simulated workflow_dispatch release-context: should_release=true for v0.0.20 at e8aa2619.
- npm run lint.
- scripts/docpact lint --root . --worktree --mode enforce.
- npm run docpact:gate -- --base origin/main --head HEAD.

## Risks / Rollback
- After merge, the main push for this workflow hotfix should skip release; rerun the existing v0.0.20 release via workflow_dispatch on main with tag_name=v0.0.20.

## Follow-ups
- Back-merge main to dev after the hotfix lands, per M2 hotfix policy.

## Workspace Integration
- Targets main as a production release workflow hotfix; root integration is only needed if the workspace pointer should move to this next/main hotfix commit.