### PR TITLE
[codex] Promote dev to main for v0.0.31 release

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-22"
-lastReviewedCommit: "723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab"
+lastReviewedCommit: "a2958acde58452e8c904fd728f8ea094d8708bec"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-22"
-lastReviewedCommit: "492e7b69a6d17fbc310f4c4f51e93d8955c11c30"
+lastReviewedCommit: "723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-22"
-lastReviewedCommit: "daaf614a1772294e60d44817dc6d80e1e4d74cb2"
+lastReviewedAt: "2026-06-23"
+lastReviewedCommit: "6616bbfa4b041c48a7b5e6f2a1b3eab2053c5f67"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-22"
-lastReviewedCommit: "a2958acde58452e8c904fd728f8ea094d8708bec"
+lastReviewedCommit: "497721d04d7b87c49f5f5cf65329b077f63ef24e"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-22"
-lastReviewedCommit: "776b2081e6142998e3cfefd72f489975edbee5f0"
+lastReviewedCommit: "492e7b69a6d17fbc310f4c4f51e93d8955c11c30"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 776b2081e6142998e3cfefd72f489975edbee5f0
+lastReviewedCommit: 492e7b69a6d17fbc310f4c4f51e93d8955c11c30
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-06-22
-lastReviewedCommit: e6e1af351e97f7d82b3a256fc852ec41e55fefb5
+lastReviewedAt: 2026-06-23
+lastReviewedCommit: 6616bbfa4b041c48a7b5e6f2a1b3eab2053c5f67
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 492e7b69a6d17fbc310f4c4f51e93d8955c11c30
+lastReviewedCommit: 723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: a2958acde58452e8c904fd728f8ea094d8708bec
+lastReviewedCommit: 497721d04d7b87c49f5f5cf65329b077f63ef24e
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab
+lastReviewedCommit: a2958acde58452e8c904fd728f8ea094d8708bec
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: a2958acde58452e8c904fd728f8ea094d8708bec
+lastReviewedCommit: 497721d04d7b87c49f5f5cf65329b077f63ef24e
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: b3882e098cc3c3e1dabf59a118b8b476cca1ac80
+lastReviewedCommit: 492e7b69a6d17fbc310f4c4f51e93d8955c11c30
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-06-22
-lastReviewedCommit: e6e1af351e97f7d82b3a256fc852ec41e55fefb5
+lastReviewedAt: 2026-06-23
+lastReviewedCommit: 6616bbfa4b041c48a7b5e6f2a1b3eab2053c5f67
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab
+lastReviewedCommit: a2958acde58452e8c904fd728f8ea094d8708bec
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 492e7b69a6d17fbc310f4c4f51e93d8955c11c30
+lastReviewedCommit: 723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: a2958acde58452e8c904fd728f8ea094d8708bec
+lastReviewedCommit: 497721d04d7b87c49f5f5cf65329b077f63ef24e
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 492e7b69a6d17fbc310f4c4f51e93d8955c11c30
+lastReviewedCommit: 723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab
+lastReviewedCommit: a2958acde58452e8c904fd728f8ea094d8708bec
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 776b2081e6142998e3cfefd72f489975edbee5f0
+lastReviewedCommit: 492e7b69a6d17fbc310f4c4f51e93d8955c11c30
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.js
   - .github/workflows/**
-lastReviewedAt: 2026-06-22
-lastReviewedCommit: daaf614a1772294e60d44817dc6d80e1e4d74cb2
+lastReviewedAt: 2026-06-23
+lastReviewedCommit: 6616bbfa4b041c48a7b5e6f2a1b3eab2053c5f67
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 492e7b69a6d17fbc310f4c4f51e93d8955c11c30
+lastReviewedCommit: 723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab
+lastReviewedCommit: a2958acde58452e8c904fd728f8ea094d8708bec
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: a2958acde58452e8c904fd728f8ea094d8708bec
+lastReviewedCommit: 497721d04d7b87c49f5f5cf65329b077f63ef24e
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 776b2081e6142998e3cfefd72f489975edbee5f0
+lastReviewedCommit: 492e7b69a6d17fbc310f4c4f51e93d8955c11c30
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab
+lastReviewedCommit: a2958acde58452e8c904fd728f8ea094d8708bec
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 776b2081e6142998e3cfefd72f489975edbee5f0
+lastReviewedCommit: 492e7b69a6d17fbc310f4c4f51e93d8955c11c30
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: a2958acde58452e8c904fd728f8ea094d8708bec
+lastReviewedCommit: 497721d04d7b87c49f5f5cf65329b077f63ef24e
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 492e7b69a6d17fbc310f4c4f51e93d8955c11c30
+lastReviewedCommit: 723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-06-22
-lastReviewedCommit: daaf614a1772294e60d44817dc6d80e1e4d74cb2
+lastReviewedAt: 2026-06-23
+lastReviewedCommit: 6616bbfa4b041c48a7b5e6f2a1b3eab2053c5f67
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 492e7b69a6d17fbc310f4c4f51e93d8955c11c30
+lastReviewedCommit: 723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab
+lastReviewedCommit: a2958acde58452e8c904fd728f8ea094d8708bec
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-06-22
-lastReviewedCommit: daaf614a1772294e60d44817dc6d80e1e4d74cb2
+lastReviewedAt: 2026-06-23
+lastReviewedCommit: 6616bbfa4b041c48a7b5e6f2a1b3eab2053c5f67
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 776b2081e6142998e3cfefd72f489975edbee5f0
+lastReviewedCommit: 492e7b69a6d17fbc310f4c4f51e93d8955c11c30
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: a2958acde58452e8c904fd728f8ea094d8708bec
+lastReviewedCommit: 497721d04d7b87c49f5f5cf65329b077f63ef24e
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 492e7b69a6d17fbc310f4c4f51e93d8955c11c30
+lastReviewedCommit: 723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: a2958acde58452e8c904fd728f8ea094d8708bec
+lastReviewedCommit: 497721d04d7b87c49f5f5cf65329b077f63ef24e
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-06-22
-lastReviewedCommit: daaf614a1772294e60d44817dc6d80e1e4d74cb2
+lastReviewedAt: 2026-06-23
+lastReviewedCommit: 6616bbfa4b041c48a7b5e6f2a1b3eab2053c5f67
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 776b2081e6142998e3cfefd72f489975edbee5f0
+lastReviewedCommit: 492e7b69a6d17fbc310f4c4f51e93d8955c11c30
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab
+lastReviewedCommit: a2958acde58452e8c904fd728f8ea094d8708bec
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-06-22
-lastReviewedCommit: daaf614a1772294e60d44817dc6d80e1e4d74cb2
+lastReviewedAt: 2026-06-23
+lastReviewedCommit: 6616bbfa4b041c48a7b5e6f2a1b3eab2053c5f67
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: a2958acde58452e8c904fd728f8ea094d8708bec
+lastReviewedCommit: 497721d04d7b87c49f5f5cf65329b077f63ef24e
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab
+lastReviewedCommit: a2958acde58452e8c904fd728f8ea094d8708bec
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 492e7b69a6d17fbc310f4c4f51e93d8955c11c30
+lastReviewedCommit: 723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 776b2081e6142998e3cfefd72f489975edbee5f0
+lastReviewedCommit: 492e7b69a6d17fbc310f4c4f51e93d8955c11c30
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-06-22
-lastReviewedCommit: daaf614a1772294e60d44817dc6d80e1e4d74cb2
+lastReviewedAt: 2026-06-23
+lastReviewedCommit: 6616bbfa4b041c48a7b5e6f2a1b3eab2053c5f67
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 776b2081e6142998e3cfefd72f489975edbee5f0
+lastReviewedCommit: 492e7b69a6d17fbc310f4c4f51e93d8955c11c30
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 492e7b69a6d17fbc310f4c4f51e93d8955c11c30
+lastReviewedCommit: 723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: 723e0c5244b9a85ec6aad07b2ba8e1aa8c1baaab
+lastReviewedCommit: a2958acde58452e8c904fd728f8ea094d8708bec
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-06-22
-lastReviewedCommit: a2958acde58452e8c904fd728f8ea094d8708bec
+lastReviewedCommit: 497721d04d7b87c49f5f5cf65329b077f63ef24e
 ---
 
 # Testing Troubleshooting

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",

--- a/src/components/LevelTextItem/form.tsx
+++ b/src/components/LevelTextItem/form.tsx
@@ -1,6 +1,7 @@
 import RequiredMark from '@/components/RequiredMark';
 import { getILCDClassification, getILCDFlowCategorization } from '@/services/classifications/api';
 import { Cascader, Form, Input, TreeSelect } from 'antd';
+import type { ReactNode } from 'react';
 import { FC, useEffect, useState } from 'react';
 import { FormattedMessage } from 'umi';
 type Props = {
@@ -13,6 +14,8 @@ type Props = {
   onData: () => void;
   rules?: any[];
   showRules?: boolean;
+  validationHelp?: ReactNode;
+  validationStatus?: 'success' | 'warning' | 'error' | 'validating';
 };
 
 const LevelTextItemForm: FC<Props> = ({
@@ -25,9 +28,12 @@ const LevelTextItemForm: FC<Props> = ({
   onData,
   rules = [],
   showRules = false,
+  validationHelp,
+  validationStatus,
 }) => {
   const [selectOptions, setSelectOptions] = useState<any>([]);
   const [hasClassId, setHasClassId] = useState<boolean>(false);
+  const hasRequiredRuleError = showRules && !hasClassId;
 
   const getNodePath = (
     targetId: string,
@@ -188,14 +194,16 @@ const LevelTextItemForm: FC<Props> = ({
         }
         name={[...name, 'showValue']}
         rules={rules}
-        validateStatus={showRules && !hasClassId ? 'error' : undefined}
+        validateStatus={hasRequiredRuleError ? 'error' : validationStatus}
         help={
-          showRules && !hasClassId ? (
+          hasRequiredRuleError ? (
             <FormattedMessage
               id='pages.contact.validator.classification.required'
               defaultMessage='Please input classification'
             />
-          ) : undefined
+          ) : (
+            validationHelp
+          )
         }
       >
         <TreeSelect

--- a/src/pages/Contacts/Components/edit.tsx
+++ b/src/pages/Contacts/Components/edit.tsx
@@ -7,6 +7,7 @@ import {
   ReffPath,
   buildValidationIssues,
   checkData,
+  collectValidationIssueRefTabNames,
   enrichValidationIssuesWithOwner,
   getAllRefObj,
   getErrRefTab,
@@ -102,6 +103,7 @@ const ContactEdit: FC<Props> = ({
   const [sdkValidationFocus, setSdkValidationFocus] = useState<ValidationIssueSdkDetail | null>(
     null,
   );
+  const [validationIssueTabNames, setValidationIssueTabNames] = useState<string[]>([]);
   const [pendingTabValidationKey, setPendingTabValidationKey] =
     useState<ContactDataSetObjectKeys | null>(null);
   const [autoCheckTriggered, setAutoCheckTriggered] = useState(false);
@@ -258,6 +260,7 @@ const ContactEdit: FC<Props> = ({
       setShowRules(false);
       setSdkValidationDetails([]);
       setSdkValidationFocus(null);
+      setValidationIssueTabNames([]);
       setPendingTabValidationKey(null);
       setAutoCheckTriggered(false);
       setRefCheckContextValue({ refCheckData: [] });
@@ -494,17 +497,13 @@ const ContactEdit: FC<Props> = ({
       setRefCheckData([]);
     }
     const errTabNames: string[] = [];
-    nonExistentRef.forEach((item: refDataType) => {
-      const tabName = getErrRefTab(item, initData);
-      if (tabName && !errTabNames.includes(tabName)) errTabNames.push(tabName);
-    });
-    unRuleVerification.forEach((item: refDataType) => {
-      const tabName = getErrRefTab(item, initData);
-      if (tabName && !errTabNames.includes(tabName)) errTabNames.push(tabName);
-    });
-    problemNodes.forEach((item) => {
-      const tabName = getErrRefTab(item, initData);
-      if (tabName && !errTabNames.includes(tabName)) errTabNames.push(tabName);
+    const { getRefTabNames, tabNames: referenceValidationTabNames } =
+      collectValidationIssueRefTabNames({
+        refs: [...nonExistentRef, ...unRuleVerification, ...problemNodes],
+        resolveTabName: (item) => getErrRefTab(item, initData),
+      });
+    referenceValidationTabNames.forEach((tabName) => {
+      if (!errTabNames.includes(tabName)) errTabNames.push(tabName);
     });
 
     const sdkValidation = validateDatasetWithSdk('contact data set', orderedJson);
@@ -536,12 +535,14 @@ const ContactEdit: FC<Props> = ({
     }
     const validationIssues = buildValidationIssues({
       datasetSdkValid: sdkValidation.success,
+      getRefTabNames,
       nonExistentRef,
       rootRef,
       sdkInvalidDetails: sdkIssueDetails,
       sdkInvalidTabNames,
       unRuleVerification,
     });
+    setValidationIssueTabNames(referenceValidationTabNames);
     const feedbackState = resolveDataCheckFeedbackState({
       hasValidationIssues:
         unRuleVerification.length > 0 ||
@@ -793,6 +794,7 @@ const ContactEdit: FC<Props> = ({
                 showRules={showRules}
                 sdkValidationDetails={sdkValidationDetails}
                 sdkValidationFocus={sdkValidationFocus}
+                validationIssueTabNames={validationIssueTabNames}
               />
             </ProForm>
           </RefCheckContext.Provider>

--- a/src/pages/Contacts/Components/form.tsx
+++ b/src/pages/Contacts/Components/form.tsx
@@ -10,7 +10,7 @@ import type { ValidationIssueSdkDetail } from '@/pages/Utils/review';
 import { useDatasetSdkValidationFormSupport } from '@/pages/Utils/validation/formSupport';
 import { ProFormInstance } from '@ant-design/pro-components';
 import { Card, Form, Input, Space, theme } from 'antd';
-import { FC, useState } from 'react';
+import { FC, useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 
 const CONTACT_SCHEMA_PATH_PREFIX = ['contactDataSet'];
@@ -25,6 +25,7 @@ type Props = {
   showRules?: boolean;
   sdkValidationDetails?: ValidationIssueSdkDetail[];
   sdkValidationFocus?: ValidationIssueSdkDetail | null;
+  validationIssueTabNames?: string[];
 };
 
 export const ContactForm: FC<Props> = ({
@@ -37,6 +38,7 @@ export const ContactForm: FC<Props> = ({
   showRules = false,
   sdkValidationDetails = [],
   sdkValidationFocus = null,
+  validationIssueTabNames = [],
 }) => {
   const { token } = theme.useToken();
   const intl = useIntl();
@@ -52,9 +54,13 @@ export const ContactForm: FC<Props> = ({
     schemaRoot: schema,
     showRules,
   });
+  const validationIssueTabs = useMemo(
+    () => new Set(validationIssueTabNames),
+    [validationIssueTabNames],
+  );
 
   const renderTabLabel = (key: string, id: string, defaultMessage: string) => {
-    const hasIssue = (sdkValidationCountsByTab[key] ?? 0) > 0;
+    const hasIssue = (sdkValidationCountsByTab[key] ?? 0) > 0 || validationIssueTabs.has(key);
 
     return (
       <span

--- a/src/pages/Flowproperties/Components/edit.tsx
+++ b/src/pages/Flowproperties/Components/edit.tsx
@@ -6,6 +6,7 @@ import type { ProblemNode, ValidationIssueSdkDetail, refDataType } from '@/pages
 import {
   buildValidationIssues,
   checkData,
+  collectValidationIssueRefTabNames,
   enrichValidationIssuesWithOwner,
   validateDatasetWithSdk,
 } from '@/pages/Utils/review';
@@ -105,6 +106,7 @@ const FlowpropertiesEdit: FC<Props> = ({
   const [sdkValidationFocus, setSdkValidationFocus] = useState<ValidationIssueSdkDetail | null>(
     null,
   );
+  const [validationIssueTabNames, setValidationIssueTabNames] = useState<string[]>([]);
   const [pendingTabValidationKey, setPendingTabValidationKey] =
     useState<FlowPropertyDataSetObjectKeys | null>(null);
   const [autoCheckTriggered, setAutoCheckTriggered] = useState(false);
@@ -278,6 +280,7 @@ const FlowpropertiesEdit: FC<Props> = ({
       setShowRules(false);
       setSdkValidationDetails([]);
       setSdkValidationFocus(null);
+      setValidationIssueTabNames([]);
       setPendingTabValidationKey(null);
       setAutoCheckTriggered(false);
       return;
@@ -420,17 +423,13 @@ const FlowpropertiesEdit: FC<Props> = ({
       setRefCheckData([]);
     }
     const errTabNames: string[] = [];
-    nonExistentRef.forEach((item) => {
-      const tabName = getErrRefTab(item, initData);
-      if (tabName && !errTabNames.includes(tabName)) errTabNames.push(tabName);
-    });
-    unRuleVerification.forEach((item) => {
-      const tabName = getErrRefTab(item, initData);
-      if (tabName && !errTabNames.includes(tabName)) errTabNames.push(tabName);
-    });
-    problemNodes.forEach((item) => {
-      const tabName = getErrRefTab(item, initData);
-      if (tabName && !errTabNames.includes(tabName)) errTabNames.push(tabName);
+    const { getRefTabNames, tabNames: referenceValidationTabNames } =
+      collectValidationIssueRefTabNames({
+        refs: [...nonExistentRef, ...unRuleVerification, ...problemNodes],
+        resolveTabName: (item) => getErrRefTab(item, initData),
+      });
+    referenceValidationTabNames.forEach((tabName) => {
+      if (!errTabNames.includes(tabName)) errTabNames.push(tabName);
     });
 
     const sdkValidation = validateDatasetWithSdk('flow property data set', orderedJson);
@@ -462,12 +461,14 @@ const FlowpropertiesEdit: FC<Props> = ({
     }
     const validationIssues = buildValidationIssues({
       datasetSdkValid: sdkValidation.success,
+      getRefTabNames,
       nonExistentRef,
       rootRef,
       sdkInvalidDetails: sdkIssueDetails,
       sdkInvalidTabNames,
       unRuleVerification,
     });
+    setValidationIssueTabNames(referenceValidationTabNames);
     const feedbackState = resolveDataCheckFeedbackState({
       hasValidationIssues:
         unRuleVerification.length > 0 ||
@@ -635,6 +636,7 @@ const FlowpropertiesEdit: FC<Props> = ({
                 showRules={showRules}
                 sdkValidationDetails={sdkValidationDetails}
                 sdkValidationFocus={sdkValidationFocus}
+                validationIssueTabNames={validationIssueTabNames}
               />
             </ProForm>
           </RefCheckContext.Provider>

--- a/src/pages/Flowproperties/Components/form.tsx
+++ b/src/pages/Flowproperties/Components/form.tsx
@@ -3,7 +3,7 @@ import LangTextItemForm from '@/components/LangTextItem/form';
 import LevelTextItemForm from '@/components/LevelTextItem/form';
 import { Card, Form, Input, Select, Space, theme } from 'antd';
 import type { FC } from 'react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 
 import RequiredMark from '@/components/RequiredMark';
@@ -31,6 +31,7 @@ type Props = {
   showRules?: boolean;
   sdkValidationDetails?: ValidationIssueSdkDetail[];
   sdkValidationFocus?: ValidationIssueSdkDetail | null;
+  validationIssueTabNames?: string[];
 };
 export const FlowpropertyForm: FC<Props> = ({
   lang,
@@ -43,6 +44,7 @@ export const FlowpropertyForm: FC<Props> = ({
   showRules = false,
   sdkValidationDetails = [],
   sdkValidationFocus = null,
+  validationIssueTabNames = [],
 }) => {
   const { token } = theme.useToken();
   const intl = useIntl();
@@ -57,9 +59,13 @@ export const FlowpropertyForm: FC<Props> = ({
     schemaRoot: schema,
     showRules,
   });
+  const validationIssueTabs = useMemo(
+    () => new Set(validationIssueTabNames),
+    [validationIssueTabNames],
+  );
 
   const renderTabLabel = (key: string, id: string, defaultMessage: string) => {
-    const hasIssue = (sdkValidationCountsByTab[key] ?? 0) > 0;
+    const hasIssue = (sdkValidationCountsByTab[key] ?? 0) > 0 || validationIssueTabs.has(key);
 
     return (
       <span

--- a/src/pages/Flows/Components/Property/edit.tsx
+++ b/src/pages/Flows/Components/Property/edit.tsx
@@ -64,6 +64,10 @@ const parseSdkFieldPathToFormName = (fieldPath?: string) => {
   return segments.map((segment) => (/^\d+$/.test(segment) ? Number(segment) : segment));
 };
 
+const isLangTextSdkFieldFormName = (formName?: Array<string | number>) => {
+  return formName?.[0] === 'generalComment' && formName?.[formName.length - 1] === '#text';
+};
+
 const PropertyEdit: FC<Props> = ({
   id,
   data,
@@ -101,7 +105,7 @@ const PropertyEdit: FC<Props> = ({
         const fieldKey = formName ? formName.map(String).join('.') : '';
         const messageText = getSdkSuggestedFixMessage(intlRef.current, detail);
 
-        if (!formName || !fieldKey || !messageText) {
+        if (!formName || !fieldKey || !messageText || isLangTextSdkFieldFormName(formName)) {
           return accumulator;
         }
 
@@ -131,6 +135,44 @@ const PropertyEdit: FC<Props> = ({
         });
         return accumulator;
       }, new Map()),
+    [sdkHighlights],
+  );
+
+  const langTextSdkFieldErrors = useMemo(
+    () =>
+      sdkHighlights.reduce<Record<string, Record<number, string[]>>>((accumulator, detail) => {
+        const formName =
+          (Array.isArray(detail.formName) && detail.formName.length > 0
+            ? detail.formName
+            : parseSdkFieldPathToFormName(detail.fieldPath)) ??
+          (detail.fieldKey ? [detail.fieldKey] : undefined);
+        const fieldName = typeof formName?.[0] === 'string' ? formName[0] : undefined;
+
+        if (!formName || !isLangTextSdkFieldFormName(formName) || !fieldName) {
+          return accumulator;
+        }
+
+        const itemIndex = typeof formName[1] === 'number' ? formName[1] : 0;
+        const messageText = getSdkSuggestedFixMessage(intlRef.current, detail);
+
+        if (!messageText) {
+          return accumulator;
+        }
+
+        if (!accumulator[fieldName]) {
+          accumulator[fieldName] = {};
+        }
+
+        if (!accumulator[fieldName][itemIndex]) {
+          accumulator[fieldName][itemIndex] = [];
+        }
+
+        if (!accumulator[fieldName][itemIndex].includes(messageText)) {
+          accumulator[fieldName][itemIndex].push(messageText);
+        }
+
+        return accumulator;
+      }, {}),
     [sdkHighlights],
   );
 
@@ -473,6 +515,7 @@ const PropertyEdit: FC<Props> = ({
             >
               <LangTextItemForm
                 name={['generalComment']}
+                fieldErrorMessages={langTextSdkFieldErrors.generalComment}
                 label={
                   <FormattedMessage
                     id='pages.flow.view.flowProperties.generalComment'

--- a/src/pages/Flows/Components/edit.tsx
+++ b/src/pages/Flows/Components/edit.tsx
@@ -8,6 +8,7 @@ import {
   ReffPath,
   buildValidationIssues,
   checkData,
+  collectValidationIssueRefTabNames,
   enrichValidationIssuesWithOwner,
   getErrRefTab,
   validateDatasetWithSdk,
@@ -103,6 +104,7 @@ const FlowsEdit: FC<Props> = ({
   const [sdkValidationFocus, setSdkValidationFocus] = useState<ValidationIssueSdkDetail | null>(
     null,
   );
+  const [validationIssueTabNames, setValidationIssueTabNames] = useState<string[]>([]);
   const [pendingTabValidationKey, setPendingTabValidationKey] =
     useState<FlowDataSetObjectKeys | null>(null);
   const [autoCheckTriggered, setAutoCheckTriggered] = useState(false);
@@ -323,6 +325,7 @@ const FlowsEdit: FC<Props> = ({
       setShowRules(false);
       setSdkValidationDetails([]);
       setSdkValidationFocus(null);
+      setValidationIssueTabNames([]);
       setPendingTabValidationKey(null);
       setAutoCheckTriggered(false);
       return;
@@ -485,17 +488,13 @@ const FlowsEdit: FC<Props> = ({
     const errTabNames: string[] = [];
     const currentDatasetTabNames: string[] = [];
     let datasetValidationMessage: string | null = null;
-    nonExistentRef.forEach((item) => {
-      const tabName = getErrRefTab(item, initData);
-      if (tabName && !errTabNames.includes(tabName)) errTabNames.push(tabName);
-    });
-    unRuleVerification.forEach((item) => {
-      const tabName = getErrRefTab(item, initData);
-      if (tabName && !errTabNames.includes(tabName)) errTabNames.push(tabName);
-    });
-    problemNodes.forEach((item) => {
-      const tabName = getErrRefTab(item, initData);
-      if (tabName && !errTabNames.includes(tabName)) errTabNames.push(tabName);
+    const { getRefTabNames, tabNames: referenceValidationTabNames } =
+      collectValidationIssueRefTabNames({
+        refs: [...nonExistentRef, ...unRuleVerification, ...problemNodes],
+        resolveTabName: (item) => getErrRefTab(item, initData),
+      });
+    referenceValidationTabNames.forEach((tabName) => {
+      if (!errTabNames.includes(tabName)) errTabNames.push(tabName);
     });
 
     const orderedJson = genFlowJsonOrdered(id, jsonData);
@@ -542,12 +541,14 @@ const FlowsEdit: FC<Props> = ({
 
     const validationIssues = buildValidationIssues({
       datasetSdkValid: currentDatasetValid,
+      getRefTabNames,
       nonExistentRef,
       rootRef,
       sdkInvalidDetails: sdkIssueDetails,
       sdkInvalidTabNames: currentDatasetTabNames,
       unRuleVerification,
     });
+    setValidationIssueTabNames(referenceValidationTabNames);
     const feedbackState = resolveDataCheckFeedbackState({
       hasValidationIssues:
         !currentDatasetValid ||
@@ -740,6 +741,7 @@ const FlowsEdit: FC<Props> = ({
                 showRules={showRules}
                 sdkValidationDetails={sdkValidationDetails}
                 sdkValidationFocus={sdkValidationFocus}
+                validationIssueTabNames={validationIssueTabNames}
               />
             </ProForm>
           </RefCheckContext.Provider>

--- a/src/pages/Flows/Components/edit.tsx
+++ b/src/pages/Flows/Components/edit.tsx
@@ -11,6 +11,7 @@ import {
   collectValidationIssueRefTabNames,
   enrichValidationIssuesWithOwner,
   getErrRefTab,
+  mapValidationIssuesToRefCheckData,
   validateDatasetWithSdk,
 } from '@/pages/Utils/review';
 import {
@@ -471,19 +472,6 @@ const FlowsEdit: FC<Props> = ({
       orderedJson: genFlowJsonOrdered(id, jsonData),
     });
     const problemNodes: ProblemNode[] = pathRef.findProblemNodes();
-    if (problemNodes && problemNodes.length > 0) {
-      const result = problemNodes.map((item) => {
-        return {
-          id: item['@refObjectId'],
-          version: item['@version'],
-          ruleVerification: item.ruleVerification,
-          nonExistent: item.nonExistent,
-        };
-      });
-      setRefCheckData(result);
-    } else {
-      setRefCheckData([]);
-    }
 
     const errTabNames: string[] = [];
     const currentDatasetTabNames: string[] = [];
@@ -549,6 +537,11 @@ const FlowsEdit: FC<Props> = ({
       unRuleVerification,
     });
     setValidationIssueTabNames(referenceValidationTabNames);
+    if (validationIssues.length > 0) {
+      setRefCheckData(mapValidationIssuesToRefCheckData(validationIssues));
+    } else {
+      setRefCheckData([]);
+    }
     const feedbackState = resolveDataCheckFeedbackState({
       hasValidationIssues:
         !currentDatasetValid ||

--- a/src/pages/Flows/Components/form.tsx
+++ b/src/pages/Flows/Components/form.tsx
@@ -51,6 +51,7 @@ type Props = {
   showRules?: boolean;
   sdkValidationDetails?: ValidationIssueSdkDetail[];
   sdkValidationFocus?: ValidationIssueSdkDetail | null;
+  validationIssueTabNames?: string[];
 };
 
 const isSdkFieldDetail = (detail: ValidationIssueSdkDetail) =>
@@ -86,6 +87,7 @@ export const FlowForm: FC<Props> = ({
   showRules = false,
   sdkValidationDetails = [],
   sdkValidationFocus = null,
+  validationIssueTabNames = [],
 }) => {
   const refCheckContext = useRefCheckContext();
   const [thisFlowType, setThisFlowType] = useState<string | undefined>(flowType);
@@ -183,10 +185,14 @@ export const FlowForm: FC<Props> = ({
       (rootSdkValidationCountsByTab.flowProperties ?? 0) +
       (sdkVisibleFlowPropertyRowsByTab.flowProperties?.size ?? 0),
   };
+  const validationIssueTabs = useMemo(
+    () => new Set(validationIssueTabNames),
+    [validationIssueTabNames],
+  );
   const focusedFlowPropertyInternalId = getFlowPropertyInternalId(sdkValidationFocus);
 
   const renderTabLabel = (key: string, id: string, defaultMessage: string) => {
-    const hasIssue = (sdkValidationCountsByTab[key] ?? 0) > 0;
+    const hasIssue = (sdkValidationCountsByTab[key] ?? 0) > 0 || validationIssueTabs.has(key);
 
     return (
       <span

--- a/src/pages/LifeCycleModels/Components/form.tsx
+++ b/src/pages/LifeCycleModels/Components/form.tsx
@@ -20,6 +20,20 @@ import schema from '../lifecyclemodels.json';
 import { licenseTypeOptions } from './optiondata';
 
 const LIFE_CYCLE_MODEL_SCHEMA_PATH_PREFIX = ['lifeCycleModelDataSet'];
+const LIFE_CYCLE_MODEL_CLASSIFICATION_FORM_NAME = [
+  'lifeCycleModelInformation',
+  'dataSetInformation',
+  'classificationInformation',
+  'common:classification',
+  'common:class',
+  'showValue',
+] as const;
+
+const isSameFormName = (left?: Array<string | number>, right?: readonly (string | number)[]) =>
+  !!left &&
+  !!right &&
+  left.length === right.length &&
+  left.every((segment, index) => segment === right[index]);
 
 type Props = {
   lang: string;
@@ -68,6 +82,26 @@ export const LifeCycleModelForm: FC<Props> = ({
     () => new Set(validationIssueTabNames),
     [validationIssueTabNames],
   );
+  const classificationSdkValidationDetail = useMemo(
+    () =>
+      sdkValidationDetails.find(
+        (detail) =>
+          detail.presentation !== 'highlight-only' &&
+          (isSameFormName(detail.formName, LIFE_CYCLE_MODEL_CLASSIFICATION_FORM_NAME) ||
+            detail.fieldPath === LIFE_CYCLE_MODEL_CLASSIFICATION_FORM_NAME.join('.')),
+      ),
+    [sdkValidationDetails],
+  );
+  const classificationSdkValidationHelp = useMemo(() => {
+    if (!classificationSdkValidationDetail) {
+      return undefined;
+    }
+
+    return intl.formatMessage({
+      id: 'pages.contact.validator.classification.required',
+      defaultMessage: 'Please input classification',
+    });
+  }, [classificationSdkValidationDetail, intl]);
 
   const renderTabLabel = (key: string, id: string, defaultMessage: string) => {
     const hasIssue = (sdkValidationCountsByTab[key] ?? 0) > 0 || validationIssueTabs.has(key);
@@ -335,6 +369,8 @@ export const LifeCycleModelForm: FC<Props> = ({
           dataType={'LifeCycleModel'}
           onData={onData}
           showRules={showRules}
+          validationHelp={classificationSdkValidationHelp}
+          validationStatus={classificationSdkValidationHelp ? 'error' : undefined}
           rules={
             showRules
               ? getRules(

--- a/src/pages/LifeCycleModels/Components/form.tsx
+++ b/src/pages/LifeCycleModels/Components/form.tsx
@@ -14,7 +14,7 @@ import { useDatasetSdkValidationFormSupport } from '@/pages/Utils/validation/for
 import { ProFormInstance } from '@ant-design/pro-components';
 import { Card, Form, Input, Select, Space, theme } from 'antd';
 import type { FC } from 'react';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 import schema from '../lifecyclemodels.json';
 import { licenseTypeOptions } from './optiondata';
@@ -32,6 +32,7 @@ type Props = {
   actionType?: 'create' | 'copy' | 'createVersion';
   sdkValidationDetails?: ValidationIssueSdkDetail[];
   sdkValidationFocus?: ValidationIssueSdkDetail | null;
+  validationIssueTabNames?: string[];
 };
 export const LifeCycleModelForm: FC<Props> = ({
   lang,
@@ -44,6 +45,7 @@ export const LifeCycleModelForm: FC<Props> = ({
   actionType,
   sdkValidationDetails = [],
   sdkValidationFocus = null,
+  validationIssueTabNames = [],
 }) => {
   const { token } = theme.useToken();
   const intl = useIntl();
@@ -62,9 +64,13 @@ export const LifeCycleModelForm: FC<Props> = ({
     schemaRoot: schema,
     showRules,
   });
+  const validationIssueTabs = useMemo(
+    () => new Set(validationIssueTabNames),
+    [validationIssueTabNames],
+  );
 
   const renderTabLabel = (key: string, id: string, defaultMessage: string) => {
-    const hasIssue = (sdkValidationCountsByTab[key] ?? 0) > 0;
+    const hasIssue = (sdkValidationCountsByTab[key] ?? 0) > 0 || validationIssueTabs.has(key);
 
     return (
       <span

--- a/src/pages/LifeCycleModels/Components/toolbar/eidtInfo.tsx
+++ b/src/pages/LifeCycleModels/Components/toolbar/eidtInfo.tsx
@@ -28,6 +28,7 @@ import {
   buildValidationIssues,
   checkReferences,
   checkVersions,
+  collectValidationIssueRefTabNames,
   dealModel,
   dealProcress,
   enrichValidationIssuesWithOwner,
@@ -188,6 +189,7 @@ const ToolbarEditInfo = forwardRef<ToolbarEditInfoHandle, Props>(
     const [sdkValidationFocus, setSdkValidationFocus] = useState<ValidationIssueSdkDetail | null>(
       null,
     );
+    const [validationIssueTabNames, setValidationIssueTabNames] = useState<string[]>([]);
     const [refCheckData, setRefCheckData] = useState<RefCheckType[]>([]);
     const parentRefCheckContext = useRefCheckContext();
     const [refCheckContextValue, setRefCheckContextValue] = useState<{
@@ -338,6 +340,7 @@ const ToolbarEditInfo = forwardRef<ToolbarEditInfoHandle, Props>(
         setShowRules(false);
         setSdkValidationDetails([]);
         setSdkValidationFocus(null);
+        setValidationIssueTabNames([]);
         onProcessInstanceValidationChange([]);
         return;
       }
@@ -551,9 +554,27 @@ const ToolbarEditInfo = forwardRef<ToolbarEditInfoHandle, Props>(
       await checkVersions(allRefs, path);
 
       const problemNodes = (path?.findProblemNodes(from) ?? []) as ReviewProblemNode[];
+      const modelDataset = orderedValidationDataset?.lifeCycleModelDataSet;
+      const shouldShowDatasetRefTabName = (item: refDataType | ReviewProblemNode) =>
+        item['@type'] !== 'lifeCycleModel data set' && item['@type'] !== 'process data set';
+      const { getRefTabNames, tabNames: referenceValidationTabNames } =
+        collectValidationIssueRefTabNames({
+          refs: [
+            ...nonExistentRef,
+            ...unRuleVerification.filter(shouldShowDatasetRefTabName),
+            ...problemNodes.filter(shouldShowDatasetRefTabName),
+          ],
+          resolveTabName: (item) => getErrRefTab(item, modelDataset),
+        });
+      referenceValidationTabNames.forEach((tabName) => {
+        if (!errTabNames.includes(tabName)) {
+          errTabNames.push(tabName);
+        }
+      });
       const validationIssues = buildValidationIssues({
         actionFrom: from,
         datasetSdkValid: currentDatasetValid,
+        getRefTabNames,
         nonExistentRef,
         problemNodes,
         rootRef,
@@ -561,6 +582,7 @@ const ToolbarEditInfo = forwardRef<ToolbarEditInfoHandle, Props>(
         sdkInvalidTabNames: currentDatasetTabNames,
         unRuleVerification,
       });
+      setValidationIssueTabNames(referenceValidationTabNames);
       if (validationIssues.length > 0) {
         setRefCheckData(mapValidationIssuesToRefCheckData(validationIssues));
       } else {
@@ -597,36 +619,6 @@ const ToolbarEditInfo = forwardRef<ToolbarEditInfoHandle, Props>(
         setSpinning(false);
         return { checkResult: true, unReview, problemNodes };
       }
-
-      const modelDataset = orderedValidationDataset?.lifeCycleModelDataSet;
-      nonExistentRef.forEach((item) => {
-        const tabName = getErrRefTab(item, modelDataset);
-        if (tabName && !errTabNames.includes(tabName)) {
-          errTabNames.push(tabName);
-        }
-      });
-      unRuleVerification.forEach((item) => {
-        const tabName = getErrRefTab(item, modelDataset);
-        if (
-          tabName &&
-          !errTabNames.includes(tabName) &&
-          item['@type'] !== 'lifeCycleModel data set' &&
-          item['@type'] !== 'process data set'
-        ) {
-          errTabNames.push(tabName);
-        }
-      });
-      problemNodes.forEach((item) => {
-        const tabName = getErrRefTab(item, modelDataset);
-        if (
-          tabName &&
-          !errTabNames.includes(tabName) &&
-          item['@type'] !== 'lifeCycleModel data set' &&
-          item['@type'] !== 'process data set'
-        ) {
-          errTabNames.push(tabName);
-        }
-      });
 
       let validationHint = intl.formatMessage({
         id: 'pages.button.check.error',
@@ -913,6 +905,7 @@ const ToolbarEditInfo = forwardRef<ToolbarEditInfoHandle, Props>(
                   showRules={showRules}
                   sdkValidationDetails={sdkValidationDetails}
                   sdkValidationFocus={sdkValidationFocus}
+                  validationIssueTabNames={validationIssueTabNames}
                 />
               </ProForm>
             </RefCheckContext.Provider>

--- a/src/pages/LifeCycleModels/sdkValidation.ts
+++ b/src/pages/LifeCycleModels/sdkValidation.ts
@@ -27,6 +27,7 @@ const LIFECYCLEMODEL_FIELD_LABELS_BY_KEY: Record<string, string> = {
   'common:referenceToOwnershipOfDataSet': 'Owner of data set',
   'common:referenceToPersonOrEntityEnteringTheData': 'Data entry by',
   'common:timeStamp': 'Time stamp (last saved)',
+  '@classId': 'Classification',
   '@refObjectId': 'Reference identifier',
   baseName: 'Base name',
   functionalUnitFlowProperties: 'Quantitative product or process properties',

--- a/src/pages/Processes/Components/edit.tsx
+++ b/src/pages/Processes/Components/edit.tsx
@@ -396,6 +396,7 @@ const ProcessEdit: FC<Props> = ({
   });
   const intl = useIntl();
   const [refCheckData, setRefCheckData] = useState<RefCheckType[]>([]);
+  const [validationIssueTabNames, setValidationIssueTabNames] = useState<string[]>([]);
   const [refCheckContextValue, setRefCheckContextValue] = useState<{
     refCheckData: RefCheckType[];
   }>({
@@ -1204,9 +1205,47 @@ const ProcessEdit: FC<Props> = ({
     allRefs.add(`${processDetail.id}:${processDetail.version}:process data set`);
     await checkVersions(allRefs, path);
     const problemNodes = (path?.findProblemNodes(from) ?? []) as RefProblemNode[];
+    const referenceValidationTabNames: string[] = [];
+    const referenceValidationTabNamesByKey = new Map<string, string[]>();
+
+    const getReferenceValidationKey = (ref: refDataType | RefProblemNode) =>
+      `${ref['@type']}:${ref['@refObjectId']}:${ref['@version']}`;
+
+    const collectReferenceValidationTabName = (item: refDataType | RefProblemNode) => {
+      const tabName = getErrRefTab(item, processDetail);
+
+      if (!tabName) {
+        return;
+      }
+
+      if (!errTabNames.includes(tabName)) {
+        errTabNames.push(tabName);
+      }
+
+      if (!referenceValidationTabNames.includes(tabName)) {
+        referenceValidationTabNames.push(tabName);
+      }
+
+      const key = getReferenceValidationKey(item);
+      const existingTabNames = referenceValidationTabNamesByKey.get(key) ?? [];
+      if (!existingTabNames.includes(tabName)) {
+        referenceValidationTabNamesByKey.set(key, [...existingTabNames, tabName]);
+      }
+    };
+
+    nonExistentRef.forEach((item) => {
+      collectReferenceValidationTabName(item);
+    });
+    unRuleVerification.forEach((item) => {
+      collectReferenceValidationTabName(item);
+    });
+    problemNodes.forEach((item) => {
+      collectReferenceValidationTabName(item);
+    });
     const validationIssues = buildValidationIssues({
       actionFrom: from,
       datasetSdkValid: currentDatasetValid,
+      getRefTabNames: (ref) => referenceValidationTabNamesByKey.get(getReferenceValidationKey(ref)),
       nonExistentRef,
       problemNodes,
       rootRef,
@@ -1214,6 +1253,9 @@ const ProcessEdit: FC<Props> = ({
       sdkInvalidTabNames: currentDatasetTabNames,
       unRuleVerification,
     });
+
+    setValidationIssueTabNames(referenceValidationTabNames);
+
     if (validationIssues.length > 0) {
       setRefCheckData(mapValidationIssuesToRefCheckData(validationIssues));
     } else {
@@ -1236,25 +1278,6 @@ const ProcessEdit: FC<Props> = ({
       setSpinning(false);
       return { checkResult: true, unReview };
     }
-
-    nonExistentRef.forEach((item) => {
-      const tabName = getErrRefTab(item, processDetail);
-      if (tabName && !errTabNames.includes(tabName)) {
-        errTabNames.push(tabName);
-      }
-    });
-    unRuleVerification.forEach((item) => {
-      const tabName = getErrRefTab(item, processDetail);
-      if (tabName && !errTabNames.includes(tabName)) {
-        errTabNames.push(tabName);
-      }
-    });
-    problemNodes.forEach((item) => {
-      const tabName = getErrRefTab(item, processDetail);
-      if (tabName && !errTabNames.includes(tabName)) {
-        errTabNames.push(tabName);
-      }
-    });
 
     let validationHint = intl.formatMessage({
       id: 'pages.button.check.error',
@@ -1462,6 +1485,7 @@ const ProcessEdit: FC<Props> = ({
   const onEdit = useCallback(() => {
     setDrawerVisible(true);
     setActiveTabKey('processInformation');
+    setValidationIssueTabNames([]);
     setSdkValidationFocus(null);
   }, [setViewDrawerVisible]);
 
@@ -1486,6 +1510,7 @@ const ProcessEdit: FC<Props> = ({
     if (!drawerVisible) {
       setShowRules(false);
       setRefCheckData([]);
+      setValidationIssueTabNames([]);
       setSdkValidationDetails([]);
       setSdkValidationFocus(null);
       setSdkValidationDismissedFieldKeys(new Set());
@@ -1765,6 +1790,7 @@ const ProcessEdit: FC<Props> = ({
                 sdkValidationDismissedFieldKeys={sdkValidationDismissedFieldKeys}
                 sdkValidationFocus={sdkValidationFocus}
                 showRules={showRules}
+                validationIssueTabNames={validationIssueTabNames}
               />
               <Form.Item name='id' hidden>
                 <Input />

--- a/src/pages/Processes/Components/edit.tsx
+++ b/src/pages/Processes/Components/edit.tsx
@@ -14,6 +14,7 @@ import {
   buildValidationIssues,
   checkReferences,
   checkVersions,
+  collectValidationIssueRefTabNames,
   dealProcress,
   enrichValidationIssuesWithOwner,
   getAllRefObj,
@@ -1205,47 +1206,20 @@ const ProcessEdit: FC<Props> = ({
     allRefs.add(`${processDetail.id}:${processDetail.version}:process data set`);
     await checkVersions(allRefs, path);
     const problemNodes = (path?.findProblemNodes(from) ?? []) as RefProblemNode[];
-    const referenceValidationTabNames: string[] = [];
-    const referenceValidationTabNamesByKey = new Map<string, string[]>();
-
-    const getReferenceValidationKey = (ref: refDataType | RefProblemNode) =>
-      `${ref['@type']}:${ref['@refObjectId']}:${ref['@version']}`;
-
-    const collectReferenceValidationTabName = (item: refDataType | RefProblemNode) => {
-      const tabName = getErrRefTab(item, processDetail);
-
-      if (!tabName) {
-        return;
-      }
-
+    const { getRefTabNames, tabNames: referenceValidationTabNames } =
+      collectValidationIssueRefTabNames({
+        refs: [...nonExistentRef, ...unRuleVerification, ...problemNodes],
+        resolveTabName: (item) => getErrRefTab(item, processDetail),
+      });
+    referenceValidationTabNames.forEach((tabName) => {
       if (!errTabNames.includes(tabName)) {
         errTabNames.push(tabName);
       }
-
-      if (!referenceValidationTabNames.includes(tabName)) {
-        referenceValidationTabNames.push(tabName);
-      }
-
-      const key = getReferenceValidationKey(item);
-      const existingTabNames = referenceValidationTabNamesByKey.get(key) ?? [];
-      if (!existingTabNames.includes(tabName)) {
-        referenceValidationTabNamesByKey.set(key, [...existingTabNames, tabName]);
-      }
-    };
-
-    nonExistentRef.forEach((item) => {
-      collectReferenceValidationTabName(item);
-    });
-    unRuleVerification.forEach((item) => {
-      collectReferenceValidationTabName(item);
-    });
-    problemNodes.forEach((item) => {
-      collectReferenceValidationTabName(item);
     });
     const validationIssues = buildValidationIssues({
       actionFrom: from,
       datasetSdkValid: currentDatasetValid,
-      getRefTabNames: (ref) => referenceValidationTabNamesByKey.get(getReferenceValidationKey(ref)),
+      getRefTabNames,
       nonExistentRef,
       problemNodes,
       rootRef,

--- a/src/pages/Processes/Components/form.tsx
+++ b/src/pages/Processes/Components/form.tsx
@@ -78,6 +78,7 @@ type Props = {
   sdkValidationDetails?: ValidationIssueSdkDetail[];
   sdkValidationDismissedFieldKeys?: ReadonlySet<string>;
   sdkValidationFocus?: ValidationIssueSdkDetail | null;
+  validationIssueTabNames?: string[];
 };
 
 type FlowStateCodeItem = {
@@ -282,6 +283,7 @@ export const ProcessForm: FC<Props> = ({
   sdkValidationDetails = [],
   sdkValidationDismissedFieldKeys = EMPTY_SDK_DISMISSED_FIELD_KEYS,
   sdkValidationFocus,
+  validationIssueTabNames = [],
 }) => {
   const intl = useIntl();
   const intlRef = useRef(intl);
@@ -545,6 +547,15 @@ export const ProcessForm: FC<Props> = ({
 
     return accumulator;
   }, {});
+  const validationIssueTabs = useMemo(
+    () =>
+      new Set(
+        validationIssueTabNames.filter(
+          (tabName): tabName is string => typeof tabName === 'string' && tabName.length > 0,
+        ),
+      ),
+    [validationIssueTabNames],
+  );
 
   useEffect(() => {
     const formInstance = formRef.current;
@@ -711,7 +722,7 @@ export const ProcessForm: FC<Props> = ({
 
   const renderTabLabel = (key: string, id: string, defaultMessage: string) => {
     const issueCount = sdkValidationCountsByTab[key] ?? 0;
-    const hasIssue = issueCount > 0;
+    const hasIssue = issueCount > 0 || validationIssueTabs.has(key);
 
     return (
       <span

--- a/src/pages/Sources/Components/edit.tsx
+++ b/src/pages/Sources/Components/edit.tsx
@@ -7,6 +7,7 @@ import {
   ReffPath,
   buildValidationIssues,
   checkData,
+  collectValidationIssueRefTabNames,
   enrichValidationIssuesWithOwner,
   getErrRefTab,
   validateDatasetWithSdk,
@@ -95,6 +96,7 @@ const SourceEdit: FC<Props> = ({
   const [sdkValidationFocus, setSdkValidationFocus] = useState<ValidationIssueSdkDetail | null>(
     null,
   );
+  const [validationIssueTabNames, setValidationIssueTabNames] = useState<string[]>([]);
   const [pendingTabValidationKey, setPendingTabValidationKey] =
     useState<SourceDataSetObjectKeys | null>(null);
   const [autoCheckTriggered, setAutoCheckTriggered] = useState(false);
@@ -387,6 +389,7 @@ const SourceEdit: FC<Props> = ({
       setShowRules(false);
       setSdkValidationDetails([]);
       setSdkValidationFocus(null);
+      setValidationIssueTabNames([]);
       setPendingTabValidationKey(null);
       setAutoCheckTriggered(false);
       return;
@@ -441,17 +444,13 @@ const SourceEdit: FC<Props> = ({
       setRefCheckData([]);
     }
     const errTabNames: string[] = [];
-    nonExistentRef.forEach((item: refDataType) => {
-      const tabName = getErrRefTab(item, initData);
-      if (tabName && !errTabNames.includes(tabName)) errTabNames.push(tabName);
-    });
-    unRuleVerification.forEach((item: refDataType) => {
-      const tabName = getErrRefTab(item, initData);
-      if (tabName && !errTabNames.includes(tabName)) errTabNames.push(tabName);
-    });
-    problemNodes.forEach((item) => {
-      const tabName = getErrRefTab(item, initData);
-      if (tabName && !errTabNames.includes(tabName)) errTabNames.push(tabName);
+    const { getRefTabNames, tabNames: referenceValidationTabNames } =
+      collectValidationIssueRefTabNames({
+        refs: [...nonExistentRef, ...unRuleVerification, ...problemNodes],
+        resolveTabName: (item) => getErrRefTab(item, initData),
+      });
+    referenceValidationTabNames.forEach((tabName) => {
+      if (!errTabNames.includes(tabName)) errTabNames.push(tabName);
     });
 
     const sdkValidation = validateDatasetWithSdk('source data set', orderedJson);
@@ -483,12 +482,14 @@ const SourceEdit: FC<Props> = ({
     }
     const validationIssues = buildValidationIssues({
       datasetSdkValid: sdkValidation.success,
+      getRefTabNames,
       nonExistentRef,
       rootRef,
       sdkInvalidDetails: sdkIssueDetails,
       sdkInvalidTabNames,
       unRuleVerification,
     });
+    setValidationIssueTabNames(referenceValidationTabNames);
     const feedbackState = resolveDataCheckFeedbackState({
       hasValidationIssues:
         unRuleVerification.length > 0 ||
@@ -652,6 +653,7 @@ const SourceEdit: FC<Props> = ({
                 showRules={showRules}
                 sdkValidationDetails={sdkValidationDetails}
                 sdkValidationFocus={sdkValidationFocus}
+                validationIssueTabNames={validationIssueTabNames}
               />
             </ProForm>
           </RefCheckContext.Provider>

--- a/src/pages/Sources/Components/form.tsx
+++ b/src/pages/Sources/Components/form.tsx
@@ -1,6 +1,6 @@
 import { FileType, getBase64, getOriginalFileUrl, isImage } from '@/services/supabase/storage';
 import { Card, Form, Image, Input, Select, Space, Upload, UploadFile } from 'antd';
-import { FC, useState } from 'react';
+import { FC, useMemo, useState } from 'react';
 
 import DatasetCreateVersionFormItem from '@/components/DatasetCreateVersionFormItem';
 import { UploadButton } from '@/components/FileViewer/upload';
@@ -35,6 +35,7 @@ type Props = {
   showRules?: boolean;
   sdkValidationDetails?: ValidationIssueSdkDetail[];
   sdkValidationFocus?: ValidationIssueSdkDetail | null;
+  validationIssueTabNames?: string[];
 };
 
 export const SourceForm: FC<Props> = ({
@@ -51,6 +52,7 @@ export const SourceForm: FC<Props> = ({
   showRules = false,
   sdkValidationDetails = [],
   sdkValidationFocus = null,
+  validationIssueTabNames = [],
 }) => {
   const [previewOpen, setPreviewOpen] = useState(false);
   const [previewImage, setPreviewImage] = useState('');
@@ -67,6 +69,10 @@ export const SourceForm: FC<Props> = ({
     schemaRoot: schema,
     showRules,
   });
+  const validationIssueTabs = useMemo(
+    () => new Set(validationIssueTabNames),
+    [validationIssueTabNames],
+  );
   const handlePreview = async (file: UploadFile) => {
     if (isImage(file)) {
       if (!file.url && !file.preview) {
@@ -86,7 +92,7 @@ export const SourceForm: FC<Props> = ({
   };
 
   const renderTabLabel = (key: string, id: string, defaultMessage: string) => {
-    const hasIssue = (sdkValidationCountsByTab[key] ?? 0) > 0;
+    const hasIssue = (sdkValidationCountsByTab[key] ?? 0) > 0 || validationIssueTabs.has(key);
 
     return (
       <span

--- a/src/pages/Unitgroups/Components/edit.tsx
+++ b/src/pages/Unitgroups/Components/edit.tsx
@@ -7,6 +7,7 @@ import {
   ReffPath,
   buildValidationIssues,
   checkData,
+  collectValidationIssueRefTabNames,
   enrichValidationIssuesWithOwner,
   getErrRefTab,
   validateDatasetWithSdk,
@@ -91,6 +92,7 @@ const UnitGroupEdit: FC<Props> = ({
   const [sdkValidationFocus, setSdkValidationFocus] = useState<ValidationIssueSdkDetail | null>(
     null,
   );
+  const [validationIssueTabNames, setValidationIssueTabNames] = useState<string[]>([]);
   const [pendingTabValidationKey, setPendingTabValidationKey] =
     useState<UnitGroupDataSetObjectKeys | null>(null);
   const [autoCheckTriggered, setAutoCheckTriggered] = useState(false);
@@ -271,6 +273,7 @@ const UnitGroupEdit: FC<Props> = ({
       setShowRules(false);
       setSdkValidationDetails([]);
       setSdkValidationFocus(null);
+      setValidationIssueTabNames([]);
       setPendingTabValidationKey(null);
       setAutoCheckTriggered(false);
       return;
@@ -443,17 +446,13 @@ const UnitGroupEdit: FC<Props> = ({
     const errTabNames: string[] = [];
     const currentDatasetTabNames: string[] = [];
     let datasetValidationMessage: string | null = null;
-    nonExistentRef.forEach((item) => {
-      const tabName = getErrRefTab(item, initData);
-      if (tabName && !errTabNames.includes(tabName)) errTabNames.push(tabName);
-    });
-    unRuleVerification.forEach((item) => {
-      const tabName = getErrRefTab(item, initData);
-      if (tabName && !errTabNames.includes(tabName)) errTabNames.push(tabName);
-    });
-    problemNodes.forEach((item) => {
-      const tabName = getErrRefTab(item, initData);
-      if (tabName && !errTabNames.includes(tabName)) errTabNames.push(tabName);
+    const { getRefTabNames, tabNames: referenceValidationTabNames } =
+      collectValidationIssueRefTabNames({
+        refs: [...nonExistentRef, ...unRuleVerification, ...problemNodes],
+        resolveTabName: (item) => getErrRefTab(item, initData),
+      });
+    referenceValidationTabNames.forEach((tabName) => {
+      if (!errTabNames.includes(tabName)) errTabNames.push(tabName);
     });
     const sdkValidation = validateDatasetWithSdk('unit group data set', orderedJson);
     const sdkIssues = sdkValidation.issues;
@@ -504,12 +503,14 @@ const UnitGroupEdit: FC<Props> = ({
     }
     const validationIssues = buildValidationIssues({
       datasetSdkValid: currentDatasetValid,
+      getRefTabNames,
       nonExistentRef,
       rootRef,
       sdkInvalidDetails: sdkIssueDetails,
       sdkInvalidTabNames: currentDatasetTabNames,
       unRuleVerification,
     });
+    setValidationIssueTabNames(referenceValidationTabNames);
     const feedbackState = resolveDataCheckFeedbackState({
       hasValidationIssues:
         !currentDatasetValid ||
@@ -685,6 +686,7 @@ const UnitGroupEdit: FC<Props> = ({
                 showRules={showRules}
                 sdkValidationDetails={sdkValidationDetails}
                 sdkValidationFocus={sdkValidationFocus}
+                validationIssueTabNames={validationIssueTabNames}
               />
             </ProForm>
           </RefCheckContext.Provider>

--- a/src/pages/Unitgroups/Components/form.tsx
+++ b/src/pages/Unitgroups/Components/form.tsx
@@ -41,6 +41,7 @@ type Props = {
   showRules?: boolean;
   sdkValidationDetails?: ValidationIssueSdkDetail[];
   sdkValidationFocus?: ValidationIssueSdkDetail | null;
+  validationIssueTabNames?: string[];
 };
 
 const isSdkFieldDetail = (detail: ValidationIssueSdkDetail) =>
@@ -69,6 +70,7 @@ export const UnitGroupForm: FC<Props> = ({
   showRules = false,
   sdkValidationDetails = [],
   sdkValidationFocus = null,
+  validationIssueTabNames = [],
 }) => {
   const { token } = theme.useToken();
   const intl = useIntl();
@@ -159,10 +161,14 @@ export const UnitGroupForm: FC<Props> = ({
     ...rootSdkValidationCountsByTab,
     units: (rootSdkValidationCountsByTab.units ?? 0) + (sdkVisibleUnitRowsByTab.units?.size ?? 0),
   };
+  const validationIssueTabs = useMemo(
+    () => new Set(validationIssueTabNames),
+    [validationIssueTabNames],
+  );
   const focusedUnitInternalId = getUnitInternalId(sdkValidationFocus);
 
   const renderTabLabel = (key: string, id: string, defaultMessage: string) => {
-    const hasIssue = (sdkValidationCountsByTab[key] ?? 0) > 0;
+    const hasIssue = (sdkValidationCountsByTab[key] ?? 0) > 0 || validationIssueTabs.has(key);
 
     return (
       <span

--- a/src/pages/Utils/review.tsx
+++ b/src/pages/Utils/review.tsx
@@ -374,6 +374,31 @@ const pushValidationIssue = (
   issues.push(issue);
 };
 
+type ValidationIssueRefTabNamesResolver = (
+  ref: refDataType,
+) => string | string[] | null | undefined;
+
+const getValidationIssueRefTabProps = (
+  ref: refDataType,
+  getRefTabNames?: ValidationIssueRefTabNamesResolver,
+): Pick<ValidationIssue, 'tabName' | 'tabNames'> => {
+  const rawTabNames = getRefTabNames?.(ref);
+  const tabNames = (Array.isArray(rawTabNames) ? rawTabNames : [rawTabNames])
+    .map((tabName) => (typeof tabName === 'string' ? tabName.trim() : ''))
+    .filter(
+      (tabName, index, allTabNames) => tabName.length > 0 && allTabNames.indexOf(tabName) === index,
+    );
+
+  if (tabNames.length === 0) {
+    return {};
+  }
+
+  return {
+    tabName: tabNames[0],
+    tabNames,
+  };
+};
+
 export const mapValidationIssuesToRefCheckData = (issues: ValidationIssue[]): RefCheckType[] => {
   const issueMap = new Map<string, RefCheckType>();
 
@@ -833,6 +858,7 @@ export const validateDatasetWithSdk = (
 export const buildValidationIssues = ({
   rootRef,
   datasetSdkValid,
+  getRefTabNames,
   sdkInvalidTabNames = [],
   sdkInvalidDetails = [],
   nonExistentRef = [],
@@ -842,6 +868,7 @@ export const buildValidationIssues = ({
 }: {
   actionFrom?: 'checkData' | 'review';
   datasetSdkValid: boolean;
+  getRefTabNames?: ValidationIssueRefTabNamesResolver;
   sdkInvalidDetails?: ValidationIssueSdkDetail[];
   sdkInvalidTabNames?: string[];
   nonExistentRef?: refDataType[];
@@ -879,6 +906,7 @@ export const buildValidationIssues = ({
       code: 'ruleVerificationFailed',
       link: getDatasetDetailAbsoluteUrl(ref),
       ref,
+      ...getValidationIssueRefTabProps(ref, getRefTabNames),
     });
   });
 
@@ -887,6 +915,7 @@ export const buildValidationIssues = ({
       code: 'nonExistentRef',
       link: getDatasetDetailAbsoluteUrl(ref),
       ref,
+      ...getValidationIssueRefTabProps(ref, getRefTabNames),
     });
   });
 
@@ -902,6 +931,7 @@ export const buildValidationIssues = ({
         code: 'versionIsInTg',
         link: getDatasetDetailAbsoluteUrl(ref),
         ref,
+        ...getValidationIssueRefTabProps(ref, getRefTabNames),
       });
       return;
     }
@@ -915,6 +945,7 @@ export const buildValidationIssues = ({
         link: getDatasetDetailAbsoluteUrl(ref),
         ref,
         underReviewVersion: node.underReviewVersion,
+        ...getValidationIssueRefTabProps(ref, getRefTabNames),
       });
     }
   });

--- a/src/pages/Utils/review.tsx
+++ b/src/pages/Utils/review.tsx
@@ -193,6 +193,40 @@ export type ValidationIssueSdkDetail = {
 const getValidationIssueRefKey = (ref: refDataType) =>
   `${ref['@type']}:${ref['@refObjectId']}:${ref['@version']}`;
 
+export const collectValidationIssueRefTabNames = <T extends refDataType>({
+  refs,
+  resolveTabName,
+}: {
+  refs: T[];
+  resolveTabName: (ref: T) => string | null | undefined;
+}) => {
+  const tabNames: string[] = [];
+  const tabNamesByRefKey = new Map<string, string[]>();
+
+  refs.forEach((ref) => {
+    const tabName = resolveTabName(ref);
+
+    if (!tabName) {
+      return;
+    }
+
+    if (!tabNames.includes(tabName)) {
+      tabNames.push(tabName);
+    }
+
+    const key = getValidationIssueRefKey(ref);
+    const refTabNames = tabNamesByRefKey.get(key) ?? [];
+    if (!refTabNames.includes(tabName)) {
+      tabNamesByRefKey.set(key, [...refTabNames, tabName]);
+    }
+  });
+
+  return {
+    getRefTabNames: (ref: refDataType) => tabNamesByRefKey.get(getValidationIssueRefKey(ref)),
+    tabNames,
+  };
+};
+
 const getValidationIssueOwnerName = (user?: {
   display_name?: string | null;
   email?: string | null;

--- a/src/pages/Utils/validation/sdkDetails.ts
+++ b/src/pages/Utils/validation/sdkDetails.ts
@@ -141,6 +141,23 @@ const collectLeafUnionIssues = (
   );
 };
 
+const getMeaningfulUnionLeafIssues = (
+  issue: DatasetSdkValidationIssueLike,
+): DatasetSdkValidationIssueLike[] => {
+  const leafIssues = collectLeafUnionIssues(issue);
+  const issuePathLength = toPathArray(issue.path).length;
+  const fieldLeafIssues = leafIssues.filter(
+    (candidate) => toPathArray(candidate.path).length > issuePathLength,
+  );
+
+  if (fieldLeafIssues.length > 0) {
+    return fieldLeafIssues;
+  }
+
+  const nonTypeLeafIssues = leafIssues.filter((candidate) => candidate.code !== 'invalid_type');
+  return nonTypeLeafIssues.length > 0 ? nonTypeLeafIssues : leafIssues;
+};
+
 const resolveDatasetSdkIssue = (
   issue: DatasetSdkValidationIssueLike,
 ): DatasetSdkValidationIssueLike => {
@@ -151,18 +168,25 @@ const resolveDatasetSdkIssue = (
     };
   }
 
-  const leafIssues = collectLeafUnionIssues(issue);
-  const preferredLeafIssue =
-    leafIssues.find(
-      (candidate) => toPathArray(candidate.path).length > toPathArray(issue.path).length,
-    ) ??
-    leafIssues.find((candidate) => candidate.code !== 'invalid_type') ??
-    leafIssues[0];
+  const preferredLeafIssue = getMeaningfulUnionLeafIssues(issue)[0];
 
   return {
     ...preferredLeafIssue,
     path: toPathArray(preferredLeafIssue?.path),
   };
+};
+
+const resolveDatasetSdkIssues = (
+  issue: DatasetSdkValidationIssueLike,
+): DatasetSdkValidationIssueLike[] => {
+  if (issue.code !== 'invalid_union') {
+    return [resolveDatasetSdkIssue(issue)];
+  }
+
+  return getMeaningfulUnionLeafIssues(issue).map((leafIssue) => ({
+    ...leafIssue,
+    path: toPathArray(leafIssue.path),
+  }));
 };
 
 const toRootFormPath = (path: PropertyKey[], datasetKey: string): Array<string | number> => {
@@ -190,10 +214,33 @@ const getActualValueLength = (value: unknown) => {
   return undefined;
 };
 
+const getExplicitSdkValidationCode = (issue: DatasetSdkValidationIssueLike) => {
+  const paramValidationCode =
+    typeof issue.params?.validationCode === 'string'
+      ? normalizeString(issue.params.validationCode)
+      : undefined;
+
+  if (paramValidationCode) {
+    return paramValidationCode;
+  }
+
+  const rawValidationCode = normalizeString(issue.rawCode);
+  if (issue.code === 'custom' && rawValidationCode && rawValidationCode !== 'custom') {
+    return rawValidationCode;
+  }
+
+  return undefined;
+};
+
 const getDatasetSdkValidationCode = (
   issue: DatasetSdkValidationIssueLike,
   actualValue: unknown,
 ) => {
+  const explicitValidationCode = getExplicitSdkValidationCode(issue);
+  if (explicitValidationCode) {
+    return explicitValidationCode;
+  }
+
   if (actualValue === undefined) {
     switch (issue.code) {
       case 'required_missing':
@@ -519,61 +566,65 @@ export const normalizeSimpleDatasetSdkValidationDetails = (
   const detailMap = new Map<string, ValidationIssueSdkDetail>();
 
   issues.forEach((issue) => {
-    const resolvedIssue = resolveDatasetSdkIssue(issue);
-    const path = toPathArray(resolvedIssue.path);
-    if (path.length === 0) {
-      return;
-    }
+    const resolvedIssues = resolveDatasetSdkIssues(issue);
 
-    const rootPath = toRootFormPath(path, config.datasetKey);
-    if (rootPath.length === 0) {
-      return;
-    }
+    resolvedIssues.forEach((resolvedIssue) => {
+      const path = toPathArray(resolvedIssue.path);
+      if (path.length === 0) {
+        return;
+      }
 
-    const formName = getSimpleSdkIssueFormName(rootPath, orderedJson, config);
-    const fieldPath = formName.map(String).join('.');
-    const actualValue =
-      resolvedIssue.input !== undefined
-        ? resolvedIssue.input
-        : getValueAtPath(orderedJson, [config.datasetKey, ...rootPath]);
-    const fieldKey = getSimpleSdkIssueFieldKey(rootPath);
-    const { actual, limit, reasonMessage, suggestedFix, validationCode, validationParams } =
-      getDatasetSdkIssueReason(resolvedIssue, actualValue);
-    const tabName = getSimpleSdkIssueTabName(rootPath, config);
-    /* istanbul ignore next -- detail key fallbacks only guard against impossible/legacy malformed sdk payloads */
-    const detailKey = [
-      tabName ?? 'unknown',
-      fieldPath,
-      validationCode,
-      JSON.stringify(validationParams),
-    ].join(':');
+      const rootPath = toRootFormPath(path, config.datasetKey);
+      if (rootPath.length === 0) {
+        return;
+      }
 
-    const detail: ValidationIssueSdkDetail = {
-      actual,
-      fieldKey,
-      fieldLabel: getSimpleSdkIssueFieldLabel(rootPath, orderedJson, config),
-      fieldPath,
-      formName,
-      key: detailKey,
-      limit,
-      presentation: 'field',
-      rawCode: resolvedIssue.rawCode ?? resolvedIssue.code,
-      reasonMessage,
-      suggestedFix,
-      tabName,
-      validationCode,
-      validationParams,
-    };
+      const formName = getSimpleSdkIssueFormName(rootPath, orderedJson, config);
+      const fieldPath = formName.map(String).join('.');
+      const actualValue =
+        resolvedIssue.input !== undefined
+          ? resolvedIssue.input
+          : getValueAtPath(orderedJson, [config.datasetKey, ...rootPath]);
+      const fieldKey = getSimpleSdkIssueFieldKey(rootPath);
+      const { actual, limit, reasonMessage, suggestedFix, validationCode, validationParams } =
+        getDatasetSdkIssueReason(resolvedIssue, actualValue);
+      const tabName = getSimpleSdkIssueTabName(rootPath, config);
+      /* istanbul ignore next -- detail key fallbacks only guard against impossible/legacy malformed sdk payloads */
+      const detailKey = [
+        tabName ?? 'unknown',
+        fieldPath,
+        validationCode,
+        JSON.stringify(validationParams),
+      ].join(':');
 
-    if (!detailMap.has(detail.key)) {
-      detailMap.set(detail.key, detail);
-    }
+      const detail: ValidationIssueSdkDetail = {
+        actual,
+        fieldKey,
+        fieldLabel: getSimpleSdkIssueFieldLabel(rootPath, orderedJson, config),
+        fieldPath,
+        formName,
+        key: detailKey,
+        limit,
+        presentation: 'field',
+        rawCode: resolvedIssue.rawCode ?? resolvedIssue.code,
+        reasonMessage,
+        suggestedFix,
+        tabName,
+        validationCode,
+        validationParams,
+      };
+
+      if (!detailMap.has(detail.key)) {
+        detailMap.set(detail.key, detail);
+      }
+    });
   });
 
   return Array.from(detailMap.values());
 };
 
 export const simpleSdkValidationTestUtils = {
+  collectLeafUnionIssues,
   getDatasetSdkIssueReason,
   getSimpleSdkIssueFieldKey,
   getSimpleSdkIssueFormName,

--- a/tests/unit/components/LevelTextItemForm.test.tsx
+++ b/tests/unit/components/LevelTextItemForm.test.tsx
@@ -49,8 +49,12 @@ jest.mock('antd', () => {
     );
   };
 
-  const FormItem = ({ children, label, help, hidden }: any) => (
-    <div data-testid='form-item' data-hidden={hidden ? 'true' : 'false'}>
+  const FormItem = ({ children, label, help, hidden, validateStatus }: any) => (
+    <div
+      data-testid='form-item'
+      data-hidden={hidden ? 'true' : 'false'}
+      data-validate-status={validateStatus}
+    >
       {label ? <label>{typeof label === 'string' ? label : label}</label> : null}
       <div>{children}</div>
       {help ? <div role='alert'>{help}</div> : null}
@@ -146,6 +150,34 @@ describe('LevelTextItemForm', () => {
 
     expect(screen.getByText('Classification')).toBeInTheDocument();
     expect(screen.getByText('Please input classification')).toBeInTheDocument();
+  });
+
+  it('shows external validation help when classification validation fails', async () => {
+    mockGetILCDClassification.mockResolvedValue({ data: [], success: true });
+    const formRef = createFormRef();
+
+    render(
+      <LevelTextItemForm
+        name={['classification']}
+        lang='en'
+        dataType='Process'
+        flowType='Product flow'
+        formRef={formRef}
+        hidden={false}
+        onData={jest.fn()}
+        rules={[]}
+        showRules={false}
+        validationHelp='Select an existing classification.'
+        validationStatus='error'
+      />,
+    );
+
+    expect(screen.getAllByTestId('form-item')[0]).toHaveAttribute('data-validate-status', 'error');
+    expect(screen.getByText('Select an existing classification.')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockGetILCDClassification).toHaveBeenCalledWith('Process', 'en', ['all']);
+    });
   });
 
   it('fetches flow categorization when requesting elementary flow data', async () => {

--- a/tests/unit/pages/Contacts/ContactEdit.test.tsx
+++ b/tests/unit/pages/Contacts/ContactEdit.test.tsx
@@ -342,6 +342,25 @@ jest.mock('@/components/RefsOfNewVersionDrawer', () => ({
 jest.mock('@/pages/Utils/review', () => ({
   __esModule: true,
   buildValidationIssues: (...args: any[]) => mockBuildValidationIssues(...args),
+  collectValidationIssueRefTabNames: ({ refs, resolveTabName }: any) => {
+    const tabNames: string[] = [];
+    const tabNamesByKey = new Map<string, string[]>();
+
+    refs.forEach((ref: any) => {
+      const tabName = resolveTabName(ref);
+      if (!tabName) return;
+      if (!tabNames.includes(tabName)) tabNames.push(tabName);
+      const key = `${ref['@type']}:${ref['@refObjectId']}:${ref['@version']}`;
+      const refTabNames = tabNamesByKey.get(key) ?? [];
+      if (!refTabNames.includes(tabName)) tabNamesByKey.set(key, [...refTabNames, tabName]);
+    });
+
+    return {
+      getRefTabNames: (ref: any) =>
+        tabNamesByKey.get(`${ref['@type']}:${ref['@refObjectId']}:${ref['@version']}`),
+      tabNames,
+    };
+  },
   enrichValidationIssuesWithOwner: (...args: any[]) => mockEnrichValidationIssuesWithOwner(...args),
   ReffPath: jest
     .fn()

--- a/tests/unit/pages/Contacts/ContactForm.test.tsx
+++ b/tests/unit/pages/Contacts/ContactForm.test.tsx
@@ -298,6 +298,15 @@ describe('ContactForm component', () => {
     });
   });
 
+  it('highlights tabs with reference validation issues using the error color token', () => {
+    renderForm({ validationIssueTabNames: ['contactInformation'] });
+
+    expect(screen.getByText('Contact information')).toHaveStyle({
+      color: '#ff4d4f',
+      fontWeight: '600',
+    });
+  });
+
   it('falls back to the primary color when sdk-highlighted tabs have no explicit error color token', () => {
     mockSdkValidationCountsByTab = {
       contactInformation: 1,

--- a/tests/unit/pages/Flowproperties/edit.test.tsx
+++ b/tests/unit/pages/Flowproperties/edit.test.tsx
@@ -328,6 +328,25 @@ jest.mock('@/pages/Utils/review', () => ({
   __esModule: true,
   buildValidationIssues: (...args: any[]) => mockBuildValidationIssues(...args),
   checkData: (...args: any[]) => mockCheckData(...args),
+  collectValidationIssueRefTabNames: ({ refs, resolveTabName }: any) => {
+    const tabNames: string[] = [];
+    const tabNamesByKey = new Map<string, string[]>();
+
+    refs.forEach((ref: any) => {
+      const tabName = resolveTabName(ref);
+      if (!tabName) return;
+      if (!tabNames.includes(tabName)) tabNames.push(tabName);
+      const key = `${ref['@type']}:${ref['@refObjectId']}:${ref['@version']}`;
+      const refTabNames = tabNamesByKey.get(key) ?? [];
+      if (!refTabNames.includes(tabName)) tabNamesByKey.set(key, [...refTabNames, tabName]);
+    });
+
+    return {
+      getRefTabNames: (ref: any) =>
+        tabNamesByKey.get(`${ref['@type']}:${ref['@refObjectId']}:${ref['@version']}`),
+      tabNames,
+    };
+  },
   enrichValidationIssuesWithOwner: (...args: any[]) => mockEnrichValidationIssuesWithOwner(...args),
   ReffPath: jest.fn(() => ({
     findProblemNodes: () => mockFindProblemNodes(),

--- a/tests/unit/pages/Flowproperties/form.test.tsx
+++ b/tests/unit/pages/Flowproperties/form.test.tsx
@@ -433,6 +433,34 @@ describe('FlowpropertyForm', () => {
     });
   });
 
+  it('highlights tabs with reference validation issues using the error color token', () => {
+    const formRef = {
+      current: {
+        setFieldsValue: jest.fn(),
+        setFieldValue: jest.fn(),
+        getFieldsValue: jest.fn(() => ({})),
+      },
+    };
+
+    renderWithProviders(
+      <FlowpropertyForm
+        lang='en'
+        activeTabKey='flowPropertiesInformation'
+        drawerVisible={true}
+        formRef={formRef as any}
+        onData={jest.fn()}
+        onTabChange={jest.fn()}
+        formType='create'
+        validationIssueTabNames={['administrativeInformation']}
+      />,
+    );
+
+    expect(screen.getByText('Administrative information')).toHaveStyle({
+      color: '#ff4d4f',
+      fontWeight: '600',
+    });
+  });
+
   it('falls back to the primary color when sdk-highlighted tabs have no explicit error color token', () => {
     mockSdkValidationCountsByTab = {
       administrativeInformation: 1,

--- a/tests/unit/pages/Flows/Components/Property/edit.test.tsx
+++ b/tests/unit/pages/Flows/Components/Property/edit.test.tsx
@@ -20,12 +20,20 @@ const toText = (node: any): string => {
 };
 
 let lastFormApi: any = null;
+let mockLangTextItemFormProps: any[] = [];
 
 jest.mock('umi', () => ({
   __esModule: true,
   FormattedMessage: ({ defaultMessage, id }: any) => defaultMessage ?? id,
   useIntl: () => ({
-    formatMessage: ({ defaultMessage, id }: any) => defaultMessage ?? id,
+    formatMessage: ({ defaultMessage, id }: any) => {
+      const messages: Record<string, string> = {
+        'pages.validationIssues.sdkDetail.suggestedFix.localized_text_zh_must_include_chinese_character':
+          'Chinese text must include at least one Chinese character',
+      };
+
+      return messages[id] ?? defaultMessage ?? id;
+    },
   }),
 }));
 
@@ -42,7 +50,10 @@ jest.mock('@/style/custom.less', () => ({
 
 jest.mock('@/components/LangTextItem/form', () => ({
   __esModule: true,
-  default: () => <div data-testid='lang-form'>lang-form</div>,
+  default: (props: any) => {
+    mockLangTextItemFormProps.push(props);
+    return <div data-testid='lang-form'>lang-form</div>;
+  },
 }));
 
 jest.mock('@/pages/Flowproperties/Components/select/form', () => ({
@@ -247,6 +258,7 @@ describe('FlowPropertyEdit', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     lastFormApi = null;
+    mockLangTextItemFormProps = [];
   });
 
   it('updates the targeted flow property, reloads the table, and closes the drawer', async () => {
@@ -554,6 +566,67 @@ describe('FlowPropertyEdit', () => {
 
     expect(lastFormApi.setFields).not.toHaveBeenCalled();
     expect(lastFormApi.getFieldError(['meanValue'])).toEqual(['Local mean value error']);
+  });
+
+  it('passes localized general-comment sdk errors to the lang-text field renderer', async () => {
+    const actionRef = { current: { reload: jest.fn() } };
+    renderWithProviders(
+      <PropertyEdit
+        id='1'
+        data={
+          [
+            {
+              '@dataSetInternalID': '1',
+              generalComment: [
+                {
+                  '#text': 'English comment',
+                  '@xml:lang': 'en',
+                },
+                {
+                  '#text': 'English content',
+                  '@xml:lang': 'zh',
+                },
+              ],
+            },
+          ] as any
+        }
+        lang='en'
+        buttonType='text'
+        actionRef={actionRef as any}
+        setViewDrawerVisible={jest.fn()}
+        onData={jest.fn()}
+        autoOpen
+        sdkHighlights={
+          [
+            {
+              fieldPath: 'flowProperty[#prop-1].generalComment.1.#text',
+              formName: ['generalComment', 1, '#text'],
+              key: 'flow-property-general-comment-language-highlight',
+              reasonMessage:
+                "@xml:lang values starting with 'zh' must include at least one Chinese character",
+              tabName: 'flowProperties',
+              validationCode: 'localized_text_zh_must_include_chinese_character',
+            },
+          ] as any
+        }
+      />,
+    );
+
+    await screen.findByRole('dialog', { name: /edit flow property/i });
+    await waitFor(() => expect(lastFormApi).not.toBeNull());
+
+    const generalCommentLangTextProps = mockLangTextItemFormProps.find(
+      (props) => Array.isArray(props.name) && props.name[0] === 'generalComment',
+    );
+
+    expect(generalCommentLangTextProps?.fieldErrorMessages).toEqual({
+      1: ['Chinese text must include at least one Chinese character'],
+    });
+    expect(lastFormApi.setFields).not.toHaveBeenCalledWith([
+      expect.objectContaining({
+        name: ['generalComment', 1, '#text'],
+      }),
+    ]);
   });
 
   it('uses the flow-property frontend required copy for sdk required_missing highlights', async () => {

--- a/tests/unit/pages/Flows/Components/edit.test.tsx
+++ b/tests/unit/pages/Flows/Components/edit.test.tsx
@@ -26,6 +26,7 @@ const mockCheckData = jest.fn(async () => {});
 const mockFindProblemNodes = jest.fn(() => []);
 const mockGetErrRefTab = jest.fn(() => '');
 const mockBuildValidationIssues = jest.fn(() => []);
+const mockMapValidationIssuesToRefCheckData = jest.fn(() => []);
 const mockEnrichValidationIssuesWithOwner = jest.fn(async (issues: any[]) => issues);
 const mockValidateEnhanced = jest.fn(() => ({ success: true }));
 const mockValidateDatasetWithSdk = jest.fn(() => ({ success: true, issues: [] }));
@@ -34,6 +35,7 @@ const mockJsonToList = jest.fn((value: any) => {
   return Array.isArray(value) ? value : [value];
 });
 let latestFlowFormProps: any = null;
+let mockLatestRefCheckProviderValue: any = null;
 
 const flowTypeOfDatasetIssuePath = [
   'flowDataSet',
@@ -256,7 +258,10 @@ jest.mock('@/components/RefsOfNewVersionDrawer', () => ({
 jest.mock('@/contexts/refCheckContext', () => ({
   __esModule: true,
   RefCheckContext: {
-    Provider: ({ children }: any) => <div>{children}</div>,
+    Provider: ({ children, value }: any) => {
+      mockLatestRefCheckProviderValue = value;
+      return <div>{children}</div>;
+    },
   },
   useRefCheckContext: () => mockParentRefCheckContext,
 }));
@@ -378,6 +383,8 @@ jest.mock('@/pages/Utils/review', () => ({
   })),
   checkData: (...args: any[]) => mockCheckData(...args),
   getErrRefTab: (...args: any[]) => mockGetErrRefTab(...args),
+  mapValidationIssuesToRefCheckData: (...args: any[]) =>
+    mockMapValidationIssuesToRefCheckData(...args),
   validateDatasetWithSdk: (...args: any[]) => mockValidateDatasetWithSdk(...args),
 }));
 
@@ -471,8 +478,10 @@ describe('FlowsEdit', () => {
   beforeEach(() => {
     latestRefsDrawerProps = null;
     latestFlowFormProps = null;
+    mockLatestRefCheckProviderValue = null;
     jest.clearAllMocks();
     mockBuildValidationIssues.mockReturnValue([]);
+    mockMapValidationIssuesToRefCheckData.mockReturnValue([]);
     mockEnrichValidationIssuesWithOwner.mockImplementation(async (issues: any[]) => issues);
     mockCheckData.mockResolvedValue(undefined);
     mockFindProblemNodes.mockReturnValue([]);
@@ -860,6 +869,59 @@ describe('FlowsEdit', () => {
       ),
     );
     expect(mockGetErrRefTab).toHaveBeenCalled();
+  });
+
+  it('maps flow-property reference validation issues back into ref-check context', async () => {
+    const flowPropertyRef = {
+      '@type': 'flow property data set',
+      '@refObjectId': 'fp-1',
+      '@version': '1.0.0',
+    };
+    const validationIssues = [
+      {
+        code: 'nonExistentRef',
+        link: '/mydata/flowproperties?id=fp-1&version=1.0.0',
+        ref: flowPropertyRef,
+        tabName: 'flowProperties',
+      },
+    ];
+    const mappedRefCheckData = [
+      {
+        id: 'fp-1',
+        version: '1.0.0',
+        ruleVerification: true,
+        nonExistent: true,
+      },
+    ];
+
+    mockCheckData.mockImplementation(async (_ref: any, _unRule: any[], nonExistent: any[]) => {
+      nonExistent.push(flowPropertyRef);
+    });
+    mockGetErrRefTab.mockReturnValue('flowProperties');
+    mockBuildValidationIssues.mockReturnValueOnce(validationIssues);
+    mockMapValidationIssuesToRefCheckData.mockReturnValueOnce(mappedRefCheckData);
+
+    renderWithProviders(
+      <FlowsEdit
+        id='flow-1'
+        version='1.0.0'
+        buttonType='text'
+        lang='en'
+        updateErrRef={jest.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /edit/i }));
+    await screen.findByTestId('flow-form');
+    await userEvent.click(screen.getByRole('button', { name: /^data check$/i }));
+
+    await waitFor(() =>
+      expect(mockMapValidationIssuesToRefCheckData).toHaveBeenCalledWith(validationIssues),
+    );
+    await waitFor(() =>
+      expect(mockLatestRefCheckProviderValue?.refCheckData).toEqual(mappedRefCheckData),
+    );
+    expect(latestFlowFormProps.validationIssueTabNames).toEqual(['flowProperties']);
   });
 
   it('shows the generic flow data-check error when issues do not map to tabs', async () => {

--- a/tests/unit/pages/Flows/Components/edit.test.tsx
+++ b/tests/unit/pages/Flows/Components/edit.test.tsx
@@ -353,6 +353,25 @@ jest.mock('@/pages/Utils/updateReference', () => ({
 jest.mock('@/pages/Utils/review', () => ({
   __esModule: true,
   buildValidationIssues: (...args: any[]) => mockBuildValidationIssues(...args),
+  collectValidationIssueRefTabNames: ({ refs, resolveTabName }: any) => {
+    const tabNames: string[] = [];
+    const tabNamesByKey = new Map<string, string[]>();
+
+    refs.forEach((ref: any) => {
+      const tabName = resolveTabName(ref);
+      if (!tabName) return;
+      if (!tabNames.includes(tabName)) tabNames.push(tabName);
+      const key = `${ref['@type']}:${ref['@refObjectId']}:${ref['@version']}`;
+      const refTabNames = tabNamesByKey.get(key) ?? [];
+      if (!refTabNames.includes(tabName)) tabNamesByKey.set(key, [...refTabNames, tabName]);
+    });
+
+    return {
+      getRefTabNames: (ref: any) =>
+        tabNamesByKey.get(`${ref['@type']}:${ref['@refObjectId']}:${ref['@version']}`),
+      tabNames,
+    };
+  },
   enrichValidationIssuesWithOwner: (...args: any[]) => mockEnrichValidationIssuesWithOwner(...args),
   ReffPath: jest.fn(() => ({
     findProblemNodes: () => mockFindProblemNodes(),

--- a/tests/unit/pages/Flows/Components/form.test.tsx
+++ b/tests/unit/pages/Flows/Components/form.test.tsx
@@ -64,7 +64,7 @@ jest.mock('antd', () => {
       <div>
         {tabList.map((tab: any) => (
           <button type='button' key={tab.key} onClick={() => onTabChange?.(tab.key)}>
-            {toText(tab.tab)}
+            {tab.tab}
           </button>
         ))}
       </div>
@@ -97,7 +97,16 @@ jest.mock('antd', () => {
   const Space = ({ children }: any) => <div>{children}</div>;
   const Tooltip = ({ children }: any) => <>{children}</>;
   const Divider = ({ children }: any) => <div>{children}</div>;
-  const theme = { useToken: () => ({ token: { colorTextDescription: '#000' } }) };
+  const theme = {
+    useToken: () => ({
+      token: {
+        colorError: '#ff4d4f',
+        colorPrimary: '#1677ff',
+        colorTextDescription: '#000',
+        fontWeightStrong: 600,
+      },
+    }),
+  };
   return { __esModule: true, Card, Form, Input, Select, Space, Tooltip, Divider, theme };
 });
 
@@ -257,6 +266,17 @@ describe('FlowForm (src/pages/Flows/Components/form.tsx)', () => {
 
     fireEvent.click(screen.getByText('Modelling and validation'));
     expect(props.onTabChange).toHaveBeenCalled();
+  });
+
+  it('highlights tabs with reference validation issues using the error color token', async () => {
+    await act(async () => {
+      render(<FlowForm {...baseProps()} validationIssueTabNames={['administrativeInformation']} />);
+    });
+
+    expect(screen.getByText('Administrative information').parentElement).toHaveStyle({
+      color: '#ff4d4f',
+      fontWeight: '600',
+    });
   });
 
   it('resets classification fields when switching away from elementary flow', async () => {

--- a/tests/unit/pages/Flows/sdkValidation.test.ts
+++ b/tests/unit/pages/Flows/sdkValidation.test.ts
@@ -187,6 +187,88 @@ describe('Flows sdkValidation', () => {
     );
   });
 
+  it('maps each TIDAS union flow-property leaf issue to the owning row and detail field', () => {
+    const details = normalizeFlowSdkValidationDetails(
+      [
+        {
+          code: 'invalid_union',
+          errors: [
+            [
+              {
+                code: 'invalid_type',
+                expected: 'object',
+                message: 'Invalid input: expected object, received array',
+                path: [],
+              },
+            ],
+            [
+              {
+                code: 'custom',
+                message:
+                  "@xml:lang values starting with 'zh' must include at least one Chinese character",
+                params: {
+                  validationCode: 'localized_text_zh_must_include_chinese_character',
+                },
+                path: [0, 'generalComment', 1, '#text'],
+              },
+              {
+                code: 'invalid_type',
+                expected: 'string',
+                message: 'Invalid input: expected string, received undefined',
+                path: [1, 'meanValue'],
+              },
+            ],
+          ],
+          path: ['flowDataSet', 'flowProperties', 'flowProperty'],
+          rawCode: 'invalid_union',
+        },
+      ],
+      {
+        flowDataSet: {
+          flowProperties: {
+            flowProperty: [
+              {
+                '@dataSetInternalID': 'prop-1',
+                generalComment: [
+                  {
+                    '#text': 'English comment',
+                    '@xml:lang': 'en',
+                  },
+                  {
+                    '#text': 'English content',
+                    '@xml:lang': 'zh',
+                  },
+                ],
+              },
+              {
+                '@dataSetInternalID': 'prop-2',
+                meanValue: undefined,
+              },
+            ],
+          },
+        },
+      },
+    );
+
+    expect(details).toEqual([
+      expect.objectContaining({
+        fieldPath: 'flowProperty[#prop-1].generalComment.1.#text',
+        formName: ['generalComment', 1, '#text'],
+        reasonMessage:
+          "@xml:lang values starting with 'zh' must include at least one Chinese character",
+        tabName: 'flowProperties',
+        validationCode: 'localized_text_zh_must_include_chinese_character',
+      }),
+      expect.objectContaining({
+        fieldPath: 'flowProperty[#prop-2].meanValue',
+        formName: ['meanValue'],
+        suggestedFix: 'Fill in the required value for this field.',
+        tabName: 'flowProperties',
+        validationCode: 'required_missing',
+      }),
+    ]);
+  });
+
   it('falls back to positional flow-property paths when dataset internal ids are unavailable', () => {
     const details = normalizeFlowSdkValidationDetails(
       [

--- a/tests/unit/pages/LifeCycleModels/Components/form.test.tsx
+++ b/tests/unit/pages/LifeCycleModels/Components/form.test.tsx
@@ -325,6 +325,21 @@ describe('LifeCycleModelForm', () => {
     });
   });
 
+  it('highlights tabs with reference validation issues using the error color token', () => {
+    renderWithProviders(
+      <LifeCycleModelForm
+        {...baseProps}
+        activeTabKey='lifeCycleModelInformation'
+        validationIssueTabNames={['modellingAndValidation']}
+      />,
+    );
+
+    expect(screen.getByText('Modelling and validation').parentElement).toHaveStyle({
+      color: '#ff4d4f',
+      fontWeight: '600',
+    });
+  });
+
   it('falls back to the primary color when sdk-highlighted tabs have no explicit error color token', () => {
     mockSdkValidationCountsByTab = {
       complianceDeclarations: 1,

--- a/tests/unit/pages/LifeCycleModels/Components/form.test.tsx
+++ b/tests/unit/pages/LifeCycleModels/Components/form.test.tsx
@@ -56,9 +56,9 @@ jest.mock('@/components/LangTextItem/form', () => ({
 
 jest.mock('@/components/LevelTextItem/form', () => ({
   __esModule: true,
-  default: ({ name, dataType, onData }: any) => (
+  default: ({ name, dataType, onData, validationHelp, validationStatus }: any) => (
     <button type='button' data-testid='level-text-form' onClick={onData}>
-      {JSON.stringify({ name, dataType })}
+      {JSON.stringify({ name, dataType, validationHelp, validationStatus })}
     </button>
   ),
 }));
@@ -338,6 +338,64 @@ describe('LifeCycleModelForm', () => {
       color: '#ff4d4f',
       fontWeight: '600',
     });
+  });
+
+  it('passes sdk classification validation errors to the classification field', () => {
+    const classificationFormName = [
+      'lifeCycleModelInformation',
+      'dataSetInformation',
+      'classificationInformation',
+      'common:classification',
+      'common:class',
+      'showValue',
+    ];
+
+    renderWithProviders(
+      <LifeCycleModelForm
+        {...baseProps}
+        activeTabKey='lifeCycleModelInformation'
+        sdkValidationDetails={[
+          {
+            fieldPath: classificationFormName.join('.'),
+            formName: classificationFormName,
+            key: 'classification-not-found',
+            suggestedFix: 'Select an existing classification.',
+            tabName: 'lifeCycleModelInformation',
+            validationCode: 'custom',
+          } as any,
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId('level-text-form')).toHaveTextContent('"validationStatus":"error"');
+    expect(screen.getByTestId('level-text-form')).toHaveTextContent(
+      '"validationHelp":"Please input classification"',
+    );
+  });
+
+  it('matches sdk classification validation errors by fieldPath fallback', () => {
+    const classificationFieldPath =
+      'lifeCycleModelInformation.dataSetInformation.classificationInformation.common:classification.common:class.showValue';
+
+    renderWithProviders(
+      <LifeCycleModelForm
+        {...baseProps}
+        activeTabKey='lifeCycleModelInformation'
+        sdkValidationDetails={[
+          {
+            fieldPath: classificationFieldPath,
+            key: 'classification-field-path-only',
+            tabName: 'lifeCycleModelInformation',
+            validationCode: 'custom',
+          } as any,
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId('level-text-form')).toHaveTextContent('"validationStatus":"error"');
+    expect(screen.getByTestId('level-text-form')).toHaveTextContent(
+      '"validationHelp":"Please input classification"',
+    );
   });
 
   it('falls back to the primary color when sdk-highlighted tabs have no explicit error color token', () => {

--- a/tests/unit/pages/LifeCycleModels/Components/toolbar/eidtInfo.test.tsx
+++ b/tests/unit/pages/LifeCycleModels/Components/toolbar/eidtInfo.test.tsx
@@ -395,6 +395,25 @@ jest.mock('@/pages/Utils/review', () => ({
   checkReferences: (...args: any[]) => mockCheckReferences(...args),
   checkVersions: (...args: any[]) => mockCheckVersions(...args),
   checkRequiredFields: (...args: any[]) => mockCheckRequiredFields(...args),
+  collectValidationIssueRefTabNames: ({ refs, resolveTabName }: any) => {
+    const tabNames: string[] = [];
+    const tabNamesByKey = new Map<string, string[]>();
+
+    refs.forEach((ref: any) => {
+      const tabName = resolveTabName(ref);
+      if (!tabName) return;
+      if (!tabNames.includes(tabName)) tabNames.push(tabName);
+      const key = `${ref['@type']}:${ref['@refObjectId']}:${ref['@version']}`;
+      const refTabNames = tabNamesByKey.get(key) ?? [];
+      if (!refTabNames.includes(tabName)) tabNamesByKey.set(key, [...refTabNames, tabName]);
+    });
+
+    return {
+      getRefTabNames: (ref: any) =>
+        tabNamesByKey.get(`${ref['@type']}:${ref['@refObjectId']}:${ref['@version']}`),
+      tabNames,
+    };
+  },
   dealModel: (...args: any[]) => mockDealModel(...args),
   dealProcress: (...args: any[]) => mockDealProcress(...args),
   enrichValidationIssuesWithOwner: (...args: any[]) => mockEnrichValidationIssuesWithOwner(...args),

--- a/tests/unit/pages/LifeCycleModels/sdkValidation.test.ts
+++ b/tests/unit/pages/LifeCycleModels/sdkValidation.test.ts
@@ -211,6 +211,62 @@ describe('LifeCycleModels sdkValidation', () => {
     ]);
   });
 
+  it('maps classification existence issues to the classification showValue field', () => {
+    const details = normalizeLifeCycleModelSdkValidationDetails(
+      [
+        {
+          code: 'custom',
+          message: 'Classification does not exist',
+          path: [
+            'lifeCycleModelDataSet',
+            'lifeCycleModelInformation',
+            'dataSetInformation',
+            'classificationInformation',
+            'common:classification',
+            'common:class',
+            0,
+            '@classId',
+          ],
+        },
+      ],
+      {
+        lifeCycleModelDataSet: {
+          lifeCycleModelInformation: {
+            dataSetInformation: {
+              classificationInformation: {
+                'common:classification': {
+                  'common:class': [
+                    {
+                      '@classId': 'missing-classification',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    );
+
+    expect(details).toEqual([
+      expect.objectContaining({
+        fieldLabel: 'Classification',
+        fieldPath:
+          'lifeCycleModelInformation.dataSetInformation.classificationInformation.common:classification.common:class.showValue',
+        formName: [
+          'lifeCycleModelInformation',
+          'dataSetInformation',
+          'classificationInformation',
+          'common:classification',
+          'common:class',
+          'showValue',
+        ],
+        tabName: 'lifeCycleModelInformation',
+        validationCode: 'custom',
+      }),
+    ]);
+  });
+
   it('ignores non-metadata roots when building the form-level validation list', () => {
     expect(
       normalizeLifeCycleModelSdkValidationDetails(

--- a/tests/unit/pages/Processes/Components/edit.test.tsx
+++ b/tests/unit/pages/Processes/Components/edit.test.tsx
@@ -147,6 +147,25 @@ jest.mock('@/pages/Utils/review', () => ({
   buildValidationIssues: (...args: any[]) => mockBuildValidationIssues(...args),
   checkReferences: (...args: any[]) => mockCheckReferences(...args),
   checkVersions: (...args: any[]) => mockCheckVersions(...args),
+  collectValidationIssueRefTabNames: ({ refs, resolveTabName }: any) => {
+    const tabNames: string[] = [];
+    const tabNamesByKey = new Map<string, string[]>();
+
+    refs.forEach((ref: any) => {
+      const tabName = resolveTabName(ref);
+      if (!tabName) return;
+      if (!tabNames.includes(tabName)) tabNames.push(tabName);
+      const key = `${ref['@type']}:${ref['@refObjectId']}:${ref['@version']}`;
+      const refTabNames = tabNamesByKey.get(key) ?? [];
+      if (!refTabNames.includes(tabName)) tabNamesByKey.set(key, [...refTabNames, tabName]);
+    });
+
+    return {
+      getRefTabNames: (ref: any) =>
+        tabNamesByKey.get(`${ref['@type']}:${ref['@refObjectId']}:${ref['@version']}`),
+      tabNames,
+    };
+  },
   dealProcress: (...args: any[]) => mockDealProcress(...args),
   enrichValidationIssuesWithOwner: (...args: any[]) => mockEnrichValidationIssuesWithOwner(...args),
   getAllRefObj: (...args: any[]) => mockGetAllRefObj(...args),

--- a/tests/unit/pages/Processes/Components/edit.test.tsx
+++ b/tests/unit/pages/Processes/Components/edit.test.tsx
@@ -2102,6 +2102,54 @@ describe('ProcessEdit component', () => {
     );
   });
 
+  it('passes reference issue tabs into the validation modal and process form during data check', async () => {
+    const sourceRef = {
+      '@type': 'source data set',
+      '@refObjectId': 'source-1',
+      '@version': '01.00.000',
+    };
+    const validationIssues = [
+      {
+        code: 'ruleVerificationFailed',
+        ref: sourceRef,
+        tabName: 'modellingAndValidation',
+        tabNames: ['modellingAndValidation'],
+      },
+    ];
+    mockDealProcress.mockImplementationOnce(
+      (_processDetail, _unReview, _underReview, unRuleVerification) => {
+        unRuleVerification.push(sourceRef);
+      },
+    );
+    mockGetErrRefTab.mockImplementationOnce((ref: any) =>
+      ref?.['@refObjectId'] === 'source-1' ? 'modellingAndValidation' : '',
+    );
+    mockBuildValidationIssues.mockImplementationOnce(({ getRefTabNames, unRuleVerification }) => {
+      expect(unRuleVerification).toEqual([sourceRef]);
+      expect(getRefTabNames(sourceRef)).toEqual(['modellingAndValidation']);
+      return validationIssues;
+    });
+    mockMapValidationIssuesToRefCheckData.mockReturnValueOnce([{ id: 'source-1' }]);
+
+    render(<ProcessEdit {...baseProps} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    await screen.findByRole('dialog', { name: 'Edit process' });
+    fireEvent.click(screen.getByRole('button', { name: 'Data Check' }));
+
+    await waitFor(() =>
+      expect(latestProcessFormProps.validationIssueTabNames).toEqual(['modellingAndValidation']),
+    );
+    await waitFor(() =>
+      expect(mockShowValidationIssueModal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          issues: validationIssues,
+          title: 'Data validation issues',
+        }),
+      ),
+    );
+  });
+
   it('falls back to empty exchanges when reference updates return no exchange payload', async () => {
     mockUpdateRefsData.mockReturnValue(undefined);
     mockGetRefsOfNewVersion

--- a/tests/unit/pages/Processes/Components/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/form.test.tsx
@@ -751,6 +751,17 @@ describe('ProcessForm component', () => {
     });
   });
 
+  it('highlights tabs that contain reference validation issues', () => {
+    render(<ProcessForm {...defaultProps} validationIssueTabNames={['exchanges']} />);
+
+    expect(screen.getByRole('button', { name: 'Exchanges' }).querySelector('span')).toHaveStyle({
+      color: 'red',
+    });
+    expect(
+      screen.getByRole('button', { name: 'Process information' }).querySelector('span'),
+    ).not.toHaveStyle({ color: 'red' });
+  });
+
   it('counts review and compliance issues on their rendered tabs', async () => {
     render(
       <ProcessForm

--- a/tests/unit/pages/Sources/SourceEdit.test.tsx
+++ b/tests/unit/pages/Sources/SourceEdit.test.tsx
@@ -404,6 +404,25 @@ jest.mock('@/components/RefsOfNewVersionDrawer', () => ({
 jest.mock('@/pages/Utils/review', () => ({
   __esModule: true,
   buildValidationIssues: (...args: any[]) => mockBuildValidationIssues(...args),
+  collectValidationIssueRefTabNames: ({ refs, resolveTabName }: any) => {
+    const tabNames: string[] = [];
+    const tabNamesByKey = new Map<string, string[]>();
+
+    refs.forEach((ref: any) => {
+      const tabName = resolveTabName(ref);
+      if (!tabName) return;
+      if (!tabNames.includes(tabName)) tabNames.push(tabName);
+      const key = `${ref['@type']}:${ref['@refObjectId']}:${ref['@version']}`;
+      const refTabNames = tabNamesByKey.get(key) ?? [];
+      if (!refTabNames.includes(tabName)) tabNamesByKey.set(key, [...refTabNames, tabName]);
+    });
+
+    return {
+      getRefTabNames: (ref: any) =>
+        tabNamesByKey.get(`${ref['@type']}:${ref['@refObjectId']}:${ref['@version']}`),
+      tabNames,
+    };
+  },
   enrichValidationIssuesWithOwner: (...args: any[]) => mockEnrichValidationIssuesWithOwner(...args),
   ReffPath: jest.fn().mockImplementation(() => ({
     findProblemNodes: () => mockFindProblemNodes(),

--- a/tests/unit/pages/Sources/SourceForm.test.tsx
+++ b/tests/unit/pages/Sources/SourceForm.test.tsx
@@ -453,6 +453,15 @@ describe('SourceForm component', () => {
     });
   });
 
+  it('highlights tabs with reference validation issues using the error color token', () => {
+    renderForm({ validationIssueTabNames: ['sourceInformation'] });
+
+    expect(screen.getByText('Source information')).toHaveStyle({
+      color: '#ff4d4f',
+      fontWeight: '600',
+    });
+  });
+
   it('falls back to the primary color when sdk-highlighted tabs have no explicit error color token', () => {
     mockSdkValidationCountsByTab = {
       sourceInformation: 1,

--- a/tests/unit/pages/Unitgroups/Components/edit.test.tsx
+++ b/tests/unit/pages/Unitgroups/Components/edit.test.tsx
@@ -220,6 +220,25 @@ jest.mock('@/pages/Utils/review', () => ({
   },
   buildValidationIssues: (...args: any[]) => mockBuildValidationIssues(...args),
   checkData: (...args: any[]) => mockCheckData(...args),
+  collectValidationIssueRefTabNames: ({ refs, resolveTabName }: any) => {
+    const tabNames: string[] = [];
+    const tabNamesByKey = new Map<string, string[]>();
+
+    refs.forEach((ref: any) => {
+      const tabName = resolveTabName(ref);
+      if (!tabName) return;
+      if (!tabNames.includes(tabName)) tabNames.push(tabName);
+      const key = `${ref['@type']}:${ref['@refObjectId']}:${ref['@version']}`;
+      const refTabNames = tabNamesByKey.get(key) ?? [];
+      if (!refTabNames.includes(tabName)) tabNamesByKey.set(key, [...refTabNames, tabName]);
+    });
+
+    return {
+      getRefTabNames: (ref: any) =>
+        tabNamesByKey.get(`${ref['@type']}:${ref['@refObjectId']}:${ref['@version']}`),
+      tabNames,
+    };
+  },
   enrichValidationIssuesWithOwner: (...args: any[]) => mockEnrichValidationIssuesWithOwner(...args),
   getErrRefTab: (...args: any[]) => mockGetErrRefTab(...args),
   validateDatasetWithSdk: (...args: any[]) => mockValidateDatasetWithSdk(...args),

--- a/tests/unit/pages/Unitgroups/Components/form.test.tsx
+++ b/tests/unit/pages/Unitgroups/Components/form.test.tsx
@@ -172,7 +172,7 @@ jest.mock('antd', () => {
               data-active={tab.key === activeTabKey}
               onClick={() => onTabChange?.(tab.key)}
             >
-              {toText(tab.tab)}
+              {tab.tab}
             </button>
           ))}
         </div>
@@ -213,7 +213,10 @@ jest.mock('antd', () => {
   const theme = {
     useToken: () => ({
       token: {
+        colorError: '#ff4d4f',
+        colorPrimary: '#1677ff',
         colorTextDescription: '#999',
+        fontWeightStrong: 600,
       },
     }),
   };
@@ -522,6 +525,21 @@ describe('UnitGroupForm', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /administrative information/i }));
     expect(baseProps.onTabChange).toHaveBeenCalledWith('administrativeInformation');
+  });
+
+  it('highlights tabs with reference validation issues using the error color token', () => {
+    renderWithProviders(
+      <UnitGroupForm
+        {...baseProps}
+        activeTabKey='unitGroupInformation'
+        validationIssueTabNames={['modellingAndValidation']}
+      />,
+    );
+
+    expect(screen.getByText('Modelling and validation').parentElement).toHaveStyle({
+      color: '#ff4d4f',
+      fontWeight: '600',
+    });
   });
 
   it('adds schema-driven rules on the information tab when showRules is enabled', () => {

--- a/tests/unit/pages/Utils/sdkDetails.test.ts
+++ b/tests/unit/pages/Utils/sdkDetails.test.ts
@@ -833,6 +833,7 @@ describe('simple dataset sdk validation detail mapping', () => {
           fieldLabel: 'Localized text (ZH)',
           rawCode: 'localized_text_zh_must_include_chinese_character',
           tabName: 'meta',
+          validationCode: 'localized_text_zh_must_include_chinese_character',
         }),
         expect.objectContaining({
           fieldPath: 'custom.meta.dynamic',
@@ -845,6 +846,49 @@ describe('simple dataset sdk validation detail mapping', () => {
       ]),
     );
     expect(details).toHaveLength(4);
+  });
+
+  it('promotes custom sdk params validationCode into the detail validation code', () => {
+    const details = normalizeSimpleDatasetSdkValidationDetails(
+      [
+        {
+          code: 'custom',
+          message:
+            "@xml:lang values starting with 'zh' must include at least one Chinese character",
+          params: {
+            validationCode: 'localized_text_zh_must_include_chinese_character',
+          },
+          path: ['demoDataSet', 'meta', 'localized', 0, '#text'],
+        },
+      ],
+      {
+        demoDataSet: {
+          meta: {
+            localized: [
+              {
+                '@xml:lang': 'zh',
+                '#text': 'English content',
+              },
+            ],
+          },
+        },
+      },
+      simpleConfig,
+    );
+
+    expect(details).toEqual([
+      expect.objectContaining({
+        fieldPath: 'meta.localized.0.#text',
+        formName: ['meta', 'localized', 0, '#text'],
+        reasonMessage:
+          "@xml:lang values starting with 'zh' must include at least one Chinese character",
+        tabName: 'meta',
+        validationCode: 'localized_text_zh_must_include_chinese_character',
+        validationParams: expect.objectContaining({
+          validationCode: 'localized_text_zh_must_include_chinese_character',
+        }),
+      }),
+    ]);
   });
 
   it('covers fallback field-label, tab-name, and language-helper branches for sparse paths', () => {

--- a/tests/unit/utils/review.validation.test.ts
+++ b/tests/unit/utils/review.validation.test.ts
@@ -1,6 +1,7 @@
 import {
   buildValidationIssues,
   checkReferences,
+  collectValidationIssueRefTabNames,
   dealModel,
   dealProcress,
   enrichValidationIssuesWithOwner,
@@ -449,6 +450,50 @@ describe('review helper coverage', () => {
         tabNames: ['exchanges'],
       }),
     ]);
+  });
+
+  it('collects unique validation tab names by reference key', () => {
+    const firstRef = {
+      '@type': 'source data set',
+      '@refObjectId': 'source-1',
+      '@version': '01.00.000',
+      tabName: 'administrativeInformation',
+    };
+    const duplicateRef = {
+      ...firstRef,
+      tabName: 'administrativeInformation',
+    };
+    const secondTabRef = {
+      ...firstRef,
+      tabName: 'sourceInformation',
+    };
+    const emptyTabRef = {
+      '@type': 'contact data set',
+      '@refObjectId': 'contact-1',
+      '@version': '01.00.000',
+      tabName: '',
+    };
+
+    const result = collectValidationIssueRefTabNames({
+      refs: [firstRef, duplicateRef, secondTabRef, emptyTabRef],
+      resolveTabName: (ref) => ref.tabName,
+    });
+
+    expect(result.tabNames).toEqual(['administrativeInformation', 'sourceInformation']);
+    expect(
+      result.getRefTabNames({
+        '@type': 'source data set',
+        '@refObjectId': 'source-1',
+        '@version': '01.00.000',
+      }),
+    ).toEqual(['administrativeInformation', 'sourceInformation']);
+    expect(
+      result.getRefTabNames({
+        '@type': 'contact data set',
+        '@refObjectId': 'contact-1',
+        '@version': '01.00.000',
+      }),
+    ).toBeUndefined();
   });
 
   it('suppresses the root rule-verification issue when sdk invalid already covers the same dataset', () => {

--- a/tests/unit/utils/review.validation.test.ts
+++ b/tests/unit/utils/review.validation.test.ts
@@ -384,6 +384,73 @@ describe('review helper coverage', () => {
     ).toEqual([]);
   });
 
+  it('adds resolved tab names to reference validation issues', () => {
+    const rootRef = {
+      '@type': 'process data set',
+      '@refObjectId': 'process-root',
+      '@version': '01.00.000',
+    } as const;
+    const sourceRef = {
+      '@type': 'source data set',
+      '@refObjectId': 'source-1',
+      '@version': '01.00.000',
+    } as const;
+    const flowRef = {
+      '@type': 'flow data set',
+      '@refObjectId': 'flow-1',
+      '@version': '01.00.000',
+    } as const;
+
+    const issues = buildValidationIssues({
+      actionFrom: 'review',
+      datasetSdkValid: true,
+      getRefTabNames: (ref) => {
+        if (ref['@refObjectId'] === 'source-1') {
+          return ['modellingAndValidation', 'modellingAndValidation'];
+        }
+
+        if (ref['@refObjectId'] === 'flow-1') {
+          return 'exchanges';
+        }
+
+        return undefined;
+      },
+      nonExistentRef: [sourceRef],
+      problemNodes: [
+        {
+          ...flowRef,
+          ruleVerification: true,
+          nonExistent: false,
+          versionUnderReview: true,
+          underReviewVersion: '01.00.000',
+        },
+      ],
+      rootRef,
+      unRuleVerification: [flowRef],
+    });
+
+    expect(issues).toEqual([
+      expect.objectContaining({
+        code: 'ruleVerificationFailed',
+        ref: flowRef,
+        tabName: 'exchanges',
+        tabNames: ['exchanges'],
+      }),
+      expect.objectContaining({
+        code: 'nonExistentRef',
+        ref: sourceRef,
+        tabName: 'modellingAndValidation',
+        tabNames: ['modellingAndValidation'],
+      }),
+      expect.objectContaining({
+        code: 'underReview',
+        ref: flowRef,
+        tabName: 'exchanges',
+        tabNames: ['exchanges'],
+      }),
+    ]);
+  });
+
   it('suppresses the root rule-verification issue when sdk invalid already covers the same dataset', () => {
     const rootRef = {
       '@type': 'process data set',


### PR DESCRIPTION
## Promotion Contract

- base branch: `main`
- source branch: `ForeverYoung5:codex/release-v0.0.31-dev-to-main` (forked from `dev`)
- validated environment before promotion: local release gate and local build
- back-merge required after merge: No. This is a `dev -> main` promote PR.
- root workspace integration expected: Yes. After merge, update the `lca-workspace` submodule pointer once the promoted `main` SHA is release-eligible.

- [x] this PR promotes `dev` into `main`
- [x] integrated behavior was verified in `dev` before promotion
- [x] if the PR includes a direct `main` hotfix path, the required `main -> dev` back-merge plan is documented (N/A)

## Linked Issue

No GitHub issue was provided for this release promotion request.

## Promotion Facts

- Promotes current `dev` through `a743261b` plus release metadata commits on this branch.
- Includes the merged validation fixes from PR #547.
- Merges current `main` through `1fd70ea` into the promotion branch before release bump.
- Bumps `package.json` from `0.0.30` to `0.0.31`, so canonical `main` release automation can create the next release tag.
- Tag `v0.0.31` does not exist yet.

## Validation Facts

- `npm run docpact:gate -- --base origin/main`
- `npm run lint`
- `npm run build`
- pre-push gate on `fork/codex/release-v0.0.31-dev-to-main` with `DOCPACT_BASE_REF=origin/main`: `npm run docpact:gate -- --base origin/main`, `npm run lint`, `npm run test:coverage`, `npm run test:coverage:assert-full`
- Coverage gate: 344/344 test suites passed, 4276/4276 tests passed, 357/357 tracked source files at 100/100/100/100.

## Integration And Follow-Up

- After this PR merges to `main`, canonical `main` release workflow should create tag `v0.0.31`, run the release gate, deploy the web app, and build the draft Electron release.
- Root workspace integration should bump the `tiangong-lca-next` pointer after the promoted `main` SHA is ready.
- No `main -> dev` back-merge is required for this promote PR.
