### PR TITLE
fix: sync review-submit drawer terminal state

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-06-29'
-lastReviewedCommit: 'b48000e68a07d92ee26d3ef00d153f32083f33cb'
+lastReviewedAt: "2026-06-30"
+lastReviewedCommit: "7e9e69b423ca159846ddb326e9ed75afd060d7a4"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-06-29
-lastReviewedCommit: b48000e68a07d92ee26d3ef00d153f32083f33cb
+lastReviewedAt: 2026-06-30
+lastReviewedCommit: 7e9e69b423ca159846ddb326e9ed75afd060d7a4
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-06-29
-lastReviewedCommit: d34c5904ea7a95f221c9e976cefe8b4a86ea1ab3
+lastReviewedAt: 2026-06-30
+lastReviewedCommit: fca98160c2ef470778d32cee67b633d5ce8ed117
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.js
   - .github/workflows/**
-lastReviewedAt: 2026-06-29
-lastReviewedCommit: b48000e68a07d92ee26d3ef00d153f32083f33cb
+lastReviewedAt: 2026-06-30
+lastReviewedCommit: 7e9e69b423ca159846ddb326e9ed75afd060d7a4
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-06-29
-lastReviewedCommit: b48000e68a07d92ee26d3ef00d153f32083f33cb
+lastReviewedAt: 2026-06-30
+lastReviewedCommit: 7e9e69b423ca159846ddb326e9ed75afd060d7a4
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-06-29
-lastReviewedCommit: b48000e68a07d92ee26d3ef00d153f32083f33cb
+lastReviewedAt: 2026-06-30
+lastReviewedCommit: 7e9e69b423ca159846ddb326e9ed75afd060d7a4
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-06-29
-lastReviewedCommit: b48000e68a07d92ee26d3ef00d153f32083f33cb
+lastReviewedAt: 2026-06-30
+lastReviewedCommit: 7e9e69b423ca159846ddb326e9ed75afd060d7a4
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-06-29
-lastReviewedCommit: b48000e68a07d92ee26d3ef00d153f32083f33cb
+lastReviewedAt: 2026-06-30
+lastReviewedCommit: 7e9e69b423ca159846ddb326e9ed75afd060d7a4
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-06-29
-lastReviewedCommit: b48000e68a07d92ee26d3ef00d153f32083f33cb
+lastReviewedAt: 2026-06-30
+lastReviewedCommit: 7e9e69b423ca159846ddb326e9ed75afd060d7a4
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-06-29
-lastReviewedCommit: b48000e68a07d92ee26d3ef00d153f32083f33cb
+lastReviewedAt: 2026-06-30
+lastReviewedCommit: 7e9e69b423ca159846ddb326e9ed75afd060d7a4
 ---
 
 # Testing Troubleshooting

--- a/src/pages/Processes/Components/edit.tsx
+++ b/src/pages/Processes/Components/edit.tsx
@@ -100,6 +100,9 @@ const REVIEW_SUBMIT_JOB_PENDING_STATUSES = new Set<ReviewSubmitGateUiStatus>([
   'waiting_gate',
   'submitting',
 ]);
+const REVIEW_SUBMIT_JOB_LATEST_SYNC_INITIAL_DELAY_MS = 250;
+const REVIEW_SUBMIT_JOB_LATEST_SYNC_INTERVAL_MS = 5000;
+const REVIEW_SUBMIT_JOB_LATEST_SYNC_MAX_ATTEMPTS = 24;
 const REVIEW_SUBMIT_GATE_REASON_GUIDANCE = {
   revision_report_stale: {
     titleId: 'pages.process.reviewSubmitGate.reason.revisionReportStale.title',
@@ -260,7 +263,30 @@ const formatReviewSubmitGateEvidenceRecord = (value: unknown): string | null => 
     .filter((part): part is [string, string] => Boolean(part[1]))
     .map(([label, value]) => `${label}: ${value}`);
 
-  return parts.length > 0 ? parts.join(', ') : null;
+  if (parts.length > 0) {
+    return parts.join(', ');
+  }
+
+  const diagnosticParts = [
+    ['error', pickReviewSubmitGateEvidenceValue(record, ['error'])],
+    ['worker_job_id', pickReviewSubmitGateEvidenceValue(record, ['worker_job_id', 'workerJobId'])],
+    [
+      'submit_worker_job_id',
+      pickReviewSubmitGateEvidenceValue(record, ['submit_worker_job_id', 'submitWorkerJobId']),
+    ],
+    [
+      'gate_worker_job_id',
+      pickReviewSubmitGateEvidenceValue(record, ['gate_worker_job_id', 'gateWorkerJobId']),
+    ],
+    [
+      'review_submit_job_id',
+      pickReviewSubmitGateEvidenceValue(record, ['review_submit_job_id', 'reviewSubmitJobId']),
+    ],
+  ]
+    .filter((part): part is [string, string] => Boolean(part[1]))
+    .map(([label, value]) => `${label}: ${value}`);
+
+  return diagnosticParts.length > 0 ? diagnosticParts.join(', ') : null;
 };
 
 const formatReviewSubmitGateEvidence = (details: unknown): string[] => {
@@ -277,6 +303,54 @@ const formatReviewSubmitGateEvidence = (details: unknown): string[] => {
     .map(formatReviewSubmitGateEvidenceRecord)
     .filter((item): item is string => Boolean(item));
 };
+
+const getBlockingReasonsFromResult = (
+  result: unknown,
+): ReviewSubmitGateBlockingReason[] | undefined => {
+  const resultRecord = toReviewSubmitGateEvidenceRecord(result);
+  if (!resultRecord || !Array.isArray(resultRecord.blockingReasons)) {
+    return undefined;
+  }
+
+  return resultRecord.blockingReasons as ReviewSubmitGateBlockingReason[];
+};
+
+const getReviewSubmitJobBlockingReasons = (
+  jobData?: ReviewSubmitJobResult,
+): ReviewSubmitGateBlockingReason[] | undefined => {
+  const gateWorkerJob = jobData?.gateWorkerJob ?? undefined;
+  const blockingReasons =
+    jobData?.gate?.blockingReasons ??
+    getBlockingReasonsFromResult(gateWorkerJob?.result) ??
+    getBlockingReasonsFromResult(jobData?.result) ??
+    getBlockingReasonsFromResult(jobData?.error?.details);
+
+  if (blockingReasons && blockingReasons.length > 0) {
+    return blockingReasons;
+  }
+
+  if (!jobData?.error?.code && !jobData?.error?.message && jobData?.error?.details === undefined) {
+    return undefined;
+  }
+
+  return [
+    {
+      code: jobData.error?.code,
+      message: jobData.error?.message,
+      details: {
+        ...(toReviewSubmitGateEvidenceRecord(jobData.error?.details) ?? {
+          error: jobData.error?.details,
+        }),
+        review_submit_job_id: jobData.reviewSubmitJobId,
+        submit_worker_job_id: jobData.submitWorkerJobId ?? jobData.rootJobId,
+        gate_worker_job_id: jobData.gateWorkerJobId,
+      },
+    },
+  ];
+};
+
+const isReviewSubmitTerminalStatus = (status: ReviewSubmitGateUiStatus) =>
+  status !== 'not_run' && !REVIEW_SUBMIT_JOB_PENDING_STATUSES.has(status);
 
 const collectChangedFieldPaths = (
   value: unknown,
@@ -375,6 +449,9 @@ const ProcessEdit: FC<Props> = ({
   actionFrom,
 }) => {
   const [drawerVisible, setDrawerVisible] = useState(false);
+  const drawerVisibleRef = useRef(false);
+  const reviewSubmitLatestSyncTimeoutRef = useRef<number | null>(null);
+  const reviewSubmitLatestSyncTokenRef = useRef(0);
   const formRefEdit = useRef<ProFormInstance>();
   const [activeTabKey, setActiveTabKey] = useState<TabKeysType>('processInformation');
   const [fromData, setFromData] = useState<FormProcessWithDatas>();
@@ -415,9 +492,24 @@ const ProcessEdit: FC<Props> = ({
   const [refsNewList, setRefsNewList] = useState<RefVersionItem[]>([]);
   const [refsOldList, setRefsOldList] = useState<RefVersionItem[]>([]);
 
-  const resetReviewSubmitGateState = useCallback(() => {
-    setReviewSubmitGateState({ status: 'not_run' });
+  useEffect(() => {
+    drawerVisibleRef.current = drawerVisible;
+  }, [drawerVisible]);
+
+  const cancelReviewSubmitLatestSync = useCallback(() => {
+    reviewSubmitLatestSyncTokenRef.current += 1;
+    if (reviewSubmitLatestSyncTimeoutRef.current !== null) {
+      window.clearTimeout(reviewSubmitLatestSyncTimeoutRef.current);
+      reviewSubmitLatestSyncTimeoutRef.current = null;
+    }
   }, []);
+
+  useEffect(() => () => cancelReviewSubmitLatestSync(), [cancelReviewSubmitLatestSync]);
+
+  const resetReviewSubmitGateState = useCallback(() => {
+    cancelReviewSubmitLatestSync();
+    setReviewSubmitGateState({ status: 'not_run' });
+  }, [cancelReviewSubmitLatestSync]);
 
   const getReviewSubmitGateStatusMessage = useCallback(
     (status: ReviewSubmitGateUiStatus) => {
@@ -1315,6 +1407,108 @@ const ProcessEdit: FC<Props> = ({
     return handleCheckData('checkData', validationTarget, { silent });
   };
 
+  const applyReviewSubmitJobState = useCallback(
+    (
+      jobData: ReviewSubmitJobResult | undefined,
+      fallback?: { revisionChecksum?: string },
+    ): { status: ReviewSubmitGateUiStatus; messageText: string } => {
+      const status = jobData?.status ?? 'error';
+      const gateData = jobData?.gate ?? undefined;
+      const gateWorkerJob = jobData?.gateWorkerJob ?? undefined;
+      const gateRunId = jobData?.gateRunId ?? gateData?.gateRunId ?? undefined;
+      const revisionChecksum =
+        jobData?.datasetRevision?.revisionChecksum ??
+        gateData?.datasetRevision?.revisionChecksum ??
+        (gateWorkerJob?.result &&
+        typeof gateWorkerJob.result === 'object' &&
+        'datasetRevision' in gateWorkerJob.result
+          ? (
+              gateWorkerJob.result as {
+                datasetRevision?: { revisionChecksum?: string };
+              }
+            ).datasetRevision?.revisionChecksum
+          : undefined) ??
+        fallback?.revisionChecksum;
+      const blockingReasons = getReviewSubmitJobBlockingReasons(jobData);
+      const messageText = jobData?.error?.message || getReviewSubmitGateStatusMessage(status);
+
+      setReviewSubmitGateState({
+        status,
+        reviewSubmitJobId: jobData?.reviewSubmitJobId,
+        gateRunId,
+        revisionChecksum,
+        blockingReasons,
+        message: jobData?.error?.message,
+      });
+
+      return { status, messageText };
+    },
+    [getReviewSubmitGateStatusMessage],
+  );
+
+  const startReviewSubmitLatestSync = useCallback(
+    (processDetail: ProcessCheckTarget) => {
+      cancelReviewSubmitLatestSync();
+      const syncToken = reviewSubmitLatestSyncTokenRef.current;
+
+      const syncLatest = async (remainingAttempts: number): Promise<void> => {
+        if (!drawerVisibleRef.current || reviewSubmitLatestSyncTokenRef.current !== syncToken) {
+          return;
+        }
+
+        const latestResult = await requestReviewSubmitJob(
+          'processes',
+          processDetail.id,
+          processDetail.version,
+          null,
+          {
+            action: 'read_latest',
+          },
+        );
+
+        if (!drawerVisibleRef.current || reviewSubmitLatestSyncTokenRef.current !== syncToken) {
+          return;
+        }
+
+        const latestJobData = latestResult.data?.[0] as ReviewSubmitJobResult | undefined;
+        if (!latestJobData || latestResult.error) {
+          if (remainingAttempts > 1) {
+            reviewSubmitLatestSyncTimeoutRef.current = window.setTimeout(() => {
+              reviewSubmitLatestSyncTimeoutRef.current = null;
+              void syncLatest(remainingAttempts - 1);
+            }, REVIEW_SUBMIT_JOB_LATEST_SYNC_INTERVAL_MS);
+          }
+          return;
+        }
+
+        const { status, messageText } = applyReviewSubmitJobState(latestJobData, {
+          revisionChecksum: latestResult.revisionChecksum,
+        });
+
+        if (REVIEW_SUBMIT_JOB_PENDING_STATUSES.has(status)) {
+          if (remainingAttempts > 1) {
+            reviewSubmitLatestSyncTimeoutRef.current = window.setTimeout(() => {
+              reviewSubmitLatestSyncTimeoutRef.current = null;
+              void syncLatest(remainingAttempts - 1);
+            }, REVIEW_SUBMIT_JOB_LATEST_SYNC_INTERVAL_MS);
+          }
+          return;
+        }
+
+        trackReviewSubmitTask(latestJobData);
+        if (isReviewSubmitTerminalStatus(status) && status !== 'submitted') {
+          message.error(messageText);
+        }
+      };
+
+      reviewSubmitLatestSyncTimeoutRef.current = window.setTimeout(() => {
+        reviewSubmitLatestSyncTimeoutRef.current = null;
+        void syncLatest(REVIEW_SUBMIT_JOB_LATEST_SYNC_MAX_ATTEMPTS);
+      }, REVIEW_SUBMIT_JOB_LATEST_SYNC_INITIAL_DELAY_MS);
+    },
+    [applyReviewSubmitJobState, cancelReviewSubmitLatestSync],
+  );
+
   const runReviewSubmitJob = async (processDetail: ProcessCheckTarget) => {
     const jobResult = await requestReviewSubmitJob(
       'processes',
@@ -1344,41 +1538,8 @@ const ProcessEdit: FC<Props> = ({
     }
 
     const jobData = jobResult.data?.[0] as ReviewSubmitJobResult | undefined;
-    const status = jobData?.status ?? 'error';
-    const gateData = jobData?.gate ?? undefined;
-    const gateWorkerJob = jobData?.gateWorkerJob ?? undefined;
-    const gateRunId = jobData?.gateRunId ?? gateData?.gateRunId ?? undefined;
-    const revisionChecksum =
-      jobData?.datasetRevision?.revisionChecksum ??
-      gateData?.datasetRevision?.revisionChecksum ??
-      (gateWorkerJob?.result &&
-      typeof gateWorkerJob.result === 'object' &&
-      'datasetRevision' in gateWorkerJob.result
-        ? (
-            gateWorkerJob.result as {
-              datasetRevision?: { revisionChecksum?: string };
-            }
-          ).datasetRevision?.revisionChecksum
-        : undefined) ??
-      jobResult.revisionChecksum;
-    const blockingReasons =
-      gateData?.blockingReasons ??
-      (gateWorkerJob?.result &&
-      typeof gateWorkerJob.result === 'object' &&
-      'blockingReasons' in gateWorkerJob.result &&
-      Array.isArray((gateWorkerJob.result as { blockingReasons?: unknown }).blockingReasons)
-        ? ((gateWorkerJob.result as { blockingReasons?: ReviewSubmitGateBlockingReason[] })
-            .blockingReasons ?? [])
-        : undefined);
-    const messageText = jobData?.error?.message || getReviewSubmitGateStatusMessage(status);
-
-    setReviewSubmitGateState({
-      status,
-      reviewSubmitJobId: jobData?.reviewSubmitJobId,
-      gateRunId,
-      revisionChecksum,
-      blockingReasons,
-      message: jobData?.error?.message,
+    const { status, messageText } = applyReviewSubmitJobState(jobData, {
+      revisionChecksum: jobResult.revisionChecksum,
     });
 
     if (jobData) {
@@ -1398,6 +1559,7 @@ const ProcessEdit: FC<Props> = ({
             'Review submission task has been created. Track progress in the task center.',
         }),
       );
+      startReviewSubmitLatestSync(processDetail);
       return 'queued' as const;
     }
 

--- a/tests/unit/pages/Processes/Components/edit.test.tsx
+++ b/tests/unit/pages/Processes/Components/edit.test.tsx
@@ -1679,6 +1679,114 @@ describe('ProcessEdit component', () => {
     expect(mockRequestOpenLcaTaskCenter).toHaveBeenCalled();
   });
 
+  it('syncs pending review-submit jobs to latest terminal errors in the drawer', async () => {
+    mockUpdateProcess.mockResolvedValue({
+      data: [
+        {
+          id: 'process-1',
+          version: '1.0.0',
+          json: { processDataSet: processDataset },
+          state_code: 10,
+          rule_verification: true,
+        },
+      ],
+    });
+    mockRequestReviewSubmitJob
+      .mockResolvedValueOnce({
+        data: [{ status: 'waiting_gate', reviewSubmitJobId: 'job-waiting' }],
+        error: null,
+        reviewSubmitJobId: 'job-waiting',
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            status: 'error',
+            reviewSubmitJobId: 'job-waiting',
+            submitWorkerJobId: 'submit-worker-1',
+            gateWorkerJobId: 'gate-worker-1',
+            error: {
+              code: 'calculator_gate_error',
+              message:
+                'calculator review-submit gate worker failed before producing a passed/blocked report',
+              details: {
+                error: 'failed to build review-submit gate snapshot',
+                worker_job_id: 'gate-worker-1',
+              },
+            },
+            gate: {
+              status: 'error',
+              blockingReasons: [
+                {
+                  code: 'calculator_gate_error',
+                  message: 'failed to build review-submit gate snapshot',
+                  details: {
+                    error: 'failed to build review-submit gate snapshot',
+                    worker_job_id: 'gate-worker-1',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        error: null,
+      });
+
+    render(<ProcessEdit {...baseProps} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    await screen.findByRole('dialog', { name: 'Edit process' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit for Review' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Review submission is waiting for the numerical stability gate to finish.',
+      ),
+    );
+
+    await waitFor(() => expect(mockRequestReviewSubmitJob).toHaveBeenCalledTimes(2));
+    expect(mockRequestReviewSubmitJob).toHaveBeenNthCalledWith(
+      1,
+      'processes',
+      'process-1',
+      '1.0.0',
+      null,
+      {
+        action: 'enqueue',
+        reviewSubmitJobId: undefined,
+      },
+    );
+    expect(mockRequestReviewSubmitJob).toHaveBeenLastCalledWith(
+      'processes',
+      'process-1',
+      '1.0.0',
+      null,
+      {
+        action: 'read_latest',
+      },
+    );
+    expect(screen.getByRole('alert')).not.toHaveTextContent(
+      'Review submission is waiting for the numerical stability gate to finish.',
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'calculator review-submit gate worker failed before producing a passed/blocked report',
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'calculator_gate_error: failed to build review-submit gate snapshot',
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'error: failed to build review-submit gate snapshot, worker_job_id: gate-worker-1',
+    );
+    expect(mockTrackReviewSubmitTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'error',
+        reviewSubmitJobId: 'job-waiting',
+        submitWorkerJobId: 'submit-worker-1',
+        gateWorkerJobId: 'gate-worker-1',
+      }),
+    );
+  });
+
   it('clears a review-submit job state after data changes', async () => {
     mockUpdateProcess.mockResolvedValue({
       data: [

--- a/tests/unit/services/reviews/api.test.ts
+++ b/tests/unit/services/reviews/api.test.ts
@@ -722,6 +722,62 @@ describe('review-submit job helpers', () => {
     );
   });
 
+  it('treats read_latest structured HTTP errors as terminal job results', async () => {
+    mockFunctionsInvoke.mockResolvedValue({
+      data: null,
+      error: {
+        message: 'FunctionsHttpError',
+        context: {
+          status: 502,
+          json: async () => ({
+            ok: false,
+            command: 'dataset_review_submit_job_read_latest',
+            data: {
+              status: 'error',
+              reviewSubmitJobId: '33333333-3333-4333-8333-333333333333',
+              submitWorkerJobId: '00000000-0000-4000-8000-000000000001',
+              gateWorkerJobId: '22222222-2222-4222-8222-222222222222',
+              error: {
+                code: 'calculator_gate_error',
+                message:
+                  'calculator review-submit gate worker failed before producing a passed/blocked report',
+                details: {
+                  error: 'failed to build review-submit gate snapshot',
+                  worker_job_id: '22222222-2222-4222-8222-222222222222',
+                },
+              },
+            },
+          }),
+        },
+      },
+    });
+
+    const result = await reviewsApi.requestReviewSubmitJobApi({
+      action: 'read_latest',
+      table: 'processes',
+      id: '11111111-1111-4111-8111-111111111111',
+      version: '01.00.000',
+    });
+
+    expect(result).toEqual({
+      data: [
+        expect.objectContaining({
+          status: 'error',
+          reviewSubmitJobId: '33333333-3333-4333-8333-333333333333',
+          submitWorkerJobId: '00000000-0000-4000-8000-000000000001',
+          gateWorkerJobId: '22222222-2222-4222-8222-222222222222',
+          error: expect.objectContaining({
+            code: 'calculator_gate_error',
+          }),
+        }),
+      ],
+      error: null,
+      count: null,
+      status: 502,
+      statusText: 'OK',
+    });
+  });
+
   it('falls back to an empty bearer token when the auth session omits the access token', async () => {
     mockAuthGetSession.mockResolvedValueOnce({
       data: {

--- a/tests/unit/services/reviews/taskCenter.test.ts
+++ b/tests/unit/services/reviews/taskCenter.test.ts
@@ -172,6 +172,93 @@ describe('reviews/taskCenter', () => {
     ]);
   });
 
+  it('hydrates latest coordinator errors with worker ids and blocking diagnostics', async () => {
+    mockRequestWorkerJobsApi.mockResolvedValue({
+      data: [
+        {
+          id: '00000000-0000-4000-8000-000000000001',
+          jobKind: 'review_submit.submit',
+          subjectType: 'processes',
+          subjectId: '33333333-3333-4333-8333-333333333333',
+          subjectVersion: '01.00.000',
+          status: 'failed',
+          errorCode: 'calculator_gate_error',
+          errorMessage:
+            'calculator review-submit gate worker failed before producing a passed/blocked report',
+          createdAt: '2026-03-12T10:59:00.000Z',
+          updatedAt: '2026-03-12T11:02:00.000Z',
+        },
+      ],
+      error: null,
+    });
+    mockRequestReviewSubmitJobApi.mockResolvedValue({
+      data: [
+        {
+          status: 'error',
+          reviewSubmitJobId: '11111111-1111-4111-8111-111111111111',
+          submitWorkerJobId: '00000000-0000-4000-8000-000000000001',
+          gateWorkerJobId: '22222222-2222-4222-8222-222222222222',
+          error: {
+            code: 'calculator_gate_error',
+            message:
+              'calculator review-submit gate worker failed before producing a passed/blocked report',
+            details: {
+              error: 'failed to build review-submit gate snapshot',
+              worker_job_id: '22222222-2222-4222-8222-222222222222',
+            },
+          },
+          gate: {
+            status: 'error',
+            blockingReasons: [
+              {
+                code: 'calculator_gate_error',
+                message: 'failed to build review-submit gate snapshot',
+                details: {
+                  error: 'failed to build review-submit gate snapshot',
+                  worker_job_id: '22222222-2222-4222-8222-222222222222',
+                },
+              },
+            ],
+          },
+        },
+      ],
+      error: null,
+    });
+
+    const taskCenter = loadTaskCenterModule();
+    const tasks = await taskCenter.refreshReviewSubmitTasks();
+
+    expect(mockRequestReviewSubmitJobApi).toHaveBeenCalledWith({
+      action: 'read_latest',
+      table: 'processes',
+      id: '33333333-3333-4333-8333-333333333333',
+      version: '01.00.000',
+    });
+    expect(tasks).toEqual([
+      expect.objectContaining({
+        id: '00000000-0000-4000-8000-000000000001',
+        reviewSubmitJobId: '11111111-1111-4111-8111-111111111111',
+        submitWorkerJobId: '00000000-0000-4000-8000-000000000001',
+        gateWorkerJobId: '22222222-2222-4222-8222-222222222222',
+        phase: 'error',
+        state: 'failed',
+        error:
+          'calculator review-submit gate worker failed before producing a passed/blocked report',
+        blockingReasons: [
+          {
+            code: 'calculator_gate_error',
+            message: 'failed to build review-submit gate snapshot',
+            details: {
+              error: 'failed to build review-submit gate snapshot',
+              worker_job_id: '22222222-2222-4222-8222-222222222222',
+            },
+          },
+        ],
+        blockerCodes: ['calculator_gate_error'],
+      }),
+    ]);
+  });
+
   it('does not infer final submit completion from a completed gate worker alone', async () => {
     mockRequestWorkerJobsApi.mockResolvedValue({
       data: [


### PR DESCRIPTION
Closes #556

## Summary
- Syncs the process edit drawer from pending review-submit jobs to the latest terminal `read_latest` result.
- Preserves structured HTTP error envelopes from `app_dataset_review_submit_jobs` so terminal `error` states and diagnostics remain visible.
- Extends task-center and process-drawer tests for failed coordinator/latest-job diagnostics.
- Records required docpact review evidence for the frontend runtime and testing gate docs.

## Key Decisions
- Keeps the worker/Supavisor snapshot-builder root cause out of scope for this frontend issue.
- Uses the existing `requestReviewSubmitJob(..., { action: 'read_latest' })` path instead of introducing a new backend API.
- Keeps Task Center as the background progress/diagnostics surface while the drawer lightly syncs the current process latest state.

## Validation
- `npm run test:ci -- tests/unit/services/reviews/api.test.ts tests/unit/services/reviews/taskCenter.test.ts tests/unit/pages/Processes/Components/edit.test.tsx --runInBand --testTimeout=30000`
- `npm run lint:js`
- `npm run tsc`
- `npx prettier -c src/pages/Processes/Components/edit.tsx tests/unit/pages/Processes/Components/edit.test.tsx tests/unit/services/reviews/api.test.ts tests/unit/services/reviews/taskCenter.test.ts`
- `npm run docpact:gate`
- `npm run prepush:gate`

## Risks / Rollback
- Low risk; the change is scoped to existing review-submit UI state sync and diagnostics.
- Roll back by reverting this PR if the drawer sync produces noisy or unexpected status updates.

## Follow-ups
- Worker/Supavisor snapshot-builder failures remain out of scope and should be handled separately if needed.

## Workspace Integration
- Requires a later workspace submodule pointer bump after merge/promote per workspace policy.
