### PR TITLE
fix: prevent duplicate review-submit enqueue

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-30"
-lastReviewedCommit: "7e9e69b423ca159846ddb326e9ed75afd060d7a4"
+lastReviewedCommit: "66966c8ff569fc29b66f8af4bd8d6e5ecc90327f"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-30
-lastReviewedCommit: 7e9e69b423ca159846ddb326e9ed75afd060d7a4
+lastReviewedCommit: 66966c8ff569fc29b66f8af4bd8d6e5ecc90327f
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-06-30
-lastReviewedCommit: fca98160c2ef470778d32cee67b633d5ce8ed117
+lastReviewedCommit: 5164635bd577c436357f1eb05d5700a42080bd34
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-06-30
-lastReviewedCommit: 7e9e69b423ca159846ddb326e9ed75afd060d7a4
+lastReviewedCommit: 66966c8ff569fc29b66f8af4bd8d6e5ecc90327f
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-06-30
-lastReviewedCommit: 7e9e69b423ca159846ddb326e9ed75afd060d7a4
+lastReviewedCommit: 66966c8ff569fc29b66f8af4bd8d6e5ecc90327f
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-06-30
-lastReviewedCommit: 7e9e69b423ca159846ddb326e9ed75afd060d7a4
+lastReviewedCommit: 66966c8ff569fc29b66f8af4bd8d6e5ecc90327f
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-06-30
-lastReviewedCommit: 7e9e69b423ca159846ddb326e9ed75afd060d7a4
+lastReviewedCommit: 66966c8ff569fc29b66f8af4bd8d6e5ecc90327f
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-06-30
-lastReviewedCommit: 7e9e69b423ca159846ddb326e9ed75afd060d7a4
+lastReviewedCommit: 66966c8ff569fc29b66f8af4bd8d6e5ecc90327f
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-06-30
-lastReviewedCommit: 7e9e69b423ca159846ddb326e9ed75afd060d7a4
+lastReviewedCommit: 66966c8ff569fc29b66f8af4bd8d6e5ecc90327f
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-06-30
-lastReviewedCommit: 7e9e69b423ca159846ddb326e9ed75afd060d7a4
+lastReviewedCommit: 66966c8ff569fc29b66f8af4bd8d6e5ecc90327f
 ---
 
 # Testing Troubleshooting

--- a/src/locales/en-US/pages_process.ts
+++ b/src/locales/en-US/pages_process.ts
@@ -722,6 +722,8 @@ export default {
   'pages.process.reviewSubmitJob.cancelled': 'Review submission job was cancelled.',
   'pages.process.reviewSubmitJob.backgroundProcessing': 'Review submission is still processing in the background. You can retry later to refresh the latest status.',
   'pages.process.reviewSubmitJob.enqueued': 'Review submission task has been created. Track progress in the task center.',
+  'pages.process.reviewSubmitJob.alreadyRunning': 'A review submission gate check is already running.',
+  'pages.process.reviewSubmitJob.checkRunningFailed': 'Failed to check whether a review submission gate is already running.',
   'pages.process.reviewSubmitTaskCenter.kind': 'Review Submit',
   'pages.process.reviewSubmitTaskCenter.phase.queued': 'Queued',
   'pages.process.reviewSubmitTaskCenter.phase.running': 'Gate running',

--- a/src/locales/zh-CN/pages_process.ts
+++ b/src/locales/zh-CN/pages_process.ts
@@ -719,6 +719,8 @@ export default {
   'pages.process.reviewSubmitJob.cancelled': '提交审核任务已取消。',
   'pages.process.reviewSubmitJob.backgroundProcessing': '提交审核仍在后台处理中，稍后可重新点击以刷新最新状态。',
   'pages.process.reviewSubmitJob.enqueued': '提交审核任务已创建，请在任务中心查看进度。',
+  'pages.process.reviewSubmitJob.alreadyRunning': '提交审核门禁检查正在运行，请稍后再试。',
+  'pages.process.reviewSubmitJob.checkRunningFailed': '检查提交审核门禁运行状态失败。',
   'pages.process.reviewSubmitTaskCenter.kind': '提交审核',
   'pages.process.reviewSubmitTaskCenter.phase.queued': '已排队',
   'pages.process.reviewSubmitTaskCenter.phase.running': '门禁运行中',

--- a/src/pages/Processes/Components/edit.tsx
+++ b/src/pages/Processes/Components/edit.tsx
@@ -56,6 +56,11 @@ import type {
 } from '@/services/reviews/api';
 import { trackReviewSubmitTask } from '@/services/reviews/taskCenter';
 import { getUserTeamId } from '@/services/roles/api';
+import {
+  requestWorkerJobsApi,
+  type WorkerJobResult,
+  type WorkerJobStatus,
+} from '@/services/workerJobs/api';
 import styles from '@/style/custom.less';
 import { isRuleVerificationPassed } from '@/utils/ruleVerification';
 import { CloseOutlined, FormOutlined, ProductOutlined } from '@ant-design/icons';
@@ -78,6 +83,7 @@ type ProcessCheckTarget = FormProcessWithDatas & {
   stateCode: number;
   ruleVerification: boolean;
 };
+type ProcessReviewSubmitTarget = Pick<ProcessCheckTarget, 'id' | 'version'>;
 type HandleSubmitResult = Awaited<ReturnType<typeof updateProcess>>;
 type RefProblemNode = ProblemNode & {
   versionUnderReview?: boolean;
@@ -100,6 +106,14 @@ const REVIEW_SUBMIT_JOB_PENDING_STATUSES = new Set<ReviewSubmitGateUiStatus>([
   'waiting_gate',
   'submitting',
 ]);
+const REVIEW_SUBMIT_ROOT_WORKER_KIND = 'review_submit.submit';
+const REVIEW_SUBMIT_GATE_WORKER_KIND = 'review_submit.gate';
+const REVIEW_SUBMIT_ACTIVE_WORKER_STATUSES = new Set<WorkerJobStatus>([
+  'queued',
+  'running',
+  'waiting',
+]);
+const REVIEW_SUBMIT_ACTIVE_WORKER_LIST_LIMIT = 20;
 const REVIEW_SUBMIT_JOB_LATEST_SYNC_INITIAL_DELAY_MS = 250;
 const REVIEW_SUBMIT_JOB_LATEST_SYNC_INTERVAL_MS = 5000;
 const REVIEW_SUBMIT_JOB_LATEST_SYNC_MAX_ATTEMPTS = 24;
@@ -351,6 +365,106 @@ const getReviewSubmitJobBlockingReasons = (
 
 const isReviewSubmitTerminalStatus = (status: ReviewSubmitGateUiStatus) =>
   status !== 'not_run' && !REVIEW_SUBMIT_JOB_PENDING_STATUSES.has(status);
+
+const isReviewSubmitWorkerStatusActive = (status: unknown): status is WorkerJobStatus =>
+  typeof status === 'string' && REVIEW_SUBMIT_ACTIVE_WORKER_STATUSES.has(status as WorkerJobStatus);
+
+const isReviewSubmitGateCheckActive = (
+  jobData?: ReviewSubmitJobResult,
+): jobData is ReviewSubmitJobResult => {
+  if (!jobData) {
+    return false;
+  }
+
+  if (REVIEW_SUBMIT_JOB_PENDING_STATUSES.has(jobData.status)) {
+    return true;
+  }
+
+  if (jobData.gate?.status && REVIEW_SUBMIT_JOB_PENDING_STATUSES.has(jobData.gate.status)) {
+    return true;
+  }
+
+  return (
+    isReviewSubmitWorkerStatusActive(jobData.gateWorkerJob?.status) ||
+    isReviewSubmitWorkerStatusActive(jobData.workerJob?.status) ||
+    isReviewSubmitWorkerStatusActive(jobData.submitWorkerJob?.status)
+  );
+};
+
+const isReviewSubmitWorkerJob = (
+  workerJob?: WorkerJobResult | null,
+): workerJob is WorkerJobResult =>
+  workerJob?.jobKind === REVIEW_SUBMIT_ROOT_WORKER_KIND ||
+  workerJob?.jobKind === REVIEW_SUBMIT_GATE_WORKER_KIND;
+
+const isReviewSubmitWorkerJobForProcess = (
+  workerJob: WorkerJobResult,
+  processDetail: ProcessReviewSubmitTarget,
+): boolean =>
+  isReviewSubmitWorkerJob(workerJob) &&
+  workerJob.subjectType === 'processes' &&
+  workerJob.subjectId === processDetail.id &&
+  (!workerJob.subjectVersion || workerJob.subjectVersion === processDetail.version);
+
+const findActiveReviewSubmitWorkerJob = (
+  workerJobs: WorkerJobResult[] | null | undefined,
+  processDetail: ProcessReviewSubmitTarget,
+): WorkerJobResult | undefined =>
+  workerJobs?.find(
+    (workerJob) =>
+      isReviewSubmitWorkerJobForProcess(workerJob, processDetail) &&
+      isReviewSubmitWorkerStatusActive(workerJob.status),
+  );
+
+const reviewSubmitJobStatusFromWorkerJob = (workerJob: WorkerJobResult): ReviewSubmitJobStatus => {
+  if (workerJob.phase === 'submitting') {
+    return 'submitting';
+  }
+  if (workerJob.status === 'queued') {
+    return 'queued';
+  }
+  return 'waiting_gate';
+};
+
+const reviewSubmitJobFromActiveWorkerJob = (
+  workerJob: WorkerJobResult,
+  processDetail: ProcessReviewSubmitTarget,
+): ReviewSubmitJobResult => {
+  const isGateWorker = workerJob.jobKind === REVIEW_SUBMIT_GATE_WORKER_KIND;
+  const rootJobId = workerJob.rootJobId ?? (isGateWorker ? undefined : workerJob.id);
+
+  return {
+    status: reviewSubmitJobStatusFromWorkerJob(workerJob),
+    submitWorkerJobId: isGateWorker ? rootJobId : workerJob.id,
+    rootJobId,
+    gateWorkerJobId: isGateWorker ? workerJob.id : undefined,
+    datasetRevision: {
+      table: 'processes',
+      id: processDetail.id,
+      version: processDetail.version,
+    },
+    workerJob,
+    submitWorkerJob: isGateWorker ? null : workerJob,
+    gateWorkerJob: isGateWorker ? workerJob : null,
+  };
+};
+
+const isReviewSubmitJobNotFoundResult = (result: {
+  error?: {
+    code?: string;
+    message?: string;
+  } | null;
+  status?: number;
+  statusText?: string;
+}): boolean => {
+  if (!result.error) {
+    return false;
+  }
+
+  const code = `${result.error.code ?? result.statusText ?? ''}`.toLowerCase();
+  const messageText = `${result.error.message ?? ''}`.toLowerCase();
+  return result.status === 404 || code.includes('not_found') || messageText.includes('not found');
+};
 
 const collectChangedFieldPaths = (
   value: unknown,
@@ -1509,7 +1623,106 @@ const ProcessEdit: FC<Props> = ({
     [applyReviewSubmitJobState, cancelReviewSubmitLatestSync],
   );
 
+  const readActiveReviewSubmitWorkerJob = async (processDetail: ProcessReviewSubmitTarget) => {
+    const result = await requestWorkerJobsApi<WorkerJobResult>({
+      action: 'list',
+      subjectType: 'processes',
+      subjectId: processDetail.id,
+      statuses: ['queued', 'running', 'waiting'],
+      limit: REVIEW_SUBMIT_ACTIVE_WORKER_LIST_LIMIT,
+    });
+
+    if (result.error) {
+      return { error: result.error, workerJob: undefined };
+    }
+
+    return {
+      error: null,
+      workerJob: findActiveReviewSubmitWorkerJob(result.data, processDetail),
+    };
+  };
+
+  const failReviewSubmitRunningCheck = (messageText: string, revisionChecksum?: string) => {
+    setReviewSubmitGateState({
+      status: 'error',
+      message: messageText,
+      revisionChecksum,
+    });
+    message.error(messageText);
+    return 'failed' as const;
+  };
+
+  const showActiveReviewSubmitJob = (
+    jobData: ReviewSubmitJobResult,
+    fallback?: { revisionChecksum?: string },
+  ) => {
+    applyReviewSubmitJobState(jobData, fallback);
+    trackReviewSubmitTask(jobData);
+    requestOpenLcaTaskCenter();
+    message.warning(
+      intl.formatMessage({
+        id: 'pages.process.reviewSubmitJob.alreadyRunning',
+        defaultMessage: 'A review submission gate check is already running.',
+      }),
+    );
+    return 'queued' as const;
+  };
+
   const runReviewSubmitJob = async (processDetail: ProcessCheckTarget) => {
+    const activeWorkerCheck = await readActiveReviewSubmitWorkerJob(processDetail);
+
+    if (activeWorkerCheck.error) {
+      return failReviewSubmitRunningCheck(
+        activeWorkerCheck.error.message ||
+          intl.formatMessage({
+            id: 'pages.process.reviewSubmitJob.checkRunningFailed',
+            defaultMessage: 'Failed to check whether a review submission gate is already running.',
+          }),
+      );
+    }
+
+    if (activeWorkerCheck.workerJob) {
+      return showActiveReviewSubmitJob(
+        reviewSubmitJobFromActiveWorkerJob(activeWorkerCheck.workerJob, processDetail),
+      );
+    }
+
+    const handleActiveReviewSubmitJob = (
+      jobData: ReviewSubmitJobResult,
+      fallback?: { revisionChecksum?: string },
+    ) => {
+      startReviewSubmitLatestSync(processDetail);
+      return showActiveReviewSubmitJob(jobData, fallback);
+    };
+
+    const latestResult = await requestReviewSubmitJob(
+      'processes',
+      processDetail.id,
+      processDetail.version,
+      null,
+      {
+        action: 'read_latest',
+      },
+    );
+
+    if (latestResult.error && !isReviewSubmitJobNotFoundResult(latestResult)) {
+      return failReviewSubmitRunningCheck(
+        latestResult.error.message ||
+          intl.formatMessage({
+            id: 'pages.process.reviewSubmitJob.checkRunningFailed',
+            defaultMessage: 'Failed to check whether a review submission gate is already running.',
+          }),
+        latestResult.revisionChecksum,
+      );
+    }
+
+    const latestJobData = latestResult.data?.[0] as ReviewSubmitJobResult | undefined;
+    if (isReviewSubmitGateCheckActive(latestJobData)) {
+      return handleActiveReviewSubmitJob(latestJobData, {
+        revisionChecksum: latestResult.revisionChecksum,
+      });
+    }
+
     const jobResult = await requestReviewSubmitJob(
       'processes',
       processDetail.id,
@@ -1570,6 +1783,32 @@ const ProcessEdit: FC<Props> = ({
   const submitReview = async () => {
     setSpinning(true);
     resetReviewSubmitGateState();
+
+    if (id && version) {
+      const activeWorkerCheck = await readActiveReviewSubmitWorkerJob({ id, version });
+
+      if (activeWorkerCheck.error) {
+        failReviewSubmitRunningCheck(
+          activeWorkerCheck.error.message ||
+            intl.formatMessage({
+              id: 'pages.process.reviewSubmitJob.checkRunningFailed',
+              defaultMessage:
+                'Failed to check whether a review submission gate is already running.',
+            }),
+        );
+        setSpinning(false);
+        return;
+      }
+
+      if (activeWorkerCheck.workerJob) {
+        showActiveReviewSubmitJob(
+          reviewSubmitJobFromActiveWorkerJob(activeWorkerCheck.workerJob, { id, version }),
+        );
+        setSpinning(false);
+        return;
+      }
+    }
+
     const updateResult = await handleSubmit(false, { langIntent: 'validation' });
     const validationTarget = await resolveProcessCheckTarget(updateResult);
     const updatedProcess = toSavedProcessCheckTarget(updateResult);

--- a/tests/unit/pages/Processes/Components/edit.test.tsx
+++ b/tests/unit/pages/Processes/Components/edit.test.tsx
@@ -138,6 +138,7 @@ const mockSubmitDatasetReview = jest.fn();
 const mockValidateDatasetWithSdk = jest.fn(() => ({ success: true, issues: [] }));
 const mockRequestOpenLcaTaskCenter = jest.fn();
 const mockTrackReviewSubmitTask = jest.fn();
+const mockRequestWorkerJobsApi = jest.fn();
 
 jest.mock('@/pages/Utils/review', () => ({
   __esModule: true,
@@ -186,6 +187,11 @@ jest.mock('@/services/lca/taskCenter', () => ({
 jest.mock('@/services/reviews/taskCenter', () => ({
   __esModule: true,
   trackReviewSubmitTask: (...args: any[]) => mockTrackReviewSubmitTask(...args),
+}));
+
+jest.mock('@/services/workerJobs/api', () => ({
+  __esModule: true,
+  requestWorkerJobsApi: (...args: any[]) => mockRequestWorkerJobsApi(...args),
 }));
 
 jest.mock('@/components/ValidationIssueModal', () => ({
@@ -431,6 +437,13 @@ describe('ProcessEdit component', () => {
     },
   });
 
+  const mockNoRunningReviewSubmitJob = () => {
+    mockRequestReviewSubmitJob.mockResolvedValueOnce({
+      data: [],
+      error: null,
+    });
+  };
+
   afterEach(() => {
     jest.useRealTimers();
   });
@@ -512,6 +525,8 @@ describe('ProcessEdit component', () => {
     mockSubmitDatasetReview.mockResolvedValue({ data: [{ review: { id: 'review-1' } }] });
     mockRequestOpenLcaTaskCenter.mockReset();
     mockTrackReviewSubmitTask.mockReset();
+    mockRequestWorkerJobsApi.mockReset();
+    mockRequestWorkerJobsApi.mockResolvedValue({ data: [], error: null });
     mockGetRefsOfCurrentVersion.mockResolvedValue({ oldRefs: [] });
     mockGetRefsOfNewVersion.mockResolvedValue({ newRefs: [], oldRefs: [] });
     mockUpdateRefsData.mockImplementation((data: any) => data);
@@ -1405,6 +1420,7 @@ describe('ProcessEdit component', () => {
         },
       ],
     });
+    mockNoRunningReviewSubmitJob();
     mockRequestReviewSubmitJob.mockResolvedValueOnce({
       data: null,
       error: { message: 'review submission failed' },
@@ -1435,6 +1451,7 @@ describe('ProcessEdit component', () => {
         },
       ],
     });
+    mockNoRunningReviewSubmitJob();
     mockRequestReviewSubmitJob.mockResolvedValueOnce({
       data: null,
       error: {},
@@ -1467,6 +1484,7 @@ describe('ProcessEdit component', () => {
         },
       ],
     });
+    mockNoRunningReviewSubmitJob();
     mockRequestReviewSubmitJob.mockResolvedValueOnce({
       data: [
         {
@@ -1548,6 +1566,7 @@ describe('ProcessEdit component', () => {
         },
       ],
     });
+    mockNoRunningReviewSubmitJob();
     mockRequestReviewSubmitJob.mockResolvedValueOnce({
       data: [{ status: 'stale', reviewSubmitJobId: 'job-stale', gateRunId: 'gate-run-stale' }],
       error: null,
@@ -1582,6 +1601,7 @@ describe('ProcessEdit component', () => {
         },
       ],
     });
+    mockNoRunningReviewSubmitJob();
     mockRequestReviewSubmitJob.mockResolvedValueOnce({
       data: [{ status: 'submitted', reviewSubmitJobId: 'job-no-checksum' }],
       error: null,
@@ -1630,6 +1650,199 @@ describe('ProcessEdit component', () => {
     expect(mockSubmitDatasetReview).not.toHaveBeenCalled();
   });
 
+  it('enqueues a review-submit job when latest lookup reports no existing job', async () => {
+    mockUpdateProcess.mockResolvedValue({
+      data: [
+        {
+          id: 'process-1',
+          version: '1.0.0',
+          json: { processDataSet: processDataset },
+          state_code: 10,
+          rule_verification: true,
+        },
+      ],
+    });
+    mockRequestReviewSubmitJob
+      .mockResolvedValueOnce({
+        data: null,
+        error: { code: 'NOT_FOUND', message: 'Review-submit job not found' },
+        status: 404,
+      })
+      .mockResolvedValueOnce({
+        data: [{ status: 'submitted', reviewSubmitJobId: 'job-created-after-not-found' }],
+        error: null,
+      });
+
+    render(<ProcessEdit {...baseProps} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    await screen.findByRole('dialog', { name: 'Edit process' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit for Review' }));
+
+    await waitFor(() =>
+      expect(mockRequestReviewSubmitJob).toHaveBeenNthCalledWith(
+        2,
+        'processes',
+        'process-1',
+        '1.0.0',
+        null,
+        {
+          action: 'enqueue',
+          reviewSubmitJobId: undefined,
+        },
+      ),
+    );
+    expect(mockAntdMessage.error).not.toHaveBeenCalledWith('Review-submit job not found');
+    expect(mockAntdMessage.success).toHaveBeenCalledWith('Review submitted successfully');
+  });
+
+  it('does not enqueue a new review-submit job when an active root worker job exists', async () => {
+    mockUpdateProcess.mockResolvedValue({
+      data: [
+        {
+          id: 'process-1',
+          version: '1.0.0',
+          json: { processDataSet: processDataset },
+          state_code: 10,
+          rule_verification: true,
+        },
+      ],
+    });
+    mockRequestWorkerJobsApi.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'root-worker-running',
+          jobKind: 'review_submit.submit',
+          status: 'running',
+          subjectType: 'processes',
+          subjectId: 'process-1',
+          subjectVersion: '1.0.0',
+        },
+      ],
+      error: null,
+    });
+
+    render(<ProcessEdit {...baseProps} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    await screen.findByRole('dialog', { name: 'Edit process' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit for Review' }));
+
+    await waitFor(() =>
+      expect(mockAntdMessage.warning).toHaveBeenCalledWith(
+        'A review submission gate check is already running.',
+      ),
+    );
+    expect(mockRequestWorkerJobsApi).toHaveBeenCalledWith({
+      action: 'list',
+      subjectType: 'processes',
+      subjectId: 'process-1',
+      statuses: ['queued', 'running', 'waiting'],
+      limit: 20,
+    });
+    expect(mockUpdateProcess).not.toHaveBeenCalled();
+    expect(mockValidateDatasetWithSdk).not.toHaveBeenCalled();
+    expect(mockRequestReviewSubmitJob).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Review submission is waiting for the numerical stability gate to finish.',
+    );
+    expect(mockTrackReviewSubmitTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'waiting_gate',
+        submitWorkerJobId: 'root-worker-running',
+        rootJobId: 'root-worker-running',
+        datasetRevision: {
+          table: 'processes',
+          id: 'process-1',
+          version: '1.0.0',
+        },
+        submitWorkerJob: expect.objectContaining({
+          id: 'root-worker-running',
+          jobKind: 'review_submit.submit',
+          status: 'running',
+        }),
+      }),
+    );
+    expect(mockRequestOpenLcaTaskCenter).toHaveBeenCalled();
+    expect(mockSubmitDatasetReview).not.toHaveBeenCalled();
+  });
+
+  it('does not enqueue a new review-submit job when a gate check is already running', async () => {
+    mockUpdateProcess.mockResolvedValue({
+      data: [
+        {
+          id: 'process-1',
+          version: '1.0.0',
+          json: { processDataSet: processDataset },
+          state_code: 10,
+          rule_verification: true,
+        },
+      ],
+    });
+    mockRequestReviewSubmitJob.mockResolvedValueOnce({
+      data: [
+        {
+          status: 'waiting_gate',
+          reviewSubmitJobId: 'job-running',
+          gateWorkerJobId: 'gate-worker-running',
+          gateWorkerJob: {
+            id: 'gate-worker-running',
+            status: 'running',
+          },
+        },
+      ],
+      error: null,
+      revisionChecksum: 'f'.repeat(64),
+    });
+
+    render(<ProcessEdit {...baseProps} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    await screen.findByRole('dialog', { name: 'Edit process' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit for Review' }));
+
+    await waitFor(() =>
+      expect(mockAntdMessage.warning).toHaveBeenCalledWith(
+        'A review submission gate check is already running.',
+      ),
+    );
+    expect(mockRequestReviewSubmitJob).toHaveBeenNthCalledWith(
+      1,
+      'processes',
+      'process-1',
+      '1.0.0',
+      null,
+      {
+        action: 'read_latest',
+      },
+    );
+    expect(mockRequestReviewSubmitJob).not.toHaveBeenCalledWith(
+      'processes',
+      'process-1',
+      '1.0.0',
+      null,
+      {
+        action: 'enqueue',
+        reviewSubmitJobId: undefined,
+      },
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Review submission is waiting for the numerical stability gate to finish.',
+    );
+    expect(mockTrackReviewSubmitTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'waiting_gate',
+        reviewSubmitJobId: 'job-running',
+        gateWorkerJobId: 'gate-worker-running',
+      }),
+    );
+    expect(mockRequestOpenLcaTaskCenter).toHaveBeenCalled();
+    expect(mockSubmitDatasetReview).not.toHaveBeenCalled();
+  });
+
   it('enqueues queued review-submit jobs and sends the user to the task center', async () => {
     mockUpdateProcess.mockResolvedValue({
       data: [
@@ -1642,6 +1855,7 @@ describe('ProcessEdit component', () => {
         },
       ],
     });
+    mockNoRunningReviewSubmitJob();
     mockRequestReviewSubmitJob.mockResolvedValueOnce({
       data: [{ status: 'queued', reviewSubmitJobId: 'job-queued' }],
       error: null,
@@ -1656,8 +1870,30 @@ describe('ProcessEdit component', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Submit for Review' }));
 
-    await waitFor(() => expect(mockRequestReviewSubmitJob).toHaveBeenCalledTimes(1));
-    expect(mockRequestReviewSubmitJob).toHaveBeenCalledWith(
+    await waitFor(() =>
+      expect(mockRequestReviewSubmitJob).toHaveBeenCalledWith(
+        'processes',
+        'process-1',
+        '1.0.0',
+        null,
+        {
+          action: 'enqueue',
+          reviewSubmitJobId: undefined,
+        },
+      ),
+    );
+    expect(mockRequestReviewSubmitJob).toHaveBeenNthCalledWith(
+      1,
+      'processes',
+      'process-1',
+      '1.0.0',
+      null,
+      {
+        action: 'read_latest',
+      },
+    );
+    expect(mockRequestReviewSubmitJob).toHaveBeenNthCalledWith(
+      2,
       'processes',
       'process-1',
       '1.0.0',
@@ -1692,6 +1928,10 @@ describe('ProcessEdit component', () => {
       ],
     });
     mockRequestReviewSubmitJob
+      .mockResolvedValueOnce({
+        data: [],
+        error: null,
+      })
       .mockResolvedValueOnce({
         data: [{ status: 'waiting_gate', reviewSubmitJobId: 'job-waiting' }],
         error: null,
@@ -1744,9 +1984,19 @@ describe('ProcessEdit component', () => {
       ),
     );
 
-    await waitFor(() => expect(mockRequestReviewSubmitJob).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockRequestReviewSubmitJob).toHaveBeenCalledTimes(3));
     expect(mockRequestReviewSubmitJob).toHaveBeenNthCalledWith(
       1,
+      'processes',
+      'process-1',
+      '1.0.0',
+      null,
+      {
+        action: 'read_latest',
+      },
+    );
+    expect(mockRequestReviewSubmitJob).toHaveBeenNthCalledWith(
+      2,
       'processes',
       'process-1',
       '1.0.0',
@@ -1799,6 +2049,7 @@ describe('ProcessEdit component', () => {
         },
       ],
     });
+    mockNoRunningReviewSubmitJob();
     mockRequestReviewSubmitJob.mockResolvedValueOnce({
       data: [{ status: 'stale', reviewSubmitJobId: 'job-stale' }],
       error: null,


### PR DESCRIPTION
## Branch Contract

- base branch: `dev`
- validated environment: local (no live Supabase smoke was run)
- back-merge required after merge: No
- root workspace integration expected: No immediate root integration for this dev PR; root can bump after the change is promoted to `main` if needed.

- [x] this PR targets `dev`
- [x] if the work started from `main`, this PR documents why it is a hotfix or production-only exception

## Linked Issue

Closes #556

## Change Facts

- Checks active `review_submit.submit` / `review_submit.gate` worker jobs for the current process id/version before the submit-review save/validation/enqueue flow starts.
- If an active review-submit worker exists, the UI shows the running-state warning, syncs the task into the task center, opens the task center, and returns without creating a new enqueue request.
- Keeps the pre-enqueue latest/coordinator guard as a race-condition fallback and adds localized copy for running-check states.
- Records docpact review metadata for the governed frontend/runtime and testing-gate docs required by the local pre-push gate.

## Validation Facts

- `npm run test:ci -- tests/unit/pages/Processes/Components/edit.test.tsx --runInBand --testTimeout=30000`
- `npx prettier -c src/pages/Processes/Components/edit.tsx tests/unit/pages/Processes/Components/edit.test.tsx src/locales/en-US/pages_process.ts src/locales/zh-CN/pages_process.ts`
- `npm run tsc`
- `npm run lint:js`
- `git diff --check`
- `npm run docpact:gate`
- pre-push `npm run prepush:gate` via `git push -u fork fix/issue-556-running-gate-guard` (347 suites, 4346 tests, 100% coverage)
- `npm run build`

## Risks And Follow-Up

- The guard depends on `app_worker_jobs` exposing active worker rows for `subjectType=processes` and the current process id.
- The frontend still opens the task center for the existing task; it only avoids duplicate save/validation/enqueue creation.
- No unrelated local `src/services/processes/data.ts` formatting diff is included in this PR.