### PR TITLE
Release v0.0.22 for LCIA all-unit fix

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "7c4323cce6914f9c81bad1fe3647586ad9bbc2dc"
+lastReviewedCommit: "aee2425164f09c9400156ef7fb4f736cf9272a8b"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: cda6505285c9818324e6f7bd20489fc2fd977c27
+lastReviewedCommit: cc25a48f120b93607341830354353bcc3f8bbb86
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 7c4323cce6914f9c81bad1fe3647586ad9bbc2dc
+lastReviewedCommit: cc25a48f120b93607341830354353bcc3f8bbb86
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: cda6505285c9818324e6f7bd20489fc2fd977c27
+lastReviewedCommit: aee2425164f09c9400156ef7fb4f736cf9272a8b
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: cda6505285c9818324e6f7bd20489fc2fd977c27
+lastReviewedCommit: aee2425164f09c9400156ef7fb4f736cf9272a8b
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 7c4323cce6914f9c81bad1fe3647586ad9bbc2dc
+lastReviewedCommit: aee2425164f09c9400156ef7fb4f736cf9272a8b
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 7c4323cce6914f9c81bad1fe3647586ad9bbc2dc
+lastReviewedCommit: aee2425164f09c9400156ef7fb4f736cf9272a8b
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 7c4323cce6914f9c81bad1fe3647586ad9bbc2dc
+lastReviewedCommit: aee2425164f09c9400156ef7fb4f736cf9272a8b
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 7c4323cce6914f9c81bad1fe3647586ad9bbc2dc
+lastReviewedCommit: aee2425164f09c9400156ef7fb4f736cf9272a8b
 ---
 
 # Testing Troubleshooting

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
## Summary
- Bump `package.json` from `0.0.21` to `0.0.22` so the main Build/release workflow creates a new package tag and performs the web/release deployment for the merged LCIA all-unit fixes.
- Record required docpact review evidence for the release/package change.

## Why
- The previous main merge at `046acf0` completed Release Context only; Release Gate, Web deploy, and release jobs were skipped because `package.json` stayed at `0.0.21` and existing tag `v0.0.21` already points to `c512257`.
- Creating or moving another `v0.0.21` tag would violate the workflow/version contract. A patch bump to `0.0.22` is the safe release signal.

## Validation
- `npm run lint`
- `npm run docpact:gate -- --base origin/main`
- `git diff --check origin/main..HEAD`

## Expected after merge
- Build/release should create `v0.0.22` on the merged main commit.
- Release Gate, Web deploy, and release jobs should run instead of being skipped.

Refs #510