### PR TITLE
Fix validation issue modal column overflow

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-08"
-lastReviewedCommit: "c2b13d45239ff152272f4075a1a06f7a16593441"
+lastReviewedCommit: "5682ce18ee59f625110945553ee01e9a6b5d60d9"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: b8895f11d69f23f026fe9329bd2c893002b498e4
+lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: b8895f11d69f23f026fe9329bd2c893002b498e4
+lastReviewedCommit: 5720aa816910678fca95f96fd2800b2a5c9417d1
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
+lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
+lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
+lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
+lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
+lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
+lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
+lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
 ---
 
 # Testing Troubleshooting

--- a/src/components/ValidationIssueModal/index.tsx
+++ b/src/components/ValidationIssueModal/index.tsx
@@ -4,6 +4,7 @@ import { getSdkSuggestedFixMessage } from '@/pages/Utils/validation/messages';
 import { CloseOutlined } from '@ant-design/icons';
 import { Button, ConfigProvider, Modal, Space, Table, message, theme } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
+import type { CSSProperties } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { getBrandTheme } from '../../../config/branding';
@@ -161,6 +162,13 @@ const getValidationIssueListSeparator = (intl: IntlShapeLike) =>
 
 const MULTIPLICATION_FACTOR_FIELD_TOKEN = '@multiplicationFactor';
 const PROCESS_INSTANCE_FIELD_PATH_PREFIX = 'processInstance[#';
+const VALIDATION_ISSUE_TABLE_SCROLL_X = 1164;
+
+const validationIssueCellTextStyle: CSSProperties = {
+  overflowWrap: 'anywhere',
+  whiteSpace: 'normal',
+  wordBreak: 'break-word',
+};
 
 /* istanbul ignore next -- process-instance detail text fallbacks are UI-only formatting branches */
 const getSdkDetailFieldToken = (detail?: ValidationIssueSdkDetail) => {
@@ -759,9 +767,10 @@ const ValidationIssueModalContent = ({
                 color: token.colorPrimary,
                 fontWeight: token.fontWeightStrong,
                 height: 'auto',
+                maxWidth: '100%',
                 padding: 0,
                 textAlign: 'left',
-                whiteSpace: 'normal',
+                ...validationIssueCellTextStyle,
               }}
               onClick={() =>
                 onNavigate({ detail: detailItem.detail, tabName: detailItem.detail.tabName })
@@ -884,6 +893,10 @@ const ValidationIssueModalContent = ({
         defaultMessage: 'ID',
       }),
       key: 'id',
+      width: 220,
+      onCell: () => ({
+        style: validationIssueCellTextStyle,
+      }),
       render: (_, groupedIssue) => groupedIssue.ref['@refObjectId'],
     },
     {
@@ -901,6 +914,10 @@ const ValidationIssueModalContent = ({
         defaultMessage: 'Issue',
       }),
       key: 'issue',
+      width: 380,
+      onCell: () => ({
+        style: validationIssueCellTextStyle,
+      }),
       render: (_, groupedIssue) => {
         if (groupedIssue.issues.length <= 1) {
           return renderIssueCell(groupedIssue.issues[0]);
@@ -926,6 +943,9 @@ const ValidationIssueModalContent = ({
       }),
       key: 'ownerName',
       width: 160,
+      onCell: () => ({
+        style: validationIssueCellTextStyle,
+      }),
       render: (_, groupedIssue) => groupedIssue.ownerName,
     },
     {
@@ -979,7 +999,7 @@ const ValidationIssueModalContent = ({
       dataSource={groupedIssues}
       pagination={false}
       rowKey={(groupedIssue) => getValidationIssueGroupKey(groupedIssue)}
-      scroll={{ y: 360 }}
+      scroll={{ x: VALIDATION_ISSUE_TABLE_SCROLL_X, y: 360 }}
       sticky
       size='small'
       style={{
@@ -987,6 +1007,7 @@ const ValidationIssueModalContent = ({
         borderRadius: token.borderRadiusLG,
         overflow: 'hidden',
       }}
+      tableLayout='fixed'
     />
   );
 };

--- a/tests/unit/components/ValidationIssueModal.test.tsx
+++ b/tests/unit/components/ValidationIssueModal.test.tsx
@@ -27,12 +27,14 @@ jest.mock('antd', () => {
     disabled,
     loading,
     onClick,
+    style,
     type,
   }: {
     children?: React.ReactNode;
     disabled?: boolean;
     loading?: boolean;
     onClick?: () => void;
+    style?: React.CSSProperties;
     type?: string;
   }) => (
     <button
@@ -40,6 +42,7 @@ jest.mock('antd', () => {
       data-button-type={type}
       data-loading={loading ? 'true' : 'false'}
       disabled={disabled || loading}
+      style={style}
       onClick={disabled || loading ? undefined : onClick}
     >
       {children}
@@ -93,23 +96,33 @@ jest.mock('antd', () => {
     rowKey,
     scroll,
     sticky,
+    tableLayout,
   }: {
     columns: Array<{
       title: React.ReactNode;
       key?: string;
       dataIndex?: string;
+      onCell?: (record: any, rowIndex?: number) => React.TdHTMLAttributes<HTMLTableCellElement>;
       render?: (value: unknown, record: any, index: number) => React.ReactNode;
+      width?: number | string;
     }>;
     dataSource: any[];
     rowKey?: ((record: any) => string) | string;
     scroll?: {
+      x?: number | string;
       y?: number;
     };
     sticky?: boolean;
+    tableLayout?: 'auto' | 'fixed';
   }) => {
     latestTableDataSource = dataSource;
     return (
-      <table data-scroll-y={scroll?.y} data-sticky={sticky ? 'true' : 'false'}>
+      <table
+        data-scroll-x={scroll?.x}
+        data-scroll-y={scroll?.y}
+        data-sticky={sticky ? 'true' : 'false'}
+        data-table-layout={tableLayout}
+      >
         <thead>
           <tr>
             {columns.map((column) => (
@@ -131,7 +144,12 @@ jest.mock('antd', () => {
               {columns.map((column) => {
                 const value = column.dataIndex ? record[column.dataIndex] : undefined;
                 const content = column.render?.(value, record, rowIndex) ?? value ?? null;
-                return <td key={column.key ?? String(column.dataIndex)}>{content}</td>;
+                const cellProps = column.onCell?.(record, rowIndex) ?? {};
+                return (
+                  <td {...cellProps} key={column.key ?? String(column.dataIndex)}>
+                    {content}
+                  </td>
+                );
               })}
             </tr>
           ))}
@@ -218,6 +236,7 @@ describe('ValidationIssueModal', () => {
         'pages.process.view.modellingAndValidation': '建模信息',
         'pages.process.view.administrativeInformation': '管理信息',
         'pages.process.view.exchanges': '输入/输出',
+        'pages.lifeCycleModel.view.exchanges': '输入/输出',
         'pages.validationIssues.fixIssue': '修复问题',
         'pages.validationIssues.notifyDataOwner': '通知数据拥有者',
         'pages.validationIssues.dataOwnerNotified': '已通知',
@@ -1066,7 +1085,9 @@ describe('ValidationIssueModal', () => {
     });
 
     expect(screen.getByRole('table')).toHaveAttribute('data-scroll-y', '360');
+    expect(screen.getByRole('table')).toHaveAttribute('data-scroll-x', '1164');
     expect(screen.getByRole('table')).toHaveAttribute('data-sticky', 'true');
+    expect(screen.getByRole('table')).toHaveAttribute('data-table-layout', 'fixed');
 
     const rowTexts = Array.from(document.querySelectorAll('tbody tr')).map((row) =>
       row.textContent?.replace(/\s+/g, ' ').trim(),
@@ -1082,6 +1103,58 @@ describe('ValidationIssueModal', () => {
     expect(rowTexts[1]).toContain('flow-1');
     expect(rowTexts[2]).toContain('process-1');
     expect(rowTexts[3]).toContain('model-1');
+
+    await act(async () => {
+      modalHandle?.destroy();
+    });
+  });
+
+  it('wraps long lifecycle model issue paths within the issue column', async () => {
+    const onNavigate = jest.fn();
+    let modalHandle: { destroy: () => void } | null = null;
+
+    await act(async () => {
+      modalHandle = showValidationIssueModal({
+        intl,
+        issues: [
+          {
+            code: 'sdkInvalid',
+            link: 'http://localhost:8000/mydata/lifecyclemodels?id=model-long-path&version=01.01.000',
+            ref: {
+              '@refObjectId': 'model-long-path',
+              '@type': 'lifeCycleModel data set',
+              '@version': '01.01.000',
+            },
+            sdkDetails: [
+              {
+                key: 'model-long-path-detail',
+                fieldLabel: 'Version',
+                fieldPath:
+                  'processInstance[#model-process].connections.outputExchange.downstreamProcess.@version',
+                presentation: 'highlight-only',
+                processInstanceLabel: '过程 非烧结砖，高压压制成型；高压压制成型；生产混合，在工厂',
+                reasonMessage: 'Version is required',
+                tabName: 'exchanges',
+                validationCode: 'required_missing',
+              },
+            ],
+          },
+        ],
+        onNavigate,
+        title: '数据校验问题',
+      }) as { destroy: () => void };
+    });
+
+    const longPathButton = screen.getByRole('button', {
+      name: /connections\.outputExchange\.downstreamProcess\.@version/,
+    });
+    const issueCell = longPathButton.closest('td');
+
+    expect(longPathButton).toHaveStyle('max-width: 100%');
+    expect(longPathButton).toHaveStyle('overflow-wrap: anywhere');
+    expect(longPathButton).toHaveStyle('white-space: normal');
+    expect(issueCell).toHaveStyle('overflow-wrap: anywhere');
+    expect(issueCell).toHaveStyle('white-space: normal');
 
     await act(async () => {
       modalHandle?.destroy();


### PR DESCRIPTION
## Summary

- constrain the validation issue modal table with fixed layout, explicit column widths, and horizontal scroll
- allow long SDK issue paths to wrap within the Issue column instead of painting over adjacent columns
- add focused coverage for lifecycle model paths like `connections.outputExchange.downstreamProcess.@version`
- record docpact review evidence for the affected repo governance docs

## Root Cause

The modal table only had vertical scrolling and left the Issue column unconstrained. Long continuous SDK path tokens could expand or paint outside the intended column, and row hover backgrounds from adjacent cells made the overflowed tail appear to disappear.

## Validation

- `npm run test:ci -- tests/unit/components/ValidationIssueModal.test.tsx --runInBand --testTimeout=30000`
- `npx prettier --check src/components/ValidationIssueModal/index.tsx tests/unit/components/ValidationIssueModal.test.tsx`
- `npx eslint --cache --ext .js,.jsx,.ts,.tsx --format=stylish src/components/ValidationIssueModal/index.tsx tests/unit/components/ValidationIssueModal.test.tsx`
- `npm run tsc`
- `npm run build`
- `npm run docpact:gate`
- pre-push `npm run prepush:gate` (`npm run lint`, `npm run test:coverage`, `npm run test:coverage:assert-full`)

Closes #579
