### PR TITLE
chore: release dev to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-01"
-lastReviewedCommit: "41c686f3d884c2bae0a018e84a32026e042c0ad5"
+lastReviewedCommit: "e4356fd5fc6e3696134a4ae184bcb96809acb737"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-01"
-lastReviewedCommit: "b9fb27fec11aa57f0e4e7774ab3957109348e0c6"
+lastReviewedCommit: "41c686f3d884c2bae0a018e84a32026e042c0ad5"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-01"
-lastReviewedCommit: "e4356fd5fc6e3696134a4ae184bcb96809acb737"
+lastReviewedCommit: "d786dce9ed4e19370d8a4322e2fe1c1886b3dbbd"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: b9fb27fec11aa57f0e4e7774ab3957109348e0c6
+lastReviewedCommit: 41c686f3d884c2bae0a018e84a32026e042c0ad5
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: e4356fd5fc6e3696134a4ae184bcb96809acb737
+lastReviewedCommit: 2a44d73b237dcc0c85e39496512af5fdac140864
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 41c686f3d884c2bae0a018e84a32026e042c0ad5
+lastReviewedCommit: e4356fd5fc6e3696134a4ae184bcb96809acb737
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: fbfffe7009bb60d011b6a5df6c12af0e628422b1
+lastReviewedCommit: 46049bc581ede1230147984e43dd4b34fa607116
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: e042c319f9210f49b3b6c6614a95f4ded316e2d4
+lastReviewedCommit: 2a44d73b237dcc0c85e39496512af5fdac140864
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 46049bc581ede1230147984e43dd4b34fa607116
+lastReviewedCommit: e042c319f9210f49b3b6c6614a95f4ded316e2d4
 ---
 
 # Development Bootstrap

--- a/docs/agents/contribution-path-analysis-design.md
+++ b/docs/agents/contribution-path-analysis-design.md
@@ -21,7 +21,7 @@ checkPaths:
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 1f8d4a411ef6822b5ded6e596cae3f5b13d35cdc
+lastReviewedCommit: 72291932dcc89626e2c88f8c1fe775284587a664
 ---
 
 # Contribution Path Analysis Design

--- a/docs/agents/data_audit_instruction.md
+++ b/docs/agents/data_audit_instruction.md
@@ -18,8 +18,8 @@ checkPaths:
   - docs/agents/data_audit_instruction.md
   - src/pages/Review/**
   - src/pages/ManageSystem/**
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: f8f9e56f2b00ee98e2a2df2591b2dc4625f540d2
+lastReviewedAt: 2026-07-01
+lastReviewedCommit: 41c686f3d884c2bae0a018e84a32026e042c0ad5
 ---
 
 # Audit Status Reference

--- a/docs/agents/lca-analysis-visualization-plan.md
+++ b/docs/agents/lca-analysis-visualization-plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 1f8d4a411ef6822b5ded6e596cae3f5b13d35cdc
+lastReviewedCommit: 72291932dcc89626e2c88f8c1fe775284587a664
 ---
 
 # LCA Analysis And Visualization Plan

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
+lastReviewedCommit: d786dce9ed4e19370d8a4322e2fe1c1886b3dbbd
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: b9fb27fec11aa57f0e4e7774ab3957109348e0c6
+lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 41c686f3d884c2bae0a018e84a32026e042c0ad5
+lastReviewedCommit: e4356fd5fc6e3696134a4ae184bcb96809acb737
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: b9fb27fec11aa57f0e4e7774ab3957109348e0c6
+lastReviewedCommit: 41c686f3d884c2bae0a018e84a32026e042c0ad5
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 41c686f3d884c2bae0a018e84a32026e042c0ad5
+lastReviewedCommit: e4356fd5fc6e3696134a4ae184bcb96809acb737
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: b9fb27fec11aa57f0e4e7774ab3957109348e0c6
+lastReviewedCommit: 41c686f3d884c2bae0a018e84a32026e042c0ad5
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: e4356fd5fc6e3696134a4ae184bcb96809acb737
+lastReviewedCommit: d786dce9ed4e19370d8a4322e2fe1c1886b3dbbd
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/team_management.md
+++ b/docs/agents/team_management.md
@@ -19,8 +19,8 @@ checkPaths:
   - src/pages/Teams/**
   - src/pages/Review/**
   - src/pages/ManageSystem/**
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: f8f9e56f2b00ee98e2a2df2591b2dc4625f540d2
+lastReviewedAt: 2026-07-01
+lastReviewedCommit: 41c686f3d884c2bae0a018e84a32026e042c0ad5
 ---
 
 # Team Management Reference

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
+lastReviewedCommit: d786dce9ed4e19370d8a4322e2fe1c1886b3dbbd
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: b9fb27fec11aa57f0e4e7774ab3957109348e0c6
+lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: b9fb27fec11aa57f0e4e7774ab3957109348e0c6
+lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
+lastReviewedCommit: d786dce9ed4e19370d8a4322e2fe1c1886b3dbbd
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: b9fb27fec11aa57f0e4e7774ab3957109348e0c6
+lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
+lastReviewedCommit: d786dce9ed4e19370d8a4322e2fe1c1886b3dbbd
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
+lastReviewedCommit: d786dce9ed4e19370d8a4322e2fe1c1886b3dbbd
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: b9fb27fec11aa57f0e4e7774ab3957109348e0c6
+lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/util_calculate.md
+++ b/docs/agents/util_calculate.md
@@ -21,7 +21,7 @@ checkPaths:
   - src/components/LcaTaskCenter/**
   - src/pages/Processes/Analysis/**
 lastReviewedAt: 2026-07-01
-lastReviewedCommit: 1f8d4a411ef6822b5ded6e596cae3f5b13d35cdc
+lastReviewedCommit: 72291932dcc89626e2c88f8c1fe775284587a664
 ---
 
 # Lifecycle Model Calculation Reference

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",

--- a/src/components/HeaderActionIcon/index.tsx
+++ b/src/components/HeaderActionIcon/index.tsx
@@ -8,6 +8,16 @@ export const HEADER_ACTION_ICON_STYLE: React.CSSProperties = {
   cursor: 'pointer',
 };
 
+export const getHeaderBadgeStyle = (backgroundColor: string): React.CSSProperties => ({
+  backgroundColor,
+  borderRadius: '7px',
+  minWidth: '14px',
+  height: '14px',
+  lineHeight: '14px',
+  padding: '0 4px',
+  fontSize: '9px',
+});
+
 type HeaderActionIconProps = {
   title: React.ReactNode;
   icon: React.ReactElement<any>;

--- a/src/components/LcaTaskCenter/index.tsx
+++ b/src/components/LcaTaskCenter/index.tsx
@@ -1,4 +1,4 @@
-import HeaderActionIcon from '@/components/HeaderActionIcon';
+import HeaderActionIcon, { getHeaderBadgeStyle } from '@/components/HeaderActionIcon';
 import type {
   LcaBackgroundTask,
   LcaTaskPhase,
@@ -1818,6 +1818,7 @@ const LcaTaskCenter: React.FC = () => {
       })),
     [intl],
   );
+  const badgeStyle = getHeaderBadgeStyle(token.colorError);
 
   useEffect(() => {
     setExpandedTaskKeys((current) =>
@@ -1968,7 +1969,7 @@ const LcaTaskCenter: React.FC = () => {
         })}
         icon={<ClockCircleOutlined />}
         badgeCount={runningCount + attentionCount}
-        badgeStyle={attentionCount > 0 ? { backgroundColor: '#cf1322' } : undefined}
+        badgeStyle={badgeStyle}
         onClick={() => {
           setOpen(true);
           void refreshAllTasks().catch(() => undefined);

--- a/src/components/Notification/index.tsx
+++ b/src/components/Notification/index.tsx
@@ -1,4 +1,4 @@
-import HeaderActionIcon from '@/components/HeaderActionIcon';
+import HeaderActionIcon, { getHeaderBadgeStyle } from '@/components/HeaderActionIcon';
 import {
   getFreshUserMetadata,
   updateDataNotificationTime,
@@ -186,15 +186,7 @@ const Notification: React.FC = () => {
     setActiveTabKey(key as NotificationTabKey);
   };
 
-  const badgeStyles = {
-    backgroundColor: token.colorError,
-    borderRadius: '7px',
-    minWidth: '14px',
-    height: '14px',
-    lineHeight: '14px',
-    padding: '0 4px',
-    fontSize: '9px',
-  };
+  const badgeStyles = getHeaderBadgeStyle(token.colorError);
 
   const items = [
     {

--- a/src/locales/en-US/pages_teams.ts
+++ b/src/locales/en-US/pages_teams.ts
@@ -47,6 +47,10 @@ export default {
   'pages.team.info.public.tooltip': 'After enabling, allow others to contact the team leader through email',
   'pages.team.info.showInHome': 'Apply to display on the homepage',
   'pages.team.info.showInHome.tooltip': 'After enabling, allow the logo and team introduction to be displayed on the homepage',
+  'pages.team.info.section.basic': 'Basic Information',
+  'pages.team.info.section.visibility': 'Team visibility and display',
+  'pages.team.info.section.logo': 'Team Logo',
+  'pages.team.info.logo.helper': 'Transparent PNG or SVG is recommended for the best display effect.',
   'pages.team.info.lightLogo.required': 'Please upload light logo!',
   'pages.team.info.darkLogo.required': 'Please upload dark logo!',
 };

--- a/src/locales/zh-CN/pages_teams.ts
+++ b/src/locales/zh-CN/pages_teams.ts
@@ -46,6 +46,10 @@ export default {
   'pages.team.info.public.tooltip': '开启后，允许他人通过邮箱联系团队负责人',
   'pages.team.info.showInHome': '申请首页展示',
   'pages.team.info.showInHome.tooltip': '开启后，允许在首页展示Logo及团队简介',
+  'pages.team.info.section.basic': '基本信息',
+  'pages.team.info.section.visibility': '团队可见性与展示',
+  'pages.team.info.section.logo': '团队标志',
+  'pages.team.info.logo.helper': '建议使用透明背景的 PNG 或 SVG 格式，以获得最佳展示效果。',
   'pages.team.info.lightLogo.required': '请上传亮色Logo!',
   'pages.team.info.darkLogo.required': '请上传暗色Logo!',
 };

--- a/src/pages/Teams/index.less
+++ b/src/pages/Teams/index.less
@@ -1,0 +1,278 @@
+.team-page-tabs {
+  .ant-tabs-tabpane {
+    padding-left: 24px;
+  }
+
+  .ant-tabs-tab {
+    padding: 12px 24px 12px 0;
+  }
+
+  .ant-tabs-tab + .ant-tabs-tab {
+    margin-top: 16px;
+  }
+}
+
+.team-info-form {
+  max-width: 1080px;
+}
+
+.team-info-card {
+  margin-bottom: 16px;
+  padding: 24px 28px;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.team-info-section-title {
+  position: relative;
+  margin-bottom: 20px;
+  padding-left: 14px;
+  color: rgba(0, 0, 0, 0.88);
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 24px;
+
+  &::before {
+    position: absolute;
+    top: 4px;
+    left: 0;
+    width: 3px;
+    height: 16px;
+    background: var(--ant-color-primary);
+    border-radius: 2px;
+    content: '';
+  }
+}
+
+.team-info-basic-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+}
+
+.team-info-basic-fields {
+  min-width: 0;
+}
+
+.team-lang-field {
+  & + & {
+    margin-top: 20px;
+    padding-top: 20px;
+    border-top: 1px solid rgba(5, 5, 5, 0.06);
+  }
+
+  .ant-row {
+    max-width: 620px;
+  }
+
+  .ant-form-item {
+    margin-bottom: 0;
+  }
+}
+
+.team-switch-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 0;
+}
+
+.team-switch-item {
+  margin-bottom: 0;
+  padding-right: 44px;
+
+  & + & {
+    padding-right: 0;
+    padding-left: 44px;
+    border-left: 1px solid rgba(5, 5, 5, 0.08);
+  }
+
+  .ant-form-item-row {
+    display: grid;
+    grid-template-columns: minmax(0, max-content) auto;
+    gap: 16px;
+    align-items: center;
+  }
+
+  .ant-form-item-label {
+    padding-bottom: 0;
+    text-align: left;
+  }
+
+  .ant-form-item-control {
+    width: max-content;
+  }
+
+  .ant-form-item-label > label {
+    color: rgba(0, 0, 0, 0.88);
+  }
+}
+
+.team-logo-card {
+  margin-bottom: 0;
+}
+
+.team-logo-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 0;
+  align-items: start;
+}
+
+.team-logo-form-item {
+  margin-bottom: 0;
+  padding-right: 44px;
+
+  & + & {
+    padding-right: 0;
+    padding-left: 44px;
+    border-left: 1px solid rgba(5, 5, 5, 0.08);
+  }
+
+  .ant-form-item-label {
+    padding-bottom: 8px;
+  }
+
+  .ant-form-item-label > label {
+    color: rgba(0, 0, 0, 0.88);
+    font-weight: 500;
+  }
+
+  .ant-upload-wrapper,
+  .ant-upload-list,
+  .ant-upload-list-item-container,
+  .ant-upload-select {
+    width: 168px !important;
+    height: 168px !important;
+  }
+}
+
+.team-logo-upload {
+  width: 168px;
+
+  .ant-upload-select {
+    background: #fafafa !important;
+    border-color: rgba(92, 36, 106, 0.42) !important;
+    border-style: dashed !important;
+    border-radius: 12px !important;
+  }
+
+  .team-logo-upload-plus {
+    color: rgba(0, 0, 0, 0.88);
+    font-size: 30px;
+  }
+
+  .ant-upload-list-item {
+    padding: 0 !important;
+    overflow: hidden;
+    border-color: #d9d9d9 !important;
+    border-radius: 6px !important;
+
+    &::before {
+      background: transparent !important;
+    }
+  }
+
+  .ant-upload-list-item-thumbnail,
+  .ant-upload-list-item-thumbnail img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+
+  .ant-upload-list-item-name {
+    display: none;
+  }
+
+  .ant-upload-list-item-actions {
+    inset-inline-start: 0 !important;
+    width: 100%;
+    background: transparent !important;
+
+    .ant-upload-list-item-action {
+      background: transparent !important;
+    }
+
+    .anticon {
+      margin: 0 12px;
+      font-size: 20px;
+      filter: drop-shadow(0 1px 2px rgba(255, 255, 255, 0.6));
+    }
+
+    .anticon-eye {
+      color: rgba(0, 0, 0, 0.75) !important;
+    }
+
+    .anticon-delete {
+      color: #ff4d4f !important;
+    }
+  }
+}
+
+.team-logo-upload-dark.team-logo-upload-has-file {
+  .ant-upload-list-item,
+  .ant-upload-list-item-thumbnail {
+    background: #141414;
+  }
+
+  .ant-upload-list-item-actions {
+    .anticon {
+      filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
+    }
+
+    .anticon-eye {
+      color: #fff !important;
+    }
+  }
+}
+
+.team-logo-helper {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  width: min(100%, 680px);
+  margin-top: 18px;
+  padding: 8px 12px;
+  color: rgba(0, 0, 0, 0.45);
+  background: #fafafa;
+  border: 1px solid rgba(5, 5, 5, 0.06);
+  border-radius: 6px;
+}
+
+.team-info-submitter {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 24px;
+
+  .ant-btn-primary {
+    min-width: 120px;
+  }
+}
+
+@media (max-width: 960px) {
+  .team-page-tabs {
+    .ant-tabs-tabpane {
+      padding-left: 16px;
+    }
+  }
+
+  .team-info-basic-grid,
+  .team-switch-grid,
+  .team-logo-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .team-switch-item,
+  .team-switch-item + .team-switch-item,
+  .team-logo-form-item + .team-logo-form-item {
+    padding-right: 0;
+    padding-left: 0;
+    border-left: 0;
+  }
+
+  .team-switch-item + .team-switch-item,
+  .team-logo-form-item + .team-logo-form-item {
+    margin-top: 20px;
+  }
+}

--- a/src/pages/Teams/index.tsx
+++ b/src/pages/Teams/index.tsx
@@ -1,4 +1,3 @@
-import { darkLogoPreviewStyle } from '@/components/AllTeams/logoPreviewStyle';
 import LangTextItemForm from '@/components/LangTextItem/form';
 import RequiredMark from '@/components/RequiredMark';
 import { ListPagination } from '@/services/general/data';
@@ -51,6 +50,7 @@ import {
 import { Children, useEffect, useRef, useState } from 'react';
 import { v4 } from 'uuid';
 import AddMemberModal from './Components/AddMemberModal';
+import './index.less';
 
 const DEFAULT_CREATE_TEAM_RANK = -1;
 const DEFAULT_CREATE_TEAM_IS_PUBLIC = false;
@@ -177,6 +177,11 @@ const Team = () => {
   };
 
   const renderTeamInfoForm = () => {
+    const hasLightLogoPreview =
+      lightLogo.length > 0 && lightLogoPreviewUrl && lightLogoPreviewUrl !== '.';
+    const hasDarkLogoPreview =
+      darkLogo.length > 0 && darkLogoPreviewUrl && darkLogoPreviewUrl !== '.';
+
     const getParams = (input: Record<string, any>) => {
       const result: Record<string, any> = {};
 
@@ -397,262 +402,323 @@ const Team = () => {
     };
 
     return (
-      <Flex gap='small' vertical style={{ maxWidth: '50%', minWidth: '200px' }}>
-        <Spin spinning={teamInfoSpinning}>
-          <ProForm
-            disabled={
-              (userRole !== 'admin' && userRole !== 'owner' && action !== 'create') || rank > 0
-            }
-            formRef={formRefEdit}
-            submitter={{
-              resetButtonProps: false,
-              render: (_, dom) => (
-                <div style={{ display: 'flex', justifyContent: 'center' }}>
-                  {Children.toArray(dom)}
-                </div>
-              ),
-            }}
-            onFinish={(values) => submitTeamInfo(values)}
-            initialValues={{
-              rank: DEFAULT_CREATE_TEAM_RANK,
-              is_public: DEFAULT_CREATE_TEAM_IS_PUBLIC,
-            }}
-          >
-            <Form.Item
-              label={
-                <RequiredMark
-                  label={<FormattedMessage id='pages.team.info.title' defaultMessage='Team Name' />}
-                  showError={titleError}
-                />
-              }
-              style={{ marginBottom: 0 }}
-            >
-              <LangTextItemForm
-                name='title'
-                label={<FormattedMessage id='pages.team.info.title' defaultMessage='Team Name' />}
-                rules={[
-                  {
-                    required: true,
-                    message: (
-                      <FormattedMessage
-                        id='pages.team.info.title.required'
-                        defaultMessage='Please input team name!'
-                      />
-                    ),
-                  },
-                ]}
-                setRuleErrorState={setTitleError}
+      <Spin spinning={teamInfoSpinning}>
+        <ProForm
+          className='team-info-form'
+          disabled={
+            (userRole !== 'admin' && userRole !== 'owner' && action !== 'create') || rank > 0
+          }
+          formRef={formRefEdit}
+          submitter={{
+            resetButtonProps: false,
+            render: (_, dom) => <div className='team-info-submitter'>{Children.toArray(dom)}</div>,
+          }}
+          onFinish={(values) => submitTeamInfo(values)}
+          initialValues={{
+            rank: DEFAULT_CREATE_TEAM_RANK,
+            is_public: DEFAULT_CREATE_TEAM_IS_PUBLIC,
+          }}
+        >
+          <section className='team-info-card team-info-card-basic'>
+            <div className='team-info-section-title'>
+              <FormattedMessage
+                id='pages.team.info.section.basic'
+                defaultMessage='Basic Information'
               />
-            </Form.Item>
-            <Form.Item
-              label={
-                <RequiredMark
+            </div>
+            <div className='team-info-basic-grid'>
+              <div className='team-info-basic-fields'>
+                <Form.Item
+                  className='team-lang-field'
                   label={
-                    <FormattedMessage
-                      id='pages.team.info.description'
-                      defaultMessage='Team Description'
+                    <RequiredMark
+                      label={
+                        <FormattedMessage id='pages.team.info.title' defaultMessage='Team Name' />
+                      }
+                      showError={titleError}
                     />
                   }
-                  showError={descriptionError}
-                />
-              }
-              style={{ marginBottom: 0 }}
-            >
-              <LangTextItemForm
-                name='description'
-                label={
-                  <FormattedMessage
-                    id='pages.team.info.description'
-                    defaultMessage='Team Description'
+                  style={{ marginBottom: 0 }}
+                >
+                  <LangTextItemForm
+                    name='title'
+                    label={
+                      <FormattedMessage id='pages.team.info.title' defaultMessage='Team Name' />
+                    }
+                    rules={[
+                      {
+                        required: true,
+                        message: (
+                          <FormattedMessage
+                            id='pages.team.info.title.required'
+                            defaultMessage='Please input team name!'
+                          />
+                        ),
+                      },
+                    ]}
+                    setRuleErrorState={setTitleError}
                   />
+                </Form.Item>
+                <Form.Item
+                  className='team-lang-field'
+                  label={
+                    <RequiredMark
+                      label={
+                        <FormattedMessage
+                          id='pages.team.info.description'
+                          defaultMessage='Team Description'
+                        />
+                      }
+                      showError={descriptionError}
+                    />
+                  }
+                  style={{ marginBottom: 0 }}
+                >
+                  <LangTextItemForm
+                    name='description'
+                    label={
+                      <FormattedMessage
+                        id='pages.team.info.description'
+                        defaultMessage='Team Description'
+                      />
+                    }
+                    rules={[
+                      {
+                        required: true,
+                        message: (
+                          <FormattedMessage
+                            id='pages.team.info.description.required'
+                            defaultMessage='Please input team description!'
+                          />
+                        ),
+                      },
+                    ]}
+                    setRuleErrorState={setDescriptionError}
+                  />
+                </Form.Item>
+              </div>
+            </div>
+          </section>
+
+          <section className='team-info-card'>
+            <div className='team-info-section-title'>
+              <FormattedMessage
+                id='pages.team.info.section.visibility'
+                defaultMessage='Team visibility and display'
+              />
+            </div>
+            <div className='team-switch-grid'>
+              <Form.Item
+                className='team-switch-item'
+                name='is_public'
+                label={
+                  <>
+                    <FormattedMessage id='pages.team.info.public' defaultMessage='Public' />
+                    <Tooltip title={intl.formatMessage({ id: 'pages.team.info.public.tooltip' })}>
+                      <QuestionCircleOutlined style={{ marginLeft: 4 }} />
+                    </Tooltip>
+                  </>
+                }
+                valuePropName='checked'
+              >
+                <Switch
+                  disabled={
+                    (userRole !== 'admin' && userRole !== 'owner' && action !== 'create') ||
+                    rank > 0
+                  }
+                />
+              </Form.Item>
+              <Form.Item
+                className='team-switch-item'
+                name='rank'
+                label={
+                  <>
+                    <FormattedMessage
+                      id='pages.team.info.showInHome'
+                      defaultMessage='Apply to display on the homepage'
+                    />
+                    <Tooltip
+                      title={intl.formatMessage({ id: 'pages.team.info.showInHome.tooltip' })}
+                    >
+                      <QuestionCircleOutlined style={{ marginLeft: 4 }} />
+                    </Tooltip>
+                  </>
+                }
+                valuePropName='checked'
+                getValueProps={(value) => ({
+                  checked: value === 0,
+                })}
+                normalize={(value) => {
+                  return value ? 0 : -1;
+                }}
+              >
+                <Switch
+                  disabled={
+                    (userRole !== 'admin' && userRole !== 'owner' && action !== 'create') ||
+                    rank > 0
+                  }
+                  onChange={(checked) => {
+                    setRank(checked ? 0 : -1);
+                    setLightLogoError(false);
+                    setDarkLogoError(false);
+                  }}
+                />
+              </Form.Item>
+            </div>
+          </section>
+
+          <section className='team-info-card team-logo-card'>
+            <div className='team-info-section-title'>
+              <FormattedMessage id='pages.team.info.section.logo' defaultMessage='Team Logo' />
+            </div>
+            <div className='team-logo-grid'>
+              <Form.Item
+                className='team-logo-form-item'
+                name='lightLogo'
+                label={
+                  <FormattedMessage id='pages.team.info.lightLogo' defaultMessage='Light Logo' />
                 }
                 rules={[
                   {
-                    required: true,
+                    required: rank === 0,
                     message: (
                       <FormattedMessage
-                        id='pages.team.info.description.required'
-                        defaultMessage='Please input team description!'
+                        id='pages.team.info.lightLogo.required'
+                        defaultMessage='Please upload light logo!'
                       />
                     ),
                   },
                 ]}
-                setRuleErrorState={setDescriptionError}
-              />
-            </Form.Item>
-            <Form.Item
-              name='is_public'
-              label={
-                <>
-                  <FormattedMessage id='pages.team.info.public' defaultMessage='Public' />
-                  <Tooltip title={intl.formatMessage({ id: 'pages.team.info.public.tooltip' })}>
-                    <QuestionCircleOutlined style={{ marginLeft: 4 }} />
-                  </Tooltip>
-                </>
-              }
-              valuePropName='checked'
-            >
-              <Switch
-                disabled={
-                  (userRole !== 'admin' && userRole !== 'owner' && action !== 'create') || rank > 0
-                }
-              />
-            </Form.Item>
-            <Form.Item
-              name='rank'
-              label={
-                <>
-                  <FormattedMessage
-                    id='pages.team.info.showInHome'
-                    defaultMessage='Apply to display on the homepage'
-                  />
-                  <Tooltip title={intl.formatMessage({ id: 'pages.team.info.showInHome.tooltip' })}>
-                    <QuestionCircleOutlined style={{ marginLeft: 4 }} />
-                  </Tooltip>
-                </>
-              }
-              valuePropName='checked'
-              getValueProps={(value) => ({
-                checked: value === 0,
-              })}
-              normalize={(value) => {
-                return value ? 0 : -1;
-              }}
-            >
-              <Switch
-                disabled={
-                  (userRole !== 'admin' && userRole !== 'owner' && action !== 'create') || rank > 0
-                }
-                onChange={(checked) => {
-                  setRank(checked ? 0 : -1);
-                  setLightLogoError(false);
-                  setDarkLogoError(false);
-                }}
-              />
-            </Form.Item>
-            <Form.Item
-              name='lightLogo'
-              label={
-                <FormattedMessage id='pages.team.info.lightLogo' defaultMessage='Light Logo' />
-              }
-              rules={[
-                {
-                  required: rank === 0,
-                  message: (
+                validateStatus={lightLogoError ? 'error' : undefined}
+                help={
+                  lightLogoError ? (
                     <FormattedMessage
                       id='pages.team.info.lightLogo.required'
                       defaultMessage='Please upload light logo!'
                     />
-                  ),
-                },
-              ]}
-              validateStatus={lightLogoError ? 'error' : undefined}
-              help={
-                lightLogoError ? (
-                  <FormattedMessage
-                    id='pages.team.info.lightLogo.required'
-                    defaultMessage='Please upload light logo!'
-                  />
-                ) : undefined
-              }
-            >
-              <div>
-                <Upload
-                  disabled={
-                    (userRole !== 'admin' && userRole !== 'owner' && action !== 'create') ||
-                    rank > 0
-                  }
-                  beforeUpload={(file) => {
-                    getBase64(file as FileType).then((url) => {
-                      setLightLogoPreviewUrl(url);
-                      setLightLogo([file]);
-                      setLightLogoError(false);
-                    });
+                  ) : undefined
+                }
+              >
+                <div className='team-logo-upload team-logo-upload-light'>
+                  <Upload
+                    disabled={
+                      (userRole !== 'admin' && userRole !== 'owner' && action !== 'create') ||
+                      rank > 0
+                    }
+                    beforeUpload={(file) => {
+                      getBase64(file as FileType).then((url) => {
+                        setLightLogoPreviewUrl(url);
+                        setLightLogo([file]);
+                        setLightLogoError(false);
+                      });
 
-                    return false;
-                  }}
-                  onRemove={() => removeLogo('lightLogo')}
-                  maxCount={1}
-                  listType='picture-card'
-                  fileList={
-                    lightLogo && lightLogo.length > 0
-                      ? [
-                          {
-                            uid: '-1',
-                            name: 'logo',
-                            status: 'done',
-                            url: lightLogoPreviewUrl,
-                          },
-                        ]
-                      : []
-                  }
-                >
-                  {lightLogo && lightLogo.length === 0 && <PlusOutlined />}
-                </Upload>
-              </div>
-            </Form.Item>
+                      return false;
+                    }}
+                    onRemove={() => removeLogo('lightLogo')}
+                    maxCount={1}
+                    isImageUrl={() => true}
+                    listType='picture-card'
+                    fileList={
+                      hasLightLogoPreview
+                        ? [
+                            {
+                              uid: '-1',
+                              name: 'logo.png',
+                              status: 'done',
+                              thumbUrl: lightLogoPreviewUrl,
+                              url: lightLogoPreviewUrl,
+                            },
+                          ]
+                        : []
+                    }
+                  >
+                    {!hasLightLogoPreview && <PlusOutlined className='team-logo-upload-plus' />}
+                  </Upload>
+                </div>
+              </Form.Item>
 
-            <Form.Item
-              name='darkLogo'
-              label={<FormattedMessage id='pages.team.info.darkLogo' defaultMessage='Dark Logo' />}
-              rules={[
-                {
-                  required: rank === 0,
-                  message: (
+              <Form.Item
+                className='team-logo-form-item'
+                name='darkLogo'
+                label={
+                  <FormattedMessage id='pages.team.info.darkLogo' defaultMessage='Dark Logo' />
+                }
+                rules={[
+                  {
+                    required: rank === 0,
+                    message: (
+                      <FormattedMessage
+                        id='pages.team.info.darkLogo.required'
+                        defaultMessage='Please upload dark logo!'
+                      />
+                    ),
+                  },
+                ]}
+                validateStatus={darkLogoError ? 'error' : undefined}
+                help={
+                  darkLogoError ? (
                     <FormattedMessage
                       id='pages.team.info.darkLogo.required'
                       defaultMessage='Please upload dark logo!'
                     />
-                  ),
-                },
-              ]}
-              validateStatus={darkLogoError ? 'error' : undefined}
-              help={
-                darkLogoError ? (
-                  <FormattedMessage
-                    id='pages.team.info.darkLogo.required'
-                    defaultMessage='Please upload dark logo!'
-                  />
-                ) : undefined
-              }
-            >
-              <div style={darkLogoPreviewUrl ? darkLogoPreviewStyle : {}}>
-                <Upload
-                  disabled={
-                    (userRole !== 'admin' && userRole !== 'owner' && action !== 'create') ||
-                    rank > 0
-                  }
-                  beforeUpload={(file) => {
-                    getBase64(file as FileType).then((url) => {
-                      setDarkLogoPreviewUrl(url);
-                      setDarkLogo([file]);
-                      setDarkLogoError(false);
-                    });
-                    return false;
-                  }}
-                  onRemove={() => removeLogo('darkLogo')}
-                  maxCount={1}
-                  listType='picture-card'
-                  fileList={
-                    darkLogo && darkLogo.length > 0
-                      ? [
-                          {
-                            uid: '-1',
-                            name: 'logo',
-                            status: 'done',
-                            url: darkLogoPreviewUrl,
-                          },
-                        ]
-                      : []
-                  }
+                  ) : undefined
+                }
+              >
+                <div
+                  className={[
+                    'team-logo-upload',
+                    'team-logo-upload-dark',
+                    hasDarkLogoPreview ? 'team-logo-upload-has-file' : '',
+                  ]
+                    .filter(Boolean)
+                    .join(' ')}
                 >
-                  {darkLogo && darkLogo.length === 0 && <PlusOutlined />}
-                </Upload>
-              </div>
-            </Form.Item>
-          </ProForm>
-        </Spin>
-      </Flex>
+                  <Upload
+                    disabled={
+                      (userRole !== 'admin' && userRole !== 'owner' && action !== 'create') ||
+                      rank > 0
+                    }
+                    beforeUpload={(file) => {
+                      getBase64(file as FileType).then((url) => {
+                        setDarkLogoPreviewUrl(url);
+                        setDarkLogo([file]);
+                        setDarkLogoError(false);
+                      });
+                      return false;
+                    }}
+                    onRemove={() => removeLogo('darkLogo')}
+                    maxCount={1}
+                    isImageUrl={() => true}
+                    listType='picture-card'
+                    fileList={
+                      hasDarkLogoPreview
+                        ? [
+                            {
+                              uid: '-1',
+                              name: 'logo.png',
+                              status: 'done',
+                              thumbUrl: darkLogoPreviewUrl,
+                              url: darkLogoPreviewUrl,
+                            },
+                          ]
+                        : []
+                    }
+                  >
+                    {!hasDarkLogoPreview && <PlusOutlined className='team-logo-upload-plus' />}
+                  </Upload>
+                </div>
+              </Form.Item>
+            </div>
+            <div className='team-logo-helper'>
+              <QuestionCircleOutlined />
+              <FormattedMessage
+                id='pages.team.info.logo.helper'
+                defaultMessage='Transparent PNG or SVG is recommended for the best display effect.'
+              />
+            </div>
+          </section>
+        </ProForm>
+      </Spin>
     );
   };
 
@@ -937,7 +1003,13 @@ const Team = () => {
     <PageContainer
       title={<FormattedMessage id='menu.account.team' defaultMessage='Team Management' />}
     >
-      <Tabs activeKey={activeTabKey} onChange={onTabChange} tabPosition='left' items={tabs} />
+      <Tabs
+        activeKey={activeTabKey}
+        className='team-page-tabs'
+        onChange={onTabChange}
+        tabPosition='left'
+        items={tabs}
+      />
     </PageContainer>
   );
 };

--- a/src/style/custom.less
+++ b/src/style/custom.less
@@ -47,12 +47,13 @@
 
 :global(.ant-pro-layout .ant-pro-layout-content) {
   display: flex;
-  min-height: calc(100vh - 56px);
+  flex: 1 1 auto;
+  min-height: 0;
   flex-direction: column;
 }
 
 :global(.ant-pro-layout .ant-pro-layout-content > .ant-pro-page-container) {
-  flex: 1 0 auto;
+  flex: 1 1 auto;
 }
 
 @welcome-radius: 8px;

--- a/src/style/custom.less
+++ b/src/style/custom.less
@@ -28,6 +28,9 @@
 }
 
 .app_footer {
+  flex-shrink: 0;
+  margin-top: auto;
+
   :global(.ant-pro-global-footer-list-link) {
     transition: color 0.2s ease;
   }
@@ -36,6 +39,20 @@
   :global(.ant-pro-global-footer-list-link:focus-visible) {
     color: var(--ant-color-primary);
   }
+}
+
+:global(.ant-pro-layout .ant-pro-layout-container) {
+  min-height: 100vh;
+}
+
+:global(.ant-pro-layout .ant-pro-layout-content) {
+  display: flex;
+  min-height: calc(100vh - 56px);
+  flex-direction: column;
+}
+
+:global(.ant-pro-layout .ant-pro-layout-content > .ant-pro-page-container) {
+  flex: 1 0 auto;
 }
 
 @welcome-radius: 8px;

--- a/tests/unit/components/HeaderActionIcon.test.tsx
+++ b/tests/unit/components/HeaderActionIcon.test.tsx
@@ -1,4 +1,4 @@
-import HeaderActionIcon from '@/components/HeaderActionIcon';
+import HeaderActionIcon, { getHeaderBadgeStyle } from '@/components/HeaderActionIcon';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 type ReactNode = import('react').ReactNode;
@@ -39,6 +39,18 @@ jest.mock('antd', () => ({
 }));
 
 describe('HeaderActionIcon', () => {
+  it('provides the shared compact header badge style', () => {
+    expect(getHeaderBadgeStyle('#ff4d4f')).toEqual({
+      backgroundColor: '#ff4d4f',
+      borderRadius: '7px',
+      minWidth: '14px',
+      height: '14px',
+      lineHeight: '14px',
+      padding: '0 4px',
+      fontSize: '9px',
+    });
+  });
+
   it('renders shared icon styling and badge props', () => {
     render(
       <HeaderActionIcon

--- a/tests/unit/pages/Teams/TeamPage.test.tsx
+++ b/tests/unit/pages/Teams/TeamPage.test.tsx
@@ -312,27 +312,38 @@ jest.mock('antd', () => {
     </button>
   );
 
-  const Upload = ({ beforeUpload, onRemove, fileList = [], disabled }: any) => (
-    <div data-testid='upload'>
-      <button
-        type='button'
-        disabled={disabled}
-        onClick={() =>
-          beforeUpload?.({
-            name: mockUploadFileName,
-            type: 'image/png',
-          })
-        }
-      >
-        upload-file
-      </button>
-      {fileList?.length > 0 ? (
-        <button type='button' disabled={disabled} onClick={() => onRemove?.()}>
-          remove-file
+  const Upload = ({ beforeUpload, onRemove, fileList = [], disabled, isImageUrl }: any) => {
+    const imageFlags = fileList.map((file: any) => isImageUrl?.(file));
+
+    return (
+      <div data-testid='upload'>
+        <button
+          type='button'
+          disabled={disabled}
+          onClick={() =>
+            beforeUpload?.({
+              name: mockUploadFileName,
+              type: 'image/png',
+            })
+          }
+        >
+          upload-file
         </button>
-      ) : null}
-    </div>
-  );
+        {fileList?.length > 0 ? (
+          <>
+            {imageFlags.map((flag: boolean, index: number) => (
+              <span key={index} data-testid='upload-image-flag'>
+                {String(flag)}
+              </span>
+            ))}
+            <button type='button' disabled={disabled} onClick={() => onRemove?.()}>
+              remove-file
+            </button>
+          </>
+        ) : null}
+      </div>
+    );
+  };
 
   const Button = React.forwardRef((props: any, ref: any) => {
     const { children, onClick, disabled, icon, ...rest } = props ?? {};


### PR DESCRIPTION
## Summary
- Promote `dev` to `main` for the next frontend release.
- Includes #564: team edit page UI refinement, logo upload preview states, and unified header notification badges.
- Includes #565: welcome page footer bottom alignment on tall screens without extra page scrolling.
- Resolves the release PR conflict by merging latest `origin/main` into the release branch and bumping the frontend package version to `0.0.36`.

## Validation
- Local release conflict resolution validation passed: `npm run docpact:gate`, `npm run tsc`, and `npm run build`.
- Pushed the updated release branch through the repo pre-push gate: docpact passed, lint/typecheck passed, 348 suites and 4349 tests passed, full coverage gate passed at 100%.
- Source PR #564 validation included `npm run tsc`, `npm run build`, `npm run docpact:gate`, focused team/header tests, and fork pre-push full coverage gate.
- Source PR #565 validation included `npx prettier -c src/style/custom.less`, `npm run tsc`, `npm run build`, `npm run docpact:gate`, Playwright 2048x1024 layout check, and fork pre-push full coverage gate.

## Release Notes
- This PR follows the workspace M2 promote path for `tiangong-lca-next`: `dev -> main`.
- Root workspace integration should only bump to this child `main` commit after this promote PR is merged.
