### PR TITLE
chore: release v0.0.37

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-07-01"
-lastReviewedCommit: "d786dce9ed4e19370d8a4322e2fe1c1886b3dbbd"
+lastReviewedAt: "2026-07-03"
+lastReviewedCommit: "b68dde35b639acad99120fc5f6583d1b0dea444a"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: 2a44d73b237dcc0c85e39496512af5fdac140864
+lastReviewedAt: 2026-07-03
+lastReviewedCommit: b68dde35b639acad99120fc5f6583d1b0dea444a
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: 2a44d73b237dcc0c85e39496512af5fdac140864
+lastReviewedAt: 2026-07-03
+lastReviewedCommit: 986aa5f3aa3ad849c8fc20b76e7133c6d5dcab10
 ---
 
 # Development Bootstrap

--- a/config/routes.ts
+++ b/config/routes.ts
@@ -300,23 +300,6 @@ export default [
     component: './Welcome',
   },
   {
-    path: '/admin',
-    name: 'admin',
-    icon: 'crown',
-    access: 'canAdmin',
-    routes: [
-      {
-        path: '/admin',
-        redirect: '/admin/sub-page',
-      },
-      {
-        path: '/admin/sub-page',
-        name: 'sub-page',
-        component: './Admin',
-      },
-    ],
-  },
-  {
     path: '/',
     redirect: '/welcome',
   },

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.js
   - .github/workflows/**
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: d786dce9ed4e19370d8a4322e2fe1c1886b3dbbd
+lastReviewedAt: 2026-07-03
+lastReviewedCommit: 986aa5f3aa3ad849c8fc20b76e7133c6d5dcab10
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: e4356fd5fc6e3696134a4ae184bcb96809acb737
+lastReviewedAt: 2026-07-03
+lastReviewedCommit: b68dde35b639acad99120fc5f6583d1b0dea444a
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: d786dce9ed4e19370d8a4322e2fe1c1886b3dbbd
+lastReviewedAt: 2026-07-03
+lastReviewedCommit: b68dde35b639acad99120fc5f6583d1b0dea444a
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -19,8 +19,8 @@ checkPaths:
   - config/supabaseEnv.ts
   - src/services/**
   - docker/**
-lastReviewedAt: 2026-06-29
-lastReviewedCommit: b48000e68a07d92ee26d3ef00d153f32083f33cb
+lastReviewedAt: 2026-07-03
+lastReviewedCommit: c697dfb1979da89f052c646f04f59fe3e1bf3c0f
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: d786dce9ed4e19370d8a4322e2fe1c1886b3dbbd
+lastReviewedAt: 2026-07-03
+lastReviewedCommit: 986aa5f3aa3ad849c8fc20b76e7133c6d5dcab10
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: d786dce9ed4e19370d8a4322e2fe1c1886b3dbbd
+lastReviewedAt: 2026-07-03
+lastReviewedCommit: 986aa5f3aa3ad849c8fc20b76e7133c6d5dcab10
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: d786dce9ed4e19370d8a4322e2fe1c1886b3dbbd
+lastReviewedAt: 2026-07-03
+lastReviewedCommit: 986aa5f3aa3ad849c8fc20b76e7133c6d5dcab10
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: d786dce9ed4e19370d8a4322e2fe1c1886b3dbbd
+lastReviewedAt: 2026-07-03
+lastReviewedCommit: 986aa5f3aa3ad849c8fc20b76e7133c6d5dcab10
 ---
 
 # Testing Troubleshooting

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",

--- a/src/locales/en-US/menu.ts
+++ b/src/locales/en-US/menu.ts
@@ -2,8 +2,6 @@ export default {
   'menu.welcome': 'Welcome',
   'menu.more-blocks': 'More Blocks',
   'menu.home': 'Home',
-  'menu.admin': 'Admin',
-  'menu.admin.sub-page': 'Sub-Page',
   'menu.login': 'Login',
   'menu.register': 'Register',
   'menu.register-result': 'Register Result',

--- a/src/locales/zh-CN/menu.ts
+++ b/src/locales/zh-CN/menu.ts
@@ -2,8 +2,6 @@ export default {
   'menu.welcome': '欢迎',
   'menu.more-blocks': '更多区块',
   'menu.home': '首页',
-  'menu.admin': '管理页',
-  'menu.admin.sub-page': '二级管理页',
   'menu.login': '登录',
   'menu.register': '注册',
   'menu.register-result': '注册结果',

--- a/src/services/processes/data.ts
+++ b/src/services/processes/data.ts
@@ -102,7 +102,8 @@ export type ProcessReviewItem = {
   'common:scope'?: ProcessReviewScopeItem | ProcessReviewScopeItem[];
   'common:dataQualityIndicators'?: {
     'common:dataQualityIndicator'?:
-      ProcessReviewDataQualityIndicatorItem | ProcessReviewDataQualityIndicatorItem[];
+      | ProcessReviewDataQualityIndicatorItem
+      | ProcessReviewDataQualityIndicatorItem[];
   };
   'common:reviewDetails'?: LangTextValue;
   'common:referenceToNameOfReviewerAndInstitution'?: ReferenceItem | ReferenceItem[];


### PR DESCRIPTION
## Promotion Contract
- Base branch: `main`
- Source branch: `ForeverYoung5:codex/release-dev-to-main-20260703` promoted from `dev`
- Validated environment before promotion: local release branch based on `origin/dev`, with `origin/main` merged to preserve release-line metadata
- Back-merge required after merge: No; this branch already merged `origin/main` before the release bump
- Root workspace integration expected: Yes; after merge, `lca-workspace` should bump `tiangong-lca-next` to the promoted `main` commit

- [x] this PR promotes `dev` into `main`
- [x] integrated behavior was verified in `dev` before promotion: #568 merged into `dev` on 2026-07-03
- [x] if direct `main` hotfix: N/A

## Linked Issue
Closes #569

## Promotion Facts
- Promotes #568 to `main`, hiding the obsolete `/admin/sub-page` admin route and removing its menu strings.
- Merges `origin/main` into the release branch first, preserving the existing v0.0.36 release-line state.
- Bumps `package.json` from `0.0.36` to `0.0.37`.
- Confirms `v0.0.37` was not already tagged before preparing the release branch.

## Validation Facts
- `rg -n "admin/sub-page|menu\.admin\.sub-page|Admin Sub Page|管理页|Sub Page" config src tests` returned no matches.
- `DOCPACT_BASE_REF=origin/main npm run docpact:gate`
- `npm run lint:js`
- `./node_modules/.bin/max setup && npm run tsc`
- `npm run build`
- `npm run prepush:gate`

## Integration And Follow-Up
- After this PR merges, create the root workspace integration update for the `tiangong-lca-next` submodule pointer.
