### PR TITLE
fix: recover task center jobs from worker_jobs

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-01"
-lastReviewedCommit: "e535b7a213326414b7df9c22d48a0ac36615d460"
+lastReviewedAt: "2026-06-02"
+lastReviewedCommit: "a6d8b7f106e57b6341b3e4c8cacf897a74de15e8"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "a6d8b7f106e57b6341b3e4c8cacf897a74de15e8"
+lastReviewedCommit: "b063fc0ebfec2b413495466daa5015c067d7b497"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "b063fc0ebfec2b413495466daa5015c067d7b497"
+lastReviewedCommit: "c0d6c0f9d0f7207d2c89d4c0dfdef388248ad9b2"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 710b7e5f82205c4f1509dbbcbc5f3480d341669f
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
+lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
+lastReviewedCommit: c0d6c0f9d0f7207d2c89d4c0dfdef388248ad9b2
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
+lastReviewedCommit: c0d6c0f9d0f7207d2c89d4c0dfdef388248ad9b2
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: e535b7a213326414b7df9c22d48a0ac36615d460
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
+lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
 ---
 
 # Development Bootstrap

--- a/docs/agents/contribution-path-analysis-design.md
+++ b/docs/agents/contribution-path-analysis-design.md
@@ -21,7 +21,7 @@ checkPaths:
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: d0290875e64ea22e30d0598fa1904cac895d554a
+lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
 ---
 
 # Contribution Path Analysis Design

--- a/docs/agents/contribution-path-analysis-design.md
+++ b/docs/agents/contribution-path-analysis-design.md
@@ -21,7 +21,7 @@ checkPaths:
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
+lastReviewedCommit: c0d6c0f9d0f7207d2c89d4c0dfdef388248ad9b2
 ---
 
 # Contribution Path Analysis Design

--- a/docs/agents/contribution-path-analysis-design.md
+++ b/docs/agents/contribution-path-analysis-design.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 710b7e5f82205c4f1509dbbcbc5f3480d341669f
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: d0290875e64ea22e30d0598fa1904cac895d554a
 ---
 
 # Contribution Path Analysis Design

--- a/docs/agents/lca-analysis-visualization-plan.md
+++ b/docs/agents/lca-analysis-visualization-plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 710b7e5f82205c4f1509dbbcbc5f3480d341669f
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: d0290875e64ea22e30d0598fa1904cac895d554a
 ---
 
 # LCA Analysis And Visualization Plan

--- a/docs/agents/lca-analysis-visualization-plan.md
+++ b/docs/agents/lca-analysis-visualization-plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
+lastReviewedCommit: c0d6c0f9d0f7207d2c89d4c0dfdef388248ad9b2
 ---
 
 # LCA Analysis And Visualization Plan

--- a/docs/agents/lca-analysis-visualization-plan.md
+++ b/docs/agents/lca-analysis-visualization-plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: d0290875e64ea22e30d0598fa1904cac895d554a
+lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
 ---
 
 # LCA Analysis And Visualization Plan

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.js
   - .github/workflows/**
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 710b7e5f82205c4f1509dbbcbc5f3480d341669f
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
+lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
+lastReviewedCommit: c0d6c0f9d0f7207d2c89d4c0dfdef388248ad9b2
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
+lastReviewedCommit: c0d6c0f9d0f7207d2c89d4c0dfdef388248ad9b2
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
+lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 710b7e5f82205c4f1509dbbcbc5f3480d341669f
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -81,7 +81,7 @@ The task-center recovery path is:
 
 Next owns only the UI orchestration for this job. It enqueues or reads the Edge job without treating any browser-computed checksum as authoritative, renders returned `queued`, `waiting_gate`, `submitting`, `submitted`, `blocked`, `stale`, `error`, and `cancelled` states, and shows user-facing guidance for backend-provided gate `blockingReasons` while keeping raw code/message/details as diagnostics. Next must not duplicate worker-owned blocker heuristics or infer submit readiness from worker internals.
 
-After enqueue succeeds, the process edit page must stop long blocking loading and route attention to the task center. The task center treats service-returned `worker_jobs` / coordinator rows as the task fact source. LocalStorage may cache UI projections and dismissals for resume behavior, but it must not be the authority for review-submit job state.
+After enqueue succeeds, the process edit page must stop long blocking loading and route attention to the task center. The task center treats service-returned `worker_jobs` / coordinator rows as the task fact source. The visible task identity and task actions should prefer the canonical root `review_submit.submit` worker job (`submitWorkerJobId` / `rootJobId`), while `review_submit.gate`, `gateWorkerJobId`, `gateRunId`, and retained `reviewSubmitJobId` values remain child evidence or diagnostics. LocalStorage may cache UI projections and dismissals for resume behavior, but it must not be the authority for review-submit job state.
 
 When the job reaches `submitted`, Edge/Database have already validated the gate and called the final submit-review RPC on behalf of the original user. The browser must not call `app_dataset_submit_review` after a gate pass in the main process flow. Database/Edge own the persisted-row checksum, freshness, policy assertion, and final submit idempotency; stale, blocked, wrong-policy, or wrong-checksum runs must remain backend rejections.
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 710b7e5f82205c4f1509dbbcbc5f3480d341669f
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -62,7 +62,7 @@ npm run prepush:gate
 | --- | --- | --- | --- |
 | routes, pages, app runtime, shared UI | `npm run lint`; focused `npm run test:ci -- <jest-args>`; `npm run build` | `npm run prepush:gate` | shared UX changes often affect multiple entrypoints |
 | services or env selection | `npm run lint`; focused `npm run test:ci -- <jest-args>`; `npm run build` | `npm run prepush:gate` | companion proof may live in another repo if schema or Edge runtime changed |
-| process review-submit gate/job UI or service contract | `npm run lint`; focused review/gate/job tests such as `npm run test:ci -- tests/unit/services/workerJobs/api.test.ts tests/unit/services/reviews/taskCenter.test.ts tests/unit/components/LcaTaskCenter.test.tsx tests/unit/services/reviews/api.test.ts tests/unit/utils/review.test.ts tests/unit/pages/Processes/Components/edit.test.tsx --runInBand --testTimeout=30000`; `npm run build` | smoke `app_worker_jobs`, `app_dataset_review_submit_jobs`, the worker, and final process submit-review against a safe dev environment when credentials and a queued job are available | Next must render backend job states and gate evidence, enqueue/read submit jobs instead of calling final submit-review from the browser, recover task-center state from service-backed worker jobs, and avoid duplicating worker blocker heuristics or browser-authoritative checksum logic. |
+| process review-submit gate/job UI or service contract | `npm run lint`; focused review/gate/job tests such as `npm run test:ci -- tests/unit/services/workerJobs/api.test.ts tests/unit/services/reviews/taskCenter.test.ts tests/unit/components/LcaTaskCenter.test.tsx tests/unit/services/reviews/api.test.ts tests/unit/utils/review.test.ts tests/unit/pages/Processes/Components/edit.test.tsx --runInBand --testTimeout=30000`; `npm run build` | smoke `app_worker_jobs`, `app_dataset_review_submit_jobs`, the worker, and final process submit-review against a safe dev environment when credentials and a queued job are available | Next must render backend job states and gate evidence, enqueue/read submit jobs instead of calling final submit-review from the browser, recover task-center state from service-backed worker jobs, prefer the canonical root `review_submit.submit` worker job for task identity/actions, and avoid duplicating worker blocker heuristics or browser-authoritative checksum logic. |
 | static bundles under `public/**` | `npm run lint`; `npm run build` | focused tests near the consuming feature | check both the asset and its readers |
 | sync helpers under `docker/**` | `npm run lint`; `npm run build` | run the exact helper only when the task includes it | do not hand-edit synced mirrors |
 | tests, coverage, or gate scripts | `npm run docpact:gate`; `npm run lint`; `npm run test:ci`; `npm run test:coverage`; `npm run test:coverage:assert-full` | `npm run prepush:gate` | coverage expectations remain strict |

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
+lastReviewedCommit: c0d6c0f9d0f7207d2c89d4c0dfdef388248ad9b2
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
+lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -20,7 +20,7 @@ checkPaths:
   - src/services/**
   - docker/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
+lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -20,7 +20,7 @@ checkPaths:
   - src/services/**
   - docker/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
+lastReviewedCommit: c0d6c0f9d0f7207d2c89d4c0dfdef388248ad9b2
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -19,8 +19,8 @@ checkPaths:
   - config/supabaseEnv.ts
   - src/services/**
   - docker/**
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 8c1d9ac561c56c63b7c6748bdca2404ca6d33d01
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 710b7e5f82205c4f1509dbbcbc5f3480d341669f
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
+lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
+lastReviewedCommit: c0d6c0f9d0f7207d2c89d4c0dfdef388248ad9b2
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
+lastReviewedCommit: c0d6c0f9d0f7207d2c89d4c0dfdef388248ad9b2
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 710b7e5f82205c4f1509dbbcbc5f3480d341669f
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
+lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 710b7e5f82205c4f1509dbbcbc5f3480d341669f
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
+lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
+lastReviewedCommit: c0d6c0f9d0f7207d2c89d4c0dfdef388248ad9b2
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 710b7e5f82205c4f1509dbbcbc5f3480d341669f
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: a6d8b7f106e57b6341b3e4c8cacf897a74de15e8
+lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
+lastReviewedCommit: c0d6c0f9d0f7207d2c89d4c0dfdef388248ad9b2
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/util_calculate.md
+++ b/docs/agents/util_calculate.md
@@ -21,7 +21,7 @@ checkPaths:
   - src/components/LcaTaskCenter/**
   - src/pages/Processes/Analysis/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: d0290875e64ea22e30d0598fa1904cac895d554a
+lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
 ---
 
 # Lifecycle Model Calculation Reference

--- a/docs/agents/util_calculate.md
+++ b/docs/agents/util_calculate.md
@@ -20,8 +20,8 @@ checkPaths:
   - src/services/lca/**
   - src/components/LcaTaskCenter/**
   - src/pages/Processes/Analysis/**
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: 710b7e5f82205c4f1509dbbcbc5f3480d341669f
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: d0290875e64ea22e30d0598fa1904cac895d554a
 ---
 
 # Lifecycle Model Calculation Reference

--- a/docs/agents/util_calculate.md
+++ b/docs/agents/util_calculate.md
@@ -21,7 +21,7 @@ checkPaths:
   - src/components/LcaTaskCenter/**
   - src/pages/Processes/Analysis/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: b063fc0ebfec2b413495466daa5015c067d7b497
+lastReviewedCommit: c0d6c0f9d0f7207d2c89d4c0dfdef388248ad9b2
 ---
 
 # Lifecycle Model Calculation Reference

--- a/src/components/LcaTaskCenter/index.tsx
+++ b/src/components/LcaTaskCenter/index.tsx
@@ -1132,6 +1132,24 @@ function reviewSubmitDetailContent(
         </Tag>
         {revision?.table && <Tag>{revision.table}</Tag>}
       </Space>
+      {task.submitWorkerJobId && (
+        <Typography.Text type='secondary' style={{ fontSize: 12 }}>
+          {intl.formatMessage({
+            id: 'pages.process.reviewSubmitTaskCenter.detail.submitWorkerJobId',
+            defaultMessage: 'submit_worker_job_id',
+          })}
+          : <Typography.Text copyable>{task.submitWorkerJobId}</Typography.Text>
+        </Typography.Text>
+      )}
+      {task.rootJobId && task.rootJobId !== task.submitWorkerJobId && (
+        <Typography.Text type='secondary' style={{ fontSize: 12 }}>
+          {intl.formatMessage({
+            id: 'pages.process.reviewSubmitTaskCenter.detail.rootJobId',
+            defaultMessage: 'root_job_id',
+          })}
+          : <Typography.Text copyable>{task.rootJobId}</Typography.Text>
+        </Typography.Text>
+      )}
       {task.reviewSubmitJobId && (
         <Typography.Text type='secondary' style={{ fontSize: 12 }}>
           {intl.formatMessage({

--- a/src/components/LcaTaskCenter/index.tsx
+++ b/src/components/LcaTaskCenter/index.tsx
@@ -7,6 +7,7 @@ import type {
 import {
   clearFinishedLcaTasks,
   listLcaTasks,
+  refreshLcaTasksFromWorkerJobs,
   removeLcaTask,
   subscribeLcaTaskCenterOpenRequests,
   subscribeLcaTasks,
@@ -36,6 +37,7 @@ import {
   clearFinishedTidasPackageTasks,
   downloadTidasPackageExportTask,
   listTidasPackageTasks,
+  refreshTidasPackageTasksFromWorkerJobs,
   removeTidasPackageTask,
   subscribeTidasPackageTasks,
 } from '@/services/tidasPackage/taskCenter';
@@ -60,7 +62,7 @@ import {
   message,
   theme,
 } from 'antd';
-import React, { useEffect, useMemo, useState, useSyncExternalStore } from 'react';
+import React, { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react';
 import { useIntl } from 'umi';
 
 type IntlShapeLike = ReturnType<typeof useIntl>;
@@ -804,6 +806,15 @@ function lcaDetailContent(task: LcaBackgroundTask, intl: IntlShapeLike): React.R
         </Tag>
         <Tag>{task.scope}</Tag>
       </Space>
+      {task.workerJobId && (
+        <Typography.Text type='secondary' style={{ fontSize: 12 }}>
+          {intl.formatMessage({
+            id: 'pages.process.lca.taskCenter.detail.workerJobId',
+            defaultMessage: 'worker_job_id',
+          })}
+          : <Typography.Text copyable>{task.workerJobId}</Typography.Text>
+        </Typography.Text>
+      )}
       {task.buildJobId && (
         <Typography.Text type='secondary' style={{ fontSize: 12 }}>
           {intl.formatMessage({
@@ -876,6 +887,15 @@ function packageDetailContent(
         {task.scope && <Tag>{task.scope}</Tag>}
         {singleRoot && <Tag>{singleRoot.table}</Tag>}
       </Space>
+      {task.workerJobId && (
+        <Typography.Text type='secondary' style={{ fontSize: 12 }}>
+          {intl.formatMessage({
+            id: 'component.tidasPackage.taskCenter.detail.workerJobId',
+            defaultMessage: 'worker_job_id',
+          })}
+          : <Typography.Text copyable>{task.workerJobId}</Typography.Text>
+        </Typography.Text>
+      )}
       {task.jobId && (
         <Typography.Text type='secondary' style={{ fontSize: 12 }}>
           {intl.formatMessage({
@@ -1232,28 +1252,36 @@ const LcaTaskCenter: React.FC = () => {
   const [downloadingTaskId, setDownloadingTaskId] = useState<string | null>(null);
   const [cancellingTaskId, setCancellingTaskId] = useState<string | null>(null);
   const [retryingTaskId, setRetryingTaskId] = useState<string | null>(null);
-  const [refreshingReviewTasks, setRefreshingReviewTasks] = useState(false);
+  const [refreshingTasks, setRefreshingTasks] = useState(false);
   const lcaTasks = useLcaTasks();
   const packageTasks = useTidasPackageTasks();
   const reviewSubmitTasks = useReviewSubmitTasks();
 
+  const refreshAllTasks = useCallback(async () => {
+    await Promise.all([
+      refreshLcaTasksFromWorkerJobs(),
+      refreshTidasPackageTasksFromWorkerJobs(),
+      refreshReviewSubmitTasks(),
+    ]);
+  }, []);
+
   useEffect(() => {
-    void refreshReviewSubmitTasks().catch(() => undefined);
+    void refreshAllTasks().catch(() => undefined);
     const interval = window.setInterval(() => {
-      void refreshReviewSubmitTasks().catch(() => undefined);
+      void refreshAllTasks().catch(() => undefined);
     }, 5000);
     return () => {
       window.clearInterval(interval);
     };
-  }, []);
+  }, [refreshAllTasks]);
 
   useEffect(
     () =>
       subscribeLcaTaskCenterOpenRequests(() => {
         setOpen(true);
-        void refreshReviewSubmitTasks().catch(() => undefined);
+        void refreshAllTasks().catch(() => undefined);
       }),
-    [],
+    [refreshAllTasks],
   );
 
   const items = useMemo<TaskCenterItem[]>(
@@ -1302,10 +1330,10 @@ const LcaTaskCenter: React.FC = () => {
     }
   };
 
-  const handleRefreshReviewSubmitTasks = async () => {
+  const handleRefreshTasks = async () => {
     try {
-      setRefreshingReviewTasks(true);
-      await refreshReviewSubmitTasks();
+      setRefreshingTasks(true);
+      await refreshAllTasks();
     } catch (error: any) {
       message.error(
         error?.message ||
@@ -1315,7 +1343,7 @@ const LcaTaskCenter: React.FC = () => {
           }),
       );
     } finally {
-      setRefreshingReviewTasks(false);
+      setRefreshingTasks(false);
     }
   };
 
@@ -1377,7 +1405,7 @@ const LcaTaskCenter: React.FC = () => {
         badgeStyle={attentionCount > 0 ? { backgroundColor: '#cf1322' } : undefined}
         onClick={() => {
           setOpen(true);
-          void refreshReviewSubmitTasks().catch(() => undefined);
+          void refreshAllTasks().catch(() => undefined);
         }}
       />
       <Modal
@@ -1397,9 +1425,9 @@ const LcaTaskCenter: React.FC = () => {
             <Button
               size='small'
               icon={<ReloadOutlined />}
-              loading={refreshingReviewTasks}
+              loading={refreshingTasks}
               onClick={() => {
-                void handleRefreshReviewSubmitTasks();
+                void handleRefreshTasks();
               }}
             >
               {intl.formatMessage({

--- a/src/locales/en-US/pages_process.ts
+++ b/src/locales/en-US/pages_process.ts
@@ -708,6 +708,8 @@ export default {
   'pages.process.reviewSubmitTaskCenter.errorSummary.title': 'Review submission task failed',
   'pages.process.reviewSubmitTaskCenter.errorSummary.description': 'The task stopped before review submission could complete. Retry the task after checking the saved process data.',
   'pages.process.reviewSubmitTaskCenter.errorSummary.action': 'If the task fails again, open details and share the diagnostics with an administrator.',
+  'pages.process.reviewSubmitTaskCenter.detail.submitWorkerJobId': 'submit_worker_job_id',
+  'pages.process.reviewSubmitTaskCenter.detail.rootJobId': 'root_job_id',
   'pages.process.reviewSubmitTaskCenter.detail.reviewSubmitJobId': 'review_submit_job_id',
   'pages.process.reviewSubmitTaskCenter.detail.gateWorkerJobId': 'gate_worker_job_id',
   'pages.process.reviewSubmitTaskCenter.detail.gateRunId': 'gate_run_id',

--- a/src/locales/zh-CN/pages_process.ts
+++ b/src/locales/zh-CN/pages_process.ts
@@ -705,6 +705,8 @@ export default {
   'pages.process.reviewSubmitTaskCenter.errorSummary.title': '提交审核任务失败',
   'pages.process.reviewSubmitTaskCenter.errorSummary.description': '任务在完成提交审核前停止。请检查已保存的过程数据后重试。',
   'pages.process.reviewSubmitTaskCenter.errorSummary.action': '如果重试后仍失败，请打开详情并将诊断信息提供给管理员。',
+  'pages.process.reviewSubmitTaskCenter.detail.submitWorkerJobId': 'submit_worker_job_id',
+  'pages.process.reviewSubmitTaskCenter.detail.rootJobId': 'root_job_id',
   'pages.process.reviewSubmitTaskCenter.detail.reviewSubmitJobId': 'review_submit_job_id',
   'pages.process.reviewSubmitTaskCenter.detail.gateWorkerJobId': 'gate_worker_job_id',
   'pages.process.reviewSubmitTaskCenter.detail.gateRunId': 'gate_run_id',

--- a/src/services/general/api.ts
+++ b/src/services/general/api.ts
@@ -253,6 +253,7 @@ export type ExportTidasPackageQueueResponse = {
   ok: boolean;
   mode: Exclude<TidasPackageJobMode, 'completed'>;
   job_id: string;
+  worker_job_id?: string | null;
   scope: TidasPackageManifestScope;
   root_count: number;
   code?: string;
@@ -294,6 +295,7 @@ export type EnqueueImportTidasPackageResponse = {
   ok: boolean;
   mode: 'queued' | 'in_progress' | 'completed';
   job_id: string;
+  worker_job_id?: string | null;
   source_artifact_id: string;
   code?: string;
   message?: string;

--- a/src/services/lca/api.ts
+++ b/src/services/lca/api.ts
@@ -51,6 +51,7 @@ export type LcaSolveSubmitResponse =
       snapshot_id: string;
       cache_key: string;
       job_id: string;
+      worker_job_id?: string | null;
       result_id?: never;
     }
   | {
@@ -58,6 +59,7 @@ export type LcaSolveSubmitResponse =
       snapshot_id: string;
       build_job_id: string;
       build_snapshot_id: string;
+      build_worker_job_id?: string | null;
       cache_key?: never;
       job_id?: never;
       result_id?: never;

--- a/src/services/lca/taskCenter.ts
+++ b/src/services/lca/taskCenter.ts
@@ -1,4 +1,9 @@
 import {
+  requestWorkerJobsApi,
+  type WorkerJobResult,
+  type WorkerJobStatus,
+} from '@/services/workerJobs/api';
+import {
   pollLcaJobUntilTerminal,
   submitLcaSolve,
   type LcaJobResponse,
@@ -28,6 +33,9 @@ export type LcaBackgroundTask = {
   message: string;
   createdAt: string;
   updatedAt: string;
+  workerJobId?: string;
+  rootJobId?: string;
+  jobKind?: string;
   buildJobId?: string;
   solveJobId?: string;
   snapshotId?: string;
@@ -42,6 +50,16 @@ const SOLVE_TIMEOUT_MS = 20 * 60 * 1000;
 const STORAGE_KEY = 'tg_lca_task_center_v1';
 const STORAGE_SCHEMA_VERSION = 1;
 const STORAGE_TTL_MS = 72 * 60 * 60 * 1000;
+const LCA_WORKER_JOB_STATUSES: WorkerJobStatus[] = [
+  'queued',
+  'running',
+  'waiting',
+  'completed',
+  'blocked',
+  'stale',
+  'failed',
+  'cancelled',
+];
 
 let taskSequence = 0;
 let tasks: LcaBackgroundTask[] = [];
@@ -138,6 +156,25 @@ function normalizeIso(value: unknown, fallback: string): string {
   return Number.isFinite(Date.parse(text)) ? text : fallback;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value !== 'string') {
+      continue;
+    }
+    const text = value.trim();
+    if (text) {
+      return text;
+    }
+  }
+  return undefined;
+}
+
 function normalizeRequest(value: unknown): LcaSolveRequest | undefined {
   if (!value || typeof value !== 'object') {
     return undefined;
@@ -219,6 +256,9 @@ function normalizeTask(raw: unknown, fallbackSequence: number): LcaBackgroundTas
     message?: unknown;
     createdAt?: unknown;
     updatedAt?: unknown;
+    workerJobId?: unknown;
+    rootJobId?: unknown;
+    jobKind?: unknown;
     buildJobId?: unknown;
     solveJobId?: unknown;
     snapshotId?: unknown;
@@ -254,6 +294,9 @@ function normalizeTask(raw: unknown, fallbackSequence: number): LcaBackgroundTas
     message: typeof item.message === 'string' ? item.message : 'Recovered task',
     createdAt,
     updatedAt,
+    workerJobId: typeof item.workerJobId === 'string' ? item.workerJobId : undefined,
+    rootJobId: typeof item.rootJobId === 'string' ? item.rootJobId : undefined,
+    jobKind: typeof item.jobKind === 'string' ? item.jobKind : undefined,
     buildJobId: typeof item.buildJobId === 'string' ? item.buildJobId : undefined,
     solveJobId: typeof item.solveJobId === 'string' ? item.solveJobId : undefined,
     snapshotId: typeof item.snapshotId === 'string' ? item.snapshotId : undefined,
@@ -392,6 +435,163 @@ function messageForRunningJob(job: LcaJobResponse, defaultText: string): string 
   return `${defaultText}: ${status}`;
 }
 
+function isLcaWorkerJob(job: WorkerJobResult): boolean {
+  return typeof job.jobKind === 'string' && job.jobKind.startsWith('lca.');
+}
+
+function modeFromWorkerJob(job: WorkerJobResult): LcaTaskMode {
+  return job.jobKind === 'lca.solve_all_unit' ? 'all_unit' : 'single';
+}
+
+function phaseFromWorkerJob(job: WorkerJobResult): LcaTaskPhase {
+  if (job.status === 'completed') {
+    return 'completed';
+  }
+  if (
+    job.status === 'failed' ||
+    job.status === 'stale' ||
+    job.status === 'blocked' ||
+    job.status === 'cancelled'
+  ) {
+    return 'failed';
+  }
+
+  const phase = typeof job.phase === 'string' ? job.phase : '';
+  if (phase === 'build_snapshot' || job.jobKind === 'lca.build_snapshot') {
+    return 'building_snapshot';
+  }
+  if (
+    phase === 'solve_one' ||
+    phase === 'solve_batch' ||
+    phase === 'solve_all_unit' ||
+    job.jobKind === 'lca.solve_one' ||
+    job.jobKind === 'lca.solve_batch' ||
+    job.jobKind === 'lca.solve_all_unit'
+  ) {
+    return 'solving';
+  }
+  return 'submitting';
+}
+
+function stateFromWorkerJob(job: WorkerJobResult): LcaTaskState {
+  if (job.status === 'completed') {
+    return 'completed';
+  }
+  if (job.status === 'queued' || job.status === 'running' || job.status === 'waiting') {
+    return 'running';
+  }
+  return 'failed';
+}
+
+function lcaJobIdFromWorkerJob(job: WorkerJobResult): string | undefined {
+  const result = asRecord(job.result);
+  return firstString(result?.lcaJobId, job.subjectId);
+}
+
+function snapshotIdFromWorkerJob(job: WorkerJobResult): string | undefined {
+  const result = asRecord(job.result);
+  return firstString(result?.snapshotId, job.subjectVersion);
+}
+
+function resultIdFromWorkerJob(job: WorkerJobResult): string | undefined {
+  const result = asRecord(job.result);
+  return firstString(result?.resultId);
+}
+
+function messageFromWorkerJob(job: WorkerJobResult, phase: LcaTaskPhase): string {
+  const legacyJobId = lcaJobIdFromWorkerJob(job) ?? job.id ?? '-';
+  if (job.status === 'completed') {
+    const resultId = resultIdFromWorkerJob(job);
+    return resultId ? `Completed (result ${resultId})` : 'Completed';
+  }
+  if (stateFromWorkerJob(job) === 'failed') {
+    return 'Task failed';
+  }
+  if (phase === 'building_snapshot') {
+    return `Building snapshot (${legacyJobId})`;
+  }
+  if (phase === 'solving') {
+    return `Solving (${legacyJobId})`;
+  }
+  return 'Submitting task';
+}
+
+function taskFromWorkerJob(
+  job: WorkerJobResult,
+  fallbackSequence: number,
+): LcaBackgroundTask | null {
+  const workerJobId = firstString(job.id);
+  if (!workerJobId || !isLcaWorkerJob(job)) {
+    return null;
+  }
+
+  const now = nowIso();
+  const createdAt = normalizeIso(job.createdAt, now);
+  const updatedAt = normalizeIso(job.updatedAt, createdAt);
+  const phase = phaseFromWorkerJob(job);
+  const state = stateFromWorkerJob(job);
+  const legacyJobId = lcaJobIdFromWorkerJob(job);
+  const isBuildJob = job.jobKind === 'lca.build_snapshot' || phase === 'building_snapshot';
+
+  return {
+    id: workerJobId,
+    sequence: fallbackSequence,
+    mode: modeFromWorkerJob(job),
+    scope: 'prod',
+    state,
+    phase,
+    message: messageFromWorkerJob(job, phase),
+    createdAt,
+    updatedAt,
+    workerJobId,
+    rootJobId: firstString(job.rootJobId),
+    jobKind: firstString(job.jobKind),
+    buildJobId: isBuildJob ? legacyJobId : undefined,
+    solveJobId: !isBuildJob ? legacyJobId : undefined,
+    snapshotId: snapshotIdFromWorkerJob(job),
+    resultId: resultIdFromWorkerJob(job),
+    error:
+      state === 'failed' ? firstString(job.errorMessage, job.errorCode, job.status) : undefined,
+    phaseTimeline: normalizeTimeline([], createdAt, phase),
+  };
+}
+
+function mergeWorkerJobTask(serverTask: LcaBackgroundTask): LcaBackgroundTask {
+  const current = tasks.find((item) =>
+    Boolean(
+      (serverTask.workerJobId && item.workerJobId === serverTask.workerJobId) ||
+      item.id === serverTask.id ||
+      (serverTask.buildJobId && item.buildJobId === serverTask.buildJobId) ||
+      (serverTask.solveJobId && item.solveJobId === serverTask.solveJobId),
+    ),
+  );
+
+  if (!current) {
+    return serverTask;
+  }
+
+  return {
+    ...current,
+    ...serverTask,
+    id: current.id,
+    sequence: current.sequence,
+    request: current.request,
+    mode: current.mode,
+    scope: current.scope,
+    createdAt: current.createdAt,
+    phaseTimeline:
+      current.phase === serverTask.phase && current.state === serverTask.state
+        ? current.phaseTimeline
+        : applyTaskTimelineTransition(
+            current.phaseTimeline,
+            current.phase,
+            serverTask.phase,
+            serverTask.state,
+            serverTask.updatedAt,
+          ),
+  };
+}
+
 async function waitBuildSnapshot(taskId: string, buildJobId: string): Promise<'ok' | 'failed'> {
   upsertTask(taskId, {
     phase: 'building_snapshot',
@@ -505,11 +705,17 @@ async function processSubmitResponse(
   }
 
   if (submit.mode === 'snapshot_building') {
+    upsertTask(taskId, {
+      workerJobId: submit.build_worker_job_id ?? undefined,
+      buildJobId: submit.build_job_id,
+      snapshotId: submit.build_snapshot_id,
+    });
     if (attempt >= 3) {
       upsertTask(taskId, {
         phase: 'failed',
         state: 'failed',
         buildJobId: submit.build_job_id,
+        workerJobId: submit.build_worker_job_id ?? undefined,
         snapshotId: submit.build_snapshot_id,
         message: 'Snapshot build retry limit reached',
         error: 'snapshot_build_retry_limit',
@@ -525,12 +731,30 @@ async function processSubmitResponse(
     return;
   }
 
+  upsertTask(taskId, {
+    workerJobId: submit.worker_job_id ?? undefined,
+    solveJobId: submit.job_id,
+    snapshotId: submit.snapshot_id,
+  });
   await waitSolveResult(taskId, submit.job_id);
 }
 
 async function runTask(taskId: string, request: LcaSolveRequest): Promise<void> {
   try {
     const submit = await submitLcaSolve(request);
+    if (submit.mode === 'queued' || submit.mode === 'in_progress') {
+      upsertTask(taskId, {
+        workerJobId: submit.worker_job_id ?? undefined,
+        solveJobId: submit.job_id,
+        snapshotId: submit.snapshot_id,
+      });
+    } else if (submit.mode === 'snapshot_building') {
+      upsertTask(taskId, {
+        workerJobId: submit.build_worker_job_id ?? undefined,
+        buildJobId: submit.build_job_id,
+        snapshotId: submit.build_snapshot_id,
+      });
+    }
     await processSubmitResponse(taskId, request, submit, 0);
   } catch (error) {
     upsertTask(taskId, {
@@ -604,23 +828,60 @@ async function resumeTaskAfterReload(taskId: string): Promise<void> {
   }
 }
 
-function hydrateTasksFromStorage(): void {
-  const restored = readTasksFromStorage();
-  if (restored.length === 0) {
-    return;
+export async function refreshLcaTasksFromWorkerJobs(): Promise<LcaBackgroundTask[]> {
+  const result = await requestWorkerJobsApi({
+    action: 'list',
+    subjectType: 'lca_job',
+    statuses: LCA_WORKER_JOB_STATUSES,
+    limit: MAX_TASK_ITEMS,
+  });
+  if (result.error) {
+    throw new Error(result.error.message || 'Failed to refresh LCA worker jobs');
   }
 
-  setTasks(restored);
-  const maxSequence = restored.reduce((max, item) => Math.max(max, item.sequence), 0);
+  const serverTasks = (result.data ?? [])
+    .map((job, index) => taskFromWorkerJob(job, taskSequence + index + 1))
+    .filter((item): item is LcaBackgroundTask => Boolean(item));
+  if (serverTasks.length === 0) {
+    return tasks;
+  }
+
+  const merged = tasks.slice();
+  for (const serverTask of serverTasks) {
+    const nextTask = mergeWorkerJobTask(serverTask);
+    const existingIndex = merged.findIndex((item) => item.id === nextTask.id);
+    if (existingIndex >= 0) {
+      merged[existingIndex] = nextTask;
+    } else {
+      merged.push(nextTask);
+    }
+  }
+
+  setTasks(merged);
+  const maxSequence = tasks.reduce((max, item) => Math.max(max, item.sequence), 0);
   if (maxSequence > taskSequence) {
     taskSequence = maxSequence;
   }
+  return tasks;
+}
 
-  restored
-    .filter((item) => item.state === 'running')
-    .forEach((item) => {
-      void resumeTaskAfterReload(item.id);
-    });
+function hydrateTasksFromStorage(): void {
+  const restored = readTasksFromStorage();
+  if (restored.length > 0) {
+    setTasks(restored);
+    const maxSequence = restored.reduce((max, item) => Math.max(max, item.sequence), 0);
+    if (maxSequence > taskSequence) {
+      taskSequence = maxSequence;
+    }
+
+    restored
+      .filter((item) => item.state === 'running')
+      .forEach((item) => {
+        void resumeTaskAfterReload(item.id);
+      });
+  }
+
+  void refreshLcaTasksFromWorkerJobs().catch(() => undefined);
 }
 
 export function submitLcaTask(request: LcaSolveRequest): LcaBackgroundTask {

--- a/src/services/lca/taskCenter.ts
+++ b/src/services/lca/taskCenter.ts
@@ -498,8 +498,11 @@ function resultIdFromWorkerJob(job: WorkerJobResult): string | undefined {
   return firstString(result?.resultId);
 }
 
-function messageFromWorkerJob(job: WorkerJobResult, phase: LcaTaskPhase): string {
-  const legacyJobId = lcaJobIdFromWorkerJob(job) ?? job.id ?? '-';
+function messageFromWorkerJob(
+  job: WorkerJobResult,
+  phase: LcaTaskPhase,
+  displayJobId: string,
+): string {
   if (job.status === 'completed') {
     const resultId = resultIdFromWorkerJob(job);
     return resultId ? `Completed (result ${resultId})` : 'Completed';
@@ -508,10 +511,10 @@ function messageFromWorkerJob(job: WorkerJobResult, phase: LcaTaskPhase): string
     return 'Task failed';
   }
   if (phase === 'building_snapshot') {
-    return `Building snapshot (${legacyJobId})`;
+    return `Building snapshot (${displayJobId})`;
   }
   if (phase === 'solving') {
-    return `Solving (${legacyJobId})`;
+    return `Solving (${displayJobId})`;
   }
   return 'Submitting task';
 }
@@ -531,6 +534,7 @@ function taskFromWorkerJob(
   const phase = phaseFromWorkerJob(job);
   const state = stateFromWorkerJob(job);
   const legacyJobId = lcaJobIdFromWorkerJob(job);
+  const displayJobId = legacyJobId ?? workerJobId;
   const isBuildJob = job.jobKind === 'lca.build_snapshot' || phase === 'building_snapshot';
 
   return {
@@ -540,7 +544,7 @@ function taskFromWorkerJob(
     scope: 'prod',
     state,
     phase,
-    message: messageFromWorkerJob(job, phase),
+    message: messageFromWorkerJob(job, phase, displayJobId),
     createdAt,
     updatedAt,
     workerJobId,

--- a/src/services/reviews/api.ts
+++ b/src/services/reviews/api.ts
@@ -92,6 +92,8 @@ export type ReviewSubmitJobStatus =
 export type ReviewSubmitJobResult = {
   status: ReviewSubmitJobStatus;
   reviewSubmitJobId?: string;
+  submitWorkerJobId?: string | null;
+  rootJobId?: string | null;
   gateRunId?: string | null;
   gateWorkerJobId?: string | null;
   datasetRevision?: {
@@ -105,6 +107,8 @@ export type ReviewSubmitJobResult = {
     reportSchemaVersion?: string;
   };
   gate?: ReviewSubmitGateResult | null;
+  submitWorkerJob?: WorkerJobResult | null;
+  workerJob?: WorkerJobResult | null;
   gateWorkerJob?: WorkerJobResult | null;
   error?: {
     code?: string;

--- a/src/services/reviews/taskCenter.ts
+++ b/src/services/reviews/taskCenter.ts
@@ -25,6 +25,8 @@ export type ReviewSubmitTaskPhase =
 
 export type ReviewSubmitBackgroundTask = {
   id: string;
+  submitWorkerJobId?: string;
+  rootJobId?: string;
   gateWorkerJobId?: string;
   reviewSubmitJobId?: string;
   state: ReviewSubmitTaskState;
@@ -40,6 +42,8 @@ export type ReviewSubmitBackgroundTask = {
   };
   gateRunId?: string | null;
   workerJob?: WorkerJobResult | null;
+  rootWorkerJob?: WorkerJobResult | null;
+  gateWorkerJob?: WorkerJobResult | null;
   coordinator?: ReviewSubmitJobResult | null;
   blockingReasons?: ReviewSubmitGateBlockingReason[];
   blockerCodes?: string[];
@@ -51,7 +55,8 @@ const MAX_TASK_ITEMS = 50;
 const STORAGE_KEY = 'tg_review_submit_task_center_v1';
 const STORAGE_SCHEMA_VERSION = 1;
 const STORAGE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
-const REVIEW_SUBMIT_WORKER_KIND = 'review_submit.gate';
+const REVIEW_SUBMIT_ROOT_WORKER_KIND = 'review_submit.submit';
+const REVIEW_SUBMIT_GATE_WORKER_KIND = 'review_submit.gate';
 
 let tasks: ReviewSubmitBackgroundTask[] = [];
 let dismissedTaskIds = new Set<string>();
@@ -182,6 +187,97 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const text = asNonEmptyString(value);
+    if (text) {
+      return text;
+    }
+  }
+  return undefined;
+}
+
+function isReviewSubmitWorkerJob(workerJob?: WorkerJobResult | null): boolean {
+  return (
+    workerJob?.jobKind === REVIEW_SUBMIT_ROOT_WORKER_KIND ||
+    workerJob?.jobKind === REVIEW_SUBMIT_GATE_WORKER_KIND
+  );
+}
+
+function isRootReviewSubmitWorker(
+  workerJob?: WorkerJobResult | null,
+): workerJob is WorkerJobResult {
+  return workerJob?.jobKind === REVIEW_SUBMIT_ROOT_WORKER_KIND;
+}
+
+function isGateReviewSubmitWorker(
+  workerJob?: WorkerJobResult | null,
+): workerJob is WorkerJobResult {
+  return workerJob?.jobKind === REVIEW_SUBMIT_GATE_WORKER_KIND;
+}
+
+function rootWorkerJobFromParts(
+  job?: ReviewSubmitJobResult | null,
+  workerJob?: WorkerJobResult | null,
+): WorkerJobResult | null {
+  if (job?.submitWorkerJob) {
+    return job.submitWorkerJob;
+  }
+  if (job?.workerJob && isRootReviewSubmitWorker(job.workerJob)) {
+    return job.workerJob;
+  }
+  if (isRootReviewSubmitWorker(workerJob)) {
+    return workerJob;
+  }
+  return null;
+}
+
+function gateWorkerJobFromParts(
+  job?: ReviewSubmitJobResult | null,
+  workerJob?: WorkerJobResult | null,
+): WorkerJobResult | null {
+  if (job?.gateWorkerJob) {
+    return job.gateWorkerJob;
+  }
+  if (isGateReviewSubmitWorker(workerJob)) {
+    return workerJob;
+  }
+  return null;
+}
+
+function submitWorkerJobIdFromParts(
+  job?: ReviewSubmitJobResult | null,
+  workerJob?: WorkerJobResult | null,
+): string | undefined {
+  const rootWorkerJob = rootWorkerJobFromParts(job, workerJob);
+  return firstString(
+    job?.submitWorkerJobId,
+    rootWorkerJob?.id,
+    isRootReviewSubmitWorker(workerJob) ? workerJob?.id : undefined,
+    workerJob?.rootJobId,
+  );
+}
+
+function rootJobIdFromParts(
+  job?: ReviewSubmitJobResult | null,
+  workerJob?: WorkerJobResult | null,
+): string | undefined {
+  const rootWorkerJob = rootWorkerJobFromParts(job, workerJob);
+  return firstString(job?.rootJobId, workerJob?.rootJobId, rootWorkerJob?.rootJobId);
+}
+
+function gateWorkerJobIdFromParts(
+  job?: ReviewSubmitJobResult | null,
+  workerJob?: WorkerJobResult | null,
+): string | undefined {
+  const gateWorkerJob = gateWorkerJobFromParts(job, workerJob);
+  return firstString(job?.gateWorkerJobId, gateWorkerJob?.id);
+}
+
 function blockingReasonsFromWorker(
   workerJob?: WorkerJobResult | null,
 ): ReviewSubmitGateBlockingReason[] {
@@ -249,10 +345,14 @@ function taskIdFromParts(
   job?: ReviewSubmitJobResult | null,
   workerJob?: WorkerJobResult | null,
 ): string {
+  const submitWorkerJobId = submitWorkerJobIdFromParts(job, workerJob);
+  const rootJobId = rootJobIdFromParts(job, workerJob);
+  const gateWorkerJobId = gateWorkerJobIdFromParts(job, workerJob);
   return (
+    submitWorkerJobId ||
+    rootJobId ||
+    gateWorkerJobId ||
     job?.reviewSubmitJobId ||
-    job?.gateWorkerJobId ||
-    workerJob?.id ||
     `${workerJob?.subjectType ?? 'processes'}:${workerJob?.subjectId ?? 'unknown'}:${
       workerJob?.subjectVersion ?? 'unknown'
     }`
@@ -288,9 +388,17 @@ function mapReviewSubmitTask(
           typeof reason.code === 'string' && reason.code ? [reason.code] : [],
         );
 
+  const rootWorkerJob = rootWorkerJobFromParts(job, workerJob);
+  const gateWorkerJob = gateWorkerJobFromParts(job, workerJob);
+  const submitWorkerJobId = submitWorkerJobIdFromParts(job, workerJob);
+  const rootJobId = rootJobIdFromParts(job, workerJob);
+  const gateWorkerJobId = gateWorkerJobIdFromParts(job, workerJob);
+
   return {
     id: taskIdFromParts(job, workerJob),
-    gateWorkerJobId: job?.gateWorkerJobId ?? workerJob?.id,
+    submitWorkerJobId,
+    rootJobId,
+    gateWorkerJobId,
     reviewSubmitJobId: job?.reviewSubmitJobId,
     state: phaseToState(phase),
     phase,
@@ -299,7 +407,9 @@ function mapReviewSubmitTask(
     updatedAt,
     datasetRevision: job?.datasetRevision ?? datasetRevisionFromWorker(workerJob),
     gateRunId: job?.gateRunId ?? job?.gate?.gateRunId ?? null,
-    workerJob: job?.gateWorkerJob ?? workerJob ?? null,
+    workerJob: rootWorkerJob ?? gateWorkerJob ?? workerJob ?? null,
+    rootWorkerJob,
+    gateWorkerJob,
     coordinator: job ?? null,
     blockingReasons,
     blockerCodes,
@@ -333,6 +443,9 @@ function normalizePersistedTask(raw: unknown): ReviewSubmitBackgroundTask | null
   const createdAt = normalizeIso(raw.createdAt, nowIso());
   return {
     id,
+    submitWorkerJobId:
+      typeof raw.submitWorkerJobId === 'string' ? raw.submitWorkerJobId : undefined,
+    rootJobId: typeof raw.rootJobId === 'string' ? raw.rootJobId : undefined,
     gateWorkerJobId: typeof raw.gateWorkerJobId === 'string' ? raw.gateWorkerJobId : undefined,
     reviewSubmitJobId:
       typeof raw.reviewSubmitJobId === 'string' ? raw.reviewSubmitJobId : undefined,
@@ -347,6 +460,8 @@ function normalizePersistedTask(raw: unknown): ReviewSubmitBackgroundTask | null
     gateRunId:
       typeof raw.gateRunId === 'string' || raw.gateRunId === null ? raw.gateRunId : undefined,
     workerJob: isRecord(raw.workerJob) ? (raw.workerJob as WorkerJobResult) : null,
+    rootWorkerJob: isRecord(raw.rootWorkerJob) ? (raw.rootWorkerJob as WorkerJobResult) : null,
+    gateWorkerJob: isRecord(raw.gateWorkerJob) ? (raw.gateWorkerJob as WorkerJobResult) : null,
     coordinator: isRecord(raw.coordinator) ? (raw.coordinator as ReviewSubmitJobResult) : null,
     blockingReasons: Array.isArray(raw.blockingReasons)
       ? (raw.blockingReasons as ReviewSubmitGateBlockingReason[])
@@ -398,7 +513,7 @@ async function readLatestCoordinatorForWorker(
   workerJob: WorkerJobResult,
 ): Promise<ReviewSubmitJobResult | null> {
   if (
-    workerJob.jobKind !== REVIEW_SUBMIT_WORKER_KIND ||
+    !isReviewSubmitWorkerJob(workerJob) ||
     workerJob.subjectType !== 'processes' ||
     !workerJob.subjectId ||
     !workerJob.subjectVersion
@@ -416,10 +531,98 @@ async function readLatestCoordinatorForWorker(
   if (!job || result.error) {
     return null;
   }
-  if (job.gateWorkerJobId && workerJob.id && job.gateWorkerJobId !== workerJob.id) {
+  const submitWorkerJobId = submitWorkerJobIdFromParts(job, workerJob);
+  const gateWorkerJobId = gateWorkerJobIdFromParts(job, workerJob);
+  if (
+    isRootReviewSubmitWorker(workerJob) &&
+    submitWorkerJobId &&
+    workerJob.id &&
+    submitWorkerJobId !== workerJob.id
+  ) {
+    return null;
+  }
+  if (
+    isGateReviewSubmitWorker(workerJob) &&
+    gateWorkerJobId &&
+    workerJob.id &&
+    gateWorkerJobId !== workerJob.id
+  ) {
     return null;
   }
   return job;
+}
+
+function taskIdentityValues(task: ReviewSubmitBackgroundTask): string[] {
+  return [
+    task.id,
+    task.submitWorkerJobId,
+    task.rootJobId,
+    task.gateWorkerJobId,
+    task.reviewSubmitJobId,
+  ].flatMap((value) => (value ? [value] : []));
+}
+
+function sameReviewSubmitTask(
+  left: ReviewSubmitBackgroundTask,
+  right: ReviewSubmitBackgroundTask,
+): boolean {
+  const rightIds = new Set(taskIdentityValues(right));
+  return taskIdentityValues(left).some((value) => rightIds.has(value));
+}
+
+function hasRootPrimaryWorker(task: ReviewSubmitBackgroundTask): boolean {
+  if (isRootReviewSubmitWorker(task.rootWorkerJob)) {
+    return true;
+  }
+  return isRootReviewSubmitWorker(task.workerJob);
+}
+
+function mergeReviewSubmitTask(
+  current: ReviewSubmitBackgroundTask,
+  incoming: ReviewSubmitBackgroundTask,
+): ReviewSubmitBackgroundTask {
+  const currentHasRootPrimary = hasRootPrimaryWorker(current);
+  const incomingHasRootPrimary = hasRootPrimaryWorker(incoming);
+  const preferIncoming = incomingHasRootPrimary && !currentHasRootPrimary;
+  const primary = preferIncoming ? incoming : current;
+  const secondary = preferIncoming ? current : incoming;
+  return {
+    ...secondary,
+    ...primary,
+    submitWorkerJobId: primary.submitWorkerJobId,
+    rootJobId: primary.rootJobId ?? secondary.rootJobId,
+    gateWorkerJobId: primary.gateWorkerJobId ?? secondary.gateWorkerJobId,
+    reviewSubmitJobId: primary.reviewSubmitJobId ?? secondary.reviewSubmitJobId,
+    datasetRevision: primary.datasetRevision ?? secondary.datasetRevision,
+    gateRunId: primary.gateRunId ?? secondary.gateRunId,
+    workerJob: primary.workerJob,
+    rootWorkerJob: primary.rootWorkerJob,
+    gateWorkerJob: primary.gateWorkerJob ?? secondary.gateWorkerJob,
+    coordinator: primary.coordinator ?? secondary.coordinator,
+    blockingReasons:
+      primary.blockingReasons && primary.blockingReasons.length > 0
+        ? primary.blockingReasons
+        : secondary.blockingReasons,
+    blockerCodes:
+      primary.blockerCodes && primary.blockerCodes.length > 0
+        ? primary.blockerCodes
+        : secondary.blockerCodes,
+    progress: primary.progress ?? secondary.progress,
+  };
+}
+
+function dedupeReviewSubmitTasks(
+  candidates: ReviewSubmitBackgroundTask[],
+): ReviewSubmitBackgroundTask[] {
+  return candidates.reduce<ReviewSubmitBackgroundTask[]>((accumulator, task) => {
+    const index = accumulator.findIndex((existing) => sameReviewSubmitTask(existing, task));
+    if (index < 0) {
+      accumulator.push(task);
+      return accumulator;
+    }
+    accumulator[index] = mergeReviewSubmitTask(accumulator[index], task);
+    return accumulator;
+  }, []);
 }
 
 async function loadReviewSubmitTasksFromServer(): Promise<ReviewSubmitBackgroundTask[]> {
@@ -433,15 +636,16 @@ async function loadReviewSubmitTasksFromServer(): Promise<ReviewSubmitBackground
   }
 
   const reviewSubmitWorkers = (workerJobs.data ?? []).filter(
-    (job) => job.jobKind === REVIEW_SUBMIT_WORKER_KIND && normalizeWorkerStatus(job.status),
+    (job) => isReviewSubmitWorkerJob(job) && normalizeWorkerStatus(job.status),
   );
 
-  return Promise.all(
+  const serverTasks = await Promise.all(
     reviewSubmitWorkers.map(async (workerJob) => {
       const coordinator = await readLatestCoordinatorForWorker(workerJob);
       return mapReviewSubmitTask(coordinator, workerJob);
     }),
   );
+  return dedupeReviewSubmitTasks(serverTasks);
 }
 
 export async function refreshReviewSubmitTasks(): Promise<ReviewSubmitBackgroundTask[]> {
@@ -454,13 +658,7 @@ export async function refreshReviewSubmitTasks(): Promise<ReviewSubmitBackground
       const merged = [
         ...serverTasks,
         ...tasks.filter(
-          (cached) =>
-            !serverTasks.some(
-              (serverTask) =>
-                serverTask.id === cached.id ||
-                (serverTask.gateWorkerJobId &&
-                  serverTask.gateWorkerJobId === cached.gateWorkerJobId),
-            ),
+          (cached) => !serverTasks.some((serverTask) => sameReviewSubmitTask(serverTask, cached)),
         ),
       ];
       setTasks(merged);
@@ -474,7 +672,10 @@ export async function refreshReviewSubmitTasks(): Promise<ReviewSubmitBackground
 }
 
 export function trackReviewSubmitTask(job: ReviewSubmitJobResult): ReviewSubmitBackgroundTask {
-  const task = mapReviewSubmitTask(job, job.gateWorkerJob ?? null);
+  const task = mapReviewSubmitTask(
+    job,
+    job.submitWorkerJob ?? job.workerJob ?? job.gateWorkerJob ?? null,
+  );
   setTasks([task, ...tasks]);
   void refreshReviewSubmitTasks().catch(() => undefined);
   return task;
@@ -482,14 +683,14 @@ export function trackReviewSubmitTask(job: ReviewSubmitJobResult): ReviewSubmitB
 
 export async function cancelReviewSubmitTask(taskId: string): Promise<void> {
   const task = tasks.find((item) => item.id === taskId);
-  const gateWorkerJobId = task?.gateWorkerJobId;
-  if (!gateWorkerJobId) {
-    throw new Error('Review-submit gate worker job id is missing');
+  const workerJobId = task?.submitWorkerJobId ?? task?.rootJobId ?? task?.gateWorkerJobId;
+  if (!workerJobId) {
+    throw new Error('Review-submit worker job id is missing');
   }
 
   const result = await requestWorkerJobsApi<WorkerJobResult>({
     action: 'cancel',
-    jobId: gateWorkerJobId,
+    jobId: workerJobId,
     reason: 'user_cancelled',
   });
   if (result.error) {
@@ -502,8 +703,14 @@ export async function cancelReviewSubmitTask(taskId: string): Promise<void> {
     setTasks([
       {
         ...cancelledTask,
+        id: cancelledTask.id,
         datasetRevision: cancelledTask.datasetRevision ?? task?.datasetRevision,
+        submitWorkerJobId: cancelledTask.submitWorkerJobId ?? task?.submitWorkerJobId,
+        rootJobId: cancelledTask.rootJobId ?? task?.rootJobId,
         gateWorkerJobId: cancelledTask.gateWorkerJobId ?? task?.gateWorkerJobId,
+        workerJob: cancelledTask.workerJob,
+        rootWorkerJob: cancelledTask.rootWorkerJob ?? task?.rootWorkerJob,
+        gateWorkerJob: cancelledTask.gateWorkerJob ?? task?.gateWorkerJob,
       },
       ...tasks,
     ]);

--- a/src/services/tidasPackage/taskCenter.ts
+++ b/src/services/tidasPackage/taskCenter.ts
@@ -8,6 +8,11 @@ import {
   type TidasPackageManifestScope,
 } from '@/services/general/api';
 import { normalizeTidasPackageExportErrorMessage } from '@/services/tidasPackage/exportErrors';
+import {
+  requestWorkerJobsApi,
+  type WorkerJobResult,
+  type WorkerJobStatus,
+} from '@/services/workerJobs/api';
 
 export type TidasPackageTaskState = 'running' | 'completed' | 'failed';
 export type TidasPackageTaskPhase =
@@ -28,6 +33,8 @@ export type TidasPackageBackgroundTask = {
   message: string;
   createdAt: string;
   updatedAt: string;
+  workerJobId?: string;
+  jobKind?: string;
   jobId?: string;
   scope?: TidasPackageManifestScope | null;
   rootCount: number;
@@ -48,6 +55,16 @@ const STORAGE_TTL_MS = 72 * 60 * 60 * 1000;
 const POLL_INTERVAL_MS = 1500;
 const POLL_TIMEOUT_MS = 2 * 60 * 60 * 1000;
 const POLL_TRANSIENT_ERROR_RETRY_LIMIT = 5;
+const TIDAS_PACKAGE_WORKER_JOB_STATUSES: WorkerJobStatus[] = [
+  'queued',
+  'running',
+  'waiting',
+  'completed',
+  'blocked',
+  'stale',
+  'failed',
+  'cancelled',
+];
 
 let taskSequence = 0;
 let tasks: TidasPackageBackgroundTask[] = [];
@@ -136,6 +153,25 @@ function normalizeIso(value: unknown, fallback: string): string {
   return Number.isFinite(Date.parse(text)) ? text : fallback;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value !== 'string') {
+      continue;
+    }
+    const text = value.trim();
+    if (text) {
+      return text;
+    }
+  }
+  return undefined;
+}
+
 function normalizeRequest(value: unknown): ExportTidasPackageRequest | undefined {
   if (!value || typeof value !== 'object') {
     return undefined;
@@ -186,6 +222,8 @@ function normalizeTask(raw: unknown, fallbackSequence: number): TidasPackageBack
     message?: unknown;
     createdAt?: unknown;
     updatedAt?: unknown;
+    workerJobId?: unknown;
+    jobKind?: unknown;
     jobId?: unknown;
     scope?: unknown;
     rootCount?: unknown;
@@ -216,6 +254,8 @@ function normalizeTask(raw: unknown, fallbackSequence: number): TidasPackageBack
     message: typeof item.message === 'string' ? item.message : 'Recovered task',
     createdAt,
     updatedAt,
+    workerJobId: typeof item.workerJobId === 'string' ? item.workerJobId : undefined,
+    jobKind: typeof item.jobKind === 'string' ? item.jobKind : undefined,
     jobId: typeof item.jobId === 'string' ? item.jobId : undefined,
     scope: typeof item.scope === 'string' ? (item.scope as TidasPackageManifestScope) : null,
     rootCount:
@@ -357,6 +397,151 @@ function messageFromJob(job: TidasPackageJobResponse, request?: ExportTidasPacka
   return `Export task running (${job.job_id})`;
 }
 
+function isTidasPackageExportWorkerJob(job: WorkerJobResult): boolean {
+  return job.jobKind === 'tidas.export_package';
+}
+
+function packageJobIdFromWorkerJob(job: WorkerJobResult): string | undefined {
+  const result = asRecord(job.result);
+  return firstString(result?.packageJobId, job.subjectId);
+}
+
+function artifactsFromWorkerJob(job: WorkerJobResult): Record<string, unknown>[] {
+  const result = asRecord(job.result);
+  return Array.isArray(result?.artifacts)
+    ? result.artifacts.filter((item): item is Record<string, unknown> =>
+        Boolean(item && typeof item === 'object' && !Array.isArray(item)),
+      )
+    : [];
+}
+
+function filenameFromWorkerJob(job: WorkerJobResult): string | undefined {
+  for (const artifact of artifactsFromWorkerJob(job)) {
+    const kind = firstString(artifact.artifactKind, artifact.artifact_kind);
+    if (kind && kind !== 'export_zip') {
+      continue;
+    }
+    const metadata = asRecord(artifact.metadata);
+    const filename = firstString(metadata?.filename);
+    if (filename) {
+      return filename;
+    }
+  }
+  return undefined;
+}
+
+function phaseFromWorkerJob(job: WorkerJobResult): TidasPackageTaskPhase {
+  if (job.status === 'completed') {
+    return 'completed';
+  }
+  if (
+    job.status === 'failed' ||
+    job.status === 'stale' ||
+    job.status === 'blocked' ||
+    job.status === 'cancelled'
+  ) {
+    return 'failed';
+  }
+
+  const phase = typeof job.phase === 'string' ? job.phase : '';
+  if (phase === 'collect_refs') {
+    return 'collect_refs';
+  }
+  if (phase === 'finalize_zip') {
+    return 'finalize_zip';
+  }
+  if (job.status === 'queued' || job.status === 'waiting') {
+    return 'queued';
+  }
+  return 'submitting';
+}
+
+function stateFromWorkerJob(job: WorkerJobResult): TidasPackageTaskState {
+  if (job.status === 'completed') {
+    return 'completed';
+  }
+  if (job.status === 'queued' || job.status === 'running' || job.status === 'waiting') {
+    return 'running';
+  }
+  return 'failed';
+}
+
+function messageFromWorkerJob(job: WorkerJobResult, phase: TidasPackageTaskPhase): string {
+  if (job.status === 'completed') {
+    return `Export package ready (${filenameFromWorkerJob(job) ?? 'tidas-package.zip'})`;
+  }
+  if (stateFromWorkerJob(job) === 'failed') {
+    return 'Export package failed';
+  }
+  if (phase === 'collect_refs') {
+    return 'Collecting related datasets';
+  }
+  if (phase === 'finalize_zip') {
+    return 'Materializing ZIP package';
+  }
+  return `Export task queued (${packageJobIdFromWorkerJob(job) ?? job.id ?? '-'})`;
+}
+
+function taskFromWorkerJob(
+  job: WorkerJobResult,
+  fallbackSequence: number,
+): TidasPackageBackgroundTask | null {
+  const workerJobId = firstString(job.id);
+  if (!workerJobId || !isTidasPackageExportWorkerJob(job)) {
+    return null;
+  }
+
+  const now = nowIso();
+  const createdAt = normalizeIso(job.createdAt, now);
+  const updatedAt = normalizeIso(job.updatedAt, createdAt);
+  const phase = phaseFromWorkerJob(job);
+  const state = stateFromWorkerJob(job);
+
+  return {
+    id: workerJobId,
+    sequence: fallbackSequence,
+    kind: 'tidas_package_export',
+    state,
+    phase,
+    message: messageFromWorkerJob(job, phase),
+    createdAt,
+    updatedAt,
+    workerJobId,
+    jobKind: firstString(job.jobKind),
+    jobId: packageJobIdFromWorkerJob(job),
+    scope: (firstString(job.subjectVersion) as TidasPackageManifestScope | undefined) ?? null,
+    rootCount: 0,
+    filename: filenameFromWorkerJob(job),
+    error:
+      state === 'failed' ? firstString(job.errorMessage, job.errorCode, job.status) : undefined,
+  };
+}
+
+function mergeWorkerJobTask(serverTask: TidasPackageBackgroundTask): TidasPackageBackgroundTask {
+  const current = tasks.find((item) =>
+    Boolean(
+      (serverTask.workerJobId && item.workerJobId === serverTask.workerJobId) ||
+      item.id === serverTask.id ||
+      (serverTask.jobId && item.jobId === serverTask.jobId),
+    ),
+  );
+
+  if (!current) {
+    return serverTask;
+  }
+
+  return {
+    ...current,
+    ...serverTask,
+    id: current.id,
+    sequence: current.sequence,
+    request: current.request,
+    createdAt: current.createdAt,
+    scope: current.scope ?? serverTask.scope,
+    rootCount: current.rootCount || serverTask.rootCount,
+  };
+}
+
 function applyJobToTask(taskId: string, job: TidasPackageJobResponse): void {
   const current = tasks.find((item) => item.id === taskId);
   const phase = phaseFromJob(job);
@@ -466,6 +651,7 @@ async function runExportTask(taskId: string, request: ExportTidasPackageRequest)
         queued.data.mode === 'cache_hit'
           ? 'Checking cached export package'
           : `Export task queued (${queued.data.job_id})`,
+      workerJobId: queued.data.worker_job_id ?? undefined,
       jobId: queued.data.job_id,
       scope: queued.data.scope,
       rootCount: queued.data.root_count ?? 0,
@@ -482,23 +668,62 @@ async function runExportTask(taskId: string, request: ExportTidasPackageRequest)
   }
 }
 
-function hydrateTasksFromStorage(): void {
-  const restored = readTasksFromStorage();
-  if (restored.length === 0) {
-    return;
+export async function refreshTidasPackageTasksFromWorkerJobs(): Promise<
+  TidasPackageBackgroundTask[]
+> {
+  const result = await requestWorkerJobsApi({
+    action: 'list',
+    subjectType: 'lca_package_job',
+    statuses: TIDAS_PACKAGE_WORKER_JOB_STATUSES,
+    limit: MAX_TASK_ITEMS,
+  });
+  if (result.error) {
+    throw new Error(result.error.message || 'Failed to refresh TIDAS package worker jobs');
   }
 
-  setTasks(restored);
-  const maxSequence = restored.reduce((max, item) => Math.max(max, item.sequence), 0);
+  const serverTasks = (result.data ?? [])
+    .map((job, index) => taskFromWorkerJob(job, taskSequence + index + 1))
+    .filter((item): item is TidasPackageBackgroundTask => Boolean(item));
+  if (serverTasks.length === 0) {
+    return tasks;
+  }
+
+  const merged = tasks.slice();
+  for (const serverTask of serverTasks) {
+    const nextTask = mergeWorkerJobTask(serverTask);
+    const existingIndex = merged.findIndex((item) => item.id === nextTask.id);
+    if (existingIndex >= 0) {
+      merged[existingIndex] = nextTask;
+    } else {
+      merged.push(nextTask);
+    }
+  }
+
+  setTasks(merged);
+  const maxSequence = tasks.reduce((max, item) => Math.max(max, item.sequence), 0);
   if (maxSequence > taskSequence) {
     taskSequence = maxSequence;
   }
+  return tasks;
+}
 
-  restored
-    .filter((item) => item.state === 'running' && item.jobId)
-    .forEach((item) => {
-      void pollTask(item.id, item.jobId!);
-    });
+function hydrateTasksFromStorage(): void {
+  const restored = readTasksFromStorage();
+  if (restored.length > 0) {
+    setTasks(restored);
+    const maxSequence = restored.reduce((max, item) => Math.max(max, item.sequence), 0);
+    if (maxSequence > taskSequence) {
+      taskSequence = maxSequence;
+    }
+
+    restored
+      .filter((item) => item.state === 'running' && item.jobId)
+      .forEach((item) => {
+        void pollTask(item.id, item.jobId!);
+      });
+  }
+
+  void refreshTidasPackageTasksFromWorkerJobs().catch(() => undefined);
 }
 
 export function submitTidasPackageExportTask(

--- a/src/services/tidasPackage/taskCenter.ts
+++ b/src/services/tidasPackage/taskCenter.ts
@@ -466,7 +466,11 @@ function stateFromWorkerJob(job: WorkerJobResult): TidasPackageTaskState {
   return 'failed';
 }
 
-function messageFromWorkerJob(job: WorkerJobResult, phase: TidasPackageTaskPhase): string {
+function messageFromWorkerJob(
+  job: WorkerJobResult,
+  phase: TidasPackageTaskPhase,
+  displayJobId: string,
+): string {
   if (job.status === 'completed') {
     return `Export package ready (${filenameFromWorkerJob(job) ?? 'tidas-package.zip'})`;
   }
@@ -479,7 +483,7 @@ function messageFromWorkerJob(job: WorkerJobResult, phase: TidasPackageTaskPhase
   if (phase === 'finalize_zip') {
     return 'Materializing ZIP package';
   }
-  return `Export task queued (${packageJobIdFromWorkerJob(job) ?? job.id ?? '-'})`;
+  return `Export task queued (${displayJobId})`;
 }
 
 function taskFromWorkerJob(
@@ -496,6 +500,8 @@ function taskFromWorkerJob(
   const updatedAt = normalizeIso(job.updatedAt, createdAt);
   const phase = phaseFromWorkerJob(job);
   const state = stateFromWorkerJob(job);
+  const packageJobId = packageJobIdFromWorkerJob(job);
+  const displayJobId = packageJobId ?? workerJobId;
 
   return {
     id: workerJobId,
@@ -503,12 +509,12 @@ function taskFromWorkerJob(
     kind: 'tidas_package_export',
     state,
     phase,
-    message: messageFromWorkerJob(job, phase),
+    message: messageFromWorkerJob(job, phase, displayJobId),
     createdAt,
     updatedAt,
     workerJobId,
     jobKind: firstString(job.jobKind),
-    jobId: packageJobIdFromWorkerJob(job),
+    jobId: packageJobId,
     scope: (firstString(job.subjectVersion) as TidasPackageManifestScope | undefined) ?? null,
     rootCount: 0,
     filename: filenameFromWorkerJob(job),

--- a/src/services/workerJobs/api.ts
+++ b/src/services/workerJobs/api.ts
@@ -17,6 +17,8 @@ export type WorkerJobResult = {
   jobKind?: string;
   workerRuntime?: string;
   workerQueue?: string;
+  rootJobId?: string | null;
+  parentJobId?: string | null;
   priority?: number | string | null;
   subjectType?: string;
   subjectId?: string;
@@ -26,6 +28,8 @@ export type WorkerJobResult = {
   phase?: string | null;
   progress?: number | string | null;
   result?: unknown;
+  resultRef?: unknown;
+  diagnostics?: unknown;
   errorCode?: string | null;
   errorMessage?: string | null;
   blockerCodes?: string[];

--- a/tests/unit/components/LcaTaskCenter.test.tsx
+++ b/tests/unit/components/LcaTaskCenter.test.tsx
@@ -13,6 +13,8 @@ const mockRemoveLcaTask = jest.fn();
 const mockRemoveTidasPackageTask = jest.fn();
 const mockRemoveReviewSubmitTask = jest.fn();
 const mockCancelReviewSubmitTask = jest.fn();
+const mockRefreshLcaTasksFromWorkerJobs = jest.fn();
+const mockRefreshTidasPackageTasksFromWorkerJobs = jest.fn();
 const mockRefreshReviewSubmitTasks = jest.fn();
 const mockRetryReviewSubmitTask = jest.fn();
 const mockSubscribeLcaTasks = jest.fn(() => jest.fn());
@@ -29,6 +31,7 @@ jest.mock('@/services/lca/taskCenter', () => ({
   __esModule: true,
   clearFinishedLcaTasks: () => mockClearFinishedLcaTasks(),
   listLcaTasks: () => mockTasks,
+  refreshLcaTasksFromWorkerJobs: (...args: any[]) => mockRefreshLcaTasksFromWorkerJobs(...args),
   removeLcaTask: (...args: any[]) => mockRemoveLcaTask(...args),
   subscribeLcaTaskCenterOpenRequests: (...args: any[]) =>
     mockSubscribeLcaTaskCenterOpenRequests(...args),
@@ -40,6 +43,8 @@ jest.mock('@/services/tidasPackage/taskCenter', () => ({
   clearFinishedTidasPackageTasks: () => mockClearFinishedTidasPackageTasks(),
   downloadTidasPackageExportTask: (...args: any[]) => mockDownloadTidasPackageExportTask(...args),
   listTidasPackageTasks: () => mockPackageTasks,
+  refreshTidasPackageTasksFromWorkerJobs: (...args: any[]) =>
+    mockRefreshTidasPackageTasksFromWorkerJobs(...args),
   removeTidasPackageTask: (...args: any[]) => mockRemoveTidasPackageTask(...args),
   subscribeTidasPackageTasks: (...args: any[]) => mockSubscribeTidasPackageTasks(...args),
 }));
@@ -196,6 +201,8 @@ describe('LcaTaskCenter', () => {
     mockReviewSubmitTasks = [];
     mockDownloadTidasPackageExportTask.mockResolvedValue({ filename: 'downloaded.zip' });
     mockCancelReviewSubmitTask.mockResolvedValue(undefined);
+    mockRefreshLcaTasksFromWorkerJobs.mockResolvedValue([]);
+    mockRefreshTidasPackageTasksFromWorkerJobs.mockResolvedValue([]);
     mockRefreshReviewSubmitTasks.mockResolvedValue([]);
     mockRetryReviewSubmitTask.mockResolvedValue(undefined);
   });
@@ -524,6 +531,8 @@ describe('LcaTaskCenter', () => {
     ).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    await waitFor(() => expect(mockRefreshLcaTasksFromWorkerJobs).toHaveBeenCalled());
+    await waitFor(() => expect(mockRefreshTidasPackageTasksFromWorkerJobs).toHaveBeenCalled());
     await waitFor(() => expect(mockRefreshReviewSubmitTasks).toHaveBeenCalled());
 
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
@@ -547,7 +556,7 @@ describe('LcaTaskCenter', () => {
     expect(mockRemoveReviewSubmitTask).toHaveBeenCalledWith('submit-worker-blocked');
   });
 
-  it('refreshes review-submit tasks on mount, timer, open request, and manual refresh failures', async () => {
+  it('refreshes worker-backed task families on mount, timer, open request, and manual refresh failures', async () => {
     jest.useFakeTimers();
     let openRequestListener: (() => void) | undefined;
     mockSubscribeLcaTaskCenterOpenRequests.mockImplementation((listener: () => void) => {
@@ -559,20 +568,36 @@ describe('LcaTaskCenter', () => {
     render(<LcaTaskCenter />);
 
     await waitFor(() => expect(mockRefreshReviewSubmitTasks).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockRefreshLcaTasksFromWorkerJobs).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(mockRefreshTidasPackageTasksFromWorkerJobs).toHaveBeenCalledTimes(1),
+    );
 
     await act(async () => {
       jest.advanceTimersByTime(5000);
     });
     await waitFor(() => expect(mockRefreshReviewSubmitTasks).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockRefreshLcaTasksFromWorkerJobs).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(mockRefreshTidasPackageTasksFromWorkerJobs).toHaveBeenCalledTimes(2),
+    );
 
     act(() => {
       openRequestListener?.();
     });
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     await waitFor(() => expect(mockRefreshReviewSubmitTasks).toHaveBeenCalledTimes(3));
+    await waitFor(() => expect(mockRefreshLcaTasksFromWorkerJobs).toHaveBeenCalledTimes(3));
+    await waitFor(() =>
+      expect(mockRefreshTidasPackageTasksFromWorkerJobs).toHaveBeenCalledTimes(3),
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'open-lca-task-center' }));
     await waitFor(() => expect(mockRefreshReviewSubmitTasks).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(mockRefreshLcaTasksFromWorkerJobs).toHaveBeenCalledTimes(4));
+    await waitFor(() =>
+      expect(mockRefreshTidasPackageTasksFromWorkerJobs).toHaveBeenCalledTimes(4),
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
     await waitFor(() =>

--- a/tests/unit/components/LcaTaskCenter.test.tsx
+++ b/tests/unit/components/LcaTaskCenter.test.tsx
@@ -240,6 +240,7 @@ describe('LcaTaskCenter', () => {
         message: 'running message',
         createdAt: '2026-03-12T12:00:00.000Z',
         updatedAt: '2026-03-12T12:01:00.000Z',
+        workerJobId: 'worker-lca-1',
         solveJobId: 'solve-1',
         error: 'Solve failed once',
         phaseTimeline: [
@@ -306,6 +307,9 @@ describe('LcaTaskCenter', () => {
       screen.getAllByText((_, element) => element?.textContent?.includes('build_job_id') ?? false)
         .length,
     ).toBeGreaterThan(0);
+    expect(
+      screen.getByText((_, element) => element?.textContent === 'worker_job_id: worker-lca-1'),
+    ).toBeInTheDocument();
     expect(
       screen.getAllByText((_, element) => element?.textContent?.includes('result_id') ?? false)
         .length,
@@ -922,6 +926,7 @@ describe('LcaTaskCenter', () => {
         message: 'finished',
         createdAt: '2026-03-12T12:00:00.000Z',
         updatedAt: '2026-03-12T12:00:04.000Z',
+        workerJobId: 'worker-package-1',
         filename: 'custom.zip',
         jobId: 'job-1',
         scope: 'current_user',
@@ -1092,6 +1097,9 @@ describe('LcaTaskCenter', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText((_, element) => element?.textContent === 'job_id: job-1'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText((_, element) => element?.textContent === 'worker_job_id: worker-package-1'),
     ).toBeInTheDocument();
 
     const downloadButtons = screen.getAllByRole('button', { name: 'Download' });

--- a/tests/unit/components/LcaTaskCenter.test.tsx
+++ b/tests/unit/components/LcaTaskCenter.test.tsx
@@ -430,7 +430,8 @@ describe('LcaTaskCenter', () => {
   it('renders service-backed review-submit tasks with blocker guidance and cancel/remove actions', async () => {
     mockReviewSubmitTasks = [
       {
-        id: 'review-running',
+        id: 'submit-worker-running',
+        submitWorkerJobId: 'submit-worker-running',
         gateWorkerJobId: 'gate-worker-running',
         reviewSubmitJobId: 'review-job-running',
         state: 'running',
@@ -446,7 +447,9 @@ describe('LcaTaskCenter', () => {
         },
       },
       {
-        id: 'review-blocked',
+        id: 'submit-worker-blocked',
+        submitWorkerJobId: 'submit-worker-blocked',
+        rootJobId: 'root-worker-blocked',
         gateWorkerJobId: 'gate-worker-blocked',
         reviewSubmitJobId: 'review-job-blocked',
         state: 'failed',
@@ -501,6 +504,14 @@ describe('LcaTaskCenter', () => {
     expect(
       screen.getByText((_, element) => element?.textContent === 'dataset: process-2 @ 01.00.000'),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        (_, element) => element?.textContent === 'submit_worker_job_id: submit-worker-blocked',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText((_, element) => element?.textContent === 'root_job_id: root-worker-blocked'),
+    ).toBeInTheDocument();
     expect(screen.getByText('same input/output flow')).toBeInTheDocument();
     expect(
       screen.getAllByText(
@@ -516,20 +527,24 @@ describe('LcaTaskCenter', () => {
     await waitFor(() => expect(mockRefreshReviewSubmitTasks).toHaveBeenCalled());
 
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
-    await waitFor(() => expect(mockRetryReviewSubmitTask).toHaveBeenCalledWith('review-blocked'));
+    await waitFor(() =>
+      expect(mockRetryReviewSubmitTask).toHaveBeenCalledWith('submit-worker-blocked'),
+    );
     await waitFor(() =>
       expect(message.success).toHaveBeenCalledWith('Review-submit task restarted'),
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-    await waitFor(() => expect(mockCancelReviewSubmitTask).toHaveBeenCalledWith('review-running'));
+    await waitFor(() =>
+      expect(mockCancelReviewSubmitTask).toHaveBeenCalledWith('submit-worker-running'),
+    );
     await waitFor(() =>
       expect(message.success).toHaveBeenCalledWith('Review-submit task cancelled'),
     );
 
     const removeButtons = screen.getAllByRole('button', { name: 'Remove' });
     fireEvent.click(removeButtons[1]);
-    expect(mockRemoveReviewSubmitTask).toHaveBeenCalledWith('review-blocked');
+    expect(mockRemoveReviewSubmitTask).toHaveBeenCalledWith('submit-worker-blocked');
   });
 
   it('refreshes review-submit tasks on mount, timer, open request, and manual refresh failures', async () => {

--- a/tests/unit/services/lca/taskCenter.test.ts
+++ b/tests/unit/services/lca/taskCenter.test.ts
@@ -65,6 +65,7 @@ function loadTaskCenterModule(setupMocks?: (mocks: any) => void) {
   const mocks = {
     submitLcaSolve: jest.fn(),
     pollLcaJobUntilTerminal: jest.fn(),
+    requestWorkerJobsApi: jest.fn().mockResolvedValue({ data: [], error: null }),
   };
 
   setupMocks?.(mocks);
@@ -73,6 +74,11 @@ function loadTaskCenterModule(setupMocks?: (mocks: any) => void) {
     __esModule: true,
     submitLcaSolve: (...args: any[]) => mocks.submitLcaSolve(...args),
     pollLcaJobUntilTerminal: (...args: any[]) => mocks.pollLcaJobUntilTerminal(...args),
+  }));
+
+  jest.doMock('@/services/workerJobs/api', () => ({
+    __esModule: true,
+    requestWorkerJobsApi: (...args: any[]) => mocks.requestWorkerJobsApi(...args),
   }));
 
   const module = require('@/services/lca/taskCenter');
@@ -89,6 +95,7 @@ describe('lca task center', () => {
   afterEach(() => {
     jest.useRealTimers();
     jest.dontMock('@/services/lca/api');
+    jest.dontMock('@/services/workerJobs/api');
     window.localStorage.clear();
   });
 
@@ -411,6 +418,87 @@ describe('lca task center', () => {
     expect(module.listLcaTasks()).toEqual([]);
 
     unsubscribe();
+  });
+
+  it('refreshes LCA tasks from canonical worker_jobs and keeps legacy job ids as domain refs', async () => {
+    const { module, mocks } = loadTaskCenterModule((next) => {
+      next.requestWorkerJobsApi.mockResolvedValue({
+        data: [
+          {
+            id: 'worker-build-1',
+            jobKind: 'lca.build_snapshot',
+            status: 'running',
+            phase: 'build_snapshot',
+            subjectType: 'lca_job',
+            subjectId: 'legacy-build-1',
+            subjectVersion: 'snapshot-build-worker',
+            createdAt: '2026-03-12T11:00:00.000Z',
+            updatedAt: '2026-03-12T11:00:02.000Z',
+          },
+          {
+            id: 'worker-solve-1',
+            jobKind: 'lca.solve_all_unit',
+            status: 'completed',
+            subjectType: 'lca_job',
+            subjectId: 'legacy-solve-1',
+            subjectVersion: 'snapshot-solve-worker',
+            result: {
+              lcaJobId: 'legacy-solve-1',
+              snapshotId: 'snapshot-solve-worker',
+              resultId: 'result-worker-1',
+            },
+            createdAt: '2026-03-12T10:00:00.000Z',
+            updatedAt: '2026-03-12T10:10:00.000Z',
+          },
+          {
+            id: 'review-worker',
+            jobKind: 'review_submit.submit',
+            status: 'running',
+          },
+        ],
+        error: null,
+      });
+    });
+
+    await module.refreshLcaTasksFromWorkerJobs();
+
+    expect(mocks.requestWorkerJobsApi).toHaveBeenCalledWith({
+      action: 'list',
+      subjectType: 'lca_job',
+      statuses: [
+        'queued',
+        'running',
+        'waiting',
+        'completed',
+        'blocked',
+        'stale',
+        'failed',
+        'cancelled',
+      ],
+      limit: 30,
+    });
+    expect(module.listLcaTasks()).toEqual([
+      expect.objectContaining({
+        id: 'worker-build-1',
+        workerJobId: 'worker-build-1',
+        jobKind: 'lca.build_snapshot',
+        buildJobId: 'legacy-build-1',
+        snapshotId: 'snapshot-build-worker',
+        phase: 'building_snapshot',
+        state: 'running',
+      }),
+      expect.objectContaining({
+        id: 'worker-solve-1',
+        workerJobId: 'worker-solve-1',
+        jobKind: 'lca.solve_all_unit',
+        solveJobId: 'legacy-solve-1',
+        snapshotId: 'snapshot-solve-worker',
+        resultId: 'result-worker-1',
+        mode: 'all_unit',
+        phase: 'completed',
+        state: 'completed',
+      }),
+    ]);
   });
 
   it('notifies and unsubscribes task-center open request listeners', () => {

--- a/tests/unit/services/lca/taskCenter.test.ts
+++ b/tests/unit/services/lca/taskCenter.test.ts
@@ -218,6 +218,9 @@ describe('lca task center', () => {
           message: 'Metadata task',
           createdAt: 123,
           updatedAt: 456,
+          workerJobId: 'worker-meta',
+          rootJobId: 'root-meta',
+          jobKind: 'lca.solve_one',
           snapshotId: 'snapshot-meta',
           resultId: 'result-meta',
           error: 'meta-error',
@@ -260,6 +263,9 @@ describe('lca task center', () => {
     expect(metadataTask).toMatchObject({
       id: 'metadata-task',
       sequence: 9,
+      workerJobId: 'worker-meta',
+      rootJobId: 'root-meta',
+      jobKind: 'lca.solve_one',
       snapshotId: 'snapshot-meta',
       resultId: 'result-meta',
       error: 'meta-error',
@@ -497,6 +503,265 @@ describe('lca task center', () => {
         mode: 'all_unit',
         phase: 'completed',
         state: 'completed',
+      }),
+    ]);
+  });
+
+  it('maps canonical worker_jobs failed, solving, and fallback submitting states', async () => {
+    const { module } = loadTaskCenterModule((next) => {
+      next.requestWorkerJobsApi.mockResolvedValue({
+        data: [
+          {
+            id: 'worker-failed-1',
+            jobKind: 'lca.solve_one',
+            status: 'blocked',
+            subjectType: 'lca_job',
+            subjectId: 'legacy-failed-1',
+            createdAt: '2026-03-12T11:20:00.000Z',
+            updatedAt: '2026-03-12T11:21:00.000Z',
+          },
+          {
+            id: 'worker-solving-1',
+            jobKind: 'lca.solve_all_unit',
+            status: 'running',
+            subjectType: 'lca_job',
+            subjectId: 'legacy-solving-1',
+            phase: 'unknown-worker-phase',
+            createdAt: '2026-03-12T11:10:00.000Z',
+            updatedAt: '2026-03-12T11:11:00.000Z',
+          },
+          {
+            id: 'worker-submitting-1',
+            jobKind: 'lca.prepare',
+            status: 'waiting',
+            subjectType: 'lca_job',
+            phase: 123,
+            createdAt: '2026-03-12T11:00:00.000Z',
+            updatedAt: '2026-03-12T11:01:00.000Z',
+          },
+          {
+            id: 'worker-build-no-phase',
+            jobKind: 'lca.build_snapshot',
+            status: 'running',
+            subjectType: 'lca_job',
+            createdAt: '2026-03-12T10:50:00.000Z',
+            updatedAt: '2026-03-12T10:51:00.000Z',
+          },
+          {
+            id: 'worker-completed-no-result',
+            jobKind: 'lca.solve_one',
+            status: 'completed',
+            subjectType: 'lca_job',
+            subjectId: 'legacy-completed-no-result',
+            result: {},
+            createdAt: '2026-03-12T10:40:00.000Z',
+            updatedAt: '2026-03-12T10:41:00.000Z',
+          },
+        ],
+        error: null,
+      });
+    });
+
+    await module.refreshLcaTasksFromWorkerJobs();
+    const tasks = module.listLcaTasks();
+
+    expect(tasks.find((item: any) => item.id === 'worker-failed-1')).toMatchObject({
+      state: 'failed',
+      phase: 'failed',
+      message: 'Task failed',
+      error: 'blocked',
+    });
+    expect(tasks.find((item: any) => item.id === 'worker-solving-1')).toMatchObject({
+      mode: 'all_unit',
+      state: 'running',
+      phase: 'solving',
+      message: 'Solving (legacy-solving-1)',
+    });
+    expect(tasks.find((item: any) => item.id === 'worker-submitting-1')).toMatchObject({
+      state: 'running',
+      phase: 'submitting',
+      message: 'Submitting task',
+    });
+    expect(tasks.find((item: any) => item.id === 'worker-build-no-phase')).toMatchObject({
+      state: 'running',
+      phase: 'building_snapshot',
+      message: 'Building snapshot (worker-build-no-phase)',
+    });
+    expect(tasks.find((item: any) => item.id === 'worker-completed-no-result')).toMatchObject({
+      state: 'completed',
+      phase: 'completed',
+      message: 'Completed',
+      resultId: undefined,
+    });
+  });
+
+  it('merges worker_jobs updates into existing local tasks by canonical and legacy ids', async () => {
+    storePersistedTasks([
+      {
+        id: 'local-worker-match',
+        sequence: 7,
+        mode: 'single',
+        scope: 'prod',
+        state: 'running',
+        phase: 'building_snapshot',
+        message: 'local worker',
+        createdAt: '2026-03-12T09:00:00.000Z',
+        updatedAt: '2026-03-12T09:01:00.000Z',
+        workerJobId: 'worker-match',
+        phaseTimeline: [{ phase: 'building_snapshot', startedAt: '2026-03-12T09:00:00.000Z' }],
+      },
+      {
+        id: 'local-id-match',
+        sequence: 8,
+        mode: 'single',
+        scope: 'prod',
+        state: 'running',
+        phase: 'submitting',
+        message: 'local id',
+        createdAt: '2026-03-12T09:10:00.000Z',
+        updatedAt: '2026-03-12T09:11:00.000Z',
+        phaseTimeline: [{ phase: 'submitting', startedAt: '2026-03-12T09:10:00.000Z' }],
+      },
+      {
+        id: 'local-build-match',
+        sequence: 9,
+        mode: 'single',
+        scope: 'prod',
+        state: 'running',
+        phase: 'submitting',
+        message: 'local build',
+        createdAt: '2026-03-12T09:20:00.000Z',
+        updatedAt: '2026-03-12T09:21:00.000Z',
+        buildJobId: 'legacy-build-match',
+        phaseTimeline: [{ phase: 'submitting', startedAt: '2026-03-12T09:20:00.000Z' }],
+      },
+      {
+        id: 'local-solve-match',
+        sequence: 10,
+        mode: 'single',
+        scope: 'prod',
+        state: 'running',
+        phase: 'submitting',
+        message: 'local solve',
+        createdAt: '2026-03-12T09:30:00.000Z',
+        updatedAt: '2026-03-12T09:31:00.000Z',
+        solveJobId: 'legacy-solve-match',
+        phaseTimeline: [{ phase: 'submitting', startedAt: '2026-03-12T09:30:00.000Z' }],
+      },
+    ]);
+    const { module } = loadTaskCenterModule((next) => {
+      next.requestWorkerJobsApi.mockResolvedValue({
+        data: [
+          {
+            id: 'worker-match',
+            jobKind: 'lca.build_snapshot',
+            status: 'running',
+            subjectType: 'lca_job',
+            subjectId: 'legacy-worker-match',
+            createdAt: '2026-03-12T10:00:00.000Z',
+            updatedAt: '2026-03-12T10:01:00.000Z',
+          },
+          {
+            id: 'local-id-match',
+            jobKind: 'lca.prepare',
+            status: 'waiting',
+            subjectType: 'lca_job',
+            createdAt: '2026-03-12T10:10:00.000Z',
+            updatedAt: '2026-03-12T10:11:00.000Z',
+          },
+          {
+            id: 'worker-build-match',
+            jobKind: 'lca.build_snapshot',
+            status: 'running',
+            subjectType: 'lca_job',
+            subjectId: 'legacy-build-match',
+            createdAt: '2026-03-12T10:20:00.000Z',
+            updatedAt: '2026-03-12T10:21:00.000Z',
+          },
+          {
+            id: 'worker-solve-match',
+            jobKind: 'lca.solve_one',
+            status: 'running',
+            subjectType: 'lca_job',
+            subjectId: 'legacy-solve-match',
+            createdAt: '2026-03-12T10:30:00.000Z',
+            updatedAt: '2026-03-12T10:31:00.000Z',
+          },
+        ],
+        error: null,
+      });
+    });
+
+    await module.refreshLcaTasksFromWorkerJobs();
+    const tasks = module.listLcaTasks();
+
+    expect(tasks.find((item: any) => item.id === 'local-worker-match')).toMatchObject({
+      sequence: 7,
+      phase: 'building_snapshot',
+    });
+    expect(
+      tasks.find((item: any) => item.id === 'local-worker-match')?.phaseTimeline[0],
+    ).toMatchObject({
+      phase: 'building_snapshot',
+      startedAt: '2026-03-12T09:00:00.000Z',
+    });
+    expect(tasks.find((item: any) => item.id === 'local-id-match')).toMatchObject({
+      phase: 'submitting',
+      workerJobId: 'local-id-match',
+    });
+    expect(tasks.find((item: any) => item.id === 'local-build-match')).toMatchObject({
+      phase: 'building_snapshot',
+      workerJobId: 'worker-build-match',
+      buildJobId: 'legacy-build-match',
+    });
+    expect(tasks.find((item: any) => item.id === 'local-solve-match')).toMatchObject({
+      phase: 'solving',
+      workerJobId: 'worker-solve-match',
+      solveJobId: 'legacy-solve-match',
+    });
+  });
+
+  it('surfaces worker_jobs refresh API errors with explicit and fallback messages', async () => {
+    const explicit = loadTaskCenterModule((next) => {
+      next.requestWorkerJobsApi.mockResolvedValue({ data: null, error: { message: 'api down' } });
+    });
+    await expect(explicit.module.refreshLcaTasksFromWorkerJobs()).rejects.toThrow('api down');
+
+    const fallback = loadTaskCenterModule((next) => {
+      next.requestWorkerJobsApi.mockResolvedValue({ data: null, error: {} });
+    });
+    await expect(fallback.module.refreshLcaTasksFromWorkerJobs()).rejects.toThrow(
+      'Failed to refresh LCA worker jobs',
+    );
+  });
+
+  it('keeps existing LCA tasks when worker_jobs refresh returns no mappable tasks', async () => {
+    storePersistedTasks([
+      {
+        id: 'existing-lca-task',
+        sequence: 1,
+        mode: 'single',
+        scope: 'prod',
+        state: 'completed',
+        phase: 'completed',
+        message: 'existing',
+        createdAt: '2026-03-12T09:00:00.000Z',
+        updatedAt: '2026-03-12T09:01:00.000Z',
+        phaseTimeline: [{ phase: 'completed', startedAt: '2026-03-12T09:00:00.000Z' }],
+      },
+    ]);
+    const { module } = loadTaskCenterModule((next) => {
+      next.requestWorkerJobsApi.mockResolvedValue({
+        error: null,
+      });
+    });
+
+    const refreshed = await module.refreshLcaTasksFromWorkerJobs();
+
+    expect(refreshed).toEqual([
+      expect.objectContaining({
+        id: 'existing-lca-task',
+        message: 'existing',
       }),
     ]);
   });

--- a/tests/unit/services/reviews/taskCenter.test.ts
+++ b/tests/unit/services/reviews/taskCenter.test.ts
@@ -42,7 +42,13 @@ describe('reviews/taskCenter', () => {
     const task = taskCenter.trackReviewSubmitTask({
       status: 'waiting_gate',
       reviewSubmitJobId: '11111111-1111-4111-8111-111111111111',
+      submitWorkerJobId: '00000000-0000-4000-8000-000000000001',
       gateWorkerJobId: '22222222-2222-4222-8222-222222222222',
+      submitWorkerJob: {
+        id: '00000000-0000-4000-8000-000000000001',
+        jobKind: 'review_submit.submit',
+        status: 'waiting',
+      },
       datasetRevision: {
         table: 'processes',
         id: '33333333-3333-4333-8333-333333333333',
@@ -53,7 +59,8 @@ describe('reviews/taskCenter', () => {
 
     expect(task).toEqual(
       expect.objectContaining({
-        id: '11111111-1111-4111-8111-111111111111',
+        id: '00000000-0000-4000-8000-000000000001',
+        submitWorkerJobId: '00000000-0000-4000-8000-000000000001',
         gateWorkerJobId: '22222222-2222-4222-8222-222222222222',
         state: 'running',
         phase: 'waiting_gate',
@@ -69,8 +76,19 @@ describe('reviews/taskCenter', () => {
     mockRequestWorkerJobsApi.mockResolvedValue({
       data: [
         {
+          id: '00000000-0000-4000-8000-000000000001',
+          jobKind: 'review_submit.submit',
+          subjectType: 'processes',
+          subjectId: '33333333-3333-4333-8333-333333333333',
+          subjectVersion: '01.00.000',
+          status: 'waiting',
+          createdAt: '2026-03-12T10:59:00.000Z',
+          updatedAt: '2026-03-12T11:02:00.000Z',
+        },
+        {
           id: '22222222-2222-4222-8222-222222222222',
           jobKind: 'review_submit.gate',
+          rootJobId: '00000000-0000-4000-8000-000000000001',
           subjectType: 'processes',
           subjectId: '33333333-3333-4333-8333-333333333333',
           subjectVersion: '01.00.000',
@@ -96,9 +114,16 @@ describe('reviews/taskCenter', () => {
         {
           status: 'blocked',
           reviewSubmitJobId: '11111111-1111-4111-8111-111111111111',
+          submitWorkerJobId: '00000000-0000-4000-8000-000000000001',
           gateWorkerJobId: '22222222-2222-4222-8222-222222222222',
+          submitWorkerJob: {
+            id: '00000000-0000-4000-8000-000000000001',
+            jobKind: 'review_submit.submit',
+            status: 'waiting',
+          },
           gateWorkerJob: {
             id: '22222222-2222-4222-8222-222222222222',
+            jobKind: 'review_submit.gate',
             status: 'blocked',
           },
           datasetRevision: {
@@ -134,9 +159,12 @@ describe('reviews/taskCenter', () => {
       id: '33333333-3333-4333-8333-333333333333',
       version: '01.00.000',
     });
+    expect(mockRequestReviewSubmitJobApi).toHaveBeenCalledTimes(2);
     expect(tasks).toEqual([
       expect.objectContaining({
-        id: '11111111-1111-4111-8111-111111111111',
+        id: '00000000-0000-4000-8000-000000000001',
+        submitWorkerJobId: '00000000-0000-4000-8000-000000000001',
+        gateWorkerJobId: '22222222-2222-4222-8222-222222222222',
         phase: 'blocked',
         state: 'failed',
         blockerCodes: ['flow_lcia_semantic_mismatch'],
@@ -375,6 +403,8 @@ describe('reviews/taskCenter', () => {
           {
             id: 'cached-task',
             phase: 'running',
+            submitWorkerJobId: 'submit-worker-cached',
+            rootJobId: 'root-worker-cached',
             gateWorkerJobId: '22222222-2222-4222-8222-222222222222',
             reviewSubmitJobId: '11111111-1111-4111-8111-111111111111',
             message: 'Cached task is still running',
@@ -388,6 +418,16 @@ describe('reviews/taskCenter', () => {
             gateRunId: null,
             workerJob: {
               id: '22222222-2222-4222-8222-222222222222',
+              status: 'running',
+            },
+            rootWorkerJob: {
+              id: 'root-worker-cached',
+              jobKind: 'review_submit.submit',
+              status: 'running',
+            },
+            gateWorkerJob: {
+              id: '22222222-2222-4222-8222-222222222222',
+              jobKind: 'review_submit.gate',
               status: 'running',
             },
             coordinator: {
@@ -407,11 +447,23 @@ describe('reviews/taskCenter', () => {
       expect.objectContaining({
         id: 'cached-task',
         phase: 'running',
+        submitWorkerJobId: 'submit-worker-cached',
+        rootJobId: 'root-worker-cached',
         gateWorkerJobId: '22222222-2222-4222-8222-222222222222',
         reviewSubmitJobId: '11111111-1111-4111-8111-111111111111',
         message: 'Cached task is still running',
         createdAt: '2026-03-12T12:00:00.000Z',
         updatedAt: '2026-03-12T12:00:00.000Z',
+        rootWorkerJob: {
+          id: 'root-worker-cached',
+          jobKind: 'review_submit.submit',
+          status: 'running',
+        },
+        gateWorkerJob: {
+          id: '22222222-2222-4222-8222-222222222222',
+          jobKind: 'review_submit.gate',
+          status: 'running',
+        },
         gateRunId: null,
         blockerCodes: ['flow_lcia_semantic_mismatch'],
         progress: 0,
@@ -590,8 +642,153 @@ describe('reviews/taskCenter', () => {
 
     await expect(taskCenter.refreshReviewSubmitTasks()).resolves.toEqual([
       expect.objectContaining({
-        id: 'server-job',
+        id: 'same-worker',
         gateWorkerJobId: 'same-worker',
+        reviewSubmitJobId: 'server-job',
+      }),
+    ]);
+  });
+
+  it('hydrates root worker projections and ignores stale root coordinator ids', async () => {
+    mockRequestWorkerJobsApi.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'root-worker-from-coordinator',
+          jobKind: 'review_submit.submit',
+          subjectType: 'processes',
+          subjectId: '33333333-3333-4333-8333-333333333333',
+          subjectVersion: '01.00.000',
+          status: 'running',
+          createdAt: '2026-03-12T11:00:00.000Z',
+          updatedAt: '2026-03-12T11:02:00.000Z',
+        },
+        {
+          id: 'root-worker-stale',
+          jobKind: 'review_submit.submit',
+          subjectType: 'processes',
+          subjectId: '44444444-4444-4444-8444-444444444444',
+          subjectVersion: '01.00.000',
+          status: 'completed',
+          createdAt: '2026-03-12T10:00:00.000Z',
+          updatedAt: '2026-03-12T10:02:00.000Z',
+        },
+      ],
+      error: null,
+    });
+    mockRequestReviewSubmitJobApi
+      .mockResolvedValueOnce({
+        data: [
+          {
+            status: 'waiting_gate',
+            reviewSubmitJobId: 'coordinator-for-root',
+            workerJob: {
+              id: 'root-worker-from-coordinator',
+              jobKind: 'review_submit.submit',
+              status: 'running',
+            },
+          },
+        ],
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            status: 'submitted',
+            reviewSubmitJobId: 'stale-coordinator-root',
+            submitWorkerJobId: 'different-root-worker',
+          },
+        ],
+        error: null,
+      });
+
+    const taskCenter = loadTaskCenterModule();
+    await expect(taskCenter.refreshReviewSubmitTasks()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'root-worker-from-coordinator',
+          submitWorkerJobId: 'root-worker-from-coordinator',
+          reviewSubmitJobId: 'coordinator-for-root',
+          phase: 'waiting_gate',
+        }),
+        expect.objectContaining({
+          id: 'root-worker-stale',
+          submitWorkerJobId: 'root-worker-stale',
+          reviewSubmitJobId: undefined,
+          phase: 'passed',
+        }),
+      ]),
+    );
+  });
+
+  it('prefers canonical root worker tasks while preserving legacy gate metadata', async () => {
+    mockRequestWorkerJobsApi.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'gate-worker-for-merge',
+          jobKind: 'review_submit.gate',
+          rootJobId: 'root-worker-for-merge',
+          subjectType: 'processes',
+          subjectId: '33333333-3333-4333-8333-333333333333',
+          subjectVersion: '01.00.000',
+          status: 'blocked',
+          blockerCodes: ['flow_lcia_semantic_mismatch'],
+          result: {
+            blockingReasons: [
+              {
+                code: 'flow_lcia_semantic_mismatch',
+              },
+            ],
+          },
+          progress: 0.4,
+          createdAt: '2026-03-12T10:59:00.000Z',
+          updatedAt: '2026-03-12T11:01:00.000Z',
+        },
+        {
+          id: 'root-worker-for-merge',
+          jobKind: 'review_submit.submit',
+          status: 'running',
+          createdAt: '2026-03-12T11:00:00.000Z',
+          updatedAt: '2026-03-12T11:02:00.000Z',
+        },
+      ],
+      error: null,
+    });
+    mockRequestReviewSubmitJobApi.mockResolvedValueOnce({
+      data: [
+        {
+          status: 'blocked',
+          reviewSubmitJobId: 'review-job-for-merge',
+          gateWorkerJobId: 'gate-worker-for-merge',
+          gateRunId: 'gate-run-for-merge',
+        },
+      ],
+      error: null,
+    });
+
+    const taskCenter = loadTaskCenterModule();
+    await expect(taskCenter.refreshReviewSubmitTasks()).resolves.toEqual([
+      expect.objectContaining({
+        id: 'root-worker-for-merge',
+        submitWorkerJobId: 'root-worker-for-merge',
+        gateWorkerJobId: 'gate-worker-for-merge',
+        reviewSubmitJobId: 'review-job-for-merge',
+        rootJobId: 'root-worker-for-merge',
+        datasetRevision: {
+          table: 'processes',
+          id: '33333333-3333-4333-8333-333333333333',
+          version: '01.00.000',
+        },
+        gateRunId: 'gate-run-for-merge',
+        gateWorkerJob: expect.objectContaining({
+          id: 'gate-worker-for-merge',
+        }),
+        blockingReasons: [
+          {
+            code: 'flow_lcia_semantic_mismatch',
+          },
+        ],
+        blockerCodes: ['flow_lcia_semantic_mismatch'],
+        progress: 0.4,
       }),
     ]);
   });
@@ -625,10 +822,11 @@ describe('reviews/taskCenter', () => {
     });
 
     await expect(
-      taskCenter.retryReviewSubmitTask('11111111-1111-4111-8111-111111111111'),
+      taskCenter.retryReviewSubmitTask('22222222-2222-4222-8222-222222222222'),
     ).resolves.toEqual(
       expect.objectContaining({
-        id: '44444444-4444-4444-8444-444444444444',
+        id: '55555555-5555-4555-8555-555555555555',
+        reviewSubmitJobId: '44444444-4444-4444-8444-444444444444',
         phase: 'waiting_gate',
       }),
     );
@@ -643,7 +841,7 @@ describe('reviews/taskCenter', () => {
   it('surfaces cancel and retry failures', async () => {
     const taskCenter = loadTaskCenterModule();
     await expect(taskCenter.cancelReviewSubmitTask('missing-task')).rejects.toThrow(
-      'Review-submit gate worker job id is missing',
+      'Review-submit worker job id is missing',
     );
     await expect(taskCenter.retryReviewSubmitTask('missing-task')).rejects.toThrow(
       'Review-submit dataset revision is missing',
@@ -672,10 +870,10 @@ describe('reviews/taskCenter', () => {
         error: {},
       });
     await expect(
-      taskCenter.cancelReviewSubmitTask('11111111-1111-4111-8111-111111111111'),
+      taskCenter.cancelReviewSubmitTask('22222222-2222-4222-8222-222222222222'),
     ).rejects.toThrow('cancel failed');
     await expect(
-      taskCenter.cancelReviewSubmitTask('11111111-1111-4111-8111-111111111111'),
+      taskCenter.cancelReviewSubmitTask('22222222-2222-4222-8222-222222222222'),
     ).rejects.toThrow('Failed to cancel review-submit task');
 
     mockRequestReviewSubmitJobApi
@@ -694,13 +892,13 @@ describe('reviews/taskCenter', () => {
         error: {},
       });
     await expect(
-      taskCenter.retryReviewSubmitTask('11111111-1111-4111-8111-111111111111'),
+      taskCenter.retryReviewSubmitTask('22222222-2222-4222-8222-222222222222'),
     ).rejects.toThrow('retry failed');
     await expect(
-      taskCenter.retryReviewSubmitTask('11111111-1111-4111-8111-111111111111'),
+      taskCenter.retryReviewSubmitTask('22222222-2222-4222-8222-222222222222'),
     ).rejects.toThrow('Review-submit retry returned no job');
     await expect(
-      taskCenter.retryReviewSubmitTask('11111111-1111-4111-8111-111111111111'),
+      taskCenter.retryReviewSubmitTask('22222222-2222-4222-8222-222222222222'),
     ).rejects.toThrow('Failed to retry review-submit task');
   });
 
@@ -781,7 +979,8 @@ describe('reviews/taskCenter', () => {
 
     await expect(taskCenter.retryReviewSubmitTask('track-refresh-fails')).resolves.toEqual(
       expect.objectContaining({
-        id: 'retry-refresh-fails',
+        id: 'retry-refresh-worker',
+        reviewSubmitJobId: 'retry-refresh-fails',
       }),
     );
     await taskCenter.refreshReviewSubmitTasks().catch(() => undefined);
@@ -825,18 +1024,18 @@ describe('reviews/taskCenter', () => {
       ],
       error: null,
     });
-    await taskCenter.cancelReviewSubmitTask('11111111-1111-4111-8111-111111111111');
+    await taskCenter.cancelReviewSubmitTask('22222222-2222-4222-8222-222222222222');
     expect(mockRequestWorkerJobsApi).toHaveBeenCalledWith({
       action: 'cancel',
       jobId: '22222222-2222-4222-8222-222222222222',
       reason: 'user_cancelled',
     });
 
-    taskCenter.removeReviewSubmitTask('11111111-1111-4111-8111-111111111111');
+    taskCenter.removeReviewSubmitTask('22222222-2222-4222-8222-222222222222');
     expect(taskCenter.listReviewSubmitTasks()).toEqual([]);
     expect(
       JSON.parse(window.localStorage.getItem(REVIEW_SUBMIT_STORAGE_KEY) ?? '{}').dismissedTaskIds,
-    ).toContain('11111111-1111-4111-8111-111111111111');
+    ).toContain('22222222-2222-4222-8222-222222222222');
   });
 
   it('clears only finished review-submit tasks', () => {

--- a/tests/unit/services/tidasPackage/taskCenter.test.ts
+++ b/tests/unit/services/tidasPackage/taskCenter.test.ts
@@ -211,6 +211,8 @@ describe('tidasPackage/taskCenter', () => {
             message: 'done',
             createdAt: 123,
             updatedAt: '2026-03-21T11:00:00.000Z',
+            workerJobId: 'worker-normalized-task',
+            jobKind: 'tidas.export_package',
             scope: 123,
             rootCount: 3,
           },
@@ -223,6 +225,8 @@ describe('tidasPackage/taskCenter', () => {
       expect.objectContaining({
         id: 'normalized-task',
         sequence: 1,
+        workerJobId: 'worker-normalized-task',
+        jobKind: 'tidas.export_package',
         scope: null,
         createdAt: '2026-03-21T10:00:00.000Z',
         updatedAt: '2026-03-21T11:00:00.000Z',
@@ -321,6 +325,171 @@ describe('tidasPackage/taskCenter', () => {
         phase: 'completed',
         scope: 'selected_roots',
         filename: 'worker-export.zip',
+      }),
+    ]);
+  });
+
+  it('maps canonical export worker_jobs phase and artifact fallback branches', async () => {
+    mockRequestWorkerJobsApi.mockResolvedValue({
+      data: [
+        {
+          id: 'worker-package-completed-fallback',
+          jobKind: 'tidas.export_package',
+          status: 'completed',
+          subjectType: 'lca_package_job',
+          subjectId: 'package-completed-fallback',
+          result: {
+            artifacts: [
+              {
+                artifactKind: 'diagnostic_json',
+                metadata: { filename: 'ignored.json' },
+              },
+            ],
+          },
+          createdAt: '2026-03-21T09:40:00.000Z',
+          updatedAt: '2026-03-21T09:41:00.000Z',
+        },
+        {
+          id: 'worker-package-failed',
+          jobKind: 'tidas.export_package',
+          status: 'blocked',
+          subjectType: 'lca_package_job',
+          subjectId: 'package-failed',
+          createdAt: '2026-03-21T09:30:00.000Z',
+          updatedAt: '2026-03-21T09:31:00.000Z',
+        },
+        {
+          id: 'worker-package-collect',
+          jobKind: 'tidas.export_package',
+          status: 'running',
+          phase: 'collect_refs',
+          subjectType: 'lca_package_job',
+          subjectId: 'package-collect',
+          createdAt: '2026-03-21T09:20:00.000Z',
+          updatedAt: '2026-03-21T09:21:00.000Z',
+        },
+        {
+          id: 'worker-package-finalize',
+          jobKind: 'tidas.export_package',
+          status: 'running',
+          phase: 'finalize_zip',
+          subjectType: 'lca_package_job',
+          subjectId: 'package-finalize',
+          createdAt: '2026-03-21T09:10:00.000Z',
+          updatedAt: '2026-03-21T09:11:00.000Z',
+        },
+        {
+          id: 'worker-package-queued',
+          jobKind: 'tidas.export_package',
+          status: 'queued',
+          phase: 123,
+          subjectType: 'lca_package_job',
+          subjectId: 123,
+          result: { packageJobId: null },
+          createdAt: '2026-03-21T09:00:00.000Z',
+          updatedAt: '2026-03-21T09:01:00.000Z',
+        },
+        {
+          id: 'worker-package-submitting',
+          jobKind: 'tidas.export_package',
+          status: 'running',
+          phase: 'unknown-worker-phase',
+          subjectType: 'lca_package_job',
+          subjectId: 'package-submitting',
+          createdAt: '2026-03-21T08:50:00.000Z',
+          updatedAt: '2026-03-21T08:51:00.000Z',
+        },
+      ],
+      error: null,
+    });
+
+    const taskCenter = loadTaskCenterModule();
+    await taskCenter.refreshTidasPackageTasksFromWorkerJobs();
+    const tasks = taskCenter.listTidasPackageTasks();
+
+    expect(tasks.find((item) => item.id === 'worker-package-completed-fallback')).toMatchObject({
+      state: 'completed',
+      phase: 'completed',
+      filename: undefined,
+      message: 'Export package ready (tidas-package.zip)',
+    });
+    expect(tasks.find((item) => item.id === 'worker-package-failed')).toMatchObject({
+      state: 'failed',
+      phase: 'failed',
+      message: 'Export package failed',
+      error: 'blocked',
+    });
+    expect(tasks.find((item) => item.id === 'worker-package-collect')).toMatchObject({
+      state: 'running',
+      phase: 'collect_refs',
+      message: 'Collecting related datasets',
+    });
+    expect(tasks.find((item) => item.id === 'worker-package-finalize')).toMatchObject({
+      state: 'running',
+      phase: 'finalize_zip',
+      message: 'Materializing ZIP package',
+    });
+    expect(tasks.find((item) => item.id === 'worker-package-queued')).toMatchObject({
+      state: 'running',
+      phase: 'queued',
+      jobId: undefined,
+      message: 'Export task queued (worker-package-queued)',
+    });
+    expect(tasks.find((item) => item.id === 'worker-package-submitting')).toMatchObject({
+      state: 'running',
+      phase: 'submitting',
+      message: 'Export task queued (package-submitting)',
+    });
+  });
+
+  it('surfaces worker_jobs refresh API errors with explicit and fallback messages', async () => {
+    const explicitModule = loadTaskCenterModule();
+    mockRequestWorkerJobsApi.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'package api down' },
+    });
+    await expect(explicitModule.refreshTidasPackageTasksFromWorkerJobs()).rejects.toThrow(
+      'package api down',
+    );
+
+    const fallbackModule = loadTaskCenterModule();
+    mockRequestWorkerJobsApi.mockResolvedValueOnce({ data: null, error: {} });
+    await expect(fallbackModule.refreshTidasPackageTasksFromWorkerJobs()).rejects.toThrow(
+      'Failed to refresh TIDAS package worker jobs',
+    );
+  });
+
+  it('keeps existing export tasks when worker_jobs refresh returns no mappable tasks', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        savedAt: new Date().toISOString(),
+        tasks: [
+          {
+            id: 'existing-export-task',
+            state: 'completed',
+            phase: 'completed',
+            message: 'existing',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            sequence: 1,
+            jobId: 'existing-package-job',
+          },
+        ],
+      }),
+    );
+    mockRequestWorkerJobsApi.mockResolvedValue({
+      error: null,
+    });
+
+    const taskCenter = loadTaskCenterModule();
+    const refreshed = await taskCenter.refreshTidasPackageTasksFromWorkerJobs();
+
+    expect(refreshed).toEqual([
+      expect.objectContaining({
+        id: 'existing-export-task',
+        message: 'existing',
       }),
     ]);
   });

--- a/tests/unit/services/tidasPackage/taskCenter.test.ts
+++ b/tests/unit/services/tidasPackage/taskCenter.test.ts
@@ -5,12 +5,18 @@ const STORAGE_KEY = 'tg_tidas_package_task_center_v1';
 const mockQueueExportTidasPackageApi = jest.fn();
 const mockGetTidasPackageJobApi = jest.fn();
 const mockDownloadReadyTidasPackageExportApi = jest.fn();
+const mockRequestWorkerJobsApi = jest.fn();
 
 jest.mock('@/services/general/api', () => ({
   queueExportTidasPackageApi: (...args: any[]) => mockQueueExportTidasPackageApi(...args),
   getTidasPackageJobApi: (...args: any[]) => mockGetTidasPackageJobApi(...args),
   downloadReadyTidasPackageExportApi: (...args: any[]) =>
     mockDownloadReadyTidasPackageExportApi(...args),
+}));
+
+jest.mock('@/services/workerJobs/api', () => ({
+  __esModule: true,
+  requestWorkerJobsApi: (...args: any[]) => mockRequestWorkerJobsApi(...args),
 }));
 
 function loadTaskCenterModule() {
@@ -32,6 +38,8 @@ describe('tidasPackage/taskCenter', () => {
     mockQueueExportTidasPackageApi.mockReset();
     mockGetTidasPackageJobApi.mockReset();
     mockDownloadReadyTidasPackageExportApi.mockReset();
+    mockRequestWorkerJobsApi.mockReset();
+    mockRequestWorkerJobsApi.mockResolvedValue({ data: [], error: null });
     jest.useRealTimers();
     localStorage.clear();
   });
@@ -247,6 +255,72 @@ describe('tidasPackage/taskCenter', () => {
       expect.objectContaining({
         id: 'scoped-task',
         scope: 'open_data',
+      }),
+    ]);
+  });
+
+  it('refreshes export tasks from canonical worker_jobs and preserves package job ids', async () => {
+    mockRequestWorkerJobsApi.mockResolvedValue({
+      data: [
+        {
+          id: 'worker-package-export',
+          jobKind: 'tidas.export_package',
+          status: 'completed',
+          subjectType: 'lca_package_job',
+          subjectId: 'package-job-1',
+          subjectVersion: 'selected_roots',
+          result: {
+            packageJobId: 'package-job-1',
+            packageJobStatus: 'completed',
+            artifacts: [
+              {
+                artifactKind: 'export_zip',
+                metadata: { filename: 'worker-export.zip' },
+              },
+            ],
+          },
+          createdAt: '2026-03-21T09:00:00.000Z',
+          updatedAt: '2026-03-21T09:02:00.000Z',
+        },
+        {
+          id: 'worker-package-import',
+          jobKind: 'tidas.import_package',
+          status: 'running',
+          subjectType: 'lca_package_job',
+          subjectId: 'package-import-1',
+        },
+      ],
+      error: null,
+    });
+
+    const taskCenter = loadTaskCenterModule();
+    await taskCenter.refreshTidasPackageTasksFromWorkerJobs();
+
+    expect(mockRequestWorkerJobsApi).toHaveBeenCalledWith({
+      action: 'list',
+      subjectType: 'lca_package_job',
+      statuses: [
+        'queued',
+        'running',
+        'waiting',
+        'completed',
+        'blocked',
+        'stale',
+        'failed',
+        'cancelled',
+      ],
+      limit: 30,
+    });
+    expect(taskCenter.listTidasPackageTasks()).toEqual([
+      expect.objectContaining({
+        id: 'worker-package-export',
+        workerJobId: 'worker-package-export',
+        jobKind: 'tidas.export_package',
+        jobId: 'package-job-1',
+        state: 'completed',
+        phase: 'completed',
+        scope: 'selected_roots',
+        filename: 'worker-export.zip',
       }),
     ]);
   });


### PR DESCRIPTION
Refs #500

## Summary
- Prefer the canonical `review_submit.submit` root worker job as the review-submit task center identity while preserving `review_submit.gate` child evidence for gate/blocker/diagnostic details.
- Recover LCA background tasks from canonical `worker_jobs` rows with `subjectType='lca_job'` and `jobKind` starting with `lca.*`; legacy `lca_jobs` ids remain domain references for snapshot/result lookup.
- Recover TIDAS export tasks from canonical `worker_jobs` rows with `subjectType='lca_package_job'` and `jobKind='tidas.export_package'`; legacy package job ids remain download/domain references.
- Refresh task center polling/manual-open behavior so review-submit, LCA, and TIDAS export task families all query the worker_jobs projection.
- Add omission-prevention coverage for worker job status/phase fallbacks, merge/recovery matching, empty/error responses, and worker_job_id detail rendering.

## Scope note
TIDAS import is intentionally not converted in this PR. The current UI import path is still a blocking import interaction rather than a tracked task-center flow; it remains a #500 follow-up unless we redesign import as an async worker task surfaced in the task center.

## Validation
- `npm run test:ci -- tests/unit/services/lca/taskCenter.test.ts tests/unit/services/tidasPackage/taskCenter.test.ts tests/unit/components/LcaTaskCenter.test.tsx --runInBand --testTimeout=30000`
- `npm run lint`
- `npm run build`
- `npm run test:coverage`
- `npm run test:coverage:assert-full`
- `scripts/docpact validate-config --root . --strict && scripts/docpact lint --root . --worktree --mode enforce`
- Push pre-push gate passed: docpact gate against `origin/dev`; `npm run lint`; full coverage 337 suites / 4165 tests; 100/100/100/100 coverage.

## Remaining in #500
- Decide and implement whether TIDAS import should become an async worker task-center flow.
- After PR merge, run dev UI smoke against review-submit, LCA solve, and TIDAS export recovery from `worker_jobs`.
