### PR TITLE
chore: release v0.0.41 - promote dev to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-08"
-lastReviewedCommit: "247466a03e832d37182320917a73bfb70e4da27d"
+lastReviewedCommit: "a7f4365e258d82d3a1b6c09de9bbeb79100a272a"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-08"
-lastReviewedCommit: "c2b13d45239ff152272f4075a1a06f7a16593441"
+lastReviewedCommit: "5682ce18ee59f625110945553ee01e9a6b5d60d9"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-08"
-lastReviewedCommit: "fb19ecd0b7fac061ae54cbade1c35e7f81ac7cc1"
+lastReviewedCommit: "c2b13d45239ff152272f4075a1a06f7a16593441"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: b8895f11d69f23f026fe9329bd2c893002b498e4
+lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: 247466a03e832d37182320917a73bfb70e4da27d
+lastReviewedCommit: a7f4365e258d82d3a1b6c09de9bbeb79100a272a
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: d7a2b798daa0048619b35f5723968e5fca36148d
+lastReviewedCommit: b8895f11d69f23f026fe9329bd2c893002b498e4
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: 247466a03e832d37182320917a73bfb70e4da27d
+lastReviewedCommit: 47f70019eae759ef055f76862faa28aad0faca6d
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: b8895f11d69f23f026fe9329bd2c893002b498e4
+lastReviewedCommit: 5720aa816910678fca95f96fd2800b2a5c9417d1
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: d7a2b798daa0048619b35f5723968e5fca36148d
+lastReviewedCommit: b8895f11d69f23f026fe9329bd2c893002b498e4
 ---
 
 # Development Bootstrap

--- a/docs/agents/contribution-path-analysis-design.md
+++ b/docs/agents/contribution-path-analysis-design.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: 72291932dcc89626e2c88f8c1fe775284587a664
+lastReviewedAt: 2026-07-08
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 ---
 
 # Contribution Path Analysis Design

--- a/docs/agents/contribution-path-analysis-design.md
+++ b/docs/agents/contribution-path-analysis-design.md
@@ -21,7 +21,7 @@ checkPaths:
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: 730e919362e2a1791863eea759cae40d137ffea3
+lastReviewedCommit: a7f4365e258d82d3a1b6c09de9bbeb79100a272a
 ---
 
 # Contribution Path Analysis Design

--- a/docs/agents/lca-analysis-visualization-plan.md
+++ b/docs/agents/lca-analysis-visualization-plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: 730e919362e2a1791863eea759cae40d137ffea3
+lastReviewedCommit: a7f4365e258d82d3a1b6c09de9bbeb79100a272a
 ---
 
 # LCA Analysis And Visualization Plan

--- a/docs/agents/lca-analysis-visualization-plan.md
+++ b/docs/agents/lca-analysis-visualization-plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: 72291932dcc89626e2c88f8c1fe775284587a664
+lastReviewedAt: 2026-07-08
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 ---
 
 # LCA Analysis And Visualization Plan

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: 247466a03e832d37182320917a73bfb70e4da27d
+lastReviewedCommit: a7f4365e258d82d3a1b6c09de9bbeb79100a272a
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
+lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.js
   - .github/workflows/**
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
+lastReviewedAt: 2026-07-08
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: fb19ecd0b7fac061ae54cbade1c35e7f81ac7cc1
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: 730e919362e2a1791863eea759cae40d137ffea3
+lastReviewedCommit: a7f4365e258d82d3a1b6c09de9bbeb79100a272a
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
+lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: 247466a03e832d37182320917a73bfb70e4da27d
+lastReviewedCommit: a7f4365e258d82d3a1b6c09de9bbeb79100a272a
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: fb19ecd0b7fac061ae54cbade1c35e7f81ac7cc1
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
+lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -19,8 +19,8 @@ checkPaths:
   - config/supabaseEnv.ts
   - src/services/**
   - docker/**
-lastReviewedAt: 2026-06-29
-lastReviewedCommit: b48000e68a07d92ee26d3ef00d153f32083f33cb
+lastReviewedAt: 2026-07-08
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -20,7 +20,7 @@ checkPaths:
   - src/services/**
   - docker/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: 730e919362e2a1791863eea759cae40d137ffea3
+lastReviewedCommit: a7f4365e258d82d3a1b6c09de9bbeb79100a272a
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
+lastReviewedAt: 2026-07-08
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
+lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: 247466a03e832d37182320917a73bfb70e4da27d
+lastReviewedCommit: a7f4365e258d82d3a1b6c09de9bbeb79100a272a
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
+lastReviewedAt: 2026-07-08
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: 247466a03e832d37182320917a73bfb70e4da27d
+lastReviewedCommit: a7f4365e258d82d3a1b6c09de9bbeb79100a272a
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
+lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
+lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
+lastReviewedAt: 2026-07-08
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: 247466a03e832d37182320917a73bfb70e4da27d
+lastReviewedCommit: a7f4365e258d82d3a1b6c09de9bbeb79100a272a
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: 247466a03e832d37182320917a73bfb70e4da27d
+lastReviewedCommit: a7f4365e258d82d3a1b6c09de9bbeb79100a272a
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: f6e731491ee17c4c40703754b027042cb0470587
+lastReviewedAt: 2026-07-08
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
+lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/util_calculate.md
+++ b/docs/agents/util_calculate.md
@@ -20,8 +20,8 @@ checkPaths:
   - src/services/lca/**
   - src/components/LcaTaskCenter/**
   - src/pages/Processes/Analysis/**
-lastReviewedAt: 2026-07-01
-lastReviewedCommit: 72291932dcc89626e2c88f8c1fe775284587a664
+lastReviewedAt: 2026-07-08
+lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
 ---
 
 # Lifecycle Model Calculation Reference

--- a/docs/agents/util_calculate.md
+++ b/docs/agents/util_calculate.md
@@ -21,7 +21,7 @@ checkPaths:
   - src/components/LcaTaskCenter/**
   - src/pages/Processes/Analysis/**
 lastReviewedAt: 2026-07-08
-lastReviewedCommit: 730e919362e2a1791863eea759cae40d137ffea3
+lastReviewedCommit: a7f4365e258d82d3a1b6c09de9bbeb79100a272a
 ---
 
 # Lifecycle Model Calculation Reference

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",

--- a/src/components/ValidationIssueModal/index.tsx
+++ b/src/components/ValidationIssueModal/index.tsx
@@ -4,6 +4,7 @@ import { getSdkSuggestedFixMessage } from '@/pages/Utils/validation/messages';
 import { CloseOutlined } from '@ant-design/icons';
 import { Button, ConfigProvider, Modal, Space, Table, message, theme } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
+import type { CSSProperties } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { getBrandTheme } from '../../../config/branding';
@@ -161,6 +162,13 @@ const getValidationIssueListSeparator = (intl: IntlShapeLike) =>
 
 const MULTIPLICATION_FACTOR_FIELD_TOKEN = '@multiplicationFactor';
 const PROCESS_INSTANCE_FIELD_PATH_PREFIX = 'processInstance[#';
+const VALIDATION_ISSUE_TABLE_SCROLL_X = 1164;
+
+const validationIssueCellTextStyle: CSSProperties = {
+  overflowWrap: 'anywhere',
+  whiteSpace: 'normal',
+  wordBreak: 'break-word',
+};
 
 /* istanbul ignore next -- process-instance detail text fallbacks are UI-only formatting branches */
 const getSdkDetailFieldToken = (detail?: ValidationIssueSdkDetail) => {
@@ -759,9 +767,10 @@ const ValidationIssueModalContent = ({
                 color: token.colorPrimary,
                 fontWeight: token.fontWeightStrong,
                 height: 'auto',
+                maxWidth: '100%',
                 padding: 0,
                 textAlign: 'left',
-                whiteSpace: 'normal',
+                ...validationIssueCellTextStyle,
               }}
               onClick={() =>
                 onNavigate({ detail: detailItem.detail, tabName: detailItem.detail.tabName })
@@ -884,6 +893,10 @@ const ValidationIssueModalContent = ({
         defaultMessage: 'ID',
       }),
       key: 'id',
+      width: 220,
+      onCell: () => ({
+        style: validationIssueCellTextStyle,
+      }),
       render: (_, groupedIssue) => groupedIssue.ref['@refObjectId'],
     },
     {
@@ -901,6 +914,10 @@ const ValidationIssueModalContent = ({
         defaultMessage: 'Issue',
       }),
       key: 'issue',
+      width: 380,
+      onCell: () => ({
+        style: validationIssueCellTextStyle,
+      }),
       render: (_, groupedIssue) => {
         if (groupedIssue.issues.length <= 1) {
           return renderIssueCell(groupedIssue.issues[0]);
@@ -926,6 +943,9 @@ const ValidationIssueModalContent = ({
       }),
       key: 'ownerName',
       width: 160,
+      onCell: () => ({
+        style: validationIssueCellTextStyle,
+      }),
       render: (_, groupedIssue) => groupedIssue.ownerName,
     },
     {
@@ -979,7 +999,7 @@ const ValidationIssueModalContent = ({
       dataSource={groupedIssues}
       pagination={false}
       rowKey={(groupedIssue) => getValidationIssueGroupKey(groupedIssue)}
-      scroll={{ y: 360 }}
+      scroll={{ x: VALIDATION_ISSUE_TABLE_SCROLL_X, y: 360 }}
       sticky
       size='small'
       style={{
@@ -987,6 +1007,7 @@ const ValidationIssueModalContent = ({
         borderRadius: token.borderRadiusLG,
         overflow: 'hidden',
       }}
+      tableLayout='fixed'
     />
   );
 };

--- a/src/services/lifeCycleModels/referenceProcess.ts
+++ b/src/services/lifeCycleModels/referenceProcess.ts
@@ -1,0 +1,35 @@
+const INTEGER_REFERENCE_PROCESS_ID = /^-?\d+$/;
+
+export const toReferenceProcessNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? value : undefined;
+  }
+
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalizedValue = value.trim();
+  if (!INTEGER_REFERENCE_PROCESS_ID.test(normalizedValue)) {
+    return undefined;
+  }
+
+  return Number(normalizedValue);
+};
+
+export const toReferenceProcessKey = (value: unknown): string | undefined => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value) : undefined;
+  }
+
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalizedValue = value.trim();
+  return normalizedValue ? normalizedValue : undefined;
+};

--- a/src/services/lifeCycleModels/util.ts
+++ b/src/services/lifeCycleModels/util.ts
@@ -15,6 +15,7 @@ import {
 } from '../general/util';
 import { genProcessName, genProcessNameJson } from '../processes/util';
 import { FormLifeCycleModel } from './data';
+import { toReferenceProcessKey, toReferenceProcessNumber } from './referenceProcess';
 
 export function genNodeLabel(label: string, lang: string, nodeWidth: number) {
   let labelSub = label?.substring(0, nodeWidth / 7 - 4);
@@ -60,10 +61,10 @@ export const genReferenceToResultingProcess = (
 export function genLifeCycleModelJsonOrdered(id: string, data: any) {
   const nodes = data?.model?.nodes;
 
-  let referenceToReferenceProcess = null;
+  let referenceToReferenceProcess: number | undefined;
   const processInstance = nodes?.map((n: any) => {
     if (n?.data?.quantitativeReference === '1') {
-      referenceToReferenceProcess = n?.data?.index;
+      referenceToReferenceProcess = toReferenceProcessNumber(n?.data?.index);
     }
 
     const sourceEdges = data?.model?.edges?.filter((e: any) => e?.source?.cell === n?.id);
@@ -193,7 +194,7 @@ export function genLifeCycleModelJsonOrdered(id: string, data: any) {
           },
         },
         quantitativeReference: {
-          referenceToReferenceProcess: referenceToReferenceProcess ?? {},
+          referenceToReferenceProcess,
         },
         technology: {
           groupDeclarations: {},
@@ -487,6 +488,8 @@ export function genLifeCycleModelJsonOrdered(id: string, data: any) {
 }
 
 export function genLifeCycleModelInfoFromData(data: any): FormLifeCycleModel {
+  const referenceToReferenceProcess =
+    data?.lifeCycleModelInformation?.quantitativeReference?.referenceToReferenceProcess;
   const model = createTidasLifeCycleModel({
     lifeCycleModelDataSet: {
       '@xmlns': 'http://eplca.jrc.ec.europa.eu/ILCD/LifeCycleModel/2017',
@@ -579,7 +582,7 @@ export function genLifeCycleModelInfoFromData(data: any): FormLifeCycleModel {
             data?.lifeCycleModelInformation?.quantitativeReference?.functionalUnitOrOther,
           ),
           referenceToReferenceProcess:
-            data?.lifeCycleModelInformation?.quantitativeReference?.referenceToReferenceProcess,
+            toReferenceProcessNumber(referenceToReferenceProcess) ?? referenceToReferenceProcess,
         } as any,
         technology: {
           groupDeclarations: {},
@@ -848,8 +851,22 @@ export function genLifeCycleModelInfoFromData(data: any): FormLifeCycleModel {
       },
     },
   });
+  const lifeCycleModelInformation = model.lifeCycleModelDataSet.lifeCycleModelInformation;
+  const referenceToReferenceProcessFormValue = toReferenceProcessKey(
+    lifeCycleModelInformation.quantitativeReference?.referenceToReferenceProcess,
+  );
+
   return {
-    lifeCycleModelInformation: model.lifeCycleModelDataSet.lifeCycleModelInformation,
+    lifeCycleModelInformation: {
+      ...lifeCycleModelInformation,
+      quantitativeReference:
+        referenceToReferenceProcessFormValue === undefined
+          ? lifeCycleModelInformation.quantitativeReference
+          : ({
+              ...lifeCycleModelInformation.quantitativeReference,
+              referenceToReferenceProcess: referenceToReferenceProcessFormValue,
+            } as any),
+    },
     modellingAndValidation: model.lifeCycleModelDataSet.modellingAndValidation,
     administrativeInformation: model.lifeCycleModelDataSet.administrativeInformation,
   };

--- a/src/services/lifeCycleModels/util_calculate.ts
+++ b/src/services/lifeCycleModels/util_calculate.ts
@@ -12,6 +12,7 @@ import {
 import LCIAResultCalculation from '../lciaMethods/util';
 import { supabase } from '../supabase';
 import { Up2DownEdge } from './data';
+import { toReferenceProcessKey } from './referenceProcess';
 import { allocateSupplyToDemand } from './util_allocate_supply_demand';
 
 /**
@@ -1194,11 +1195,12 @@ export async function genLifeCycleModelProcesses(
   lifeCycleModelJsonOrdered: any,
   oldSubmodels: any[],
 ) {
-  const refProcessNodeId =
+  const refProcessNodeId = toReferenceProcessKey(
     lifeCycleModelJsonOrdered?.lifeCycleModelDataSet?.lifeCycleModelInformation
-      ?.quantitativeReference?.referenceToReferenceProcess;
+      ?.quantitativeReference?.referenceToReferenceProcess,
+  );
 
-  if (!refProcessNodeId) {
+  if (refProcessNodeId === undefined) {
     throw new Error('No referenceToReferenceProcess found in lifeCycleModelInformation');
   }
 
@@ -1210,9 +1212,14 @@ export async function genLifeCycleModelProcesses(
     lifeCycleModelJsonOrdered?.lifeCycleModelDataSet?.lifeCycleModelInformation?.technology
       ?.processes?.processInstance,
   ).map((p: any) => {
-    let node = modelNodes?.find((i: any) => i?.data?.index === p?.['@dataSetInternalID']);
+    const processInternalId = toReferenceProcessKey(p?.['@dataSetInternalID']);
+    let node = modelNodes?.find(
+      (i: any) => toReferenceProcessKey(i?.data?.index) === processInternalId,
+    );
     if (!node)
-      node = modelNodes?.find((i: any) => i?.['@dataSetInternalID'] === p?.['@dataSetInternalID']);
+      node = modelNodes?.find(
+        (i: any) => toReferenceProcessKey(i?.['@dataSetInternalID']) === processInternalId,
+      );
     return {
       ...p,
       nodeId: node?.id,
@@ -1222,8 +1229,8 @@ export async function genLifeCycleModelProcesses(
   const mdProcessMap = new Map<string, any>();
   const processShortDescriptionMap = new Map<string, any>();
   for (const p of mdProcesses as any[]) {
-    const nid = p?.['@dataSetInternalID'];
-    if (nid) mdProcessMap.set(nid, p);
+    const nid = toReferenceProcessKey(p?.['@dataSetInternalID']);
+    if (nid !== undefined) mdProcessMap.set(nid, p);
 
     const processId = p?.referenceToProcess?.['@refObjectId'];
     const processVersion = p?.referenceToProcess?.['@version'];

--- a/tests/unit/components/ValidationIssueModal.test.tsx
+++ b/tests/unit/components/ValidationIssueModal.test.tsx
@@ -27,12 +27,14 @@ jest.mock('antd', () => {
     disabled,
     loading,
     onClick,
+    style,
     type,
   }: {
     children?: React.ReactNode;
     disabled?: boolean;
     loading?: boolean;
     onClick?: () => void;
+    style?: React.CSSProperties;
     type?: string;
   }) => (
     <button
@@ -40,6 +42,7 @@ jest.mock('antd', () => {
       data-button-type={type}
       data-loading={loading ? 'true' : 'false'}
       disabled={disabled || loading}
+      style={style}
       onClick={disabled || loading ? undefined : onClick}
     >
       {children}
@@ -93,23 +96,33 @@ jest.mock('antd', () => {
     rowKey,
     scroll,
     sticky,
+    tableLayout,
   }: {
     columns: Array<{
       title: React.ReactNode;
       key?: string;
       dataIndex?: string;
+      onCell?: (record: any, rowIndex?: number) => React.TdHTMLAttributes<HTMLTableCellElement>;
       render?: (value: unknown, record: any, index: number) => React.ReactNode;
+      width?: number | string;
     }>;
     dataSource: any[];
     rowKey?: ((record: any) => string) | string;
     scroll?: {
+      x?: number | string;
       y?: number;
     };
     sticky?: boolean;
+    tableLayout?: 'auto' | 'fixed';
   }) => {
     latestTableDataSource = dataSource;
     return (
-      <table data-scroll-y={scroll?.y} data-sticky={sticky ? 'true' : 'false'}>
+      <table
+        data-scroll-x={scroll?.x}
+        data-scroll-y={scroll?.y}
+        data-sticky={sticky ? 'true' : 'false'}
+        data-table-layout={tableLayout}
+      >
         <thead>
           <tr>
             {columns.map((column) => (
@@ -131,7 +144,12 @@ jest.mock('antd', () => {
               {columns.map((column) => {
                 const value = column.dataIndex ? record[column.dataIndex] : undefined;
                 const content = column.render?.(value, record, rowIndex) ?? value ?? null;
-                return <td key={column.key ?? String(column.dataIndex)}>{content}</td>;
+                const cellProps = column.onCell?.(record, rowIndex) ?? {};
+                return (
+                  <td {...cellProps} key={column.key ?? String(column.dataIndex)}>
+                    {content}
+                  </td>
+                );
               })}
             </tr>
           ))}
@@ -218,6 +236,7 @@ describe('ValidationIssueModal', () => {
         'pages.process.view.modellingAndValidation': '建模信息',
         'pages.process.view.administrativeInformation': '管理信息',
         'pages.process.view.exchanges': '输入/输出',
+        'pages.lifeCycleModel.view.exchanges': '输入/输出',
         'pages.validationIssues.fixIssue': '修复问题',
         'pages.validationIssues.notifyDataOwner': '通知数据拥有者',
         'pages.validationIssues.dataOwnerNotified': '已通知',
@@ -1066,7 +1085,9 @@ describe('ValidationIssueModal', () => {
     });
 
     expect(screen.getByRole('table')).toHaveAttribute('data-scroll-y', '360');
+    expect(screen.getByRole('table')).toHaveAttribute('data-scroll-x', '1164');
     expect(screen.getByRole('table')).toHaveAttribute('data-sticky', 'true');
+    expect(screen.getByRole('table')).toHaveAttribute('data-table-layout', 'fixed');
 
     const rowTexts = Array.from(document.querySelectorAll('tbody tr')).map((row) =>
       row.textContent?.replace(/\s+/g, ' ').trim(),
@@ -1082,6 +1103,58 @@ describe('ValidationIssueModal', () => {
     expect(rowTexts[1]).toContain('flow-1');
     expect(rowTexts[2]).toContain('process-1');
     expect(rowTexts[3]).toContain('model-1');
+
+    await act(async () => {
+      modalHandle?.destroy();
+    });
+  });
+
+  it('wraps long lifecycle model issue paths within the issue column', async () => {
+    const onNavigate = jest.fn();
+    let modalHandle: { destroy: () => void } | null = null;
+
+    await act(async () => {
+      modalHandle = showValidationIssueModal({
+        intl,
+        issues: [
+          {
+            code: 'sdkInvalid',
+            link: 'http://localhost:8000/mydata/lifecyclemodels?id=model-long-path&version=01.01.000',
+            ref: {
+              '@refObjectId': 'model-long-path',
+              '@type': 'lifeCycleModel data set',
+              '@version': '01.01.000',
+            },
+            sdkDetails: [
+              {
+                key: 'model-long-path-detail',
+                fieldLabel: 'Version',
+                fieldPath:
+                  'processInstance[#model-process].connections.outputExchange.downstreamProcess.@version',
+                presentation: 'highlight-only',
+                processInstanceLabel: '过程 非烧结砖，高压压制成型；高压压制成型；生产混合，在工厂',
+                reasonMessage: 'Version is required',
+                tabName: 'exchanges',
+                validationCode: 'required_missing',
+              },
+            ],
+          },
+        ],
+        onNavigate,
+        title: '数据校验问题',
+      }) as { destroy: () => void };
+    });
+
+    const longPathButton = screen.getByRole('button', {
+      name: /connections\.outputExchange\.downstreamProcess\.@version/,
+    });
+    const issueCell = longPathButton.closest('td');
+
+    expect(longPathButton).toHaveStyle('max-width: 100%');
+    expect(longPathButton).toHaveStyle('overflow-wrap: anywhere');
+    expect(longPathButton).toHaveStyle('white-space: normal');
+    expect(issueCell).toHaveStyle('overflow-wrap: anywhere');
+    expect(issueCell).toHaveStyle('white-space: normal');
 
     await act(async () => {
       modalHandle?.destroy();

--- a/tests/unit/services/lifeCycleModels/referenceProcess.test.ts
+++ b/tests/unit/services/lifeCycleModels/referenceProcess.test.ts
@@ -1,0 +1,37 @@
+import {
+  toReferenceProcessKey,
+  toReferenceProcessNumber,
+} from '@/services/lifeCycleModels/referenceProcess';
+
+describe('reference process id normalization', () => {
+  describe('toReferenceProcessNumber', () => {
+    it('returns integers from numeric and string inputs', () => {
+      expect(toReferenceProcessNumber(0)).toBe(0);
+      expect(toReferenceProcessNumber(' 12 ')).toBe(12);
+      expect(toReferenceProcessNumber('-3')).toBe(-3);
+    });
+
+    it('rejects non-integer or non-string inputs', () => {
+      expect(toReferenceProcessNumber(1.5)).toBeUndefined();
+      expect(toReferenceProcessNumber('1.5')).toBeUndefined();
+      expect(toReferenceProcessNumber('abc')).toBeUndefined();
+      expect(toReferenceProcessNumber({ id: '1' })).toBeUndefined();
+    });
+  });
+
+  describe('toReferenceProcessKey', () => {
+    it('returns stable string keys from finite numbers and non-empty strings', () => {
+      expect(toReferenceProcessKey(0)).toBe('0');
+      expect(toReferenceProcessKey(' nodeA ')).toBe('nodeA');
+    });
+
+    it('rejects missing, non-finite, blank, or unsupported values', () => {
+      expect(toReferenceProcessKey(null)).toBeUndefined();
+      expect(toReferenceProcessKey(undefined)).toBeUndefined();
+      expect(toReferenceProcessKey(Number.NaN)).toBeUndefined();
+      expect(toReferenceProcessKey(Number.POSITIVE_INFINITY)).toBeUndefined();
+      expect(toReferenceProcessKey('   ')).toBeUndefined();
+      expect(toReferenceProcessKey({ id: 'nodeA' })).toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/services/lifeCycleModels/util.test.ts
+++ b/tests/unit/services/lifeCycleModels/util.test.ts
@@ -349,7 +349,7 @@ describe('genLifeCycleModelJsonOrdered', () => {
     expect(
       result.lifeCycleModelDataSet.lifeCycleModelInformation.quantitativeReference
         .referenceToReferenceProcess,
-    ).toBe('0');
+    ).toBe(0);
 
     expect(processes[0].referenceToProcess['@refObjectId']).toBe('proc-a');
     expect(processes[0].referenceToProcess['@uri']).toBe('../processes/proc-a.xml');

--- a/tests/unit/services/lifeCycleModels/util.test.ts
+++ b/tests/unit/services/lifeCycleModels/util.test.ts
@@ -674,6 +674,18 @@ describe('genLifeCycleModelInfoFromData', () => {
 
     expect(result.lifeCycleModelInformation.dataSetInformation['common:UUID']).toBe('-');
   });
+
+  it('should keep the reference process unset when the ordered dataset omits it', () => {
+    const ordered = genLifeCycleModelJsonOrdered('model-reference-fallback', baseModelData);
+    delete ordered.lifeCycleModelDataSet.lifeCycleModelInformation.quantitativeReference
+      .referenceToReferenceProcess;
+
+    const result = genLifeCycleModelInfoFromData(ordered.lifeCycleModelDataSet);
+
+    expect(
+      result.lifeCycleModelInformation.quantitativeReference.referenceToReferenceProcess,
+    ).toBeUndefined();
+  });
 });
 
 describe('genLifeCycleModelData', () => {

--- a/tests/unit/services/lifeCycleModels/util_calculate.test.ts
+++ b/tests/unit/services/lifeCycleModels/util_calculate.test.ts
@@ -245,6 +245,18 @@ const createSupabaseProcesses = () => [
   },
 ];
 
+const createNumericReferenceLifeCycleModelData = () => {
+  const data = clone(createLifeCycleModelData()) as any;
+  const modelInfo = data.lifeCycleModelDataSet.lifeCycleModelInformation;
+  modelInfo.quantitativeReference.referenceToReferenceProcess = 0;
+
+  const processInstances = modelInfo.technology.processes.processInstance;
+  processInstances[0]['@dataSetInternalID'] = '0';
+  processInstances[1].connections.outputExchange[0].downstreamProcess['@id'] = '0';
+
+  return data;
+};
+
 const createSelectionFallbackModelData = () => ({
   lifeCycleModelDataSet: {
     lifeCycleModelInformation: {
@@ -1227,6 +1239,30 @@ describe('genLifeCycleModelProcesses', () => {
       genLifeCycleModelProcesses('model-no-data-payload', null, data, []),
     ).rejects.toThrow('Reference process not found in database');
 
+    expect(mockFrom).toHaveBeenCalledWith('processes');
+  });
+
+  it('accepts numeric zero as the reference process id and matches string internal ids', async () => {
+    const data = createNumericReferenceLifeCycleModelData();
+    mockOr.mockResolvedValue({ data: clone(createSupabaseProcesses()) });
+    mockLCIAResultCalculation.mockResolvedValue([]);
+
+    const { lifeCycleModelProcesses } = await genLifeCycleModelProcesses(
+      'model-zero-reference',
+      [
+        {
+          id: 'graph-node-reference',
+          data: { index: '0', quantitativeReference: '1', targetAmount: 10 },
+        },
+      ] as any,
+      data,
+      [],
+    );
+
+    const primary = lifeCycleModelProcesses.find((item) => item?.modelInfo?.type === 'primary');
+
+    expect(primary).toBeDefined();
+    expect(primary?.modelInfo?.id).toBe('model-zero-reference');
     expect(mockFrom).toHaveBeenCalledWith('processes');
   });
 


### PR DESCRIPTION
## Promotion Contract

- Target base branch: `main`
- Promoted source: `origin/dev` at `5fc6cd6b`
- Release branch: `promote/dev-to-main-v0.0.41`, based on `origin/main` and merged with `origin/dev`
- Release version: `0.0.41`
- Pre-merge tag check: `v0.0.41` is not present locally/remotely before this PR
- Back-merge required: No. This is a normal dev-to-main promotion branch.
- Workspace integration expected: Yes, after the release commit is on child `main`, the root workspace can bump the `tiangong-lca-next` submodule pointer if needed.

Closes #581

## Summary

- Promote current `dev` changes into `main` for the next releasable version.
- Keep `main` release history intact by starting from `origin/main`, merging `origin/dev`, and resolving governance metadata conflicts without changing their contract semantics.
- Bump `package.json` from `0.0.40` to `0.0.41` so the `main` release workflow can create `v0.0.41` and publish a new build.
- Include the recently merged validation modal overflow fix from PR #580.

## Validation

- `npm run docpact:gate`
- `npm run test:ci -- tests/unit/services/lifeCycleModels/referenceProcess.test.ts tests/unit/services/lifeCycleModels/util.test.ts tests/unit/services/lifeCycleModels/util_calculate.test.ts tests/unit/components/ValidationIssueModal.test.tsx --runInBand --testTimeout=30000`
- `npm run build`
- Pre-push gate passed when pushing `promote/dev-to-main-v0.0.41` to the fork.

## Release Notes

- Expected release tag after merge: `v0.0.41`
- Expected release behavior: main release workflow should run the release gate, deploy the web app, and prepare the Electron release artifact according to the repository workflow.
