### PR TITLE
Use server-owned dataset version allocation

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-11"
-lastReviewedCommit: "e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a"
+lastReviewedAt: '2026-06-11'
+lastReviewedCommit: 'c77383f05f4349d99d0708b12ca707b91b12ac19'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-08"
-lastReviewedCommit: "858e8922d6387a09bdaa343748c6177b6cd9a0eb"
+lastReviewedAt: "2026-06-11"
+lastReviewedCommit: "e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-06-08
-lastReviewedCommit: 858e8922d6387a09bdaa343748c6177b6cd9a0eb
+lastReviewedAt: 2026-06-11
+lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-11
-lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
+lastReviewedCommit: c77383f05f4349d99d0708b12ca707b91b12ac19
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-06-08
-lastReviewedCommit: 9338d298f71613622ee202c357b0757484cc439c
+lastReviewedAt: 2026-06-11
+lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-06-11
-lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
+lastReviewedCommit: c77383f05f4349d99d0708b12ca707b91b12ac19
 ---
 
 # Development Bootstrap

--- a/docs/agents/contribution-path-analysis-design.md
+++ b/docs/agents/contribution-path-analysis-design.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-06-06
-lastReviewedCommit: cee1b2ceb343c9bd5481bbfbc1b7cc5349d19233
+lastReviewedAt: 2026-06-11
+lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
 ---
 
 # Contribution Path Analysis Design

--- a/docs/agents/lca-analysis-visualization-plan.md
+++ b/docs/agents/lca-analysis-visualization-plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-06-06
-lastReviewedCommit: cee1b2ceb343c9bd5481bbfbc1b7cc5349d19233
+lastReviewedAt: 2026-06-11
+lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
 ---
 
 # LCA Analysis And Visualization Plan

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-06-11
-lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
+lastReviewedCommit: c77383f05f4349d99d0708b12ca707b91b12ac19
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.js
   - .github/workflows/**
-lastReviewedAt: 2026-06-08
-lastReviewedCommit: 95d2993c9be650918ec326d3e2d6ce960d5818f7
+lastReviewedAt: 2026-06-11
+lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-06-11
-lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
+lastReviewedCommit: c77383f05f4349d99d0708b12ca707b91b12ac19
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-06-08
-lastReviewedCommit: 858e8922d6387a09bdaa343748c6177b6cd9a0eb
+lastReviewedAt: 2026-06-11
+lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-11
-lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
+lastReviewedCommit: c77383f05f4349d99d0708b12ca707b91b12ac19
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-06-08
-lastReviewedCommit: 858e8922d6387a09bdaa343748c6177b6cd9a0eb
+lastReviewedAt: 2026-06-11
+lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -19,8 +19,8 @@ checkPaths:
   - config/supabaseEnv.ts
   - src/services/**
   - docker/**
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: ec057a2a7ad6af62adf48a2f04fdf64801329f7e
+lastReviewedAt: 2026-06-11
+lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-06-11
-lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
+lastReviewedCommit: c77383f05f4349d99d0708b12ca707b91b12ac19
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-06-08
-lastReviewedCommit: 95d2993c9be650918ec326d3e2d6ce960d5818f7
+lastReviewedAt: 2026-06-11
+lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-06-08
-lastReviewedCommit: 95d2993c9be650918ec326d3e2d6ce960d5818f7
+lastReviewedAt: 2026-06-11
+lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-06-11
-lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
+lastReviewedCommit: c77383f05f4349d99d0708b12ca707b91b12ac19
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-06-11
-lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
+lastReviewedCommit: c77383f05f4349d99d0708b12ca707b91b12ac19
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-06-08
-lastReviewedCommit: 95d2993c9be650918ec326d3e2d6ce960d5818f7
+lastReviewedAt: 2026-06-11
+lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-06-08
-lastReviewedCommit: 95d2993c9be650918ec326d3e2d6ce960d5818f7
+lastReviewedAt: 2026-06-11
+lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-06-11
-lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
+lastReviewedCommit: c77383f05f4349d99d0708b12ca707b91b12ac19
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/util_calculate.md
+++ b/docs/agents/util_calculate.md
@@ -20,8 +20,8 @@ checkPaths:
   - src/services/lca/**
   - src/components/LcaTaskCenter/**
   - src/pages/Processes/Analysis/**
-lastReviewedAt: 2026-06-06
-lastReviewedCommit: cee1b2ceb343c9bd5481bbfbc1b7cc5349d19233
+lastReviewedAt: 2026-06-11
+lastReviewedCommit: e1707b3fe2e802b95f19e7d5fad71cebbcd15f7a
 ---
 
 # Lifecycle Model Calculation Reference

--- a/src/components/DatasetCreateVersionFormItem/index.tsx
+++ b/src/components/DatasetCreateVersionFormItem/index.tsx
@@ -1,0 +1,53 @@
+import { Form, Input } from 'antd';
+import type { ReactNode } from 'react';
+import { useIntl } from 'umi';
+
+type DatasetCreateVersionFormItemProps = {
+  children: ReactNode;
+  createVersion?: boolean;
+  label: ReactNode;
+  name: (string | number)[];
+  rules?: unknown[];
+};
+
+const NOTICE_MESSAGE_ID = 'pages.createVersion.versionAutoAllocationNotice';
+const NOTICE_DEFAULT_MESSAGE = 'The new version will be generated automatically.';
+
+export default function DatasetCreateVersionFormItem({
+  children,
+  createVersion,
+  label,
+  name,
+  rules,
+}: DatasetCreateVersionFormItemProps) {
+  const intl = useIntl();
+
+  if (!createVersion) {
+    return (
+      <Form.Item required={false} label={label} name={name} rules={rules as any[] | undefined}>
+        {children}
+      </Form.Item>
+    );
+  }
+
+  const message = intl.formatMessage({
+    id: NOTICE_MESSAGE_ID,
+    defaultMessage: NOTICE_DEFAULT_MESSAGE,
+  });
+
+  return (
+    <>
+      <Form.Item hidden name={name} rules={rules as any[] | undefined}>
+        <Input type='hidden' />
+      </Form.Item>
+      <Form.Item required={false} label={label}>
+        <Input
+          data-testid='dataset-create-version-auto-message'
+          disabled
+          readOnly
+          value={message}
+        />
+      </Form.Item>
+    </>
+  );
+}

--- a/src/locales/en-US/pages_general.ts
+++ b/src/locales/en-US/pages_general.ts
@@ -12,6 +12,7 @@ export default {
 
   'pages.button.add': 'Add',
   'pages.button.createVersion': 'Create Version',
+  'pages.createVersion.versionAutoAllocationNotice': 'The new version will be generated automatically.',
   'pages.button.createVersion.fail': 'Please change the data version and submit',
   'pages.button.allVersion': 'All Versions',
   'pages.button.create': 'Create',

--- a/src/locales/en-US/pages_general.ts
+++ b/src/locales/en-US/pages_general.ts
@@ -16,7 +16,7 @@ export default {
   'pages.button.allVersion': 'All Versions',
   'pages.button.create': 'Create',
   'pages.button.create.success': 'Created successfully!',
-  'pages.button.create.error.duplicateId': 'Data with the same ID already exists.',
+  'pages.button.create.error.duplicateId': 'Data with the same ID and version already exists.',
   'pages.button.save.success': 'Save successfully!',
   'pages.button.reset': 'Reset',
   'pages.button.view': 'View',

--- a/src/locales/zh-CN/pages_general.ts
+++ b/src/locales/zh-CN/pages_general.ts
@@ -11,6 +11,7 @@ export default {
   'pages.table.title.version': '版本',
   'pages.button.add': '添加',
   'pages.button.createVersion': '新增版本',
+  'pages.createVersion.versionAutoAllocationNotice': '新版本自动计算后生成',
   'pages.button.createVersion.fail': '请更改数据集版本后提交',
   'pages.button.allVersion': '所有版本',
   'pages.button.view': '查看',

--- a/src/locales/zh-CN/pages_general.ts
+++ b/src/locales/zh-CN/pages_general.ts
@@ -16,7 +16,7 @@ export default {
   'pages.button.view': '查看',
   'pages.button.view.model': '查看模型',
   'pages.button.create.success': '创建成功!',
-  'pages.button.create.error.duplicateId': '已存在ID相同的数据。',
+  'pages.button.create.error.duplicateId': '已存在ID和版本相同的数据。',
   'pages.button.save.success': '保存成功!',
   'pages.button.edit': '编辑',
   'pages.button.copy': '复制',

--- a/src/pages/Contacts/Components/create.tsx
+++ b/src/pages/Contacts/Components/create.tsx
@@ -1,5 +1,5 @@
 import ToolBarButton from '@/components/ToolBarButton';
-import { createContact, getContactDetail } from '@/services/contacts/api';
+import { createContact, createContactVersion, getContactDetail } from '@/services/contacts/api';
 import {
   ContactDataSetObjectKeys,
   ContactDetailResponse,
@@ -256,10 +256,10 @@ const ContactCreate: FC<CreateProps> = ({
               try {
                 const paramsId = actionType === 'createVersion' ? (id ?? '') : (importedId ?? v4());
                 const formFieldsValue = formRefCreate.current?.getFieldsValue();
-                const result: SupabaseMutationResult<unknown> = await createContact(
-                  paramsId,
-                  formFieldsValue,
-                );
+                const result: SupabaseMutationResult<unknown> =
+                  actionType === 'createVersion'
+                    ? await createContactVersion(id ?? '', version ?? '', formFieldsValue)
+                    : await createContact(paramsId, formFieldsValue);
                 if (result.data) {
                   message.success(
                     intl.formatMessage({
@@ -275,7 +275,7 @@ const ContactCreate: FC<CreateProps> = ({
                     isSupabaseDuplicateKeyError(result.error)
                       ? intl.formatMessage({
                           id: 'pages.button.create.error.duplicateId',
-                          defaultMessage: 'Data with the same ID already exists.',
+                          defaultMessage: 'Data with the same ID and version already exists.',
                         })
                       : (result.error?.message ?? 'Error'),
                   );

--- a/src/pages/Contacts/Components/form.tsx
+++ b/src/pages/Contacts/Components/form.tsx
@@ -1,3 +1,4 @@
+import DatasetCreateVersionFormItem from '@/components/DatasetCreateVersionFormItem';
 import LangTextItemForm from '@/components/LangTextItem/form';
 import LevelTextItemForm from '@/components/LevelTextItem/form';
 import RequiredMark from '@/components/RequiredMark';
@@ -424,8 +425,8 @@ export const ContactForm: FC<Props> = ({
               />
             }
           >
-            <Form.Item
-              required={false}
+            <DatasetCreateVersionFormItem
+              createVersion={formType === 'createVersion'}
               label={
                 <RequiredMark
                   showError={false}
@@ -448,8 +449,8 @@ export const ContactForm: FC<Props> = ({
                 ]['rules'] ?? [],
               )}
             >
-              <Input disabled={formType === 'createVersion'} />
-            </Form.Item>
+              <Input />
+            </DatasetCreateVersionFormItem>
             <ContactSelectForm
               label={
                 <FormattedMessage

--- a/src/pages/Flowproperties/Components/create.tsx
+++ b/src/pages/Flowproperties/Components/create.tsx
@@ -1,4 +1,8 @@
-import { createFlowproperties, getFlowpropertyDetail } from '@/services/flowproperties/api';
+import {
+  createFlowproperties,
+  createFlowpropertiesVersion,
+  getFlowpropertyDetail,
+} from '@/services/flowproperties/api';
 import { genFlowpropertyFromData } from '@/services/flowproperties/util';
 // import { langOptions } from '@/services/general/data';
 import styles from '@/style/custom.less';
@@ -274,10 +278,10 @@ const FlowpropertiesCreate: FC<CreateProps> = ({
               try {
                 const paramsId = actionType === 'createVersion' ? id! : (importedId ?? v4());
                 const formFieldsValue = formRefCreate.current?.getFieldsValue();
-                const result: SupabaseMutationResult<unknown> = await createFlowproperties(
-                  paramsId,
-                  formFieldsValue,
-                );
+                const result: SupabaseMutationResult<unknown> =
+                  actionType === 'createVersion'
+                    ? await createFlowpropertiesVersion(id ?? '', version ?? '', formFieldsValue)
+                    : await createFlowproperties(paramsId, formFieldsValue);
                 if (result.data) {
                   message.success(
                     intl.formatMessage({
@@ -295,7 +299,7 @@ const FlowpropertiesCreate: FC<CreateProps> = ({
                     isSupabaseDuplicateKeyError(result.error)
                       ? intl.formatMessage({
                           id: 'pages.button.create.error.duplicateId',
-                          defaultMessage: 'Data with the same ID already exists.',
+                          defaultMessage: 'Data with the same ID and version already exists.',
                         })
                       : (result.error?.message ?? 'Error'),
                   );

--- a/src/pages/Flowproperties/Components/form.tsx
+++ b/src/pages/Flowproperties/Components/form.tsx
@@ -1,3 +1,4 @@
+import DatasetCreateVersionFormItem from '@/components/DatasetCreateVersionFormItem';
 import LangTextItemForm from '@/components/LangTextItem/form';
 import LevelTextItemForm from '@/components/LevelTextItem/form';
 import { Card, Form, Input, Select, Space, theme } from 'antd';
@@ -397,8 +398,8 @@ export const FlowpropertyForm: FC<Props> = ({
             />
           }
         >
-          <Form.Item
-            required={false}
+          <DatasetCreateVersionFormItem
+            createVersion={formType === 'createVersion'}
             label={
               <RequiredMark
                 showError={false}
@@ -417,8 +418,8 @@ export const FlowpropertyForm: FC<Props> = ({
               ]['rules'],
             )}
           >
-            <Input disabled={formType === 'createVersion'} />
-          </Form.Item>
+            <Input />
+          </DatasetCreateVersionFormItem>
           {/* <FlowpropertiesSelectForm
             name={[
               'administrativeInformation',

--- a/src/pages/Flows/Components/create.tsx
+++ b/src/pages/Flows/Components/create.tsx
@@ -1,4 +1,4 @@
-import { createFlows, getFlowDetail } from '@/services/flows/api';
+import { createFlows, createFlowsVersion, getFlowDetail } from '@/services/flows/api';
 import { genFlowFromData } from '@/services/flows/util';
 import {
   formatDateTime,
@@ -371,10 +371,14 @@ const FlowsCreate: FC<CreateProps> = ({
                 //   );
                 //   return false;
                 // }
-                const result = await createFlows(paramsId, {
+                const flowPayload = {
                   ...fieldsValue,
                   flowProperties,
-                });
+                };
+                const result =
+                  actionType === 'createVersion'
+                    ? await createFlowsVersion(id ?? '', version ?? '', flowPayload)
+                    : await createFlows(paramsId, flowPayload);
                 if (result.data) {
                   message.success(
                     intl.formatMessage({
@@ -392,7 +396,7 @@ const FlowsCreate: FC<CreateProps> = ({
                     isSupabaseDuplicateKeyError(result.error)
                       ? intl.formatMessage({
                           id: 'pages.button.create.error.duplicateId',
-                          defaultMessage: 'Data with the same ID already exists.',
+                          defaultMessage: 'Data with the same ID and version already exists.',
                         })
                       : (result.error?.message ?? 'Error'),
                   );

--- a/src/pages/Flows/Components/form.tsx
+++ b/src/pages/Flows/Components/form.tsx
@@ -1,4 +1,5 @@
 /* istanbul ignore file -- flow form behavior is covered by tests; remaining misses are presentation-only branches */
+import DatasetCreateVersionFormItem from '@/components/DatasetCreateVersionFormItem';
 import LangTextItemForm from '@/components/LangTextItem/form';
 import LevelTextItemForm from '@/components/LevelTextItem/form';
 import LocationTextItemForm from '@/components/LocationTextItem/form';
@@ -1038,8 +1039,8 @@ export const FlowForm: FC<Props> = ({
             />
           }
         >
-          <Form.Item
-            required={false}
+          <DatasetCreateVersionFormItem
+            createVersion={formType === 'createVersion'}
             label={
               <RequiredMark
                 showError={false}
@@ -1058,8 +1059,8 @@ export const FlowForm: FC<Props> = ({
               ]['rules'],
             )}
           >
-            <Input disabled={formType === 'createVersion'} />
-          </Form.Item>
+            <Input />
+          </DatasetCreateVersionFormItem>
           {/* <FlowsSelectForm
             name={[
               'administrativeInformation',

--- a/src/pages/LifeCycleModels/Components/form.tsx
+++ b/src/pages/LifeCycleModels/Components/form.tsx
@@ -1,3 +1,4 @@
+import DatasetCreateVersionFormItem from '@/components/DatasetCreateVersionFormItem';
 import LangTextItemForm from '@/components/LangTextItem/form';
 import LevelTextItemForm from '@/components/LevelTextItem/form';
 import RequiredMark from '@/components/RequiredMark';
@@ -640,8 +641,8 @@ export const LifeCycleModelForm: FC<Props> = ({
             />
           }
         >
-          <Form.Item
-            required={false}
+          <DatasetCreateVersionFormItem
+            createVersion={actionType === 'createVersion'}
             label={
               <RequiredMark
                 label={
@@ -660,8 +661,8 @@ export const LifeCycleModelForm: FC<Props> = ({
               ]['common:dataSetVersion']['rules'],
             )}
           >
-            <Input disabled={actionType === 'createVersion'} />
-          </Form.Item>
+            <Input />
+          </DatasetCreateVersionFormItem>
           <Form.Item
             required={false}
             label={

--- a/src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx
+++ b/src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx
@@ -965,7 +965,7 @@ const ToolbarEdit: FC<Props> = ({
           message.error(
             intl.formatMessage({
               id: 'pages.button.create.error.duplicateId',
-              defaultMessage: 'Data with the same ID already exists.',
+              defaultMessage: 'Data with the same ID and version already exists.',
             }),
           );
           return;
@@ -1066,11 +1066,16 @@ const ToolbarEdit: FC<Props> = ({
       } else if (thisAction === 'create') {
         const newId = actionType === 'createVersion' ? thisId : (importedId ?? v4());
         const lifecycleModelPayload = { ...newData, id: newId };
-        const result = await runMutation(() =>
-          langOptions
+        const createVersionOptions =
+          actionType === 'createVersion' ? { sourceVersion: thisVersion } : undefined;
+        const result = await runMutation(() => {
+          if (createVersionOptions) {
+            return createLifeCycleModel(lifecycleModelPayload, langOptions, createVersionOptions);
+          }
+          return langOptions
             ? createLifeCycleModel(lifecycleModelPayload, langOptions)
-            : createLifeCycleModel(lifecycleModelPayload),
-        );
+            : createLifeCycleModel(lifecycleModelPayload);
+        });
         if (result.ok) {
           const savedLifeCycleModel = result.lifecycleModel;
           const savedModelId = savedLifeCycleModel?.id ?? result.modelId;

--- a/src/pages/Processes/Components/create.tsx
+++ b/src/pages/Processes/Components/create.tsx
@@ -6,7 +6,7 @@ import {
   isSupabaseDuplicateKeyError,
   jsonToList,
 } from '@/services/general/util';
-import { createProcess, getProcessDetail } from '@/services/processes/api';
+import { createProcess, createProcessVersion, getProcessDetail } from '@/services/processes/api';
 import { genProcessFromData } from '@/services/processes/util';
 import styles from '@/style/custom.less';
 import { CloseOutlined, CopyOutlined, PlusOutlined } from '@ant-design/icons';
@@ -378,9 +378,13 @@ const ProcessCreate: FC<CreateProps> = ({
                 setSpinning(false);
                 return;
               }
-              const result = await createProcess(paramsId, {
+              const processPayload = {
                 ...fromData,
-              });
+              };
+              const result =
+                actionType === 'createVersion'
+                  ? await createProcessVersion(id ?? '', version ?? '', processPayload)
+                  : await createProcess(paramsId, processPayload);
               if (result.data) {
                 message.success(
                   intl.formatMessage({
@@ -396,7 +400,7 @@ const ProcessCreate: FC<CreateProps> = ({
                   isSupabaseDuplicateKeyError(result.error)
                     ? intl.formatMessage({
                         id: 'pages.button.create.error.duplicateId',
-                        defaultMessage: 'Data with the same ID already exists.',
+                        defaultMessage: 'Data with the same ID and version already exists.',
                       })
                     : (result.error?.message ?? 'Error'),
                 );

--- a/src/pages/Processes/Components/form.tsx
+++ b/src/pages/Processes/Components/form.tsx
@@ -1,3 +1,4 @@
+import DatasetCreateVersionFormItem from '@/components/DatasetCreateVersionFormItem';
 import LangTextItemForm from '@/components/LangTextItem/form';
 import LevelTextItemForm from '@/components/LevelTextItem/form';
 import LocationTextItemForm from '@/components/LocationTextItem/form';
@@ -2333,7 +2334,8 @@ export const ProcessForm: FC<Props> = ({
             <Input />
           </Form.Item>
 
-          <Form.Item
+          <DatasetCreateVersionFormItem
+            createVersion={formType === 'createVersion'}
             label={
               <FormattedMessage
                 id='pages.process.view.administrativeInformation.dataSetVersion'
@@ -2348,7 +2350,7 @@ export const ProcessForm: FC<Props> = ({
             )}
           >
             <Input disabled={actionFrom === 'modelResult'} />
-          </Form.Item>
+          </DatasetCreateVersionFormItem>
 
           <Form.Item
             label={

--- a/src/pages/Sources/Components/create.tsx
+++ b/src/pages/Sources/Components/create.tsx
@@ -5,7 +5,7 @@ import {
   getImportedId,
   isSupabaseDuplicateKeyError,
 } from '@/services/general/util';
-import { createSource, getSourceDetail } from '@/services/sources/api';
+import { createSource, createSourceVersion, getSourceDetail } from '@/services/sources/api';
 import {
   FormSource,
   SourceDataSetObjectKeys,
@@ -130,7 +130,7 @@ const SourceCreate: FC<CreateProps> = ({
 
       const paramsId = actionType === 'createVersion' ? id! : (importedId ?? v4());
       const formFieldsValue = formRefCreate.current?.getFieldsValue();
-      const result: SupabaseMutationResult<unknown> = await createSource(paramsId, {
+      const sourcePayload = {
         ...formFieldsValue,
         sourceInformation: {
           ...fromData?.sourceInformation,
@@ -139,7 +139,11 @@ const SourceCreate: FC<CreateProps> = ({
             referenceToDigitalFile: filePaths,
           },
         },
-      });
+      };
+      const result: SupabaseMutationResult<unknown> =
+        actionType === 'createVersion'
+          ? await createSourceVersion(id ?? '', version ?? '', sourcePayload)
+          : await createSource(paramsId, sourcePayload);
 
       if (result?.data) {
         if (fileListWithUUID.length > 0) {
@@ -166,7 +170,7 @@ const SourceCreate: FC<CreateProps> = ({
           isSupabaseDuplicateKeyError(result.error)
             ? intl.formatMessage({
                 id: 'pages.button.create.error.duplicateId',
-                defaultMessage: 'Data with the same ID already exists.',
+                defaultMessage: 'Data with the same ID and version already exists.',
               })
             : (result.error?.message ?? 'Error'),
         );

--- a/src/pages/Sources/Components/form.tsx
+++ b/src/pages/Sources/Components/form.tsx
@@ -2,6 +2,7 @@ import { FileType, getBase64, getOriginalFileUrl, isImage } from '@/services/sup
 import { Card, Form, Image, Input, Select, Space, Upload, UploadFile } from 'antd';
 import { FC, useState } from 'react';
 
+import DatasetCreateVersionFormItem from '@/components/DatasetCreateVersionFormItem';
 import { UploadButton } from '@/components/FileViewer/upload';
 import LangTextItemForm from '@/components/LangTextItem/form';
 import LevelTextItemForm from '@/components/LevelTextItem/form';
@@ -380,8 +381,8 @@ export const SourceForm: FC<Props> = ({
             />
           }
         >
-          <Form.Item
-            required={false}
+          <DatasetCreateVersionFormItem
+            createVersion={formType === 'createVersion'}
             label={
               <RequiredMark
                 showError={false}
@@ -400,8 +401,8 @@ export const SourceForm: FC<Props> = ({
               ]['rules'] ?? [],
             )}
           >
-            <Input disabled={formType === 'createVersion'} />
-          </Form.Item>
+            <Input />
+          </DatasetCreateVersionFormItem>
           <ContactSelectForm
             label={
               <FormattedMessage

--- a/src/pages/Unitgroups/Components/create.tsx
+++ b/src/pages/Unitgroups/Components/create.tsx
@@ -5,7 +5,11 @@ import {
   getImportedId,
   isSupabaseDuplicateKeyError,
 } from '@/services/general/util';
-import { createUnitGroup, getUnitGroupDetail } from '@/services/unitgroups/api';
+import {
+  createUnitGroup,
+  createUnitGroupVersion,
+  getUnitGroupDetail,
+} from '@/services/unitgroups/api';
 import {
   FormUnitGroup,
   UnitDraft,
@@ -310,7 +314,10 @@ const UnitGroupCreate: FC<CreateProps> = ({
                   ...formRefCreate.current?.getFieldsValue(),
                   units,
                 };
-                const result = await createUnitGroup(paramsId, formFieldsValue);
+                const result =
+                  actionType === 'createVersion'
+                    ? await createUnitGroupVersion(id ?? '', version ?? '', formFieldsValue)
+                    : await createUnitGroup(paramsId, formFieldsValue);
                 if (result.data) {
                   message.success(
                     intl.formatMessage({
@@ -326,7 +333,7 @@ const UnitGroupCreate: FC<CreateProps> = ({
                     isSupabaseDuplicateKeyError(result.error)
                       ? intl.formatMessage({
                           id: 'pages.button.create.error.duplicateId',
-                          defaultMessage: 'Data with the same ID already exists.',
+                          defaultMessage: 'Data with the same ID and version already exists.',
                         })
                       : (result.error?.message ?? 'Error'),
                   );

--- a/src/pages/Unitgroups/Components/form.tsx
+++ b/src/pages/Unitgroups/Components/form.tsx
@@ -1,5 +1,6 @@
 /* istanbul ignore file -- unit-group form behavior is covered by tests; remaining misses are presentation-only branches */
 import AlignedNumber from '@/components/AlignedNumber';
+import DatasetCreateVersionFormItem from '@/components/DatasetCreateVersionFormItem';
 import LangTextItemForm from '@/components/LangTextItem/form';
 import LevelTextItemForm from '@/components/LevelTextItem/form';
 import QuantitativeReferenceIcon from '@/components/QuantitativeReferenceIcon';
@@ -537,8 +538,8 @@ export const UnitGroupForm: FC<Props> = ({
           }
         />
         <br />
-        <Form.Item
-          required={false}
+        <DatasetCreateVersionFormItem
+          createVersion={formType === 'createVersion'}
           label={
             <RequiredMark
               showError={false}
@@ -557,8 +558,8 @@ export const UnitGroupForm: FC<Props> = ({
             ]['rules'] ?? [],
           )}
         >
-          <Input disabled={formType === 'createVersion'} />
-        </Form.Item>
+          <Input />
+        </DatasetCreateVersionFormItem>
         <ContactSelectForm
           lang={lang}
           formRef={formRef}

--- a/src/services/contacts/api.ts
+++ b/src/services/contacts/api.ts
@@ -21,6 +21,7 @@ import {
   getDataDetail,
   getTeamIdByUserId,
   invokeDatasetCommand,
+  invokeDatasetCreateVersion,
   normalizeLangPayloadForSave,
   type NormalizeLangPayloadForSaveOptions,
 } from '../general/api';
@@ -168,6 +169,57 @@ export async function createContact(
     {
       id,
       table: 'contacts',
+      jsonOrdered: newData,
+      ruleVerification: rule_verification,
+    },
+    {
+      ruleVerification: rule_verification,
+    },
+  );
+  return attachLangNormalizationMetadata(result, langMetadata, options);
+}
+
+export async function createContactVersion(
+  id: string,
+  sourceVersion: string,
+  data: any,
+  options?: NormalizeLangPayloadForSaveOptions,
+) {
+  const rawData = genContactJsonOrdered(id, data);
+  const normalizedResult = await normalizeLangPayloadForSave(rawData, options);
+  const newData = normalizedResult?.payload ?? rawData;
+  const validationError = normalizedResult?.validationError;
+  const langMetadata = buildLangNormalizationMetadata(normalizedResult, rawData);
+  if (validationError) {
+    return attachLangNormalizationMetadata(
+      {
+        data: null,
+        error: {
+          message: validationError,
+          code: 'LANG_VALIDATION_ERROR',
+          details: '',
+          hint: '',
+          name: 'LangValidationError',
+        },
+        status: 400,
+        statusText: 'LANG_VALIDATION_ERROR',
+        count: null,
+      },
+      langMetadata,
+      options,
+    );
+  }
+  const userTeamId = (await getTeamIdByUserId()) ?? '';
+  const { ruleVerification: rule_verification } = await validateDatasetRuleVerification(
+    'contact data set',
+    newData,
+    userTeamId,
+  );
+  const result = await invokeDatasetCreateVersion(
+    {
+      id,
+      table: 'contacts',
+      sourceVersion,
       jsonOrdered: newData,
       ruleVerification: rule_verification,
     },

--- a/src/services/flowproperties/api.ts
+++ b/src/services/flowproperties/api.ts
@@ -21,6 +21,7 @@ import {
   getDataDetail,
   getTeamIdByUserId,
   invokeDatasetCommand,
+  invokeDatasetCreateVersion,
   normalizeLangPayloadForSave,
   type NormalizeLangPayloadForSaveOptions,
 } from '../general/api';
@@ -184,6 +185,57 @@ export async function createFlowproperties(
     {
       id,
       table: 'flowproperties',
+      jsonOrdered: newData,
+      ruleVerification: rule_verification,
+    },
+    {
+      ruleVerification: rule_verification,
+    },
+  );
+  return attachLangNormalizationMetadata(result, langMetadata, options);
+}
+
+export async function createFlowpropertiesVersion(
+  id: string,
+  sourceVersion: string,
+  data: any,
+  options?: NormalizeLangPayloadForSaveOptions,
+) {
+  const rawData = genFlowpropertyJsonOrdered(id, data);
+  const normalizedResult = await normalizeLangPayloadForSave(rawData, options);
+  const newData = normalizedResult?.payload ?? rawData;
+  const validationError = normalizedResult?.validationError;
+  const langMetadata = buildLangNormalizationMetadata(normalizedResult, rawData);
+  if (validationError) {
+    return attachLangNormalizationMetadata(
+      {
+        data: null,
+        error: {
+          message: validationError,
+          code: 'LANG_VALIDATION_ERROR',
+          details: '',
+          hint: '',
+          name: 'LangValidationError',
+        },
+        status: 400,
+        statusText: 'LANG_VALIDATION_ERROR',
+        count: null,
+      },
+      langMetadata,
+      options,
+    );
+  }
+  const userTeamId = (await getTeamIdByUserId()) ?? '';
+  const { ruleVerification: rule_verification } = await validateDatasetRuleVerification(
+    'flow property data set',
+    newData,
+    userTeamId,
+  );
+  const result = await invokeDatasetCreateVersion(
+    {
+      id,
+      table: 'flowproperties',
+      sourceVersion,
       jsonOrdered: newData,
       ruleVerification: rule_verification,
     },

--- a/src/services/flows/api.ts
+++ b/src/services/flows/api.ts
@@ -22,6 +22,7 @@ import {
   getDataDetail,
   getTeamIdByUserId,
   invokeDatasetCommand,
+  invokeDatasetCreateVersion,
   normalizeLangPayloadForSave,
   type NormalizeLangPayloadForSaveOptions,
 } from '../general/api';
@@ -175,6 +176,57 @@ export async function createFlows(
     {
       id,
       table: 'flows',
+      jsonOrdered: newData,
+      ruleVerification: rule_verification,
+    },
+    {
+      ruleVerification: rule_verification,
+    },
+  );
+  return attachLangNormalizationMetadata(result, langMetadata, options);
+}
+
+export async function createFlowsVersion(
+  id: string,
+  sourceVersion: string,
+  data: any,
+  options?: NormalizeLangPayloadForSaveOptions,
+) {
+  const rawData = genFlowJsonOrdered(id, data);
+  const normalizedResult = await normalizeLangPayloadForSave(rawData, options);
+  const newData = normalizedResult?.payload ?? rawData;
+  const validationError = normalizedResult?.validationError;
+  const langMetadata = buildLangNormalizationMetadata(normalizedResult, rawData);
+  if (validationError) {
+    return attachLangNormalizationMetadata(
+      {
+        data: null,
+        error: {
+          message: validationError,
+          code: 'LANG_VALIDATION_ERROR',
+          details: '',
+          hint: '',
+          name: 'LangValidationError',
+        },
+        status: 400,
+        statusText: 'LANG_VALIDATION_ERROR',
+        count: null,
+      },
+      langMetadata,
+      options,
+    );
+  }
+  const userTeamId = (await getTeamIdByUserId()) ?? '';
+  const { ruleVerification: rule_verification } = await validateDatasetRuleVerification(
+    'flow data set',
+    newData,
+    userTeamId,
+  );
+  const result = await invokeDatasetCreateVersion(
+    {
+      id,
+      table: 'flows',
+      sourceVersion,
       jsonOrdered: newData,
       ruleVerification: rule_verification,
     },

--- a/src/services/general/api.ts
+++ b/src/services/general/api.ts
@@ -188,6 +188,7 @@ export type TidasPackageRoot = {
 
 type DatasetCommandFunctionName =
   | 'app_dataset_create'
+  | 'app_dataset_create_version'
   | 'app_dataset_delete'
   | 'app_dataset_save_draft'
   | 'app_dataset_assign_team'
@@ -983,6 +984,20 @@ export async function invokeDatasetCommand<Row extends Record<string, unknown>>(
     status: 200,
     statusText: 'OK',
   };
+}
+
+export async function invokeDatasetCreateVersion<Row extends Record<string, unknown>>(
+  body: {
+    id: string;
+    table: Exclude<TidasPackageRootTable, 'lifecyclemodels'>;
+    sourceVersion: string;
+    jsonOrdered: unknown;
+    modelId?: string | null;
+    ruleVerification?: boolean | null;
+  },
+  options: { ruleVerification?: boolean | null } = {},
+): Promise<SupabaseMutationResult<Row>> {
+  return invokeDatasetCommand<Row>('app_dataset_create_version', body, options);
 }
 
 export async function getDataDetail(id: string, version: string, table: string) {

--- a/src/services/lifeCycleModels/api.ts
+++ b/src/services/lifeCycleModels/api.ts
@@ -266,6 +266,7 @@ async function applyReferenceAwareRuleVerification(
 export async function createLifeCycleModel(
   data: any,
   options?: NormalizeLangPayloadForSaveOptions,
+  createVersionOptions?: { sourceVersion: string },
 ): Promise<LifeCycleModelMutationResult> {
   const rawLifeCycleModelJsonOrdered = genLifeCycleModelJsonOrdered(data.id, data);
   const normalizedCreateResult = await normalizeLangPayloadForSave(
@@ -314,7 +315,14 @@ export async function createLifeCycleModel(
   }
   const userTeamId = (await getTeamIdByUserId()) ?? '';
   const plan = await applyReferenceAwareRuleVerification(planResult.plan, userTeamId);
-  const result = await invokeLifecycleModelBundleFunction('save_lifecycle_model_bundle', plan);
+  const savePlan = createVersionOptions?.sourceVersion
+    ? {
+        ...plan,
+        allocateVersion: true,
+        sourceVersion: createVersionOptions.sourceVersion,
+      }
+    : plan;
+  const result = await invokeLifecycleModelBundleFunction('save_lifecycle_model_bundle', savePlan);
   return attachLangNormalizationMetadata(result, langMetadata, options);
 }
 

--- a/src/services/lifeCycleModels/data.ts
+++ b/src/services/lifeCycleModels/data.ts
@@ -311,6 +311,8 @@ export type LifeCycleModelPersistencePlan = {
   mode: 'create' | 'update';
   modelId: string;
   version?: string;
+  allocateVersion?: boolean;
+  sourceVersion?: string;
   parent: {
     jsonOrdered: unknown;
     jsonTg: LifeCycleModelJsonTg;

--- a/src/services/processes/api.ts
+++ b/src/services/processes/api.ts
@@ -11,6 +11,7 @@ import {
   createLegacyMutationRemovedError,
   getRefData,
   invokeDatasetCommand,
+  invokeDatasetCreateVersion,
   normalizeLangPayloadForSave,
   type LangNormalizationMetadata,
   type NormalizeLangPayloadForSaveOptions,
@@ -300,6 +301,59 @@ export async function createProcess(
     {
       id,
       table: 'processes',
+      jsonOrdered: newData,
+      modelId: modelId ?? null,
+      ruleVerification: rule_verification,
+    },
+    {
+      ruleVerification: rule_verification,
+    },
+  );
+  return attachLangNormalizationMetadata(result, langMetadata, options);
+}
+
+export async function createProcessVersion(
+  id: string,
+  sourceVersion: string,
+  data: any,
+  modelId?: string,
+  options?: NormalizeLangPayloadForSaveOptions,
+) {
+  const rawData = genProcessJsonOrdered(id, data);
+  const normalizedResult = await normalizeLangPayloadForSave(rawData, options);
+  const newData = normalizedResult?.payload ?? rawData;
+  const validationError = normalizedResult?.validationError;
+  const langMetadata = buildLangNormalizationMetadata(normalizedResult, rawData);
+  if (validationError) {
+    return attachLangNormalizationMetadata(
+      {
+        data: null,
+        error: {
+          message: validationError,
+          code: 'LANG_VALIDATION_ERROR',
+          details: '',
+          hint: '',
+          name: 'LangValidationError',
+        },
+        status: 400,
+        statusText: 'LANG_VALIDATION_ERROR',
+        count: null,
+      },
+      langMetadata,
+      options,
+    );
+  }
+  const userTeamId = (await getTeamIdByUserId()) ?? '';
+  const { ruleVerification: rule_verification } = await validateDatasetRuleVerification(
+    'process data set',
+    newData,
+    userTeamId,
+  );
+  const result = await invokeDatasetCreateVersion<ProcessCommandRow>(
+    {
+      id,
+      table: 'processes',
+      sourceVersion,
       jsonOrdered: newData,
       modelId: modelId ?? null,
       ruleVerification: rule_verification,

--- a/src/services/sources/api.ts
+++ b/src/services/sources/api.ts
@@ -21,6 +21,7 @@ import {
   getDataDetail,
   getTeamIdByUserId,
   invokeDatasetCommand,
+  invokeDatasetCreateVersion,
   normalizeLangPayloadForSave,
   type NormalizeLangPayloadForSaveOptions,
 } from '../general/api';
@@ -166,6 +167,57 @@ export async function createSource(
     {
       id,
       table: 'sources',
+      jsonOrdered: newData,
+      ruleVerification: rule_verification,
+    },
+    {
+      ruleVerification: rule_verification,
+    },
+  );
+  return attachLangNormalizationMetadata(result, langMetadata, options);
+}
+
+export async function createSourceVersion(
+  id: string,
+  sourceVersion: string,
+  data: any,
+  options?: NormalizeLangPayloadForSaveOptions,
+) {
+  const rawData = genSourceJsonOrdered(id, data);
+  const normalizedResult = await normalizeLangPayloadForSave(rawData, options);
+  const newData = normalizedResult?.payload ?? rawData;
+  const validationError = normalizedResult?.validationError;
+  const langMetadata = buildLangNormalizationMetadata(normalizedResult, rawData);
+  if (validationError) {
+    return attachLangNormalizationMetadata(
+      {
+        data: null,
+        error: {
+          message: validationError,
+          code: 'LANG_VALIDATION_ERROR',
+          details: '',
+          hint: '',
+          name: 'LangValidationError',
+        },
+        status: 400,
+        statusText: 'LANG_VALIDATION_ERROR',
+        count: null,
+      },
+      langMetadata,
+      options,
+    );
+  }
+  const userTeamId = (await getTeamIdByUserId()) ?? '';
+  const { ruleVerification: rule_verification } = await validateDatasetRuleVerification(
+    'source data set',
+    newData,
+    userTeamId,
+  );
+  const result = await invokeDatasetCreateVersion(
+    {
+      id,
+      table: 'sources',
+      sourceVersion,
       jsonOrdered: newData,
       ruleVerification: rule_verification,
     },

--- a/src/services/unitgroups/api.ts
+++ b/src/services/unitgroups/api.ts
@@ -21,6 +21,7 @@ import {
   getDataDetail,
   getTeamIdByUserId,
   invokeDatasetCommand,
+  invokeDatasetCreateVersion,
   normalizeLangPayloadForSave,
   type NormalizeLangPayloadForSaveOptions,
 } from '../general/api';
@@ -182,6 +183,57 @@ export async function createUnitGroup(
     {
       id,
       table: 'unitgroups',
+      jsonOrdered: newData,
+      ruleVerification: rule_verification,
+    },
+    {
+      ruleVerification: rule_verification,
+    },
+  );
+  return attachLangNormalizationMetadata(result, langMetadata, options);
+}
+
+export async function createUnitGroupVersion(
+  id: string,
+  sourceVersion: string,
+  data: any,
+  options?: NormalizeLangPayloadForSaveOptions,
+) {
+  const rawData = genUnitGroupJsonOrdered(id, data);
+  const normalizedResult = await normalizeLangPayloadForSave(rawData, options);
+  const newData = normalizedResult?.payload ?? rawData;
+  const validationError = normalizedResult?.validationError;
+  const langMetadata = buildLangNormalizationMetadata(normalizedResult, rawData);
+  if (validationError) {
+    return attachLangNormalizationMetadata(
+      {
+        data: null,
+        error: {
+          message: validationError,
+          code: 'LANG_VALIDATION_ERROR',
+          details: '',
+          hint: '',
+          name: 'LangValidationError',
+        },
+        status: 400,
+        statusText: 'LANG_VALIDATION_ERROR',
+        count: null,
+      },
+      langMetadata,
+      options,
+    );
+  }
+  const userTeamId = (await getTeamIdByUserId()) ?? '';
+  const { ruleVerification: rule_verification } = await validateDatasetRuleVerification(
+    'unit group data set',
+    newData,
+    userTeamId,
+  );
+  const result = await invokeDatasetCreateVersion(
+    {
+      id,
+      table: 'unitgroups',
+      sourceVersion,
       jsonOrdered: newData,
       ruleVerification: rule_verification,
     },

--- a/tests/unit/pages/Contacts/ContactCreate.test.tsx
+++ b/tests/unit/pages/Contacts/ContactCreate.test.tsx
@@ -300,6 +300,7 @@ jest.mock('@/pages/Contacts/Components/form', () => {
 jest.mock('@/services/contacts/api', () => ({
   __esModule: true,
   createContact: jest.fn(),
+  createContactVersion: jest.fn(),
   getContactDetail: jest.fn(),
 }));
 
@@ -308,8 +309,11 @@ jest.mock('@/services/contacts/util', () => ({
   genContactFromData: jest.fn(() => ({})),
 }));
 
-const { createContact: mockCreateContact, getContactDetail: mockGetContactDetail } =
-  jest.requireMock('@/services/contacts/api');
+const {
+  createContact: mockCreateContact,
+  createContactVersion: mockCreateContactVersion,
+  getContactDetail: mockGetContactDetail,
+} = jest.requireMock('@/services/contacts/api');
 const { genContactFromData: mockGenContactFromData } = jest.requireMock('@/services/contacts/util');
 const {
   getImportedId: mockGetImportedId,
@@ -320,6 +324,7 @@ describe('ContactCreate component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockCreateContact.mockResolvedValue({ data: [{ id: 'contact-new' }] });
+    mockCreateContactVersion.mockResolvedValue({ data: [{ id: 'contact-new' }] });
     mockGetContactDetail.mockResolvedValue({
       data: { json: { contactDataSet: {} } },
     });
@@ -405,8 +410,9 @@ describe('ContactCreate component', () => {
     await user.click(within(drawer).getByRole('button', { name: 'Save' }));
 
     await waitFor(() =>
-      expect(mockCreateContact).toHaveBeenCalledWith(
+      expect(mockCreateContactVersion).toHaveBeenCalledWith(
         'contact-1',
+        '1.0.0',
         expect.objectContaining({
           contactInformation: expect.objectContaining({
             dataSetInformation: expect.objectContaining({
@@ -483,7 +489,7 @@ describe('ContactCreate component', () => {
 
     await waitFor(() =>
       expect(getMockAntdMessage().error).toHaveBeenCalledWith(
-        'Data with the same ID already exists.',
+        'Data with the same ID and version already exists.',
       ),
     );
     expect(actionRef.current.reload).not.toHaveBeenCalled();
@@ -607,7 +613,7 @@ describe('ContactCreate component', () => {
     await user.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
-      expect(mockCreateContact).toHaveBeenCalledWith('', expect.anything());
+      expect(mockCreateContactVersion).toHaveBeenCalledWith('', '', expect.anything());
     });
   });
 

--- a/tests/unit/pages/Flowproperties/create.test.tsx
+++ b/tests/unit/pages/Flowproperties/create.test.tsx
@@ -237,11 +237,15 @@ jest.mock('@/pages/Flowproperties/Components/form', () => {
 const mockCreateFlowproperties = jest.fn(async () => ({
   data: [{ id: 'fp-created', version: '1.0.0' }],
 }));
+const mockCreateFlowpropertiesVersion = jest.fn(async () => ({
+  data: [{ id: 'fp-created', version: '1.0.0' }],
+}));
 const mockGenFlowpropertyFromData = jest.fn((payload: any) => payload ?? {});
 
 jest.mock('@/services/flowproperties/api', () => ({
   __esModule: true,
   createFlowproperties: (...args: any[]) => mockCreateFlowproperties(...args),
+  createFlowpropertiesVersion: (...args: any[]) => mockCreateFlowpropertiesVersion(...args),
   getFlowpropertyDetail: (...args: any[]) => mockGetFlowpropertyDetail(...args),
 }));
 
@@ -263,6 +267,9 @@ describe('FlowpropertiesCreate', () => {
     mockGetImportedId.mockReturnValue(undefined);
     mockIsSupabaseDuplicateKeyError.mockReturnValue(false);
     mockCreateFlowproperties.mockResolvedValue({ data: [{ id: 'fp-created', version: '1.0.0' }] });
+    mockCreateFlowpropertiesVersion.mockResolvedValue({
+      data: [{ id: 'fp-created', version: '1.0.0' }],
+    });
   });
 
   it('creates a flow property and reloads table on success', async () => {
@@ -323,12 +330,35 @@ describe('FlowpropertiesCreate', () => {
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
 
     await waitFor(() =>
-      expect(mockCreateFlowproperties).toHaveBeenCalledWith(
+      expect(mockCreateFlowpropertiesVersion).toHaveBeenCalledWith(
         'fp-1',
+        '1.0.0',
         expect.objectContaining({
           flowPropertiesInformation: expect.any(Object),
         }),
       ),
+    );
+  });
+
+  it('falls back to empty create-version identifiers when runtime props are missing', async () => {
+    const actionRef: any = { current: { reload: jest.fn() } };
+
+    await act(async () => {
+      renderWithProviders(
+        <FlowpropertiesCreate
+          actionRef={actionRef}
+          lang='en'
+          actionType='createVersion'
+          {...({ id: undefined, version: undefined } as any)}
+        />,
+      );
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() =>
+      expect(mockCreateFlowpropertiesVersion).toHaveBeenCalledWith('', '', expect.any(Object)),
     );
   });
 
@@ -391,7 +421,9 @@ describe('FlowpropertiesCreate', () => {
 
     const { message } = jest.requireMock('antd');
     await waitFor(() =>
-      expect(message.error).toHaveBeenCalledWith('Data with the same ID already exists.'),
+      expect(message.error).toHaveBeenCalledWith(
+        'Data with the same ID and version already exists.',
+      ),
     );
     expect(actionRef.current.reload).not.toHaveBeenCalled();
   });

--- a/tests/unit/pages/Flowproperties/form.test.tsx
+++ b/tests/unit/pages/Flowproperties/form.test.tsx
@@ -271,7 +271,7 @@ describe('FlowpropertyForm', () => {
     expect(sourceSelectCalls[sourceSelectCalls.length - 1].defaultSourceName).toBe('ILCD format');
   });
 
-  it('marks the unit group field as required and disables version editing in createVersion mode', async () => {
+  it('marks the unit group field as required and shows auto-version copy in createVersion mode', async () => {
     const formRef = {
       current: {
         setFieldsValue: jest.fn(),
@@ -307,9 +307,10 @@ describe('FlowpropertyForm', () => {
       />,
     );
 
-    expect(
-      screen.getAllByRole('textbox').every((element) => element.hasAttribute('disabled')),
-    ).toBe(true);
+    expect(screen.getByTestId('dataset-create-version-auto-message')).toBeDisabled();
+    expect(screen.getByTestId('dataset-create-version-auto-message')).toHaveValue(
+      'The new version will be generated automatically.',
+    );
 
     rerender(
       <FlowpropertyForm

--- a/tests/unit/pages/Flows/Components/create.test.tsx
+++ b/tests/unit/pages/Flows/Components/create.test.tsx
@@ -16,6 +16,7 @@ const toText = (node: any): string => {
 // eslint-disable-next-line no-var
 var mockMessage: any;
 const mockCreateFlows = jest.fn();
+const mockCreateFlowsVersion = jest.fn();
 const mockGetFlowDetail = jest.fn();
 const mockGenFlowFromData = jest.fn();
 const mockFormatDateTime = jest.fn(() => 'formatted-time');
@@ -132,6 +133,7 @@ jest.mock('@/components/ToolBarButton', () => ({
 jest.mock('@/services/flows/api', () => ({
   __esModule: true,
   createFlows: (...args: any[]) => mockCreateFlows(...args),
+  createFlowsVersion: (...args: any[]) => mockCreateFlowsVersion(...args),
   getFlowDetail: (...args: any[]) => mockGetFlowDetail(...args),
 }));
 
@@ -205,6 +207,7 @@ describe('FlowsCreate (src/pages/Flows/Components/create.tsx)', () => {
       data: { json: { flowDataSet: { from: 'detail' } }, version: 'v1' },
     });
     mockCreateFlows.mockResolvedValue({ data: {} });
+    mockCreateFlowsVersion.mockResolvedValue({ data: {} });
   });
 
   const renderComponent = (props: any = {}) => {
@@ -360,9 +363,24 @@ describe('FlowsCreate (src/pages/Flows/Components/create.tsx)', () => {
     fireEvent.click(screen.getByText('Save'));
 
     await waitFor(() => {
-      expect(mockCreateFlows).toHaveBeenCalled();
+      expect(mockCreateFlowsVersion).toHaveBeenCalled();
     });
-    expect(mockCreateFlows).toHaveBeenCalledWith('flow-1', expect.any(Object));
+    expect(mockCreateFlowsVersion).toHaveBeenCalledWith('flow-1', '1.0', expect.any(Object));
+  });
+
+  it('falls back to empty create-version identifiers when runtime props are missing', async () => {
+    renderComponent({
+      actionType: 'createVersion',
+      id: undefined,
+      version: undefined,
+    });
+
+    fireEvent.click(screen.getByText('Create'));
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(mockCreateFlowsVersion).toHaveBeenCalledWith('', '', expect.any(Object));
+    });
   });
 
   it('falls back to an empty flow dataset payload when detail data is missing', async () => {
@@ -440,7 +458,9 @@ describe('FlowsCreate (src/pages/Flows/Components/create.tsx)', () => {
     fireEvent.click(screen.getByText('Save'));
 
     await waitFor(() => {
-      expect(mockMessage.error).toHaveBeenCalledWith('Data with the same ID already exists.');
+      expect(mockMessage.error).toHaveBeenCalledWith(
+        'Data with the same ID and version already exists.',
+      );
     });
   });
 

--- a/tests/unit/pages/LifeCycleModels/Components/form.test.tsx
+++ b/tests/unit/pages/LifeCycleModels/Components/form.test.tsx
@@ -226,7 +226,7 @@ describe('LifeCycleModelForm', () => {
     expect(baseProps.onData).toHaveBeenCalledTimes(1);
   });
 
-  it('uses the create default source and disables dataset version during createVersion', () => {
+  it('uses the create default source and shows auto-version copy during createVersion', () => {
     renderWithProviders(
       <LifeCycleModelForm
         {...baseProps}
@@ -236,7 +236,10 @@ describe('LifeCycleModelForm', () => {
       />,
     );
 
-    expect(screen.getAllByRole('textbox')[1]).toBeDisabled();
+    expect(screen.getByTestId('dataset-create-version-auto-message')).toBeDisabled();
+    expect(screen.getByTestId('dataset-create-version-auto-message')).toHaveValue(
+      'The new version will be generated automatically.',
+    );
     expect(getSourceSelectByLabel('Data set format(s)')).toHaveTextContent(
       '"defaultSourceName":"ILCD format"',
     );

--- a/tests/unit/pages/LifeCycleModels/Components/toolbar/editIndex.test.tsx
+++ b/tests/unit/pages/LifeCycleModels/Components/toolbar/editIndex.test.tsx
@@ -2114,7 +2114,9 @@ describe('ToolbarEdit', () => {
     await userEvent.click(screen.getByRole('button', { name: 'save-icon' }));
 
     await waitFor(() =>
-      expect(antMessage.error).toHaveBeenCalledWith('Data with the same ID already exists.'),
+      expect(antMessage.error).toHaveBeenCalledWith(
+        'Data with the same ID and version already exists.',
+      ),
     );
   });
 
@@ -2146,6 +2148,8 @@ describe('ToolbarEdit', () => {
         expect.objectContaining({
           id: 'model-1',
         }),
+        undefined,
+        { sourceVersion: '1.0' },
       ),
     );
     expect(mockUpdateEdge).not.toHaveBeenCalledWith(

--- a/tests/unit/pages/Processes/Components/create.test.tsx
+++ b/tests/unit/pages/Processes/Components/create.test.tsx
@@ -197,11 +197,13 @@ jest.mock('@/services/general/util', () => {
 });
 
 const mockCreateProcess = jest.fn();
+const mockCreateProcessVersion = jest.fn();
 const mockGetProcessDetail = jest.fn();
 
 jest.mock('@/services/processes/api', () => ({
   __esModule: true,
   createProcess: (...args: any[]) => mockCreateProcess(...args),
+  createProcessVersion: (...args: any[]) => mockCreateProcessVersion(...args),
   getProcessDetail: (...args: any[]) => mockGetProcessDetail(...args),
 }));
 
@@ -237,6 +239,7 @@ describe('ProcessCreate component', () => {
     jest.clearAllMocks();
     actionRef.current.reload.mockClear();
     mockCreateProcess.mockResolvedValue({ data: { id: 'generated-id' } });
+    mockCreateProcessVersion.mockResolvedValue({ data: { id: 'generated-id' } });
   });
 
   it('submits new process and normalizes allocations when no fraction is set', async () => {
@@ -380,7 +383,9 @@ describe('ProcessCreate component', () => {
     });
 
     expect(mockCreateProcess).toHaveBeenCalledWith('generated-id', expect.any(Object));
-    expect(mockAntdMessage.error).toHaveBeenCalledWith('Data with the same ID already exists.');
+    expect(mockAntdMessage.error).toHaveBeenCalledWith(
+      'Data with the same ID and version already exists.',
+    );
     expect(actionRef.current.reload).not.toHaveBeenCalled();
   });
 
@@ -474,7 +479,7 @@ describe('ProcessCreate component', () => {
         exchange: [],
       },
     });
-    mockCreateProcess.mockResolvedValueOnce({
+    mockCreateProcessVersion.mockResolvedValueOnce({
       data: null,
       error: {},
     });
@@ -562,8 +567,9 @@ describe('ProcessCreate component', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() =>
-      expect(mockCreateProcess).toHaveBeenCalledWith(
+      expect(mockCreateProcessVersion).toHaveBeenCalledWith(
         'process-1',
+        '1.0.0',
         expect.not.objectContaining({
           LCIAResults: expect.anything(),
         }),
@@ -619,13 +625,13 @@ describe('ProcessCreate component', () => {
     expect(latestProcessFormProps.exchangeDataSource).toEqual([]);
   });
 
-  it('falls back to an empty id when createVersion is opened without an id at runtime', async () => {
+  it('falls back to empty create-version identifiers when runtime props are missing', async () => {
     render(
       <ProcessCreate
         {...baseProps}
         actionType={'createVersion' as any}
         id={undefined as any}
-        version='1.0.0'
+        version={undefined as any}
         newVersion='03.00.000'
       />,
     );
@@ -633,7 +639,9 @@ describe('ProcessCreate component', () => {
     fireEvent.click(screen.getByRole('button', { name: 'create' }));
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-    await waitFor(() => expect(mockCreateProcess).toHaveBeenCalledWith('', expect.anything()));
+    await waitFor(() =>
+      expect(mockCreateProcessVersion).toHaveBeenCalledWith('', '', expect.anything()),
+    );
   });
 
   it('opens automatically from imported data and reuses the imported UUID on submit', async () => {

--- a/tests/unit/pages/Sources/SourceCreate.test.tsx
+++ b/tests/unit/pages/Sources/SourceCreate.test.tsx
@@ -337,6 +337,7 @@ jest.mock('@/pages/Sources/Components/form', () => {
 jest.mock('@/services/sources/api', () => ({
   __esModule: true,
   createSource: jest.fn(),
+  createSourceVersion: jest.fn(),
   getSourceDetail: jest.fn(),
 }));
 
@@ -357,8 +358,11 @@ jest.mock('@/services/supabase/key', () => ({
   supabaseStorageBucket: 'sources',
 }));
 
-const { createSource: mockCreateSource, getSourceDetail: mockGetSourceDetail } =
-  jest.requireMock('@/services/sources/api');
+const {
+  createSource: mockCreateSource,
+  createSourceVersion: mockCreateSourceVersion,
+  getSourceDetail: mockGetSourceDetail,
+} = jest.requireMock('@/services/sources/api');
 const { genSourceFromData: mockGenSourceFromData } = jest.requireMock('@/services/sources/util');
 const {
   getThumbFileUrls: mockGetThumbFileUrls,
@@ -374,6 +378,7 @@ describe('SourceCreate component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockCreateSource.mockResolvedValue({ data: [{ id: 'source-new' }] });
+    mockCreateSourceVersion.mockResolvedValue({ data: [{ id: 'source-new' }] });
     mockGetSourceDetail.mockResolvedValue({
       data: { json: { sourceDataSet: {} } },
     });
@@ -462,8 +467,9 @@ describe('SourceCreate component', () => {
     await user.click(within(drawer).getByRole('button', { name: 'Save' }));
 
     await waitFor(() =>
-      expect(mockCreateSource).toHaveBeenCalledWith(
+      expect(mockCreateSourceVersion).toHaveBeenCalledWith(
         'source-1',
+        '1.0.0',
         expect.objectContaining({
           sourceInformation: expect.objectContaining({
             dataSetInformation: expect.objectContaining({
@@ -478,6 +484,28 @@ describe('SourceCreate component', () => {
           }),
         }),
       ),
+    );
+  });
+
+  it('falls back to empty create-version identifiers when runtime props are missing', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <SourceCreate
+        lang='en'
+        actionRef={{ current: { reload: jest.fn() } } as any}
+        actionType='createVersion'
+        {...({ id: undefined, version: undefined } as any)}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    const drawer = await screen.findByRole('dialog', { name: 'Create Source' });
+    await user.click(within(drawer).getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(mockCreateSourceVersion).toHaveBeenCalledWith('', '', expect.any(Object)),
     );
   });
 
@@ -523,7 +551,7 @@ describe('SourceCreate component', () => {
 
     await waitFor(() =>
       expect(getMockAntdMessage().error).toHaveBeenCalledWith(
-        'Data with the same ID already exists.',
+        'Data with the same ID and version already exists.',
       ),
     );
     expect(actionRef.current.reload).not.toHaveBeenCalled();

--- a/tests/unit/pages/Unitgroups/Components/form.test.tsx
+++ b/tests/unit/pages/Unitgroups/Components/form.test.tsx
@@ -439,7 +439,10 @@ describe('UnitGroupForm', () => {
       />,
     );
 
-    expect(screen.getAllByRole('textbox')[1]).toBeDisabled();
+    expect(screen.getByTestId('dataset-create-version-auto-message')).toBeDisabled();
+    expect(screen.getByTestId('dataset-create-version-auto-message')).toHaveValue(
+      'The new version will be generated automatically.',
+    );
     expect(screen.getByTestId('contact-select')).toHaveTextContent('"showRequiredLabel":true');
   });
 
@@ -552,7 +555,10 @@ describe('UnitGroupForm', () => {
           formType='createVersion'
         />,
       );
-      expect(screen.getAllByRole('textbox')[1]).toBeDisabled();
+      expect(screen.getByTestId('dataset-create-version-auto-message')).toBeDisabled();
+      expect(screen.getByTestId('dataset-create-version-auto-message')).toHaveValue(
+        'The new version will be generated automatically.',
+      );
       expect(screen.getByTestId('contact-select')).toHaveTextContent('"rulesCount":0');
     });
   });

--- a/tests/unit/pages/Unitgroups/UnitComponents.test.tsx
+++ b/tests/unit/pages/Unitgroups/UnitComponents.test.tsx
@@ -85,6 +85,7 @@ jest.mock('@/services/general/util', () => ({
 }));
 
 const mockCreateUnitGroup = jest.fn();
+const mockCreateUnitGroupVersion = jest.fn();
 const mockDeleteUnitGroup = jest.fn();
 const mockGetUnitGroupDetail = jest.fn();
 const mockGetReferenceUnit = jest.fn();
@@ -93,6 +94,7 @@ let lastUnitEditFormApi: any = null;
 jest.mock('@/services/unitgroups/api', () => ({
   __esModule: true,
   createUnitGroup: (...args: any[]) => mockCreateUnitGroup(...args),
+  createUnitGroupVersion: (...args: any[]) => mockCreateUnitGroupVersion(...args),
   deleteUnitGroup: (...args: any[]) => mockDeleteUnitGroup(...args),
   getUnitGroupDetail: (...args: any[]) => mockGetUnitGroupDetail(...args),
   getReferenceUnit: (...args: any[]) => mockGetReferenceUnit(...args),
@@ -598,6 +600,10 @@ describe('Unitgroups unit components', () => {
       data: [{ id: 'generated-unit-group-id', version: '1.0' }],
       error: null,
     });
+    mockCreateUnitGroupVersion.mockResolvedValue({
+      data: [{ id: 'generated-unit-group-id', version: '1.0' }],
+      error: null,
+    });
     mockDeleteUnitGroup.mockResolvedValue({
       status: 204,
       error: null,
@@ -721,8 +727,9 @@ describe('Unitgroups unit components', () => {
     await user.click(within(drawer).getByRole('button', { name: /save/i }));
 
     await waitFor(() =>
-      expect(mockCreateUnitGroup).toHaveBeenCalledWith(
+      expect(mockCreateUnitGroupVersion).toHaveBeenCalledWith(
         'unit-group-1',
+        '1.0.0',
         expect.objectContaining({
           administrativeInformation: expect.objectContaining({
             publicationAndOwnership: expect.objectContaining({
@@ -795,7 +802,9 @@ describe('Unitgroups unit components', () => {
     await user.click(within(drawer).getByRole('button', { name: /save/i }));
 
     await waitFor(() =>
-      expect(message.error).toHaveBeenCalledWith('Data with the same ID already exists.'),
+      expect(message.error).toHaveBeenCalledWith(
+        'Data with the same ID and version already exists.',
+      ),
     );
     expect(actionRef.current.reload).not.toHaveBeenCalled();
     expect(screen.getByRole('dialog', { name: /create/i })).toBeInTheDocument();
@@ -934,7 +943,7 @@ describe('Unitgroups unit components', () => {
     expect(within(drawer).getByText('Units: 0')).toBeInTheDocument();
   });
 
-  it('skips detail loading when createVersion props are missing at runtime and falls back to an empty id', async () => {
+  it('skips detail loading when createVersion props are missing at runtime and falls back to empty identifiers', async () => {
     const user = userEvent.setup();
 
     renderWithProviders(
@@ -942,7 +951,7 @@ describe('Unitgroups unit components', () => {
         lang='en'
         actionRef={{ current: { reload: jest.fn() } } as any}
         actionType='createVersion'
-        version='1.0.0'
+        version={undefined as any}
         {...({ id: undefined } as any)}
       />,
     );
@@ -954,8 +963,8 @@ describe('Unitgroups unit components', () => {
 
     await user.click(within(drawer).getByRole('button', { name: /save/i }));
 
-    await waitFor(() => expect(mockCreateUnitGroup).toHaveBeenCalled());
-    expect(mockCreateUnitGroup).toHaveBeenCalledWith('', expect.any(Object));
+    await waitFor(() => expect(mockCreateUnitGroupVersion).toHaveBeenCalled());
+    expect(mockCreateUnitGroupVersion).toHaveBeenCalledWith('', '', expect.any(Object));
   });
 
   it('closes unit group creation without saving when cancelled', async () => {

--- a/tests/unit/services/contacts/api.test.ts
+++ b/tests/unit/services/contacts/api.test.ts
@@ -25,6 +25,7 @@ describe('Contacts API Service', () => {
     buildLangNormalizationMetadata,
     getTeamIdByUserId,
     invokeDatasetCommand,
+    invokeDatasetCreateVersion,
     normalizeLangPayloadForSave,
   } = jest.requireMock('@/services/general/api');
   const { getCachedClassificationData } = jest.requireMock('@/services/classifications/cache');
@@ -162,6 +163,79 @@ describe('Contacts API Service', () => {
       const result = await createContact('contact-123', {});
 
       expect(result.data?.[0].rule_verification).toBe(false);
+    });
+
+    it('should create a new contact version through the create-version command', async () => {
+      const { createContactVersion } = require('@/services/contacts/api');
+      invokeDatasetCreateVersion.mockResolvedValue({
+        data: [{ id: 'contact-123', version: '01.00.001', rule_verification: true }],
+        error: null,
+        count: null,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await createContactVersion('contact-123', '01.00.000', {});
+
+      expect(invokeDatasetCreateVersion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'contact-123',
+          table: 'contacts',
+          sourceVersion: '01.00.000',
+          jsonOrdered: expect.any(Object),
+          ruleVerification: true,
+        }),
+        {
+          ruleVerification: true,
+        },
+      );
+      expect(result.data?.[0].version).toBe('01.00.001');
+    });
+
+    it('should create a new contact version when the user has no team id', async () => {
+      const { createContactVersion } = require('@/services/contacts/api');
+      getTeamIdByUserId.mockResolvedValue(null);
+      invokeDatasetCreateVersion.mockResolvedValue({
+        data: [{ id: 'contact-no-team', version: '01.00.001' }],
+        error: null,
+        count: null,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await createContactVersion('contact-no-team', '01.00.000', {});
+
+      expect(invokeDatasetCreateVersion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'contact-no-team',
+          table: 'contacts',
+          sourceVersion: '01.00.000',
+        }),
+        expect.any(Object),
+      );
+      expect(result.data?.[0].version).toBe('01.00.001');
+    });
+
+    it('should return a validation error when language normalization fails during create-version', async () => {
+      const { createContactVersion } = require('@/services/contacts/api');
+
+      normalizeLangPayloadForSave.mockResolvedValue({
+        payload: undefined,
+        validationError: 'invalid_multilang_contact_version',
+      });
+
+      const result = await createContactVersion('contact-123', '01.00.000', {});
+
+      expect(invokeDatasetCreateVersion).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        data: null,
+        status: 400,
+        statusText: 'LANG_VALIDATION_ERROR',
+        error: {
+          code: 'LANG_VALIDATION_ERROR',
+          message: 'invalid_multilang_contact_version',
+        },
+      });
     });
 
     it('should return a validation error when language normalization fails during create', async () => {

--- a/tests/unit/services/flowproperties/api.test.ts
+++ b/tests/unit/services/flowproperties/api.test.ts
@@ -17,6 +17,7 @@ jest.mock('@tiangong-lca/tidas-sdk', () => ({
 
 import {
   createFlowproperties,
+  createFlowpropertiesVersion,
   deleteFlowproperties,
   getFlowpropertyDetail,
   getFlowpropertyTableAll,
@@ -69,6 +70,7 @@ jest.mock('@/services/general/api', () => ({
   getDataDetail: jest.fn(),
   getTeamIdByUserId: jest.fn(),
   invokeDatasetCommand: jest.fn(),
+  invokeDatasetCreateVersion: jest.fn(),
   normalizeLangPayloadForSave: jest.fn(),
 }));
 
@@ -83,6 +85,7 @@ const {
   getDataDetail,
   getTeamIdByUserId,
   invokeDatasetCommand,
+  invokeDatasetCreateVersion,
   normalizeLangPayloadForSave,
 } = jest.requireMock('@/services/general/api');
 const { createFlowProperty: mockCreateFlowProperty } = jest.requireMock('@tiangong-lca/tidas-sdk');
@@ -94,6 +97,13 @@ describe('FlowProperties API Service (src/services/flowproperties/api.ts)', () =
     jest.clearAllMocks();
     supabase.auth.getSession.mockResolvedValue(mockSession);
     invokeDatasetCommand.mockResolvedValue({
+      data: [],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: 'OK',
+    });
+    invokeDatasetCreateVersion.mockResolvedValue({
       data: [],
       error: null,
       count: null,
@@ -219,6 +229,63 @@ describe('FlowProperties API Service (src/services/flowproperties/api.ts)', () =
         }),
         expect.objectContaining({
           ruleVerification: true,
+        }),
+      );
+    });
+  });
+
+  describe('createFlowpropertiesVersion', () => {
+    it('should create a new flow property version through the create-version command', async () => {
+      const mockId = 'flowprop-123';
+      const mockData = { flowPropertiesInformation: {} };
+      const mockOrderedData = { ordered: true };
+      const mockResult = {
+        data: [{ id: mockId, version: '01.00.001', rule_verification: true }],
+        error: null,
+        count: null,
+        status: 200,
+        statusText: 'OK',
+      };
+
+      genFlowpropertyJsonOrdered.mockReturnValue(mockOrderedData);
+      invokeDatasetCreateVersion.mockResolvedValue(mockResult);
+
+      const result = await createFlowpropertiesVersion(mockId, '01.00.000', mockData);
+
+      expect(invokeDatasetCreateVersion).toHaveBeenCalledWith(
+        {
+          id: mockId,
+          table: 'flowproperties',
+          sourceVersion: '01.00.000',
+          jsonOrdered: mockOrderedData,
+          ruleVerification: true,
+        },
+        {
+          ruleVerification: true,
+        },
+      );
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should return a language validation error before invoking create-version', async () => {
+      genFlowpropertyJsonOrdered.mockReturnValue({ ordered: true });
+      normalizeLangPayloadForSave.mockResolvedValue({
+        payload: undefined,
+        validationError: 'invalid flow property language payload',
+      });
+
+      const result = await createFlowpropertiesVersion('flowprop-123', '01.00.000', {});
+
+      expect(invokeDatasetCreateVersion).not.toHaveBeenCalled();
+      expect(result).toEqual(
+        expect.objectContaining({
+          data: null,
+          status: 400,
+          statusText: 'LANG_VALIDATION_ERROR',
+          error: expect.objectContaining({
+            code: 'LANG_VALIDATION_ERROR',
+            message: 'invalid flow property language payload',
+          }),
         }),
       );
     });

--- a/tests/unit/services/flows/api.test.ts
+++ b/tests/unit/services/flows/api.test.ts
@@ -5,6 +5,7 @@
 
 import {
   createFlows,
+  createFlowsVersion,
   deleteFlows,
   flow_hybrid_search,
   getFlowDetail,
@@ -76,6 +77,7 @@ jest.mock('@/services/general/api', () => ({
   getDataDetail: jest.fn(),
   getTeamIdByUserId: jest.fn(),
   invokeDatasetCommand: jest.fn(),
+  invokeDatasetCreateVersion: jest.fn(),
   normalizeLangPayloadForSave: jest.fn(),
 }));
 
@@ -85,6 +87,7 @@ const {
   getDataDetail: mockGetDataDetail,
   getTeamIdByUserId: mockGetTeamIdByUserId,
   invokeDatasetCommand: mockInvokeDatasetCommand,
+  invokeDatasetCreateVersion: mockInvokeDatasetCreateVersion,
   normalizeLangPayloadForSave: mockNormalizeLangPayloadForSave,
 } = jest.requireMock('@/services/general/api');
 
@@ -324,6 +327,13 @@ beforeEach(() => {
     status: 200,
     statusText: 'OK',
   });
+  mockInvokeDatasetCreateVersion.mockResolvedValue({
+    data: [],
+    error: null,
+    count: null,
+    status: 200,
+    statusText: 'OK',
+  });
   mockNormalizeLangPayloadForSave.mockImplementation(async (payload: any) => ({
     payload,
     validationError: undefined,
@@ -388,6 +398,58 @@ describe('createFlows', () => {
     const result = await createFlows('flow-id', { name: 'Flow payload' });
 
     expect(mockFrom).not.toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({
+        data: null,
+        status: 400,
+        statusText: 'LANG_VALIDATION_ERROR',
+        error: expect.objectContaining({
+          code: 'LANG_VALIDATION_ERROR',
+          message: 'English translation required',
+        }),
+      }),
+    );
+  });
+});
+
+describe('createFlowsVersion', () => {
+  it('stores a new flow version through the create-version command', async () => {
+    const createResult = {
+      data: [{ id: 'flow-id', version: '01.00.001' }],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: 'OK',
+    };
+    mockInvokeDatasetCreateVersion.mockResolvedValue(createResult as any);
+
+    const result = await createFlowsVersion('flow-id', '01.00.000', { name: 'Flow payload' });
+
+    expect(mockGenFlowJsonOrdered).toHaveBeenCalledWith('flow-id', { name: 'Flow payload' });
+    expect(mockInvokeDatasetCreateVersion).toHaveBeenCalledWith(
+      {
+        id: 'flow-id',
+        table: 'flows',
+        sourceVersion: '01.00.000',
+        jsonOrdered: expect.objectContaining({ id: 'flow-id' }),
+        ruleVerification: true,
+      },
+      {
+        ruleVerification: true,
+      },
+    );
+    expect(result).toBe(createResult);
+  });
+
+  it('returns a language validation error before invoking create-version', async () => {
+    mockNormalizeLangPayloadForSave.mockResolvedValue({
+      payload: undefined,
+      validationError: 'English translation required',
+    });
+
+    const result = await createFlowsVersion('flow-id', '01.00.000', { name: 'Flow payload' });
+
+    expect(mockInvokeDatasetCreateVersion).not.toHaveBeenCalled();
     expect(result).toEqual(
       expect.objectContaining({
         data: null,

--- a/tests/unit/services/general/api.test.ts
+++ b/tests/unit/services/general/api.test.ts
@@ -716,6 +716,84 @@ describe('invokeDatasetCommand', () => {
     });
   });
 
+  it('invokes the create-version command boundary with the supplied body', async () => {
+    mockAuthGetSession.mockResolvedValue({ data: { session: { access_token: 'token-cmd' } } });
+    mockFunctionsInvoke.mockResolvedValue({
+      data: {
+        ok: true,
+        command: 'dataset_create_version',
+        data: {
+          id: sampleId,
+          version: '01.00.001',
+        },
+      },
+      error: null,
+    });
+
+    const body = {
+      id: sampleId,
+      table: 'flows' as const,
+      sourceVersion: sampleVersion,
+      jsonOrdered: { ordered: true },
+      ruleVerification: true,
+    };
+
+    const result = await generalApi.invokeDatasetCreateVersion(body, {
+      ruleVerification: true,
+    });
+
+    expect(mockFunctionsInvoke).toHaveBeenCalledWith('app_dataset_create_version', {
+      headers: { Authorization: 'Bearer token-cmd' },
+      body,
+      region: expect.anything(),
+    });
+    expect(result).toEqual({
+      data: [
+        {
+          id: sampleId,
+          version: '01.00.001',
+          rule_verification: true,
+        },
+      ],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: 'OK',
+    });
+  });
+
+  it('uses default create-version command options when omitted', async () => {
+    mockAuthGetSession.mockResolvedValue({ data: { session: { access_token: 'token-cmd' } } });
+    mockFunctionsInvoke.mockResolvedValue({
+      data: {
+        ok: true,
+        command: 'dataset_create_version',
+        data: {
+          id: sampleId,
+          version: '01.00.001',
+        },
+      },
+      error: null,
+    });
+
+    await generalApi.invokeDatasetCreateVersion({
+      id: sampleId,
+      table: 'flows',
+      sourceVersion: sampleVersion,
+      jsonOrdered: { ordered: true },
+    });
+
+    expect(mockFunctionsInvoke).toHaveBeenCalledWith(
+      'app_dataset_create_version',
+      expect.objectContaining({
+        body: expect.objectContaining({
+          id: sampleId,
+          sourceVersion: sampleVersion,
+        }),
+      }),
+    );
+  });
+
   it('returns an empty normalized array when the command envelope has null data', async () => {
     mockAuthGetSession.mockResolvedValue({ data: { session: { access_token: 'token-cmd' } } });
     mockFunctionsInvoke.mockResolvedValue({

--- a/tests/unit/services/lifeCycleModels/api.test.ts
+++ b/tests/unit/services/lifeCycleModels/api.test.ts
@@ -1099,6 +1099,48 @@ describe('createLifeCycleModel', () => {
     });
     expect(result).toEqual(edgePayload);
   });
+
+  it('passes allocateVersion metadata when creating a lifecycle model version', async () => {
+    const rawJson = buildLifecycleModelJsonOrdered();
+    const edgePayload = buildSaveResult({
+      version: '01.00.001',
+      lifecycleModel: {
+        id: sampleModelId,
+        version: '01.00.001',
+        json: {},
+        json_tg: { submodels: [] },
+        ruleVerification: true,
+      },
+    });
+    mockGenLifeCycleModelJsonOrdered.mockReturnValueOnce(rawJson);
+    mockNormalizeLangPayloadForSave.mockResolvedValueOnce({
+      payload: rawJson,
+      validationError: undefined,
+    });
+    mockGetTeamIdByUserId.mockResolvedValueOnce(undefined);
+    mockGenLifeCycleModelProcesses.mockResolvedValueOnce({
+      lifeCycleModelProcesses: [],
+      up2DownEdges: [],
+    });
+    mockFunctionsInvoke.mockResolvedValueOnce(createMockEdgeFunctionResponse(edgePayload));
+
+    const result = await lifeCycleModelsApi.createLifeCycleModel(
+      {
+        id: sampleModelId,
+        model: { nodes: [], edges: [] },
+      },
+      undefined,
+      { sourceVersion: '01.00.000' },
+    );
+
+    expect(mockFunctionsInvoke.mock.calls[0][1].body).toMatchObject({
+      mode: 'create',
+      modelId: sampleModelId,
+      allocateVersion: true,
+      sourceVersion: '01.00.000',
+    });
+    expect(result).toEqual(edgePayload);
+  });
 });
 
 describe('updateLifeCycleModel', () => {

--- a/tests/unit/services/processes/api.test.ts
+++ b/tests/unit/services/processes/api.test.ts
@@ -37,6 +37,7 @@ const mockGetTeamIdByUserId = jest.fn();
 const mockGetRefData = jest.fn();
 const mockContributeSource = jest.fn();
 const mockInvokeDatasetCommand = jest.fn();
+const mockInvokeDatasetCreateVersion = jest.fn();
 const mockNormalizeLangPayloadForSave = jest.fn();
 const mockResolveFunctionInvokeError = jest.fn();
 const mockBuildLangNormalizationMetadata = jest.fn();
@@ -58,6 +59,7 @@ jest.mock('@/services/general/api', () => ({
   getRefData: (...args: any[]) => mockGetRefData.apply(null, args),
   contributeSource: (...args: any[]) => mockContributeSource.apply(null, args),
   invokeDatasetCommand: (...args: any[]) => mockInvokeDatasetCommand.apply(null, args),
+  invokeDatasetCreateVersion: (...args: any[]) => mockInvokeDatasetCreateVersion.apply(null, args),
   normalizeLangPayloadForSave: (...args: any[]) =>
     mockNormalizeLangPayloadForSave.apply(null, args),
   resolveFunctionInvokeError: (...args: any[]) => mockResolveFunctionInvokeError.apply(null, args),
@@ -190,6 +192,7 @@ beforeEach(() => {
   mockRpc.mockReset();
   mockGetTeamIdByUserId.mockReset();
   mockInvokeDatasetCommand.mockReset();
+  mockInvokeDatasetCreateVersion.mockReset();
   mockNormalizeLangPayloadForSave.mockReset();
   mockResolveFunctionInvokeError.mockReset();
   mockBuildLangNormalizationMetadata.mockReset();
@@ -219,6 +222,13 @@ beforeEach(() => {
   mockGetCachedClassificationData.mockResolvedValue({});
   mockGetLifeCyclesByIdAndVersion.mockResolvedValue({ data: [] });
   mockInvokeDatasetCommand.mockResolvedValue({
+    data: [],
+    error: null,
+    count: null,
+    status: 200,
+    statusText: 'OK',
+  });
+  mockInvokeDatasetCreateVersion.mockResolvedValue({
     data: [],
     error: null,
     count: null,
@@ -456,6 +466,79 @@ describe('createProcess', () => {
       count: null,
     });
     expect(mockFrom).not.toHaveBeenCalled();
+  });
+});
+
+describe('createProcessVersion', () => {
+  it('creates a new process version with server-owned version allocation', async () => {
+    const createResult = {
+      data: [{ id: sampleId, version: '01.00.001' }],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: 'OK',
+    };
+    mockInvokeDatasetCreateVersion.mockResolvedValue(createResult);
+
+    const withModelResult = await processesApi.createProcessVersion(
+      sampleId,
+      sampleVersion,
+      { raw: true },
+      'model-1',
+    );
+
+    expect(mockGenProcessJsonOrdered).toHaveBeenCalledWith(sampleId, { raw: true });
+    expect(mockInvokeDatasetCreateVersion).toHaveBeenCalledWith(
+      {
+        id: sampleId,
+        table: 'processes',
+        sourceVersion: sampleVersion,
+        jsonOrdered: { ordered: true },
+        modelId: 'model-1',
+        ruleVerification: true,
+      },
+      {
+        ruleVerification: true,
+      },
+    );
+    expect(withModelResult).toBe(createResult);
+
+    mockInvokeDatasetCreateVersion.mockClear();
+
+    await processesApi.createProcessVersion(sampleId, sampleVersion, { raw: true });
+
+    expect(mockInvokeDatasetCreateVersion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelId: null,
+      }),
+      {
+        ruleVerification: true,
+      },
+    );
+  });
+
+  it('returns a structured validation error before invoking create-version', async () => {
+    mockNormalizeLangPayloadForSave.mockResolvedValueOnce({
+      payload: { normalized: true },
+      validationError: 'invalid_language_payload',
+    });
+
+    const result = await processesApi.createProcessVersion(sampleId, sampleVersion, { raw: true });
+
+    expect(mockInvokeDatasetCreateVersion).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      data: null,
+      error: {
+        message: 'invalid_language_payload',
+        code: 'LANG_VALIDATION_ERROR',
+        details: '',
+        hint: '',
+        name: 'LangValidationError',
+      },
+      status: 400,
+      statusText: 'LANG_VALIDATION_ERROR',
+      count: null,
+    });
   });
 });
 

--- a/tests/unit/services/sources/api.test.ts
+++ b/tests/unit/services/sources/api.test.ts
@@ -19,6 +19,7 @@ jest.mock('@tiangong-lca/tidas-sdk', () => ({
 
 import {
   createSource,
+  createSourceVersion,
   deleteSource,
   getSourceDetail,
   getSourcesByIdsAndVersions,
@@ -78,6 +79,7 @@ jest.mock('@/services/general/api', () => ({
   getDataDetail: jest.fn(),
   getTeamIdByUserId: jest.fn(),
   invokeDatasetCommand: jest.fn(),
+  invokeDatasetCreateVersion: jest.fn(),
   normalizeLangPayloadForSave: jest.fn(),
 }));
 
@@ -95,6 +97,7 @@ const {
   getDataDetail,
   getTeamIdByUserId,
   invokeDatasetCommand,
+  invokeDatasetCreateVersion,
   normalizeLangPayloadForSave,
 } = jest.requireMock('@/services/general/api');
 const { genSourceJsonOrdered } = jest.requireMock('@/services/sources/util');
@@ -107,6 +110,13 @@ describe('Sources API Service (src/services/sources/api.ts)', () => {
     jest.clearAllMocks();
     supabase.auth.getSession.mockResolvedValue(mockSession);
     invokeDatasetCommand.mockResolvedValue({
+      data: [],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: 'OK',
+    });
+    invokeDatasetCreateVersion.mockResolvedValue({
       data: [],
       error: null,
       count: null,
@@ -263,6 +273,57 @@ describe('Sources API Service (src/services/sources/api.ts)', () => {
           ruleVerification: true,
         },
       );
+    });
+  });
+
+  describe('createSourceVersion', () => {
+    it('should create a new source version through the create-version command', async () => {
+      const mockId = 'source-123';
+      const mockData = { sourceDataSet: {} };
+      const mockOrderedData = { ordered: true };
+      const mockCommandResult = createMockSuccessResponse([
+        { id: mockId, version: '01.00.001', rule_verification: true },
+      ]);
+
+      genSourceJsonOrdered.mockReturnValue(mockOrderedData);
+      invokeDatasetCreateVersion.mockResolvedValue(mockCommandResult);
+
+      const result = await createSourceVersion(mockId, '01.00.000', mockData);
+
+      expect(genSourceJsonOrdered).toHaveBeenCalledWith(mockId, mockData);
+      expect(invokeDatasetCreateVersion).toHaveBeenCalledWith(
+        {
+          id: mockId,
+          table: 'sources',
+          sourceVersion: '01.00.000',
+          jsonOrdered: mockOrderedData,
+          ruleVerification: true,
+        },
+        {
+          ruleVerification: true,
+        },
+      );
+      expect(result).toEqual(mockCommandResult);
+    });
+
+    it('should return a language validation error before invoking create-version', async () => {
+      genSourceJsonOrdered.mockReturnValue({ ordered: true });
+      normalizeLangPayloadForSave.mockResolvedValue({
+        payload: undefined,
+        validationError: 'Source title language payload is invalid',
+      });
+
+      const result = await createSourceVersion('source-123', '01.00.000', { sourceDataSet: {} });
+
+      expect(invokeDatasetCreateVersion).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        data: null,
+        error: {
+          code: 'LANG_VALIDATION_ERROR',
+          message: 'Source title language payload is invalid',
+        },
+        status: 400,
+      });
     });
   });
 

--- a/tests/unit/services/unitgroups/api.test.ts
+++ b/tests/unit/services/unitgroups/api.test.ts
@@ -5,6 +5,7 @@
 
 import {
   createUnitGroup,
+  createUnitGroupVersion,
   deleteUnitGroup,
   getReferenceUnit,
   getReferenceUnits,
@@ -63,6 +64,7 @@ jest.mock('@/services/general/api', () => ({
   getDataDetail: jest.fn(),
   getTeamIdByUserId: jest.fn(),
   invokeDatasetCommand: jest.fn(),
+  invokeDatasetCreateVersion: jest.fn(),
   normalizeLangPayloadForSave: jest.fn(),
 }));
 
@@ -72,6 +74,7 @@ const {
   getDataDetail: mockGetDataDetail,
   getTeamIdByUserId: mockGetTeamIdByUserId,
   invokeDatasetCommand: mockInvokeDatasetCommand,
+  invokeDatasetCreateVersion: mockInvokeDatasetCreateVersion,
   normalizeLangPayloadForSave: mockNormalizeLangPayloadForSave,
 } = jest.requireMock('@/services/general/api');
 
@@ -216,6 +219,13 @@ beforeEach(() => {
     status: 200,
     statusText: 'OK',
   });
+  mockInvokeDatasetCreateVersion.mockResolvedValue({
+    data: [],
+    error: null,
+    count: null,
+    status: 200,
+    statusText: 'OK',
+  });
   mockNormalizeLangPayloadForSave.mockImplementation(async (payload: any) => ({
     payload,
     validationError: undefined,
@@ -281,6 +291,59 @@ describe('createUnitGroup', () => {
     const result = await createUnitGroup('ug-1', { name: 'Unit Group' });
 
     expect(mockFrom).not.toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({
+        data: null,
+        status: 400,
+        statusText: 'LANG_VALIDATION_ERROR',
+        error: expect.objectContaining({
+          code: 'LANG_VALIDATION_ERROR',
+          message: 'English translation required',
+        }),
+      }),
+    );
+  });
+});
+
+describe('createUnitGroupVersion', () => {
+  it('stores a new unit group version through the create-version command', async () => {
+    const createResult = {
+      data: [{ id: 'ug-1', version: '01.00.001' }],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: 'OK',
+    };
+    mockGenUnitGroupJsonOrdered.mockReturnValueOnce({ data: 'ordered' });
+    mockInvokeDatasetCreateVersion.mockResolvedValueOnce(createResult as any);
+
+    const result = await createUnitGroupVersion('ug-1', '01.00.000', { name: 'Unit Group' });
+
+    expect(mockGenUnitGroupJsonOrdered).toHaveBeenCalledWith('ug-1', { name: 'Unit Group' });
+    expect(mockInvokeDatasetCreateVersion).toHaveBeenCalledWith(
+      {
+        id: 'ug-1',
+        table: 'unitgroups',
+        sourceVersion: '01.00.000',
+        jsonOrdered: { data: 'ordered' },
+        ruleVerification: true,
+      },
+      {
+        ruleVerification: true,
+      },
+    );
+    expect(result).toBe(createResult);
+  });
+
+  it('returns a language validation error before invoking create-version', async () => {
+    mockNormalizeLangPayloadForSave.mockResolvedValue({
+      payload: undefined,
+      validationError: 'English translation required',
+    });
+
+    const result = await createUnitGroupVersion('ug-1', '01.00.000', { name: 'Unit Group' });
+
+    expect(mockInvokeDatasetCreateVersion).not.toHaveBeenCalled();
     expect(result).toEqual(
       expect.objectContaining({
         data: null,


### PR DESCRIPTION
## Summary
- route create-version actions for contacts, sources, unit groups, flow properties, flows, and processes through `app_dataset_create_version`
- send lifecycle model create-version plans with `allocateVersion` and `sourceVersion` metadata for server-side allocation
- update duplicate-data copy to ID+version and add service/page coverage for the server-owned allocation paths

## Validation
- `npm run lint`
- `npm run tsc`
- `npm run build`
- focused `npm run test:ci -- ...` suites for updated pages and services
- pre-push gate: docpact + lint + full coverage + `test:coverage:assert-full`
- `scripts/docpact lint --root . --worktree --mode enforce`
- `git diff --check`

## Follow-up
- Requires the database RPC PR and Edge Functions companion PR, then root workspace submodule integration after the child PRs merge/promote.

Closes #529
