### PR TITLE
fix: normalize lifecycle model reference process id

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-08"
-lastReviewedCommit: "fb19ecd0b7fac061ae54cbade1c35e7f81ac7cc1"
+lastReviewedCommit: "c2b13d45239ff152272f4075a1a06f7a16593441"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: d7a2b798daa0048619b35f5723968e5fca36148d
+lastReviewedCommit: b8895f11d69f23f026fe9329bd2c893002b498e4
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: d7a2b798daa0048619b35f5723968e5fca36148d
+lastReviewedCommit: b8895f11d69f23f026fe9329bd2c893002b498e4
 ---
 
 # Development Bootstrap

--- a/docs/agents/contribution-path-analysis-design.md
+++ b/docs/agents/contribution-path-analysis-design.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: 72291932dcc89626e2c88f8c1fe775284587a664
+lastReviewedAt: 2026-07-08
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 ---
 
 # Contribution Path Analysis Design

--- a/docs/agents/lca-analysis-visualization-plan.md
+++ b/docs/agents/lca-analysis-visualization-plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: 72291932dcc89626e2c88f8c1fe775284587a664
+lastReviewedAt: 2026-07-08
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 ---
 
 # LCA Analysis And Visualization Plan

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.js
   - .github/workflows/**
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
+lastReviewedAt: 2026-07-08
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: fb19ecd0b7fac061ae54cbade1c35e7f81ac7cc1
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: fb19ecd0b7fac061ae54cbade1c35e7f81ac7cc1
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -19,8 +19,8 @@ checkPaths:
   - config/supabaseEnv.ts
   - src/services/**
   - docker/**
-lastReviewedAt: 2026-06-29
-lastReviewedCommit: b48000e68a07d92ee26d3ef00d153f32083f33cb
+lastReviewedAt: 2026-07-08
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
+lastReviewedAt: 2026-07-08
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
+lastReviewedAt: 2026-07-08
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
+lastReviewedAt: 2026-07-08
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
+lastReviewedAt: 2026-07-08
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/util_calculate.md
+++ b/docs/agents/util_calculate.md
@@ -20,8 +20,8 @@ checkPaths:
   - src/services/lca/**
   - src/components/LcaTaskCenter/**
   - src/pages/Processes/Analysis/**
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: 72291932dcc89626e2c88f8c1fe775284587a664
+lastReviewedAt: 2026-07-08
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 ---
 
 # Lifecycle Model Calculation Reference

--- a/src/services/lifeCycleModels/referenceProcess.ts
+++ b/src/services/lifeCycleModels/referenceProcess.ts
@@ -1,0 +1,35 @@
+const INTEGER_REFERENCE_PROCESS_ID = /^-?\d+$/;
+
+export const toReferenceProcessNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? value : undefined;
+  }
+
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalizedValue = value.trim();
+  if (!INTEGER_REFERENCE_PROCESS_ID.test(normalizedValue)) {
+    return undefined;
+  }
+
+  return Number(normalizedValue);
+};
+
+export const toReferenceProcessKey = (value: unknown): string | undefined => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value) : undefined;
+  }
+
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalizedValue = value.trim();
+  return normalizedValue ? normalizedValue : undefined;
+};

--- a/src/services/lifeCycleModels/util.ts
+++ b/src/services/lifeCycleModels/util.ts
@@ -15,6 +15,7 @@ import {
 } from '../general/util';
 import { genProcessName, genProcessNameJson } from '../processes/util';
 import { FormLifeCycleModel } from './data';
+import { toReferenceProcessKey, toReferenceProcessNumber } from './referenceProcess';
 
 export function genNodeLabel(label: string, lang: string, nodeWidth: number) {
   let labelSub = label?.substring(0, nodeWidth / 7 - 4);
@@ -60,10 +61,10 @@ export const genReferenceToResultingProcess = (
 export function genLifeCycleModelJsonOrdered(id: string, data: any) {
   const nodes = data?.model?.nodes;
 
-  let referenceToReferenceProcess = null;
+  let referenceToReferenceProcess: number | undefined;
   const processInstance = nodes?.map((n: any) => {
     if (n?.data?.quantitativeReference === '1') {
-      referenceToReferenceProcess = n?.data?.index;
+      referenceToReferenceProcess = toReferenceProcessNumber(n?.data?.index);
     }
 
     const sourceEdges = data?.model?.edges?.filter((e: any) => e?.source?.cell === n?.id);
@@ -193,7 +194,7 @@ export function genLifeCycleModelJsonOrdered(id: string, data: any) {
           },
         },
         quantitativeReference: {
-          referenceToReferenceProcess: referenceToReferenceProcess ?? {},
+          referenceToReferenceProcess,
         },
         technology: {
           groupDeclarations: {},
@@ -487,6 +488,8 @@ export function genLifeCycleModelJsonOrdered(id: string, data: any) {
 }
 
 export function genLifeCycleModelInfoFromData(data: any): FormLifeCycleModel {
+  const referenceToReferenceProcess =
+    data?.lifeCycleModelInformation?.quantitativeReference?.referenceToReferenceProcess;
   const model = createTidasLifeCycleModel({
     lifeCycleModelDataSet: {
       '@xmlns': 'http://eplca.jrc.ec.europa.eu/ILCD/LifeCycleModel/2017',
@@ -579,7 +582,7 @@ export function genLifeCycleModelInfoFromData(data: any): FormLifeCycleModel {
             data?.lifeCycleModelInformation?.quantitativeReference?.functionalUnitOrOther,
           ),
           referenceToReferenceProcess:
-            data?.lifeCycleModelInformation?.quantitativeReference?.referenceToReferenceProcess,
+            toReferenceProcessNumber(referenceToReferenceProcess) ?? referenceToReferenceProcess,
         } as any,
         technology: {
           groupDeclarations: {},
@@ -848,8 +851,22 @@ export function genLifeCycleModelInfoFromData(data: any): FormLifeCycleModel {
       },
     },
   });
+  const lifeCycleModelInformation = model.lifeCycleModelDataSet.lifeCycleModelInformation;
+  const referenceToReferenceProcessFormValue = toReferenceProcessKey(
+    lifeCycleModelInformation.quantitativeReference?.referenceToReferenceProcess,
+  );
+
   return {
-    lifeCycleModelInformation: model.lifeCycleModelDataSet.lifeCycleModelInformation,
+    lifeCycleModelInformation: {
+      ...lifeCycleModelInformation,
+      quantitativeReference:
+        referenceToReferenceProcessFormValue === undefined
+          ? lifeCycleModelInformation.quantitativeReference
+          : ({
+              ...lifeCycleModelInformation.quantitativeReference,
+              referenceToReferenceProcess: referenceToReferenceProcessFormValue,
+            } as any),
+    },
     modellingAndValidation: model.lifeCycleModelDataSet.modellingAndValidation,
     administrativeInformation: model.lifeCycleModelDataSet.administrativeInformation,
   };

--- a/src/services/lifeCycleModels/util_calculate.ts
+++ b/src/services/lifeCycleModels/util_calculate.ts
@@ -12,6 +12,7 @@ import {
 import LCIAResultCalculation from '../lciaMethods/util';
 import { supabase } from '../supabase';
 import { Up2DownEdge } from './data';
+import { toReferenceProcessKey } from './referenceProcess';
 import { allocateSupplyToDemand } from './util_allocate_supply_demand';
 
 /**
@@ -1194,11 +1195,12 @@ export async function genLifeCycleModelProcesses(
   lifeCycleModelJsonOrdered: any,
   oldSubmodels: any[],
 ) {
-  const refProcessNodeId =
+  const refProcessNodeId = toReferenceProcessKey(
     lifeCycleModelJsonOrdered?.lifeCycleModelDataSet?.lifeCycleModelInformation
-      ?.quantitativeReference?.referenceToReferenceProcess;
+      ?.quantitativeReference?.referenceToReferenceProcess,
+  );
 
-  if (!refProcessNodeId) {
+  if (refProcessNodeId === undefined) {
     throw new Error('No referenceToReferenceProcess found in lifeCycleModelInformation');
   }
 
@@ -1210,9 +1212,14 @@ export async function genLifeCycleModelProcesses(
     lifeCycleModelJsonOrdered?.lifeCycleModelDataSet?.lifeCycleModelInformation?.technology
       ?.processes?.processInstance,
   ).map((p: any) => {
-    let node = modelNodes?.find((i: any) => i?.data?.index === p?.['@dataSetInternalID']);
+    const processInternalId = toReferenceProcessKey(p?.['@dataSetInternalID']);
+    let node = modelNodes?.find(
+      (i: any) => toReferenceProcessKey(i?.data?.index) === processInternalId,
+    );
     if (!node)
-      node = modelNodes?.find((i: any) => i?.['@dataSetInternalID'] === p?.['@dataSetInternalID']);
+      node = modelNodes?.find(
+        (i: any) => toReferenceProcessKey(i?.['@dataSetInternalID']) === processInternalId,
+      );
     return {
       ...p,
       nodeId: node?.id,
@@ -1222,8 +1229,8 @@ export async function genLifeCycleModelProcesses(
   const mdProcessMap = new Map<string, any>();
   const processShortDescriptionMap = new Map<string, any>();
   for (const p of mdProcesses as any[]) {
-    const nid = p?.['@dataSetInternalID'];
-    if (nid) mdProcessMap.set(nid, p);
+    const nid = toReferenceProcessKey(p?.['@dataSetInternalID']);
+    if (nid !== undefined) mdProcessMap.set(nid, p);
 
     const processId = p?.referenceToProcess?.['@refObjectId'];
     const processVersion = p?.referenceToProcess?.['@version'];

--- a/tests/unit/services/lifeCycleModels/referenceProcess.test.ts
+++ b/tests/unit/services/lifeCycleModels/referenceProcess.test.ts
@@ -1,0 +1,37 @@
+import {
+  toReferenceProcessKey,
+  toReferenceProcessNumber,
+} from '@/services/lifeCycleModels/referenceProcess';
+
+describe('reference process id normalization', () => {
+  describe('toReferenceProcessNumber', () => {
+    it('returns integers from numeric and string inputs', () => {
+      expect(toReferenceProcessNumber(0)).toBe(0);
+      expect(toReferenceProcessNumber(' 12 ')).toBe(12);
+      expect(toReferenceProcessNumber('-3')).toBe(-3);
+    });
+
+    it('rejects non-integer or non-string inputs', () => {
+      expect(toReferenceProcessNumber(1.5)).toBeUndefined();
+      expect(toReferenceProcessNumber('1.5')).toBeUndefined();
+      expect(toReferenceProcessNumber('abc')).toBeUndefined();
+      expect(toReferenceProcessNumber({ id: '1' })).toBeUndefined();
+    });
+  });
+
+  describe('toReferenceProcessKey', () => {
+    it('returns stable string keys from finite numbers and non-empty strings', () => {
+      expect(toReferenceProcessKey(0)).toBe('0');
+      expect(toReferenceProcessKey(' nodeA ')).toBe('nodeA');
+    });
+
+    it('rejects missing, non-finite, blank, or unsupported values', () => {
+      expect(toReferenceProcessKey(null)).toBeUndefined();
+      expect(toReferenceProcessKey(undefined)).toBeUndefined();
+      expect(toReferenceProcessKey(Number.NaN)).toBeUndefined();
+      expect(toReferenceProcessKey(Number.POSITIVE_INFINITY)).toBeUndefined();
+      expect(toReferenceProcessKey('   ')).toBeUndefined();
+      expect(toReferenceProcessKey({ id: 'nodeA' })).toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/services/lifeCycleModels/util.test.ts
+++ b/tests/unit/services/lifeCycleModels/util.test.ts
@@ -349,7 +349,7 @@ describe('genLifeCycleModelJsonOrdered', () => {
     expect(
       result.lifeCycleModelDataSet.lifeCycleModelInformation.quantitativeReference
         .referenceToReferenceProcess,
-    ).toBe('0');
+    ).toBe(0);
 
     expect(processes[0].referenceToProcess['@refObjectId']).toBe('proc-a');
     expect(processes[0].referenceToProcess['@uri']).toBe('../processes/proc-a.xml');

--- a/tests/unit/services/lifeCycleModels/util.test.ts
+++ b/tests/unit/services/lifeCycleModels/util.test.ts
@@ -674,6 +674,18 @@ describe('genLifeCycleModelInfoFromData', () => {
 
     expect(result.lifeCycleModelInformation.dataSetInformation['common:UUID']).toBe('-');
   });
+
+  it('should keep the reference process unset when the ordered dataset omits it', () => {
+    const ordered = genLifeCycleModelJsonOrdered('model-reference-fallback', baseModelData);
+    delete ordered.lifeCycleModelDataSet.lifeCycleModelInformation.quantitativeReference
+      .referenceToReferenceProcess;
+
+    const result = genLifeCycleModelInfoFromData(ordered.lifeCycleModelDataSet);
+
+    expect(
+      result.lifeCycleModelInformation.quantitativeReference.referenceToReferenceProcess,
+    ).toBeUndefined();
+  });
 });
 
 describe('genLifeCycleModelData', () => {

--- a/tests/unit/services/lifeCycleModels/util_calculate.test.ts
+++ b/tests/unit/services/lifeCycleModels/util_calculate.test.ts
@@ -245,6 +245,18 @@ const createSupabaseProcesses = () => [
   },
 ];
 
+const createNumericReferenceLifeCycleModelData = () => {
+  const data = clone(createLifeCycleModelData()) as any;
+  const modelInfo = data.lifeCycleModelDataSet.lifeCycleModelInformation;
+  modelInfo.quantitativeReference.referenceToReferenceProcess = 0;
+
+  const processInstances = modelInfo.technology.processes.processInstance;
+  processInstances[0]['@dataSetInternalID'] = '0';
+  processInstances[1].connections.outputExchange[0].downstreamProcess['@id'] = '0';
+
+  return data;
+};
+
 const createSelectionFallbackModelData = () => ({
   lifeCycleModelDataSet: {
     lifeCycleModelInformation: {
@@ -1227,6 +1239,30 @@ describe('genLifeCycleModelProcesses', () => {
       genLifeCycleModelProcesses('model-no-data-payload', null, data, []),
     ).rejects.toThrow('Reference process not found in database');
 
+    expect(mockFrom).toHaveBeenCalledWith('processes');
+  });
+
+  it('accepts numeric zero as the reference process id and matches string internal ids', async () => {
+    const data = createNumericReferenceLifeCycleModelData();
+    mockOr.mockResolvedValue({ data: clone(createSupabaseProcesses()) });
+    mockLCIAResultCalculation.mockResolvedValue([]);
+
+    const { lifeCycleModelProcesses } = await genLifeCycleModelProcesses(
+      'model-zero-reference',
+      [
+        {
+          id: 'graph-node-reference',
+          data: { index: '0', quantitativeReference: '1', targetAmount: 10 },
+        },
+      ] as any,
+      data,
+      [],
+    );
+
+    const primary = lifeCycleModelProcesses.find((item) => item?.modelInfo?.type === 'primary');
+
+    expect(primary).toBeDefined();
+    expect(primary?.modelInfo?.id).toBe('model-zero-reference');
     expect(mockFrom).toHaveBeenCalledWith('processes');
   });
 


### PR DESCRIPTION
Closes #575

## Summary
- Serialize lifecycle model referenceToReferenceProcess as a number for SDK validation while keeping processInstance internal IDs string-compatible for editor and calculation flows.

## Key Decisions
- Keep the fix in tiangong-lca-next rather than relaxing @tiangong-lca/tidas-sdk schema, because the installed SDK schema requires referenceToReferenceProcess to be number/integer.
- Normalize calculation lookups to string keys so numeric 0 remains valid and continues matching string @dataSetInternalID values.

## Validation
- npm run test:ci -- tests/unit/services/lifeCycleModels/referenceProcess.test.ts tests/unit/services/lifeCycleModels/util.test.ts tests/unit/services/lifeCycleModels/util_calculate.test.ts tests/unit/pages/LifeCycleModels/sdkValidation.test.ts --runInBand
- npx prettier --check src/services/lifeCycleModels/referenceProcess.ts src/services/lifeCycleModels/util.ts src/services/lifeCycleModels/util_calculate.ts tests/unit/services/lifeCycleModels/referenceProcess.test.ts tests/unit/services/lifeCycleModels/util.test.ts tests/unit/services/lifeCycleModels/util_calculate.test.ts
- npm run lint:js
- npm run tsc
- npm run build
- npm run docpact:gate
- git push pre-push hook ran npm run docpact:gate and npm run prepush:gate: 349 test suites, 4355 tests, and 100% statements/branches/functions/lines coverage.

## Risks / Rollback
- Low risk: scoped to lifecycle-model reference-process ID normalization and calculation key matching; old string IDs remain accepted inside runtime calculations.

## Follow-ups
- After merge to dev and later promote eligibility, workspace integration remains pending per project policy.

## Workspace Integration
- Requires later lca-workspace submodule pointer bump after the tiangong-lca-next change is promoted/eligible for workspace integration.
