### PR TITLE
Hide obsolete admin sub-page route

### DIFF
--- a/config/routes.ts
+++ b/config/routes.ts
@@ -300,23 +300,6 @@ export default [
     component: './Welcome',
   },
   {
-    path: '/admin',
-    name: 'admin',
-    icon: 'crown',
-    access: 'canAdmin',
-    routes: [
-      {
-        path: '/admin',
-        redirect: '/admin/sub-page',
-      },
-      {
-        path: '/admin/sub-page',
-        name: 'sub-page',
-        component: './Admin',
-      },
-    ],
-  },
-  {
     path: '/',
     redirect: '/welcome',
   },

--- a/src/locales/en-US/menu.ts
+++ b/src/locales/en-US/menu.ts
@@ -2,8 +2,6 @@ export default {
   'menu.welcome': 'Welcome',
   'menu.more-blocks': 'More Blocks',
   'menu.home': 'Home',
-  'menu.admin': 'Admin',
-  'menu.admin.sub-page': 'Sub-Page',
   'menu.login': 'Login',
   'menu.register': 'Register',
   'menu.register-result': 'Register Result',

--- a/src/locales/zh-CN/menu.ts
+++ b/src/locales/zh-CN/menu.ts
@@ -2,8 +2,6 @@ export default {
   'menu.welcome': '欢迎',
   'menu.more-blocks': '更多区块',
   'menu.home': '首页',
-  'menu.admin': '管理页',
-  'menu.admin.sub-page': '二级管理页',
   'menu.login': '登录',
   'menu.register': '注册',
   'menu.register-result': '注册结果',


### PR DESCRIPTION
Closes #567

## Summary
- Remove the obsolete /admin route group that exposed the template /admin/sub-page entry to admin users.
- Remove the unused English and Chinese admin menu labels so the stale menu text is no longer shipped.

## Key Decisions
- Leave the real admin-gated national carbon dashboard route unchanged; only the dead template Admin page route was removed.

## Validation
- rg confirmed no admin/sub-page, menu.admin, ./Admin route, or p__Admin bundle references remain in config, src, or dist.
- npm run lint:js
- ./node_modules/.bin/max setup && npm run tsc
- npm run build

## Risks / Rollback
- Low-risk route cleanup; rollback is to restore the removed route block and locale keys if the template page is intentionally needed later.

## Workspace Integration
- Workspace submodule integration remains pending after this PR merges.