### PR TITLE
fix: publish Next v0.0.21

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "bcf3ed7b9e83bb4479f2f74f6d8c3c3153627ed3"
+lastReviewedCommit: "130a4732d9f87aa4ae0475751852c2f90d4fc2c4"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "df058eec79d9158a986e1d37a34637acc33d8894"
+lastReviewedCommit: "bcf3ed7b9e83bb4479f2f74f6d8c3c3153627ed3"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,11 +103,12 @@ jobs:
             package_version="$(read_package_version "${release_head}")"
             expected_tag="v${package_version}"
             tag_name="${expected_tag}"
-            package_changed=true
+            package_version_changed=true
 
             if [ -n "${PUSH_BEFORE_SHA}" ] && [ "${PUSH_BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]; then
-              if git diff --quiet "${PUSH_BEFORE_SHA}" "${release_head}" -- package.json; then
-                package_changed=false
+              previous_package_version="$(read_package_version "${PUSH_BEFORE_SHA}")"
+              if [ "${previous_package_version}" = "${package_version}" ]; then
+                package_version_changed=false
               fi
             fi
 
@@ -116,12 +117,12 @@ jobs:
               git fetch --force origin "refs/tags/${tag_name}:refs/tags/${tag_name}"
               existing_tag_commit="$(git rev-list -n 1 "${tag_name}")"
               if [ "${existing_tag_commit}" != "${release_head}" ]; then
-                if [ "${package_changed}" = "false" ]; then
+                if [ "${package_version_changed}" = "false" ]; then
                   echo "should_release=false" >> "$GITHUB_OUTPUT"
                   echo "tag_created=false" >> "$GITHUB_OUTPUT"
                   echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
                   echo "release_head=${release_head}" >> "$GITHUB_OUTPUT"
-                  echo "::notice::${tag_name} already points to ${existing_tag_commit}; package.json was unchanged in this main push, so this workflow hotfix is not a new release."
+                  echo "::notice::${tag_name} already points to ${existing_tag_commit}; package.json version was unchanged in this main push, so this workflow hotfix is not a new release."
                   exit 0
                 fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: df058eec79d9158a986e1d37a34637acc33d8894
+lastReviewedCommit: 130a4732d9f87aa4ae0475751852c2f90d4fc2c4
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 4556ebc9e1165a745d71e20a116091551a5fce38
+lastReviewedCommit: 130a4732d9f87aa4ae0475751852c2f90d4fc2c4
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: df058eec79d9158a986e1d37a34637acc33d8894
+lastReviewedCommit: bcf3ed7b9e83bb4479f2f74f6d8c3c3153627ed3
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: bcf3ed7b9e83bb4479f2f74f6d8c3c3153627ed3
+lastReviewedCommit: 130a4732d9f87aa4ae0475751852c2f90d4fc2c4
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: bcf3ed7b9e83bb4479f2f74f6d8c3c3153627ed3
+lastReviewedCommit: 130a4732d9f87aa4ae0475751852c2f90d4fc2c4
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: df058eec79d9158a986e1d37a34637acc33d8894
+lastReviewedCommit: bcf3ed7b9e83bb4479f2f74f6d8c3c3153627ed3
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: df058eec79d9158a986e1d37a34637acc33d8894
+lastReviewedCommit: bcf3ed7b9e83bb4479f2f74f6d8c3c3153627ed3
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: bcf3ed7b9e83bb4479f2f74f6d8c3c3153627ed3
+lastReviewedCommit: 130a4732d9f87aa4ae0475751852c2f90d4fc2c4
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: df058eec79d9158a986e1d37a34637acc33d8894
+lastReviewedCommit: bcf3ed7b9e83bb4479f2f74f6d8c3c3153627ed3
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: bcf3ed7b9e83bb4479f2f74f6d8c3c3153627ed3
+lastReviewedCommit: 130a4732d9f87aa4ae0475751852c2f90d4fc2c4
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: df058eec79d9158a986e1d37a34637acc33d8894
+lastReviewedCommit: bcf3ed7b9e83bb4479f2f74f6d8c3c3153627ed3
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: bcf3ed7b9e83bb4479f2f74f6d8c3c3153627ed3
+lastReviewedCommit: 130a4732d9f87aa4ae0475751852c2f90d4fc2c4
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: bcf3ed7b9e83bb4479f2f74f6d8c3c3153627ed3
+lastReviewedCommit: 130a4732d9f87aa4ae0475751852c2f90d4fc2c4
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: df058eec79d9158a986e1d37a34637acc33d8894
+lastReviewedCommit: bcf3ed7b9e83bb4479f2f74f6d8c3c3153627ed3
 ---
 
 # Testing Troubleshooting

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
## Summary
- Fix the main `Build/release` version guard to compare `package.json.version` instead of any `package.json` file diff.
- Bump the Next package version to `0.0.21` so the current main worker-jobs task-center changes can publish through the canonical release path.
- Record docpact review evidence for the affected release/test-gate governance docs.

## Why
`Build/release` failed after #506 because `v0.0.20` already points to an older main commit, while the promote merge changed dependency ranges in `package.json` without changing the package version. The workflow should treat unchanged `package.json.version` as an unchanged release version, even if other package metadata changed.

## Validation
- `npm run lint`
- `../scripts/docpact lint --root . --base origin/main --head HEAD --format json --output .docpact/runs/issue-507-final-docpact.json` -> 0 findings, 0 invalid review references
- `DOCPACT_BASE_REF=origin/main git push fork codex/issue-507-release-version-hotfix` pre-push gate:
  - docpact gate passed
  - `npm run lint` passed
  - `npm run test:coverage` passed: 337 suites, 4165 tests
  - `npm run test:coverage:assert-full` passed: 351/351 tracked source files at 100/100/100/100

## Follow-up
- After this PR is merged to `main`, confirm `Build/release` creates `v0.0.21` and the EdgeOne deploy succeeds.
- Because this is a main hotfix in an M2 repo, merge the hotfix back to `dev` after main release is confirmed.

Closes #507
