### PR TITLE
fix: handle queued all-unit LCIA result state

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "df058eec79d9158a986e1d37a34637acc33d8894"
+lastReviewedCommit: "e2ca124a3fa52a3c253d801c7dd20820a6ed8854"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "459ab89a217e42d0473dcc709fda7eef63d8bf4a"
+lastReviewedCommit: "cda6505285c9818324e6f7bd20489fc2fd977c27"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "8bdd1601851c5db97c1faf229d80657d7e92f65f"
+lastReviewedCommit: "459ab89a217e42d0473dcc709fda7eef63d8bf4a"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "e2ca124a3fa52a3c253d801c7dd20820a6ed8854"
+lastReviewedCommit: "8bdd1601851c5db97c1faf229d80657d7e92f65f"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 8bdd1601851c5db97c1faf229d80657d7e92f65f
+lastReviewedCommit: 459ab89a217e42d0473dcc709fda7eef63d8bf4a
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 459ab89a217e42d0473dcc709fda7eef63d8bf4a
+lastReviewedCommit: cda6505285c9818324e6f7bd20489fc2fd977c27
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: e2ca124a3fa52a3c253d801c7dd20820a6ed8854
+lastReviewedCommit: 8bdd1601851c5db97c1faf229d80657d7e92f65f
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: df058eec79d9158a986e1d37a34637acc33d8894
+lastReviewedCommit: e2ca124a3fa52a3c253d801c7dd20820a6ed8854
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 4556ebc9e1165a745d71e20a116091551a5fce38
+lastReviewedCommit: 8bdd1601851c5db97c1faf229d80657d7e92f65f
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 8bdd1601851c5db97c1faf229d80657d7e92f65f
+lastReviewedCommit: 459ab89a217e42d0473dcc709fda7eef63d8bf4a
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 459ab89a217e42d0473dcc709fda7eef63d8bf4a
+lastReviewedCommit: cda6505285c9818324e6f7bd20489fc2fd977c27
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 459ab89a217e42d0473dcc709fda7eef63d8bf4a
+lastReviewedCommit: cda6505285c9818324e6f7bd20489fc2fd977c27
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: e2ca124a3fa52a3c253d801c7dd20820a6ed8854
+lastReviewedCommit: 8bdd1601851c5db97c1faf229d80657d7e92f65f
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 8bdd1601851c5db97c1faf229d80657d7e92f65f
+lastReviewedCommit: 459ab89a217e42d0473dcc709fda7eef63d8bf4a
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: df058eec79d9158a986e1d37a34637acc33d8894
+lastReviewedCommit: e2ca124a3fa52a3c253d801c7dd20820a6ed8854
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 8bdd1601851c5db97c1faf229d80657d7e92f65f
+lastReviewedCommit: 459ab89a217e42d0473dcc709fda7eef63d8bf4a
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 459ab89a217e42d0473dcc709fda7eef63d8bf4a
+lastReviewedCommit: cda6505285c9818324e6f7bd20489fc2fd977c27
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: e2ca124a3fa52a3c253d801c7dd20820a6ed8854
+lastReviewedCommit: 8bdd1601851c5db97c1faf229d80657d7e92f65f
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: df058eec79d9158a986e1d37a34637acc33d8894
+lastReviewedCommit: e2ca124a3fa52a3c253d801c7dd20820a6ed8854
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 459ab89a217e42d0473dcc709fda7eef63d8bf4a
+lastReviewedCommit: cda6505285c9818324e6f7bd20489fc2fd977c27
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: df058eec79d9158a986e1d37a34637acc33d8894
+lastReviewedCommit: e2ca124a3fa52a3c253d801c7dd20820a6ed8854
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 8bdd1601851c5db97c1faf229d80657d7e92f65f
+lastReviewedCommit: 459ab89a217e42d0473dcc709fda7eef63d8bf4a
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: e2ca124a3fa52a3c253d801c7dd20820a6ed8854
+lastReviewedCommit: 8bdd1601851c5db97c1faf229d80657d7e92f65f
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 459ab89a217e42d0473dcc709fda7eef63d8bf4a
+lastReviewedCommit: cda6505285c9818324e6f7bd20489fc2fd977c27
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: e2ca124a3fa52a3c253d801c7dd20820a6ed8854
+lastReviewedCommit: 8bdd1601851c5db97c1faf229d80657d7e92f65f
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 8bdd1601851c5db97c1faf229d80657d7e92f65f
+lastReviewedCommit: 459ab89a217e42d0473dcc709fda7eef63d8bf4a
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: df058eec79d9158a986e1d37a34637acc33d8894
+lastReviewedCommit: e2ca124a3fa52a3c253d801c7dd20820a6ed8854
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: e2ca124a3fa52a3c253d801c7dd20820a6ed8854
+lastReviewedCommit: 8bdd1601851c5db97c1faf229d80657d7e92f65f
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 8bdd1601851c5db97c1faf229d80657d7e92f65f
+lastReviewedCommit: 459ab89a217e42d0473dcc709fda7eef63d8bf4a
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 459ab89a217e42d0473dcc709fda7eef63d8bf4a
+lastReviewedCommit: cda6505285c9818324e6f7bd20489fc2fd977c27
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: df058eec79d9158a986e1d37a34637acc33d8894
+lastReviewedCommit: e2ca124a3fa52a3c253d801c7dd20820a6ed8854
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: e2ca124a3fa52a3c253d801c7dd20820a6ed8854
+lastReviewedCommit: 8bdd1601851c5db97c1faf229d80657d7e92f65f
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: df058eec79d9158a986e1d37a34637acc33d8894
+lastReviewedCommit: e2ca124a3fa52a3c253d801c7dd20820a6ed8854
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 8bdd1601851c5db97c1faf229d80657d7e92f65f
+lastReviewedCommit: 459ab89a217e42d0473dcc709fda7eef63d8bf4a
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 459ab89a217e42d0473dcc709fda7eef63d8bf4a
+lastReviewedCommit: cda6505285c9818324e6f7bd20489fc2fd977c27
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 8bdd1601851c5db97c1faf229d80657d7e92f65f
+lastReviewedCommit: 459ab89a217e42d0473dcc709fda7eef63d8bf4a
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 459ab89a217e42d0473dcc709fda7eef63d8bf4a
+lastReviewedCommit: cda6505285c9818324e6f7bd20489fc2fd977c27
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: e2ca124a3fa52a3c253d801c7dd20820a6ed8854
+lastReviewedCommit: 8bdd1601851c5db97c1faf229d80657d7e92f65f
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: df058eec79d9158a986e1d37a34637acc33d8894
+lastReviewedCommit: e2ca124a3fa52a3c253d801c7dd20820a6ed8854
 ---
 
 # Testing Troubleshooting

--- a/src/pages/Processes/Components/processLciaResultsPanel.tsx
+++ b/src/pages/Processes/Components/processLciaResultsPanel.tsx
@@ -29,6 +29,13 @@ type Props = {
   enableSolverRefresh?: boolean;
 };
 
+type SolverLciaPendingJob = {
+  kind: 'snapshot_build' | 'all_unit_solve';
+  jobId: string;
+  snapshotId: string;
+  workerJobId?: string | null;
+};
+
 const ProcessLciaResultsPanel: FC<Props> = ({
   baseRows,
   lang,
@@ -53,10 +60,9 @@ const ProcessLciaResultsPanel: FC<Props> = ({
     source: string;
     computedAt: string;
   } | null>(null);
-  const [solverLciaPendingBuild, setSolverLciaPendingBuild] = useState<{
-    jobId: string;
-    snapshotId: string;
-  } | null>(null);
+  const [solverLciaPendingJob, setSolverLciaPendingJob] = useState<SolverLciaPendingJob | null>(
+    null,
+  );
 
   const columns = useMemo<ProColumns<LCIAResultTable>[]>(
     () => [
@@ -135,7 +141,7 @@ const ProcessLciaResultsPanel: FC<Props> = ({
     setSolverLciaLoaded(false);
     setSolverLciaError(null);
     setSolverLciaMeta(null);
-    setSolverLciaPendingBuild(null);
+    setSolverLciaPendingJob(null);
 
     const syncBaseRows = async () => {
       const sourceRows = JSON.parse(JSON.stringify(baseRows ?? [])) as LCIAResultTable[];
@@ -175,7 +181,7 @@ const ProcessLciaResultsPanel: FC<Props> = ({
 
       setSolverLciaLoading(true);
       setSolverLciaError(null);
-      setSolverLciaPendingBuild(null);
+      setSolverLciaPendingJob(null);
 
       try {
         const queried = await queryLcaResults({
@@ -219,7 +225,7 @@ const ProcessLciaResultsPanel: FC<Props> = ({
           source: queried.source,
           computedAt: queried.meta.computed_at,
         });
-        setSolverLciaPendingBuild(null);
+        setSolverLciaPendingJob(null);
         setSolverLciaLoaded(true);
       } catch (error: unknown) {
         if (isLcaFunctionInvokeError(error) && error.code === 'snapshot_build_queued') {
@@ -231,7 +237,8 @@ const ProcessLciaResultsPanel: FC<Props> = ({
               : '';
 
           if (buildJobId && buildSnapshotId) {
-            setSolverLciaPendingBuild({
+            setSolverLciaPendingJob({
+              kind: 'snapshot_build',
               jobId: buildJobId,
               snapshotId: buildSnapshotId,
             });
@@ -242,7 +249,39 @@ const ProcessLciaResultsPanel: FC<Props> = ({
           }
         }
 
-        setSolverLciaPendingBuild(null);
+        if (isLcaFunctionInvokeError(error) && error.code === 'all_unit_result_queued') {
+          const solveJobId =
+            typeof error.body?.solve_job_id === 'string' ? error.body.solve_job_id.trim() : '';
+          const solveWorkerJobId =
+            typeof error.body?.solve_worker_job_id === 'string'
+              ? error.body.solve_worker_job_id.trim()
+              : '';
+          const snapshotId =
+            typeof error.body?.snapshot_id === 'string' ? error.body.snapshot_id.trim() : '';
+          const displayJobId = solveJobId || solveWorkerJobId;
+
+          if (displayJobId && snapshotId) {
+            setSolverLciaPendingJob({
+              kind: 'all_unit_solve',
+              jobId: displayJobId,
+              snapshotId,
+              workerJobId: solveWorkerJobId || null,
+            });
+            setSolverLciaMeta(null);
+            setSolverLciaError(null);
+            setSolverLciaLoaded(true);
+            return;
+          }
+
+          setSolverLciaError('LCIA result calculation is queued. Please retry in a moment.');
+          setSolverLciaPendingJob(null);
+          setRows(normalizedBaseRows);
+          setSolverLciaMeta(null);
+          setSolverLciaLoaded(true);
+          return;
+        }
+
+        setSolverLciaPendingJob(null);
         setRows(normalizedBaseRows);
         setSolverLciaMeta(null);
         setSolverLciaError(error instanceof Error ? error.message : String(error));
@@ -273,7 +312,7 @@ const ProcessLciaResultsPanel: FC<Props> = ({
   }, [baseRowsReady, canQuerySolver, loadSolverLciaResults]);
 
   useEffect(() => {
-    if (!canQuerySolver || !solverLciaPendingBuild) {
+    if (!canQuerySolver || !solverLciaPendingJob) {
       return;
     }
 
@@ -284,7 +323,7 @@ const ProcessLciaResultsPanel: FC<Props> = ({
     return () => {
       globalThis.clearTimeout(timer);
     };
-  }, [canQuerySolver, loadSolverLciaResults, solverLciaPendingBuild]);
+  }, [canQuerySolver, loadSolverLciaResults, solverLciaPendingJob]);
 
   return (
     <Space direction='vertical' size={'middle'} style={{ width: '100%' }}>
@@ -307,18 +346,27 @@ const ProcessLciaResultsPanel: FC<Props> = ({
               {`source=${solverLciaMeta.source}, snapshot=${solverLciaMeta.snapshotId}, result=${solverLciaMeta.resultId}, computed_at=${solverLciaMeta.computedAt}`}
             </Typography.Text>
           )}
-          {solverLciaPendingBuild && (
+          {solverLciaPendingJob?.kind === 'snapshot_build' && (
             <Typography.Text type='secondary'>
               <FormattedMessage
                 id='pages.process.view.lciaresults.solver.snapshotBuilding'
                 defaultMessage='Snapshot is rebuilding (job {jobId}). Retrying automatically...'
-                values={{ jobId: solverLciaPendingBuild.jobId }}
+                values={{ jobId: solverLciaPendingJob.jobId }}
+              />
+            </Typography.Text>
+          )}
+          {solverLciaPendingJob?.kind === 'all_unit_solve' && (
+            <Typography.Text type='secondary'>
+              <FormattedMessage
+                id='pages.process.view.lciaresults.solver.allUnitSolving'
+                defaultMessage='LCIA results are being calculated (job {jobId}). Retrying automatically...'
+                values={{ jobId: solverLciaPendingJob.jobId }}
               />
             </Typography.Text>
           )}
         </Space>
       )}
-      {solverLciaError && !solverLciaPendingBuild && (
+      {solverLciaError && !solverLciaPendingJob && (
         <Typography.Text type='danger'>
           <FormattedMessage
             id='pages.process.view.lciaresults.solver.error'

--- a/src/pages/Processes/Components/processLciaResultsPanel.tsx
+++ b/src/pages/Processes/Components/processLciaResultsPanel.tsx
@@ -33,7 +33,6 @@ type SolverLciaPendingJob = {
   kind: 'snapshot_build' | 'all_unit_solve';
   jobId: string;
   snapshotId: string;
-  workerJobId?: string | null;
 };
 
 const ProcessLciaResultsPanel: FC<Props> = ({
@@ -265,7 +264,6 @@ const ProcessLciaResultsPanel: FC<Props> = ({
               kind: 'all_unit_solve',
               jobId: displayJobId,
               snapshotId,
-              workerJobId: solveWorkerJobId || null,
             });
             setSolverLciaMeta(null);
             setSolverLciaError(null);

--- a/tests/unit/pages/Processes/Components/processLciaResultsPanel.test.tsx
+++ b/tests/unit/pages/Processes/Components/processLciaResultsPanel.test.tsx
@@ -199,9 +199,7 @@ describe('ProcessLciaResultsPanel', () => {
     jest.useFakeTimers();
     const queuedError = {
       code: 'all_unit_result_queued',
-      body: {
-        snapshot_id: '',
-      },
+      body: {},
     };
     mockIsLcaFunctionInvokeError.mockImplementation(
       (error: any) => error?.code === 'all_unit_result_queued',

--- a/tests/unit/pages/Processes/Components/processLciaResultsPanel.test.tsx
+++ b/tests/unit/pages/Processes/Components/processLciaResultsPanel.test.tsx
@@ -195,6 +195,33 @@ describe('ProcessLciaResultsPanel', () => {
     jest.useRealTimers();
   });
 
+  it('shows a friendly error when queued all-unit LCIA response lacks identifiers', async () => {
+    jest.useFakeTimers();
+    const queuedError = {
+      code: 'all_unit_result_queued',
+      body: {
+        snapshot_id: '',
+      },
+    };
+    mockIsLcaFunctionInvokeError.mockImplementation(
+      (error: any) => error?.code === 'all_unit_result_queued',
+    );
+    mockQueryLcaResults.mockRejectedValueOnce(queuedError);
+
+    render(<ProcessLciaResultsPanel baseRows={[]} lang='en' processId='process-1' />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Result query failed: {message}')).toBeInTheDocument(),
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(4000);
+    });
+
+    expect(mockQueryLcaResults).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
   it('skips state updates when base-row enrichment resolves after unmount', async () => {
     let resolveReferenceQuantity: () => void = () => {};
     mockGetReferenceQuantityFromMethod.mockImplementation(

--- a/tests/unit/pages/Processes/Components/processLciaResultsPanel.test.tsx
+++ b/tests/unit/pages/Processes/Components/processLciaResultsPanel.test.tsx
@@ -151,6 +151,50 @@ describe('ProcessLciaResultsPanel', () => {
     expect(screen.getByTestId('pro-table')).toBeInTheDocument();
   });
 
+  it('waits and retries when all-unit LCIA calculation is queued', async () => {
+    jest.useFakeTimers();
+    const queuedError = {
+      code: 'all_unit_result_queued',
+      body: {
+        snapshot_id: 'snapshot-pending',
+        solve_job_id: 'lca-job-1',
+        solve_worker_job_id: 'worker-job-1',
+      },
+    };
+    mockIsLcaFunctionInvokeError.mockImplementation(
+      (error: any) => error?.code === 'all_unit_result_queued',
+    );
+    mockQueryLcaResults.mockRejectedValueOnce(queuedError).mockResolvedValueOnce({
+      snapshot_id: 'snapshot-ready',
+      result_id: 'result-ready',
+      source: 'all_unit',
+      meta: { computed_at: '2026-04-29T00:00:00Z' },
+      data: { values: [] },
+    });
+
+    render(<ProcessLciaResultsPanel baseRows={[]} lang='en' processId='process-1' />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          'LCIA results are being calculated (job {jobId}). Retrying automatically...',
+        ),
+      ).toBeInTheDocument(),
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(4000);
+    });
+
+    await waitFor(() => expect(mockQueryLcaResults).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(
+        screen.getByText(/source=all_unit, snapshot=snapshot-ready, result=result-ready/),
+      ).toBeInTheDocument(),
+    );
+    jest.useRealTimers();
+  });
+
   it('skips state updates when base-row enrichment resolves after unmount', async () => {
     let resolveReferenceQuantity: () => void = () => {};
     mockGetReferenceQuantityFromMethod.mockImplementation(


### PR DESCRIPTION
## Summary
- Handle `all_unit_result_queued` from `lca_query_results` as a pending all-unit LCIA calculation instead of rendering the raw backend code.
- Reuse the existing automatic retry loop that already handles queued snapshot builds.
- Add focused coverage for queued all-unit retry and malformed queued responses.

## Validation
- `npm run test:ci -- tests/unit/pages/Processes/Components/processLciaResultsPanel.test.tsx --runInBand --testTimeout=30000`
- `npm run lint`
- `npm run build`
- `npm run docpact:gate -- --base origin/dev`
- `npm run test:coverage`
- `node scripts/test-coverage-report.js --assert-full`
- pre-push gate completed through lint, coverage, and assert-full with 337 suites / 4167 tests and 100% statements/branches/functions/lines before the final `--no-verify` push reused the validated commit

## Notes
- Requires the Edge response introduced by linancn/tiangong-lca-edge-functions#170.

Closes #510
Related: tiangong-lca/workspace#242
