### PR TITLE
Release v0.0.26

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-06-11'
-lastReviewedCommit: 'c77383f05f4349d99d0708b12ca707b91b12ac19'
+lastReviewedAt: "2026-06-11"
+lastReviewedCommit: "3d0820ebd1042bac47e504463557b617ab01018c"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-11
-lastReviewedCommit: c77383f05f4349d99d0708b12ca707b91b12ac19
+lastReviewedCommit: cfaf826b89c7f8326e6c9dcb5b9b91caf6b4531e
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-06-11
-lastReviewedCommit: c77383f05f4349d99d0708b12ca707b91b12ac19
+lastReviewedCommit: cfaf826b89c7f8326e6c9dcb5b9b91caf6b4531e
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-06-11
-lastReviewedCommit: c77383f05f4349d99d0708b12ca707b91b12ac19
+lastReviewedCommit: 3d0820ebd1042bac47e504463557b617ab01018c
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-11
-lastReviewedCommit: c77383f05f4349d99d0708b12ca707b91b12ac19
+lastReviewedCommit: 3d0820ebd1042bac47e504463557b617ab01018c
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-06-11
-lastReviewedCommit: c77383f05f4349d99d0708b12ca707b91b12ac19
+lastReviewedCommit: 3d0820ebd1042bac47e504463557b617ab01018c
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-06-11
-lastReviewedCommit: c77383f05f4349d99d0708b12ca707b91b12ac19
+lastReviewedCommit: 3d0820ebd1042bac47e504463557b617ab01018c
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-06-11
-lastReviewedCommit: c77383f05f4349d99d0708b12ca707b91b12ac19
+lastReviewedCommit: 3d0820ebd1042bac47e504463557b617ab01018c
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-06-11
-lastReviewedCommit: c77383f05f4349d99d0708b12ca707b91b12ac19
+lastReviewedCommit: 3d0820ebd1042bac47e504463557b617ab01018c
 ---
 
 # Testing Troubleshooting

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
## Summary
- Bump `package.json` from `0.0.25` to `0.0.26` so the next canonical `main` push creates `v0.0.26` and runs the Build/release workflow.
- Record docpact review evidence for the release and testing gate docs touched by the version bump governance rule.

## Context
- Follows the merged promotion PR linancn/tiangong-lca-next#531.
- `v0.0.26` does not currently exist on the canonical repository.

## Validation
- `scripts/docpact lint --root /Users/foreveryoung/tiangong/workspace-worktree1/tiangong-lca-next --base origin/main --head HEAD --format json --output .docpact/runs/release-v0.0.26-final.json`
- `DOCPACT_BASE_REF=origin/main git push fork HEAD:codex/release-v0.0.26` ran the local pre-push gate successfully:
  - `npm run docpact:gate` against `origin/main`
  - `npm run lint`
  - `npm run test:coverage`
  - `npm run test:coverage:assert-full`
- Coverage result: 337 test suites passed, 4202 tests passed, 100% statements/branches/functions/lines across 352 tracked source files.

## Release expectation
- When merged into canonical `main`, `.github/workflows/build.yml` should create tag `v0.0.26` and continue the release gate, web deploy, and draft Electron release path.