### PR TITLE
[codex] pin footer on tall screens

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-01"
-lastReviewedCommit: "41c686f3d884c2bae0a018e84a32026e042c0ad5"
+lastReviewedCommit: "e4356fd5fc6e3696134a4ae184bcb96809acb737"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 41c686f3d884c2bae0a018e84a32026e042c0ad5
+lastReviewedCommit: e4356fd5fc6e3696134a4ae184bcb96809acb737
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 46049bc581ede1230147984e43dd4b34fa607116
+lastReviewedCommit: e042c319f9210f49b3b6c6614a95f4ded316e2d4
 ---
 
 # Development Bootstrap

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 41c686f3d884c2bae0a018e84a32026e042c0ad5
+lastReviewedCommit: e4356fd5fc6e3696134a4ae184bcb96809acb737
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 41c686f3d884c2bae0a018e84a32026e042c0ad5
+lastReviewedCommit: e4356fd5fc6e3696134a4ae184bcb96809acb737
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/src/style/custom.less
+++ b/src/style/custom.less
@@ -47,12 +47,13 @@
 
 :global(.ant-pro-layout .ant-pro-layout-content) {
   display: flex;
-  min-height: calc(100vh - 56px);
+  flex: 1 1 auto;
+  min-height: 0;
   flex-direction: column;
 }
 
 :global(.ant-pro-layout .ant-pro-layout-content > .ant-pro-page-container) {
-  flex: 1 0 auto;
+  flex: 1 1 auto;
 }
 
 @welcome-radius: 8px;

--- a/src/style/custom.less
+++ b/src/style/custom.less
@@ -28,6 +28,9 @@
 }
 
 .app_footer {
+  flex-shrink: 0;
+  margin-top: auto;
+
   :global(.ant-pro-global-footer-list-link) {
     transition: color 0.2s ease;
   }
@@ -36,6 +39,20 @@
   :global(.ant-pro-global-footer-list-link:focus-visible) {
     color: var(--ant-color-primary);
   }
+}
+
+:global(.ant-pro-layout .ant-pro-layout-container) {
+  min-height: 100vh;
+}
+
+:global(.ant-pro-layout .ant-pro-layout-content) {
+  display: flex;
+  min-height: calc(100vh - 56px);
+  flex-direction: column;
+}
+
+:global(.ant-pro-layout .ant-pro-layout-content > .ant-pro-page-container) {
+  flex: 1 0 auto;
 }
 
 @welcome-radius: 8px;


### PR DESCRIPTION
## Summary
- keep the app footer at the viewport bottom on tall welcome-page screens without using fixed positioning
- remove the extra full-height content minimum that pushed the footer below the viewport and caused page scrolling
- preserve normal document flow so the footer still follows content on longer pages
- record the required docpact review evidence for the layout-level style change

## Validation
- `npx prettier -c src/style/custom.less`
- `npm run tsc`
- `npm run build`
- `npm run docpact:gate`
- Playwright 2048x1024 visual/layout check on `/#/welcome` after login: `scrollHeight === clientHeight === 1024`, footer bottom `1024`, wheel scroll keeps `scrollY === 0`
- fork push pre-push gate completed successfully: 348 suites and 4349 tests passed, full coverage gate passed at 100%

## Notes
- No issue was provided for this UI-only request.
- Footer behavior is layout-only; no page data or routing logic changed.