### PR TITLE
fix: add reference lookup help tooltip

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-30"
-lastReviewedCommit: "66966c8ff569fc29b66f8af4bd8d6e5ecc90327f"
+lastReviewedAt: "2026-07-01"
+lastReviewedCommit: "b9fb27fec11aa57f0e4e7774ab3957109348e0c6"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 1f8d4a411ef6822b5ded6e596cae3f5b13d35cdc
+lastReviewedCommit: b9fb27fec11aa57f0e4e7774ab3957109348e0c6
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: dd29fc6c9b6f60f29318998bc77237a338aa470c
+lastReviewedCommit: fbfffe7009bb60d011b6a5df6c12af0e628422b1
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 1f8d4a411ef6822b5ded6e596cae3f5b13d35cdc
+lastReviewedCommit: b9fb27fec11aa57f0e4e7774ab3957109348e0c6
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 1f8d4a411ef6822b5ded6e596cae3f5b13d35cdc
+lastReviewedCommit: b9fb27fec11aa57f0e4e7774ab3957109348e0c6
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 1f8d4a411ef6822b5ded6e596cae3f5b13d35cdc
+lastReviewedCommit: b9fb27fec11aa57f0e4e7774ab3957109348e0c6
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 1f8d4a411ef6822b5ded6e596cae3f5b13d35cdc
+lastReviewedCommit: b9fb27fec11aa57f0e4e7774ab3957109348e0c6
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 1f8d4a411ef6822b5ded6e596cae3f5b13d35cdc
+lastReviewedCommit: b9fb27fec11aa57f0e4e7774ab3957109348e0c6
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 1f8d4a411ef6822b5ded6e596cae3f5b13d35cdc
+lastReviewedCommit: b9fb27fec11aa57f0e4e7774ab3957109348e0c6
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 1f8d4a411ef6822b5ded6e596cae3f5b13d35cdc
+lastReviewedCommit: b9fb27fec11aa57f0e4e7774ab3957109348e0c6
 ---
 
 # Testing Troubleshooting

--- a/src/components/ResponsiveDataList/index.less
+++ b/src/components/ResponsiveDataList/index.less
@@ -32,6 +32,26 @@
   }
 }
 
+.responsive-data-list-search-card {
+  .responsive-data-list-search-extra {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .responsive-data-list-search-extra {
+    .ant-checkbox-wrapper {
+      white-space: nowrap;
+    }
+  }
+
+  .responsive-data-list-reference-lookup-option {
+    display: inline-flex;
+    align-items: center;
+    white-space: nowrap;
+  }
+}
+
 @media (max-width: 768px) {
   .responsive-data-list-search-card {
     margin-bottom: 16px;
@@ -43,6 +63,7 @@
 
     .responsive-data-list-search-extra {
       display: flex;
+      flex-direction: column;
       align-items: center;
       white-space: nowrap;
     }

--- a/src/components/ResponsiveDataList/index.tsx
+++ b/src/components/ResponsiveDataList/index.tsx
@@ -34,7 +34,7 @@ export const responsiveSearchPrimaryColProps = {
 
 export const responsiveSearchExtraColProps = {
   className: 'responsive-data-list-search-extra',
-  flex: '100px',
+  flex: 'none',
 };
 
 export function dataListIndexColumn<T>(): Partial<ProColumns<T>> {

--- a/src/locales/en-US/pages_general.ts
+++ b/src/locales/en-US/pages_general.ts
@@ -86,6 +86,7 @@ export default {
   'pages.search.keyWord': 'Full-text search: Enter one or more keywords.',
   'pages.search.placeholder': 'AI Search: Describe the data you need in one sentence or a few key words.',
   'pages.search.referenceLookup.placeholder': 'Reference Lookup: Enter a complete dataset UUID.',
+  'pages.search.referenceLookup.tooltip': 'Find records that reference a specific dataset.\nAfter enabling this option, enter the full dataset UUID. The system searches the current data type for records whose content contains that UUID.\nThis mode does not search by name or keyword.',
   'pages.datasetUuidMention.empty': 'No data contains this ID',
   'pages.datasetUuidMention.entityKind': 'Data type',
   'pages.datasetUuidMention.error': 'Search failed. Try again later.',

--- a/src/locales/zh-CN/pages_general.ts
+++ b/src/locales/zh-CN/pages_general.ts
@@ -85,6 +85,7 @@ export default {
   'pages.search.keyWord': '全文检索：请输入一个或多个关键词。',
   'pages.search.placeholder': '智能查询：用一句话或几个关键词描述您所需要的数据。',
   'pages.search.referenceLookup.placeholder': '引用查找：请输入完整的数据集 UUID。',
+  'pages.search.referenceLookup.tooltip': '用于反向查找“哪些数据引用了指定数据集”。\n开启后，请在搜索框输入完整的数据集 UUID，系统会在当前数据类型中查找内容包含该 UUID 的记录。\n该模式不支持名称或关键词搜索。',
   'pages.datasetUuidMention.empty': '没有找到包含该 ID 的数据',
   'pages.datasetUuidMention.entityKind': '数据类型',
   'pages.datasetUuidMention.error': '查找失败，请稍后重试',

--- a/src/pages/Contacts/index.tsx
+++ b/src/pages/Contacts/index.tsx
@@ -47,6 +47,7 @@ import {
   showInvalidReferenceLookupUuidMessage,
   showReferenceLookupLimitMessage,
 } from '../Utils/referenceLookup';
+import ReferenceLookupHelpIcon from '../Utils/ReferenceLookupHelpIcon';
 import ContactCreate from './Components/create';
 import ContactDelete from './Components/delete';
 import ContactEdit from './Components/edit';
@@ -351,15 +352,18 @@ const TableList: FC = () => {
             />
           </Col>
           <Col {...responsiveSearchExtraColProps}>
-            <Checkbox
-              checked={referenceLookup}
-              onChange={(e) => setReferenceLookup(e.target.checked)}
-            >
-              <FormattedMessage
-                id='pages.search.referenceLookup'
-                defaultMessage='Reference Lookup'
-              />
-            </Checkbox>
+            <Space className='responsive-data-list-reference-lookup-option' size={4} align='center'>
+              <Checkbox
+                checked={referenceLookup}
+                onChange={(e) => setReferenceLookup(e.target.checked)}
+              >
+                <FormattedMessage
+                  id='pages.search.referenceLookup'
+                  defaultMessage='Reference Lookup'
+                />
+              </Checkbox>
+              <ReferenceLookupHelpIcon />
+            </Space>
           </Col>
         </Row>
       </Card>

--- a/src/pages/Flowproperties/index.tsx
+++ b/src/pages/Flowproperties/index.tsx
@@ -46,6 +46,7 @@ import {
   showInvalidReferenceLookupUuidMessage,
   showReferenceLookupLimitMessage,
 } from '../Utils/referenceLookup';
+import ReferenceLookupHelpIcon from '../Utils/ReferenceLookupHelpIcon';
 import FlowpropertiesCreate from './Components/create';
 import FlowpropertyView from './Components/view';
 
@@ -329,15 +330,18 @@ const TableList: FC = () => {
             />
           </Col>
           <Col {...responsiveSearchExtraColProps}>
-            <Checkbox
-              checked={referenceLookup}
-              onChange={(e) => setReferenceLookup(e.target.checked)}
-            >
-              <FormattedMessage
-                id='pages.search.referenceLookup'
-                defaultMessage='Reference Lookup'
-              />
-            </Checkbox>
+            <Space className='responsive-data-list-reference-lookup-option' size={4} align='center'>
+              <Checkbox
+                checked={referenceLookup}
+                onChange={(e) => setReferenceLookup(e.target.checked)}
+              >
+                <FormattedMessage
+                  id='pages.search.referenceLookup'
+                  defaultMessage='Reference Lookup'
+                />
+              </Checkbox>
+              <ReferenceLookupHelpIcon />
+            </Space>
           </Col>
         </Row>
       </Card>

--- a/src/pages/Flows/index.tsx
+++ b/src/pages/Flows/index.tsx
@@ -51,6 +51,7 @@ import {
   showInvalidReferenceLookupUuidMessage,
   showReferenceLookupLimitMessage,
 } from '../Utils/referenceLookup';
+import ReferenceLookupHelpIcon from '../Utils/ReferenceLookupHelpIcon';
 import FlowsCreate from './Components/create';
 import FlowsDelete from './Components/delete';
 import FlowsEdit from './Components/edit';
@@ -464,20 +465,23 @@ const TableList: FC = () => {
             >
               <FormattedMessage id='pages.search.openAI' defaultMessage='AI Search' />
             </Checkbox>
-            <Checkbox
-              checked={referenceLookup}
-              onChange={(e) => {
-                setReferenceLookup(e.target.checked);
-                if (e.target.checked) {
-                  setOpenAI(false);
-                }
-              }}
-            >
-              <FormattedMessage
-                id='pages.search.referenceLookup'
-                defaultMessage='Reference Lookup'
-              />
-            </Checkbox>
+            <Space className='responsive-data-list-reference-lookup-option' size={4} align='center'>
+              <Checkbox
+                checked={referenceLookup}
+                onChange={(e) => {
+                  setReferenceLookup(e.target.checked);
+                  if (e.target.checked) {
+                    setOpenAI(false);
+                  }
+                }}
+              >
+                <FormattedMessage
+                  id='pages.search.referenceLookup'
+                  defaultMessage='Reference Lookup'
+                />
+              </Checkbox>
+              <ReferenceLookupHelpIcon />
+            </Space>
           </Col>
         </Row>
       </Card>

--- a/src/pages/LifeCycleModels/index.tsx
+++ b/src/pages/LifeCycleModels/index.tsx
@@ -52,6 +52,7 @@ import {
   showInvalidReferenceLookupUuidMessage,
   showReferenceLookupLimitMessage,
 } from '../Utils/referenceLookup';
+import ReferenceLookupHelpIcon from '../Utils/ReferenceLookupHelpIcon';
 import LifeCycleModelCreate from './Components/create';
 import LifeCycleModelDelete from './Components/delete';
 import LifeCycleModelEdit from './Components/edit';
@@ -376,20 +377,23 @@ const TableList: FC = () => {
             >
               <FormattedMessage id='pages.search.openAI' defaultMessage='AI Search' />
             </Checkbox>
-            <Checkbox
-              checked={referenceLookup}
-              onChange={(e) => {
-                setReferenceLookup(e.target.checked);
-                if (e.target.checked) {
-                  setOpenAI(false);
-                }
-              }}
-            >
-              <FormattedMessage
-                id='pages.search.referenceLookup'
-                defaultMessage='Reference Lookup'
-              />
-            </Checkbox>
+            <Space className='responsive-data-list-reference-lookup-option' size={4} align='center'>
+              <Checkbox
+                checked={referenceLookup}
+                onChange={(e) => {
+                  setReferenceLookup(e.target.checked);
+                  if (e.target.checked) {
+                    setOpenAI(false);
+                  }
+                }}
+              >
+                <FormattedMessage
+                  id='pages.search.referenceLookup'
+                  defaultMessage='Reference Lookup'
+                />
+              </Checkbox>
+              <ReferenceLookupHelpIcon />
+            </Space>
           </Col>
         </Row>
       </Card>

--- a/src/pages/Processes/index.tsx
+++ b/src/pages/Processes/index.tsx
@@ -59,6 +59,7 @@ import {
   showInvalidReferenceLookupUuidMessage,
   showReferenceLookupLimitMessage,
 } from '../Utils/referenceLookup';
+import ReferenceLookupHelpIcon from '../Utils/ReferenceLookupHelpIcon';
 import ProcessCreate from './Components/create';
 import ProcessDelete from './Components/delete';
 import ProcessEdit from './Components/edit';
@@ -548,20 +549,23 @@ const TableList: FC = () => {
             >
               <FormattedMessage id='pages.search.openAI' defaultMessage='AI Search' />
             </Checkbox>
-            <Checkbox
-              checked={referenceLookup}
-              onChange={(e) => {
-                setReferenceLookup(e.target.checked);
-                if (e.target.checked) {
-                  setOpenAI(false);
-                }
-              }}
-            >
-              <FormattedMessage
-                id='pages.search.referenceLookup'
-                defaultMessage='Reference Lookup'
-              />
-            </Checkbox>
+            <Space className='responsive-data-list-reference-lookup-option' size={4} align='center'>
+              <Checkbox
+                checked={referenceLookup}
+                onChange={(e) => {
+                  setReferenceLookup(e.target.checked);
+                  if (e.target.checked) {
+                    setOpenAI(false);
+                  }
+                }}
+              >
+                <FormattedMessage
+                  id='pages.search.referenceLookup'
+                  defaultMessage='Reference Lookup'
+                />
+              </Checkbox>
+              <ReferenceLookupHelpIcon />
+            </Space>
           </Col>
         </Row>
       </Card>

--- a/src/pages/Sources/index.tsx
+++ b/src/pages/Sources/index.tsx
@@ -49,6 +49,7 @@ import {
   showInvalidReferenceLookupUuidMessage,
   showReferenceLookupLimitMessage,
 } from '../Utils/referenceLookup';
+import ReferenceLookupHelpIcon from '../Utils/ReferenceLookupHelpIcon';
 import SourceCreate from './Components/create';
 import SourceDelete from './Components/delete';
 import SourceEdit from './Components/edit';
@@ -346,15 +347,18 @@ const TableList: FC = () => {
             />
           </Col>
           <Col {...responsiveSearchExtraColProps}>
-            <Checkbox
-              checked={referenceLookup}
-              onChange={(e) => setReferenceLookup(e.target.checked)}
-            >
-              <FormattedMessage
-                id='pages.search.referenceLookup'
-                defaultMessage='Reference Lookup'
-              />
-            </Checkbox>
+            <Space className='responsive-data-list-reference-lookup-option' size={4} align='center'>
+              <Checkbox
+                checked={referenceLookup}
+                onChange={(e) => setReferenceLookup(e.target.checked)}
+              >
+                <FormattedMessage
+                  id='pages.search.referenceLookup'
+                  defaultMessage='Reference Lookup'
+                />
+              </Checkbox>
+              <ReferenceLookupHelpIcon />
+            </Space>
           </Col>
         </Row>
       </Card>

--- a/src/pages/Unitgroups/index.tsx
+++ b/src/pages/Unitgroups/index.tsx
@@ -44,6 +44,7 @@ import {
   showInvalidReferenceLookupUuidMessage,
   showReferenceLookupLimitMessage,
 } from '../Utils/referenceLookup';
+import ReferenceLookupHelpIcon from '../Utils/ReferenceLookupHelpIcon';
 import UnitGroupCreate from './Components/create';
 import UnitGroupView from './Components/view';
 
@@ -314,15 +315,18 @@ const TableList: FC = () => {
             />
           </Col>
           <Col {...responsiveSearchExtraColProps}>
-            <Checkbox
-              checked={referenceLookup}
-              onChange={(e) => setReferenceLookup(e.target.checked)}
-            >
-              <FormattedMessage
-                id='pages.search.referenceLookup'
-                defaultMessage='Reference Lookup'
-              />
-            </Checkbox>
+            <Space className='responsive-data-list-reference-lookup-option' size={4} align='center'>
+              <Checkbox
+                checked={referenceLookup}
+                onChange={(e) => setReferenceLookup(e.target.checked)}
+              >
+                <FormattedMessage
+                  id='pages.search.referenceLookup'
+                  defaultMessage='Reference Lookup'
+                />
+              </Checkbox>
+              <ReferenceLookupHelpIcon />
+            </Space>
           </Col>
         </Row>
       </Card>

--- a/src/pages/Utils/ReferenceLookupHelpIcon.tsx
+++ b/src/pages/Utils/ReferenceLookupHelpIcon.tsx
@@ -1,0 +1,29 @@
+import { InfoCircleOutlined } from '@ant-design/icons';
+import { Tooltip, theme } from 'antd';
+import { useIntl } from 'umi';
+
+export default function ReferenceLookupHelpIcon() {
+  const intl = useIntl();
+  const { token } = theme.useToken();
+
+  const tooltip = intl.formatMessage({
+    defaultMessage:
+      'Find records that reference a specific dataset.\nAfter enabling this option, enter the full dataset UUID. The system searches the current data type for records whose content contains that UUID.\nThis mode does not search by name or keyword.',
+    id: 'pages.search.referenceLookup.tooltip',
+  });
+
+  return (
+    <Tooltip title={<span style={{ whiteSpace: 'pre-line' }}>{tooltip}</span>}>
+      <InfoCircleOutlined
+        aria-hidden
+        style={{
+          color: token.colorTextTertiary,
+          cursor: 'help',
+          fontSize: token.fontSizeSM,
+          flexShrink: 0,
+          lineHeight: 1,
+        }}
+      />
+    </Tooltip>
+  );
+}

--- a/tests/unit/components/ResponsiveDataList.test.tsx
+++ b/tests/unit/components/ResponsiveDataList.test.tsx
@@ -77,7 +77,7 @@ describe('ResponsiveDataList helpers', () => {
     });
     expect(responsiveSearchExtraColProps).toEqual({
       className: 'responsive-data-list-search-extra',
-      flex: '100px',
+      flex: 'none',
     });
   });
 

--- a/tests/unit/pages/Utils/ReferenceLookupHelpIcon.test.tsx
+++ b/tests/unit/pages/Utils/ReferenceLookupHelpIcon.test.tsx
@@ -1,0 +1,67 @@
+import ReferenceLookupHelpIcon from '@/pages/Utils/ReferenceLookupHelpIcon';
+import { render, screen } from '@testing-library/react';
+
+const toText = (node: any): string => {
+  if (node === null || node === undefined || typeof node === 'boolean') return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(toText).join('');
+  if (typeof node === 'object' && 'props' in node && node.props?.children) {
+    return toText(node.props.children);
+  }
+  return '';
+};
+
+jest.mock('umi', () => ({
+  __esModule: true,
+  useIntl: () => ({
+    formatMessage: ({ defaultMessage, id }: { defaultMessage?: string; id: string }) =>
+      defaultMessage ?? id,
+  }),
+}));
+
+jest.mock('@ant-design/icons', () => ({
+  __esModule: true,
+  InfoCircleOutlined: (props: any) => (
+    <span data-testid='reference-lookup-help-icon' {...props}>
+      i
+    </span>
+  ),
+}));
+
+jest.mock('antd', () => ({
+  __esModule: true,
+  Tooltip: ({ children, title }: any) => (
+    <span data-testid='reference-lookup-tooltip' title={toText(title)}>
+      {children}
+    </span>
+  ),
+  theme: {
+    useToken: () => ({
+      token: {
+        colorTextTertiary: 'rgba(0, 0, 0, 0.45)',
+        fontSizeSM: 12,
+      },
+    }),
+  },
+}));
+
+describe('ReferenceLookupHelpIcon', () => {
+  it('renders a grey help icon with the detailed reference lookup tooltip', () => {
+    render(<ReferenceLookupHelpIcon />);
+
+    expect(screen.getByTestId('reference-lookup-tooltip')).toHaveAttribute(
+      'title',
+      [
+        'Find records that reference a specific dataset.',
+        'After enabling this option, enter the full dataset UUID. The system searches the current data type for records whose content contains that UUID.',
+        'This mode does not search by name or keyword.',
+      ].join('\n'),
+    );
+    expect(screen.getByTestId('reference-lookup-help-icon')).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByTestId('reference-lookup-help-icon')).toHaveStyle({
+      color: 'rgba(0, 0, 0, 0.45)',
+      cursor: 'help',
+      fontSize: '12px',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a localized Reference Lookup help icon explaining UUID-based reverse lookup
- wire the help icon into process, flow, lifecycle model, flow property, contact, unit group, and source list search controls
- make the shared search option column content-sized so Chinese and English labels do not wrap or leave excess right-side whitespace

## Validation
- npm run docpact:gate
- npm run test:ci -- tests/unit/pages/Utils/ReferenceLookupHelpIcon.test.tsx tests/unit/pages/Processes/index.test.tsx tests/unit/pages/Flows/index.test.tsx tests/unit/pages/LifeCycleModels/index.test.tsx tests/unit/pages/Flowproperties/index.test.tsx tests/unit/pages/Contacts/index.test.tsx tests/unit/pages/Unitgroups/index.test.tsx tests/unit/pages/Sources/index.test.tsx --runInBand --testTimeout=30000
- npm run test:ci -- tests/unit/components/ResponsiveDataList.test.tsx --runInBand --testTimeout=30000
- npm run tsc
- git push pre-push hook: npm run docpact:gate --base origin/dev; npm run prepush:gate

## Notes
- No linked issue; requested directly in Codex.