### PR TITLE
[codex] 优化单位组提示与流属性新增权限

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-06"
-lastReviewedCommit: "cee1b2ceb343c9bd5481bbfbc1b7cc5349d19233"
+lastReviewedAt: "2026-06-08"
+lastReviewedCommit: "858e8922d6387a09bdaa343748c6177b6cd9a0eb"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-06-06
-lastReviewedCommit: cee1b2ceb343c9bd5481bbfbc1b7cc5349d19233
+lastReviewedAt: 2026-06-08
+lastReviewedCommit: 858e8922d6387a09bdaa343748c6177b6cd9a0eb
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-06-06
-lastReviewedCommit: cee1b2ceb343c9bd5481bbfbc1b7cc5349d19233
+lastReviewedAt: 2026-06-08
+lastReviewedCommit: 9338d298f71613622ee202c357b0757484cc439c
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.js
   - .github/workflows/**
-lastReviewedAt: 2026-06-06
-lastReviewedCommit: cee1b2ceb343c9bd5481bbfbc1b7cc5349d19233
+lastReviewedAt: 2026-06-08
+lastReviewedCommit: 95d2993c9be650918ec326d3e2d6ce960d5818f7
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-06-06
-lastReviewedCommit: cee1b2ceb343c9bd5481bbfbc1b7cc5349d19233
+lastReviewedAt: 2026-06-08
+lastReviewedCommit: 858e8922d6387a09bdaa343748c6177b6cd9a0eb
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-06-06
-lastReviewedCommit: cee1b2ceb343c9bd5481bbfbc1b7cc5349d19233
+lastReviewedAt: 2026-06-08
+lastReviewedCommit: 858e8922d6387a09bdaa343748c6177b6cd9a0eb
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-06-06
-lastReviewedCommit: cee1b2ceb343c9bd5481bbfbc1b7cc5349d19233
+lastReviewedAt: 2026-06-08
+lastReviewedCommit: 95d2993c9be650918ec326d3e2d6ce960d5818f7
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-06-06
-lastReviewedCommit: cee1b2ceb343c9bd5481bbfbc1b7cc5349d19233
+lastReviewedAt: 2026-06-08
+lastReviewedCommit: 95d2993c9be650918ec326d3e2d6ce960d5818f7
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-06-06
-lastReviewedCommit: cee1b2ceb343c9bd5481bbfbc1b7cc5349d19233
+lastReviewedAt: 2026-06-08
+lastReviewedCommit: 95d2993c9be650918ec326d3e2d6ce960d5818f7
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-06-06
-lastReviewedCommit: cee1b2ceb343c9bd5481bbfbc1b7cc5349d19233
+lastReviewedAt: 2026-06-08
+lastReviewedCommit: 95d2993c9be650918ec326d3e2d6ce960d5818f7
 ---
 
 # Testing Troubleshooting

--- a/src/locales/en-US/pages_flowproperty.ts
+++ b/src/locales/en-US/pages_flowproperty.ts
@@ -1,5 +1,6 @@
 export default {
   'pages.flowproperty.referenceToReferenceUnitGroup': 'Reference unit',
+  'pages.flowproperty.title.tips': 'Need to add or supplement flow properties? Contact an administrator.',
 
   'pages.flowproperty.drawer.title.view': 'View Flow property',
   'pages.flowproperty.drawer.title.create': 'Create Flow property',

--- a/src/locales/en-US/pages_unitgroup.ts
+++ b/src/locales/en-US/pages_unitgroup.ts
@@ -1,5 +1,5 @@
 export default {
-  'pages.unitgroup.title.tips': '(Note: If you need to supplement the unit group data, please contact the administrator!)',
+  'pages.unitgroup.title.tips': 'Need to add or supplement unit groups? Contact an administrator.',
   'pages.unitgroup.refObjectId': 'Reference unit dataset identifier',
   'pages.unitgroup.drawer.title.create': 'Create Unit group',
   'pages.unitgroup.drawer.title.view': 'View Unit group',

--- a/src/locales/zh-CN/pages_flowproperty.ts
+++ b/src/locales/zh-CN/pages_flowproperty.ts
@@ -1,5 +1,6 @@
 export default {
   'pages.flowproperty.referenceToReferenceUnitGroup': '参考单位',
+  'pages.flowproperty.title.tips': '需要新增或补充流属性？请联系管理员。',
 
   'pages.flowproperty.drawer.title.view': '查看流属性',
   'pages.flowproperty.drawer.title.create': '创建流属性',

--- a/src/locales/zh-CN/pages_unitgroup.ts
+++ b/src/locales/zh-CN/pages_unitgroup.ts
@@ -1,5 +1,5 @@
 export default {
-  'pages.unitgroup.title.tips': '（注：如需补充单位组数据，请联系管理员！）',
+  'pages.unitgroup.title.tips': '需要新增或补充单位组？请联系管理员。',
   'pages.unitgroup.refObjectId': '引用参考单位数据集标识符',
   'pages.unitgroup.drawer.title.create': '创建单位组',
   'pages.unitgroup.drawer.title.view': '查看单位组',

--- a/src/pages/Flowproperties/Components/create.tsx
+++ b/src/pages/Flowproperties/Components/create.tsx
@@ -43,6 +43,7 @@ type Props = {
   version?: string;
   importData?: FlowpropertyImportData | null;
   onClose?: () => void;
+  disabled?: boolean;
   newVersion?: string;
 };
 
@@ -68,6 +69,7 @@ const FlowpropertiesCreate: FC<CreateProps> = ({
   version,
   importData,
   onClose = () => {},
+  disabled = false,
 }) => {
   const [drawerVisible, setDrawerVisible] = useState(false);
   const formRefCreate = useRef<ProFormInstance>();
@@ -194,6 +196,7 @@ const FlowpropertiesCreate: FC<CreateProps> = ({
       >
         {actionType === 'copy' ? (
           <Button
+            disabled={disabled}
             shape='circle'
             icon={<CopyOutlined />}
             size='small'
@@ -203,6 +206,7 @@ const FlowpropertiesCreate: FC<CreateProps> = ({
           ></Button>
         ) : (
           <ToolBarButton
+            disabled={disabled}
             icon={<PlusOutlined />}
             tooltip={<FormattedMessage id='pages.button.create' defaultMessage='Create' />}
             onClick={() => {

--- a/src/pages/Flowproperties/index.tsx
+++ b/src/pages/Flowproperties/index.tsx
@@ -13,9 +13,11 @@ import {
   getUnitData,
   isDataUnderReview,
 } from '@/services/general/util';
+import { getRoleByUserId } from '@/services/roles/api';
 import { TeamTable } from '@/services/teams/data';
+import { InfoCircleOutlined } from '@ant-design/icons';
 import { ActionType, PageContainer, ProColumns, ProTable } from '@ant-design/pro-components';
-import { Card, Checkbox, Col, Input, Row, Space, Tooltip, message } from 'antd';
+import { Card, Checkbox, Col, Input, Row, Space, Tooltip, message, theme } from 'antd';
 import type { FC, MutableRefObject } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl, useLocation } from 'umi';
@@ -69,12 +71,14 @@ const TableList: FC = () => {
   const [team, setTeam] = useState<TeamTable | null>(null);
   const [importData, setImportData] = useState<FlowpropertyImportData | null>(null);
   const [referenceLookup, setReferenceLookup] = useState<boolean>(false);
+  const [isSystemAdmin, setIsSystemAdmin] = useState<boolean>(false);
   const [editDrawerVisible, setEditDrawerVisible] = useState<boolean>(false);
   const [editId, setEditId] = useState<string>('');
   const [editVersion, setEditVersion] = useState<string>('');
   const isMobileDataList = useResponsiveDataListMobile();
   const location = useLocation();
   const dataSource = getDataSource(location.pathname);
+  const { token } = theme.useToken();
 
   const searchParams = new URLSearchParams(location.search);
   const tid = searchParams.get('tid');
@@ -85,6 +89,7 @@ const TableList: FC = () => {
   const intl = useIntl();
 
   const lang = getLang(intl.locale);
+  const shouldShowFlowpropertyTip = (dataSource === 'my' && !isSystemAdmin) || dataSource === 'te';
 
   const actionRef = useRef<ActionType>();
   const keyWordRef = useRef<string>('');
@@ -139,6 +144,7 @@ const TableList: FC = () => {
               key: 'copy',
               name: (
                 <FlowpropertiesCreate
+                  disabled={!isSystemAdmin}
                   actionType='copy'
                   id={row.id}
                   version={row.version}
@@ -215,6 +221,7 @@ const TableList: FC = () => {
           version={row.version}
         />
         <FlowpropertiesCreate
+          disabled={!isSystemAdmin}
           actionType='copy'
           id={row.id}
           version={row.version}
@@ -315,6 +322,7 @@ const TableList: FC = () => {
               addVersionComponent={({ newVersion }) => (
                 <FlowpropertiesCreate
                   newVersion={newVersion}
+                  disabled={!isSystemAdmin}
                   actionType='createVersion'
                   id={row.id}
                   version={row.version}
@@ -353,7 +361,19 @@ const TableList: FC = () => {
     getTeamById(tid ?? '').then((res) => {
       if (res.data.length > 0) setTeam(res.data[0] as TeamTable);
     });
+    getRoleByUserId().then((res) => {
+      const systemAdmin = res?.find(
+        (item) => item.team_id === '00000000-0000-0000-0000-000000000000' && item.role === 'admin',
+      );
+      setIsSystemAdmin(!!systemAdmin);
+    });
   }, []);
+
+  useEffect(() => {
+    if (dataSource === 'my' && isSystemAdmin) {
+      actionRef.current?.reload();
+    }
+  }, [dataSource, isSystemAdmin]);
 
   const onSearch: SearchProps['onSearch'] = (value) => {
     keyWordRef.current = value;
@@ -378,6 +398,7 @@ const TableList: FC = () => {
         <Row {...responsiveSearchRowProps}>
           <Col {...responsiveSearchPrimaryColProps}>
             <Search
+              disabled={dataSource === 'my' && !isSystemAdmin}
               size={'large'}
               placeholder={intl.formatMessage({
                 id: referenceLookup
@@ -391,6 +412,7 @@ const TableList: FC = () => {
           <Col {...responsiveSearchExtraColProps}>
             <Checkbox
               checked={referenceLookup}
+              disabled={dataSource === 'my' && !isSystemAdmin}
               onChange={(e) => setReferenceLookup(e.target.checked)}
             >
               <FormattedMessage
@@ -405,10 +427,31 @@ const TableList: FC = () => {
         {...responsiveDataListTableProps}
         rowKey={(record) => `${record.id}-${record.version}`}
         headerTitle={
-          <>
-            {getDataTitle(dataSource)} /{' '}
-            <FormattedMessage id='menu.tgdata.flowproperties' defaultMessage='Flow Properties' />
-          </>
+          <Space size={8} align='center' wrap>
+            <span style={{ display: 'inline-flex', alignItems: 'center' }}>
+              {getDataTitle(dataSource)} /{' '}
+              <FormattedMessage id='menu.tgdata.flowproperties' defaultMessage='Flow Properties' />
+            </span>
+            {shouldShowFlowpropertyTip && (
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: token.marginXXS,
+                  color: token.colorTextDescription,
+                  fontSize: token.fontSizeSM,
+                  fontWeight: 400,
+                  lineHeight: 1,
+                }}
+              >
+                <InfoCircleOutlined />
+                <FormattedMessage
+                  id='pages.flowproperty.title.tips'
+                  defaultMessage='Need to add or supplement flow properties? Contact an administrator.'
+                />
+              </span>
+            )}
+          </Space>
         }
         actionRef={actionRef}
         search={false}
@@ -422,6 +465,7 @@ const TableList: FC = () => {
           if (dataSource === 'my') {
             const filters = [
               <TableFilter
+                disabled={!isSystemAdmin}
                 key={2}
                 width={isMobileDataList ? 120 : 140}
                 onChange={(val) => {
@@ -434,13 +478,14 @@ const TableList: FC = () => {
             return [
               ...filters,
               <FlowpropertiesCreate
+                disabled={!isSystemAdmin}
                 importData={importData}
                 onClose={() => setImportData(null)}
                 lang={lang}
                 key={0}
                 actionRef={actionRef}
               />,
-              <ImportData onJsonData={handleImportData} key={1} />,
+              <ImportData disabled={!isSystemAdmin} onJsonData={handleImportData} key={1} />,
             ];
           }
           return [];
@@ -452,6 +497,13 @@ const TableList: FC = () => {
           },
           sort,
         ) => {
+          if (dataSource === 'my' && !isSystemAdmin) {
+            return {
+              data: [],
+              success: true,
+              total: 0,
+            };
+          }
           const currentKeyWord = keyWordRef.current || keyWord;
           const currentStateCode = stateCodeRef.current;
           if (referenceLookup) {

--- a/src/pages/Unitgroups/index.tsx
+++ b/src/pages/Unitgroups/index.tsx
@@ -36,7 +36,7 @@ import {
 import { UnitGroupImportItem, UnitGroupTable } from '@/services/unitgroups/data';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { ActionType, PageContainer, ProColumns, ProTable } from '@ant-design/pro-components';
-import { Card, Checkbox, Col, Input, Row, Space, Typography, message, theme } from 'antd';
+import { Card, Checkbox, Col, Input, Row, Space, message, theme } from 'antd';
 import { SearchProps } from 'antd/es/input/Search';
 import type { FC, MutableRefObject } from 'react';
 import { useEffect, useRef, useState } from 'react';
@@ -408,7 +408,7 @@ const TableList: FC = () => {
               <FormattedMessage id='menu.tgdata.unitgroups' defaultMessage='Unit Groups' />
             </span>
             {shouldShowUnitGroupTip && (
-              <Typography.Text
+              <span
                 style={{
                   display: 'inline-flex',
                   alignItems: 'center',
@@ -424,7 +424,7 @@ const TableList: FC = () => {
                   id='pages.unitgroup.title.tips'
                   defaultMessage='Need to add or supplement unit groups? Contact an administrator.'
                 />
-              </Typography.Text>
+              </span>
             )}
           </Space>
         }

--- a/src/pages/Unitgroups/index.tsx
+++ b/src/pages/Unitgroups/index.tsx
@@ -34,8 +34,9 @@ import {
   getUnitGroupTableUuidMentionSearch,
 } from '@/services/unitgroups/api';
 import { UnitGroupImportItem, UnitGroupTable } from '@/services/unitgroups/data';
+import { InfoCircleOutlined } from '@ant-design/icons';
 import { ActionType, PageContainer, ProColumns, ProTable } from '@ant-design/pro-components';
-import { Card, Checkbox, Col, Input, Row, Space, message, theme } from 'antd';
+import { Card, Checkbox, Col, Input, Row, Space, Typography, message, theme } from 'antd';
 import { SearchProps } from 'antd/es/input/Search';
 import type { FC, MutableRefObject } from 'react';
 import { useEffect, useRef, useState } from 'react';
@@ -80,6 +81,7 @@ const TableList: FC = () => {
   const intl = useIntl();
 
   const lang = getLang(intl.locale);
+  const shouldShowUnitGroupTip = (dataSource === 'my' && !isSystemAdmin) || dataSource === 'te';
 
   const actionRef = useRef<ActionType>();
   const keyWordRef = useRef<string>('');
@@ -400,18 +402,31 @@ const TableList: FC = () => {
         {...responsiveDataListTableProps}
         rowKey={(record) => `${record.id}-${record.version}`}
         headerTitle={
-          <>
-            {getDataTitle(dataSource)} /{' '}
-            <FormattedMessage id='menu.tgdata.unitgroups' defaultMessage='Unit Groups' />
-            {((dataSource === 'my' && !isSystemAdmin) || dataSource === 'te') && (
-              <span style={{ color: token.red, fontSize: token.fontSize }}>
+          <Space size={8} align='center' wrap>
+            <span style={{ display: 'inline-flex', alignItems: 'center' }}>
+              {getDataTitle(dataSource)} /{' '}
+              <FormattedMessage id='menu.tgdata.unitgroups' defaultMessage='Unit Groups' />
+            </span>
+            {shouldShowUnitGroupTip && (
+              <Typography.Text
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: token.marginXXS,
+                  color: token.colorTextDescription,
+                  fontSize: token.fontSizeSM,
+                  fontWeight: 400,
+                  lineHeight: 1,
+                }}
+              >
+                <InfoCircleOutlined />
                 <FormattedMessage
                   id='pages.unitgroup.title.tips'
-                  defaultMessage='(Note: If you need to supplement the unit group data, please contact the administrator!)'
+                  defaultMessage='Need to add or supplement unit groups? Contact an administrator.'
                 />
-              </span>
+              </Typography.Text>
             )}
-          </>
+          </Space>
         }
         actionRef={actionRef}
         search={false}

--- a/tests/integration/flowproperties/FlowpropertiesWorkflow.integration.test.tsx
+++ b/tests/integration/flowproperties/FlowpropertiesWorkflow.integration.test.tsx
@@ -149,6 +149,12 @@ const mockGetFlowpropertyTableAll = jest.fn(async () => ({
   success: true,
   total: 0,
 })) as jest.Mock<any, any[]>;
+const mockGetRoleByUserId = jest.fn(async () => [
+  {
+    team_id: '00000000-0000-0000-0000-000000000000',
+    role: 'admin',
+  },
+]) as jest.Mock<any, any[]>;
 
 jest.mock('@/services/flowproperties/api', () => ({
   __esModule: true,
@@ -232,6 +238,11 @@ jest.mock('@/services/general/api', () => ({
 jest.mock('@/services/teams/api', () => ({
   __esModule: true,
   getTeamById: jest.fn(async () => ({ data: [] })),
+}));
+
+jest.mock('@/services/roles/api', () => ({
+  __esModule: true,
+  getRoleByUserId: (...args: any[]) => mockGetRoleByUserId(...args),
 }));
 
 jest.mock('@/pages/Flowproperties/Components/view', () => {
@@ -318,6 +329,12 @@ describe('Flowproperties workflow integration', () => {
     mockCreateFlowproperties.mockResolvedValue({
       data: [{ id: 'fp-created', version: '1.0.0' }],
     });
+    mockGetRoleByUserId.mockResolvedValue([
+      {
+        team_id: '00000000-0000-0000-0000-000000000000',
+        role: 'admin',
+      },
+    ]);
     mockUpdateFlowproperties.mockResolvedValue([{ rule_verification: true, nonExistent: false }]);
     mockDeleteFlowproperties.mockResolvedValue({ status: 204 });
   });

--- a/tests/unit/pages/Flowproperties/index.test.tsx
+++ b/tests/unit/pages/Flowproperties/index.test.tsx
@@ -30,6 +30,7 @@ const mockGetLangText = jest.fn((value: any) => {
   if (typeof value === 'string') return value;
   return value?.['#text'] ?? 'Team title';
 });
+const mockGetRoleByUserId = jest.fn();
 const mockGetTeamById = jest.fn();
 const mockGetUnitData = jest.fn();
 const mockDatasetUuidMentionSearch = jest.fn();
@@ -71,6 +72,11 @@ jest.mock('@/services/teams/api', () => ({
   getTeamById: (...args: any[]) => mockGetTeamById(...args),
 }));
 
+jest.mock('@/services/roles/api', () => ({
+  __esModule: true,
+  getRoleByUserId: (...args: any[]) => mockGetRoleByUserId(...args),
+}));
+
 jest.mock('@/services/general/api', () => ({
   __esModule: true,
   attachStateCodesToRows: jest.fn(async (_table: string, rows: any[]) => rows),
@@ -109,8 +115,12 @@ jest.mock('@/components/ExportData', () => ({
 
 jest.mock('@/components/ImportData', () => ({
   __esModule: true,
-  default: ({ onJsonData }: any) => (
-    <button type='button' onClick={() => onJsonData?.([{ flowPropertyDataSet: {} }])}>
+  default: ({ disabled, onJsonData }: any) => (
+    <button
+      type='button'
+      disabled={disabled}
+      onClick={() => onJsonData?.([{ flowPropertyDataSet: {} }])}
+    >
       import-data
     </button>
   ),
@@ -118,8 +128,8 @@ jest.mock('@/components/ImportData', () => ({
 
 jest.mock('@/components/TableFilter', () => ({
   __esModule: true,
-  default: ({ onChange }: any) => (
-    <button type='button' onClick={() => onChange?.('20')}>
+  default: ({ disabled, onChange }: any) => (
+    <button type='button' disabled={disabled} onClick={() => onChange?.('20')}>
       table-filter
     </button>
   ),
@@ -151,7 +161,7 @@ jest.mock('@/pages/Utils', () => ({
 
 jest.mock('@/pages/Flowproperties/Components/create', () => ({
   __esModule: true,
-  default: ({ importData, actionType, newVersion, id, version, onClose }: any) => (
+  default: ({ disabled, importData, actionType, newVersion, id, version, onClose }: any) => (
     <div>
       <div data-testid='flowproperty-create'>
         {JSON.stringify({
@@ -160,6 +170,7 @@ jest.mock('@/pages/Flowproperties/Components/create', () => ({
           newVersion: newVersion ?? null,
           id: id ?? null,
           version: version ?? null,
+          disabled: !!disabled,
         })}
       </div>
       {onClose ? (
@@ -213,13 +224,14 @@ jest.mock('antd', () => {
 
   const ConfigProvider = ({ children }: any) => <div>{children}</div>;
   const Card = ({ children }: any) => <section>{children}</section>;
-  const Checkbox = ({ children, onChange }: any) => {
+  const Checkbox = ({ children, disabled, onChange }: any) => {
     const [checked, setChecked] = React.useState(false);
     return (
       <label>
         <input
           aria-label={toText(children)}
           checked={checked}
+          disabled={disabled}
           type='checkbox'
           onChange={() => {
             const next = !checked;
@@ -235,13 +247,17 @@ jest.mock('antd', () => {
   const Row = ({ children }: any) => <div>{children}</div>;
   const Space = ({ children }: any) => <div>{children}</div>;
   const Tooltip = ({ children }: any) => <div>{children}</div>;
-  const Search = ({ onSearch, placeholder }: any) => (
+  const Search = ({ disabled, onSearch, placeholder }: any) => (
     <div>
-      <input aria-label='search-input' placeholder={placeholder} />
-      <button type='button' onClick={() => onSearch?.('climate')}>
+      <input aria-label='search-input' disabled={disabled} placeholder={placeholder} />
+      <button type='button' disabled={disabled} onClick={() => onSearch?.('climate')}>
         search
       </button>
-      <button type='button' onClick={() => onSearch?.('D1380000-0000-4000-8000-000000000001')}>
+      <button
+        type='button'
+        disabled={disabled}
+        onClick={() => onSearch?.('D1380000-0000-4000-8000-000000000001')}
+      >
         uuid-lookup
       </button>
     </div>
@@ -251,6 +267,9 @@ jest.mock('antd', () => {
     useToken: () => ({
       token: {
         colorPrimary: '#1677ff',
+        colorTextDescription: '#6b7280',
+        fontSizeSM: 12,
+        marginXXS: 4,
       },
     }),
   };
@@ -358,6 +377,12 @@ describe('FlowpropertiesPage', () => {
     };
     mockBreakpointScreens = {};
     mockGetDataSource.mockReturnValue('my');
+    mockGetRoleByUserId.mockResolvedValue([
+      {
+        team_id: '00000000-0000-0000-0000-000000000000',
+        role: 'admin',
+      },
+    ]);
     mockGetTeamById.mockResolvedValue({
       data: [{ json: { title: [{ '@xml:lang': 'en', '#text': 'Flowproperty Team' }] } }],
     });
@@ -384,6 +409,21 @@ describe('FlowpropertiesPage', () => {
       total: 0,
     });
     mockGetUnitData.mockImplementation(async (_table: string, rows: any[]) => rows ?? []);
+  });
+
+  it('returns an empty locked table for non-admin my-data users', async () => {
+    mockGetRoleByUserId.mockResolvedValue([]);
+
+    renderWithProviders(<FlowpropertiesPage />);
+
+    await waitFor(() => expect(mockGetTeamById).toHaveBeenCalledWith('team-1'));
+    await waitFor(() => expect(screen.getByRole('button', { name: /search/i })).toBeDisabled());
+
+    expect(mockGetFlowpropertyTableAll).not.toHaveBeenCalled();
+    expect(screen.getByText(/contact an administrator/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /table-filter/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /import-data/i })).toBeDisabled();
+    expect(screen.getAllByTestId('flowproperty-create')[0]).toHaveTextContent('"disabled":true');
   });
 
   it('loads the default table and keeps imported data in the create action', async () => {
@@ -442,7 +482,7 @@ describe('FlowpropertiesPage', () => {
     renderWithProviders(<FlowpropertiesPage />);
 
     await waitFor(() => expect(mockGetFlowpropertyTableAll).toHaveBeenCalled());
-    expect(screen.getByTestId('flowproperty-view')).toHaveTextContent('fp-1:01.00.000');
+    expect(await screen.findByTestId('flowproperty-view')).toHaveTextContent('fp-1:01.00.000');
     expect(screen.getByRole('button', { name: /table-filter/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /import-data/i })).toBeInTheDocument();
   });
@@ -500,6 +540,7 @@ describe('FlowpropertiesPage', () => {
     const { rerender } = renderWithProviders(<FlowpropertiesPage />);
 
     await waitFor(() => expect(mockGetFlowpropertyTableAll).toHaveBeenCalled());
+    await screen.findByTestId('flowproperty-view');
     const initialTableCalls = mockGetFlowpropertyTableAll.mock.calls.length;
     await userEvent.click(screen.getByRole('button', { name: /contribute-action/i }));
 

--- a/tests/unit/pages/Unitgroups/index.test.tsx
+++ b/tests/unit/pages/Unitgroups/index.test.tsx
@@ -441,7 +441,7 @@ describe('UnitgroupsPage', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: /search/i })).toBeDisabled());
 
     expect(mockGetUnitGroupTableAll).not.toHaveBeenCalled();
-    expect(screen.getByText(/please contact the administrator/i)).toBeInTheDocument();
+    expect(screen.getByText(/contact an administrator/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /table-filter/i })).toBeDisabled();
     expect(screen.getByRole('button', { name: /import-data/i })).toBeDisabled();
     expect(screen.getAllByTestId('unitgroup-create')[0]).toHaveTextContent('"disabled":true');


### PR DESCRIPTION
Closes #526

## Summary
- 将单位组页面的补充数据提示从醒目的红框调整为标题旁的次级内联提示，并与标题水平居中对齐
- 更新单位组和流属性的中英文联系管理员提示文案
- 将流属性新增、导入、复制、创建版本入口限制为系统管理员可用，并在管理员权限确认后主动刷新列表
- 更新 Unitgroups、Flowproperties 页面单测和 Flowproperties workflow 集成测试
- 记录本次前端与测试治理文档的 docpact review evidence

## Validation
- `npx prettier --write src/pages/Unitgroups/index.tsx src/locales/zh-CN/pages_unitgroup.ts src/locales/en-US/pages_unitgroup.ts`
- `npx prettier --write src/pages/Flowproperties/index.tsx src/pages/Flowproperties/Components/create.tsx src/locales/zh-CN/pages_flowproperty.ts src/locales/en-US/pages_flowproperty.ts tests/unit/pages/Flowproperties/index.test.tsx`
- `npx eslint --ext .ts,.tsx src/pages/Flowproperties/index.tsx src/pages/Flowproperties/Components/create.tsx src/locales/zh-CN/pages_flowproperty.ts src/locales/en-US/pages_flowproperty.ts tests/unit/pages/Flowproperties/index.test.tsx`
- `npm run tsc`
- `npm run test:ci -- tests/unit/pages/Flowproperties/index.test.tsx tests/unit/pages/Unitgroups/index.test.tsx --runInBand --testTimeout=30000`
- `npm run test:ci -- tests/integration/flowproperties/FlowpropertiesWorkflow.integration.test.tsx tests/unit/pages/Flowproperties/index.test.tsx --runInBand --testTimeout=30000`
- `npm run docpact:gate`
- `git push --force-with-lease` (pre-push ran `npm run prepush:gate`; full local gate passed with 337 suites / 4183 tests and 100% coverage assertion)
