### PR TITLE
chore: promote lifecycle model reference error fix to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-03"
-lastReviewedCommit: "ec057a2a7ad6af62adf48a2f04fdf64801329f7e"
+lastReviewedAt: "2026-06-05"
+lastReviewedCommit: "b8c67f44fb40c5253620733b90326c2ff7435758"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: ec057a2a7ad6af62adf48a2f04fdf64801329f7e
+lastReviewedAt: 2026-06-05
+lastReviewedCommit: b8c67f44fb40c5253620733b90326c2ff7435758
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: ec057a2a7ad6af62adf48a2f04fdf64801329f7e
+lastReviewedAt: 2026-06-05
+lastReviewedCommit: b8c67f44fb40c5253620733b90326c2ff7435758
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.js
   - .github/workflows/**
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: ec057a2a7ad6af62adf48a2f04fdf64801329f7e
+lastReviewedAt: 2026-06-05
+lastReviewedCommit: b8c67f44fb40c5253620733b90326c2ff7435758
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: ec057a2a7ad6af62adf48a2f04fdf64801329f7e
+lastReviewedAt: 2026-06-05
+lastReviewedCommit: b8c67f44fb40c5253620733b90326c2ff7435758
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: ec057a2a7ad6af62adf48a2f04fdf64801329f7e
+lastReviewedAt: 2026-06-05
+lastReviewedCommit: b8c67f44fb40c5253620733b90326c2ff7435758
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: ec057a2a7ad6af62adf48a2f04fdf64801329f7e
+lastReviewedAt: 2026-06-05
+lastReviewedCommit: b8c67f44fb40c5253620733b90326c2ff7435758
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: ec057a2a7ad6af62adf48a2f04fdf64801329f7e
+lastReviewedAt: 2026-06-05
+lastReviewedCommit: b8c67f44fb40c5253620733b90326c2ff7435758
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: ec057a2a7ad6af62adf48a2f04fdf64801329f7e
+lastReviewedAt: 2026-06-05
+lastReviewedCommit: b8c67f44fb40c5253620733b90326c2ff7435758
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: ec057a2a7ad6af62adf48a2f04fdf64801329f7e
+lastReviewedAt: 2026-06-05
+lastReviewedCommit: b8c67f44fb40c5253620733b90326c2ff7435758
 ---
 
 # Testing Troubleshooting

--- a/src/locales/en-US/pages_model.ts
+++ b/src/locales/en-US/pages_model.ts
@@ -291,6 +291,7 @@ export default {
   'pages.lifecyclemodel.validator.licenseType.required': 'Please input license type',
   'pages.lifecyclemodel.validator.nodes.required': 'Please add node',
   'pages.lifecyclemodel.validator.nodes.quantitativeReference.required': 'Please select a node as reference',
+  'pages.lifecyclemodel.error.missingReferenceProcess': 'The model is missing reference process information. Complete or rebind the reference process, then try again.',
   'pages.lifecyclemodel.review.submitSuccess': 'Review submitted successfully',
   'pages.lifecyclemodel.review.submitError': 'Submit review failed',
   'pages.lifecyclemodel.review.error': 'Referenced data is under review, cannot initiate another review',

--- a/src/locales/zh-CN/pages_model.ts
+++ b/src/locales/zh-CN/pages_model.ts
@@ -287,6 +287,7 @@ export default {
   'pages.lifecyclemodel.validator.licenseType.required': '请输入许可类型',
   'pages.lifecyclemodel.validator.nodes.required': '请添加节点',
   'pages.lifecyclemodel.validator.nodes.quantitativeReference.required': '请选择一个节点作为参考',
+  'pages.lifecyclemodel.error.missingReferenceProcess': '模型缺少引用过程信息，请补全或重新绑定引用过程后重试。',
 
   'pages.lifecyclemodel.review.submitSuccess': '提交审核成功',
   'pages.lifecyclemodel.review.submitError': '提交审核失败',

--- a/src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx
+++ b/src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx
@@ -112,6 +112,30 @@ type SaveDataResult = {
 };
 
 const VISUAL_ONLY_MUTATION_OPTIONS = { ignoreHistory: true };
+const MISSING_REFERENCE_PROCESS_ERROR_MESSAGE =
+  'No referenceToReferenceProcess found in lifeCycleModelInformation';
+const MISSING_REFERENCE_PROCESS_ERROR_CODE = 'MISSING_REFERENCE_PROCESS';
+
+const toSaveMutationError = (
+  error: unknown,
+): Extract<LifeCycleModelMutationResult, { ok: false }> => {
+  const messageText =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : 'Lifecycle model save failed';
+
+  return {
+    ok: false,
+    code:
+      messageText === MISSING_REFERENCE_PROCESS_ERROR_MESSAGE
+        ? MISSING_REFERENCE_PROCESS_ERROR_CODE
+        : 'SAVE_FAILED',
+    message: messageText,
+    details: error,
+  };
+};
 
 const getProcessInstanceValidationNodeIndex = (detail?: ValidationIssueSdkDetail | null) => {
   const match = detail?.fieldPath?.match(/^processInstance\[#(.+?)\]/);
@@ -923,6 +947,20 @@ const ToolbarEdit: FC<Props> = ({
         },
       });
       const showMutationError = (result: Extract<LifeCycleModelMutationResult, { ok: false }>) => {
+        if (
+          result.code === MISSING_REFERENCE_PROCESS_ERROR_CODE ||
+          result.message === MISSING_REFERENCE_PROCESS_ERROR_MESSAGE
+        ) {
+          message.error(
+            intl.formatMessage({
+              id: 'pages.lifecyclemodel.error.missingReferenceProcess',
+              defaultMessage:
+                'The model is missing reference process information. Complete or rebind the reference process, then try again.',
+            }),
+          );
+          return;
+        }
+
         if (result.code === 'VERSION_CONFLICT') {
           message.error(
             intl.formatMessage({
@@ -955,13 +993,24 @@ const ToolbarEdit: FC<Props> = ({
 
         message.error(result.message ?? 'Error');
       };
+      const runMutation = async (
+        mutation: () => Promise<LifeCycleModelMutationResult>,
+      ): Promise<LifeCycleModelMutationResult> => {
+        try {
+          return await mutation();
+        } catch (error) {
+          return toSaveMutationError(error);
+        }
+      };
       const langOptions = options?.langIntent ? { intent: options.langIntent } : undefined;
 
       if (thisAction === 'edit') {
         const lifecycleModelPayload = { ...newData, id: thisId, version: thisVersion };
-        const result = langOptions
-          ? await updateLifeCycleModel(lifecycleModelPayload, langOptions)
-          : await updateLifeCycleModel(lifecycleModelPayload);
+        const result = await runMutation(() =>
+          langOptions
+            ? updateLifeCycleModel(lifecycleModelPayload, langOptions)
+            : updateLifeCycleModel(lifecycleModelPayload),
+        );
         if (result.ok) {
           const savedLifeCycleModel = result.lifecycleModel;
           const savedModelId = savedLifeCycleModel?.id ?? result.modelId;
@@ -1017,9 +1066,11 @@ const ToolbarEdit: FC<Props> = ({
       } else if (thisAction === 'create') {
         const newId = actionType === 'createVersion' ? thisId : (importedId ?? v4());
         const lifecycleModelPayload = { ...newData, id: newId };
-        const result = langOptions
-          ? await createLifeCycleModel(lifecycleModelPayload, langOptions)
-          : await createLifeCycleModel(lifecycleModelPayload);
+        const result = await runMutation(() =>
+          langOptions
+            ? createLifeCycleModel(lifecycleModelPayload, langOptions)
+            : createLifeCycleModel(lifecycleModelPayload),
+        );
         if (result.ok) {
           const savedLifeCycleModel = result.lifecycleModel;
           const savedModelId = savedLifeCycleModel?.id ?? result.modelId;

--- a/tests/unit/pages/LifeCycleModels/Components/toolbar/editIndex.test.tsx
+++ b/tests/unit/pages/LifeCycleModels/Components/toolbar/editIndex.test.tsx
@@ -2223,6 +2223,32 @@ describe('ToolbarEdit', () => {
     await waitFor(() => expect(antMessage.error).toHaveBeenCalledWith('Error'));
   });
 
+  it('shows a localized missing-reference-process error when create save throws', async () => {
+    const antMessage = jest.requireMock('antd').message as Record<string, jest.Mock>;
+    mockCreateLifeCycleModel.mockRejectedValueOnce(
+      new Error('No referenceToReferenceProcess found in lifeCycleModelInformation'),
+    );
+
+    render(
+      <ToolbarEdit
+        {...baseProps}
+        id=''
+        version=''
+        action='create'
+        drawerVisible={true}
+        onClose={jest.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'save-icon' }));
+
+    await waitFor(() =>
+      expect(antMessage.error).toHaveBeenCalledWith(
+        'The model is missing reference process information. Complete or rebind the reference process, then try again.',
+      ),
+    );
+  });
+
   it('shows open-data, under-review, and generic errors when edit saves fail', async () => {
     const antMessage = jest.requireMock('antd').message as Record<string, jest.Mock>;
 
@@ -2253,6 +2279,23 @@ describe('ToolbarEdit', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'save-icon' }));
     await waitFor(() => expect(antMessage.error).toHaveBeenCalledWith('generic failure'));
+  });
+
+  it('shows a localized missing-reference-process error when edit save throws', async () => {
+    const antMessage = jest.requireMock('antd').message as Record<string, jest.Mock>;
+    mockUpdateLifeCycleModel.mockRejectedValueOnce(
+      new Error('No referenceToReferenceProcess found in lifeCycleModelInformation'),
+    );
+
+    render(<ToolbarEdit {...baseProps} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'save-icon' }));
+
+    await waitFor(() =>
+      expect(antMessage.error).toHaveBeenCalledWith(
+        'The model is missing reference process information. Complete or rebind the reference process, then try again.',
+      ),
+    );
   });
 
   it('falls back to mutation result ids and versions when edit saves omit lifecycleModel payloads', async () => {


### PR DESCRIPTION
Closes #520

## Summary
- Promotes the merged lifecycle model missing-reference-process error handling fix from dev to main.
- Keeps the user-facing localized prompt added by #521 available on the main release line.

## Key Decisions
- Merged the current main release line into the promote branch so package.json stays at the existing 0.0.23 version.
- Does not add a v0.0.24 version bump, per release direction for this promote PR.

## Validation
- npm run prepush:gate via fork push on package version 0.0.23: docpact gate, lint, tsc, 337 test suites / 4181 tests, 100% coverage assert passed.

## Risks / Rollback
- Low promote risk; rollback by reverting the promote merge from main or reverting the #521 fix if needed.

## Follow-ups
- After this PR merges, lca-workspace still needs a submodule pointer update to the promoted tiangong-lca-next/main commit.

## Workspace Integration
- Workspace Integration remains Pending until the promoted main commit is integrated in lca-workspace.