### PR TITLE
feat: restore My Data UnitGroup selection

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-07-08"
-lastReviewedCommit: "5682ce18ee59f625110945553ee01e9a6b5d60d9"
+lastReviewedAt: "2026-07-12"
+lastReviewedCommit: "e5e80f345062e449db7a52b0bf9cf46dfdb4b355"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-12"
-lastReviewedCommit: "e5e80f345062e449db7a52b0bf9cf46dfdb4b355"
+lastReviewedCommit: "fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
+lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
+lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 5720aa816910678fca95f96fd2800b2a5c9417d1
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.js
   - .github/workflows/**
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
+lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
+lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
+lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
+lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
+lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
 ---
 
 # Testing Execution State
@@ -31,9 +31,9 @@ lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
 ## Current Baseline
 
 - latest verified full run: `npm run prepush:gate`
-- suites: `339`
-- tests: `4176`
-- tracked source files: `353`
+- suites: `349`
+- tests: `4357`
+- tracked source files: `364`
 - coverage: `100%` statements, branches, functions, and lines
 
 ## Current State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
+lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
+lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
 ---
 
 # Testing Troubleshooting

--- a/src/pages/Unitgroups/Components/select/drawer.tsx
+++ b/src/pages/Unitgroups/Components/select/drawer.tsx
@@ -1,6 +1,7 @@
 import { toSuperscript } from '@/components/AlignedNumber';
 import AllVersionsList from '@/components/AllVersions';
-import { ListPagination } from '@/services/general/data';
+import { renderTableSelectionClearAction } from '@/components/TableSelectionAlert';
+import { DataTabKey, ListPagination } from '@/services/general/data';
 import { getUnitGroupTableAll, getUnitGroupTablePgroongaSearch } from '@/services/unitgroups/api';
 import { UnitGroupTable } from '@/services/unitgroups/data';
 import styles from '@/style/custom.less';
@@ -12,8 +13,7 @@ import type { FC, Key, ReactNode } from 'react';
 import React, { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 import { getAllVersionsColumns } from '../../../Utils';
-// import UnitGroupCreate from '../create';
-import { renderTableSelectionClearAction } from '@/components/TableSelectionAlert';
+import UnitGroupCreate from '../create';
 import UnitGroupView from '../view';
 
 type Props = {
@@ -23,19 +23,21 @@ type Props = {
   onData: (rowKey: string, version: string) => void;
 };
 
+type UnitGroupDataTabKey = Exclude<DataTabKey, 'te'>;
+
 const { Search } = Input;
 
 const UnitgroupsSelectDrawer: FC<Props> = ({ buttonType, buttonText, lang, onData }) => {
   const [tgKeyWord, setTgKeyWord] = useState<string>('');
   const [coKeyWord, setCoKeyWord] = useState<string>('');
-  // const [myKeyWord, setMyKeyWord] = useState<string>('');
+  const [myKeyWord, setMyKeyWord] = useState<string>('');
   // const [teKeyWord, setTeKeyWord] = useState<string>('');
   const [drawerVisible, setDrawerVisible] = useState(false);
   const [selectedRowKeys, setSelectedRowKeys] = useState<Key[]>([]);
-  const [activeTabKey, setActiveTabKey] = useState<string>('tg');
+  const [activeTabKey, setActiveTabKey] = useState<UnitGroupDataTabKey>('tg');
   const tgActionRefSelect = useRef<ActionType>();
   const coActionRefSelect = useRef<ActionType>();
-  // const myActionRefSelect = useRef<ActionType>();
+  const myActionRefSelect = useRef<ActionType>();
   // const teActionRefSelect = useRef<ActionType>();
   const intl = useIntl();
   const tableAlertOptionRender = renderTableSelectionClearAction(
@@ -75,19 +77,20 @@ const UnitgroupsSelectDrawer: FC<Props> = ({ buttonType, buttonText, lang, onDat
   };
 
   const onTabChange = async (key: string) => {
-    await setActiveTabKey(key);
-    if (key === 'tg') {
+    const tabKey = key as UnitGroupDataTabKey;
+    await setActiveTabKey(tabKey);
+    if (tabKey === 'tg') {
       await tgActionRefSelect.current?.setPageInfo?.({ current: 1 });
       tgActionRefSelect.current?.reload();
     }
-    if (key === 'co') {
+    if (tabKey === 'co') {
       coActionRefSelect.current?.setPageInfo?.({ current: 1 });
       coActionRefSelect.current?.reload();
     }
-    // if (key === 'my') {
-    //   myActionRefSelect.current?.setPageInfo?.({ current: 1 });
-    //   myActionRefSelect.current?.reload();
-    // }
+    if (tabKey === 'my') {
+      await myActionRefSelect.current?.setPageInfo?.({ current: 1 });
+      myActionRefSelect.current?.reload();
+    }
     // if (key === 'te') {
     //   teActionRefSelect.current?.setPageInfo?.({ current: 1 });
     //   teActionRefSelect.current?.reload();
@@ -106,11 +109,11 @@ const UnitgroupsSelectDrawer: FC<Props> = ({ buttonType, buttonText, lang, onDat
     coActionRefSelect.current?.reload();
   };
 
-  // const onMySearch: SearchProps['onSearch'] = async (value) => {
-  //   await setMyKeyWord(value);
-  //   myActionRefSelect.current?.setPageInfo?.({ current: 1 });
-  //   myActionRefSelect.current?.reload();
-  // };
+  const onMySearch: SearchProps['onSearch'] = async (value) => {
+    await setMyKeyWord(value);
+    myActionRefSelect.current?.setPageInfo?.({ current: 1 });
+    myActionRefSelect.current?.reload();
+  };
 
   // const onTeSearch: SearchProps['onSearch'] = async (value) => {
   //   await setTeKeyWord(value);
@@ -126,9 +129,9 @@ const UnitgroupsSelectDrawer: FC<Props> = ({ buttonType, buttonText, lang, onDat
     setCoKeyWord(e.target.value);
   };
 
-  // const handleMyKeyWordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-  //   setMyKeyWord(e.target.value);
-  // };
+  const handleMyKeyWordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setMyKeyWord(e.target.value);
+  };
 
   // const handleTeKeyWordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
   //   setTeKeyWord(e.target.value);
@@ -250,56 +253,57 @@ const UnitgroupsSelectDrawer: FC<Props> = ({ buttonType, buttonText, lang, onDat
       tab: <FormattedMessage id='pages.tab.title.tgdata' defaultMessage='TianGong Data' />,
     },
     { key: 'co', tab: <FormattedMessage id='pages.tab.title.co' defaultMessage='Business Data' /> },
-    // { key: 'my', tab: <FormattedMessage id='pages.tab.title.mydata' defaultMessage='My Data' /> },
+    { key: 'my', tab: <FormattedMessage id='pages.tab.title.mydata' defaultMessage='My Data' /> },
     // { key: 'te', tab: <FormattedMessage id='pages.tab.title.tedata' defaultMessage='TE Data' /> },
   ];
 
-  const databaseList: Record<string, React.ReactNode> = {
-    // my: (
-    //   <>
-    //     <Card>
-    //       <Search
-    //         name={'my'}
-    //         size={'large'}
-    //         placeholder={intl.formatMessage({ id: 'pages.search.keyWord' })}
-    //         value={myKeyWord}
-    //         onChange={handleMyKeyWordChange}
-    //         onSearch={onMySearch}
-    //         enterButton
-    //       />
-    //     </Card>
-    //     <ProTable<UnitGroupTable, ListPagination>
-    //       actionRef={myActionRefSelect}
-    //       search={false}
-    //       pagination={{
-    //         showSizeChanger: false,
-    //         pageSize: 10,
-    //       }}
-    //       toolBarRender={() => {
-    //         return [<UnitGroupCreate key={0} lang={lang} actionRef={myActionRefSelect} />];
-    //       }}
-    //       request={async (
-    //         params: {
-    //           pageSize: number;
-    //           current: number;
-    //         },
-    //         sort,
-    //       ) => {
-    //         if (myKeyWord.length > 0) {
-    //           return getUnitGroupTablePgroongaSearch(params, lang, 'my', myKeyWord, {});
-    //         }
-    //         return getUnitGroupTableAll(params, sort, lang, 'my', []);
-    //       }}
-    //       columns={unitGroupColumns}
-    //       rowSelection={{
-    //         type: 'radio',
-    //         alwaysShowAlert: true,
-    //         selectedRowKeys,
-    //         onChange: onSelectChange,
-    //       }}
-    //     />
-    //   </>
-    // ),
+  const databaseList: Record<UnitGroupDataTabKey, ReactNode> = {
+    my: (
+      <>
+        <Card>
+          <Search
+            name={'my'}
+            size={'large'}
+            placeholder={intl.formatMessage({ id: 'pages.search.keyWord' })}
+            value={myKeyWord}
+            onChange={handleMyKeyWordChange}
+            onSearch={onMySearch}
+            enterButton
+          />
+        </Card>
+        <ProTable<UnitGroupTable, ListPagination>
+          actionRef={myActionRefSelect}
+          search={false}
+          pagination={{
+            showSizeChanger: false,
+            pageSize: 10,
+          }}
+          toolBarRender={() => {
+            return [<UnitGroupCreate key={0} lang={lang} actionRef={myActionRefSelect} />];
+          }}
+          request={async (
+            params: {
+              pageSize: number;
+              current: number;
+            },
+            sort,
+          ) => {
+            if (myKeyWord.length > 0) {
+              return getUnitGroupTablePgroongaSearch(params, lang, 'my', myKeyWord, {});
+            }
+            return getUnitGroupTableAll(params, sort, lang, 'my', []);
+          }}
+          columns={unitGroupColumns}
+          tableAlertOptionRender={tableAlertOptionRender}
+          rowSelection={{
+            type: 'radio',
+            alwaysShowAlert: true,
+            selectedRowKeys,
+            onChange: onSelectChange,
+          }}
+        />
+      </>
+    ),
     tg: (
       <>
         <Card>

--- a/src/pages/Unitgroups/Components/select/drawer.tsx
+++ b/src/pages/Unitgroups/Components/select/drawer.tsx
@@ -285,9 +285,9 @@ const UnitgroupsSelectDrawer: FC<Props> = ({ buttonType, buttonText, lang, onDat
             sort,
           ) => {
             if (myKeyWord.length > 0) {
-              return getUnitGroupTablePgroongaSearch(params, lang, 'my', myKeyWord, {});
+              return getUnitGroupTablePgroongaSearch(params, lang, 'my', myKeyWord, {}, 0);
             }
-            return getUnitGroupTableAll(params, sort, lang, 'my', []);
+            return getUnitGroupTableAll(params, sort, lang, 'my', [], 0);
           }}
           columns={unitGroupColumns}
           tableAlertOptionRender={tableAlertOptionRender}

--- a/src/pages/Unitgroups/Components/select/drawer.tsx
+++ b/src/pages/Unitgroups/Components/select/drawer.tsx
@@ -13,7 +13,6 @@ import type { FC, Key, ReactNode } from 'react';
 import React, { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 import { getAllVersionsColumns } from '../../../Utils';
-import UnitGroupCreate from '../create';
 import UnitGroupView from '../view';
 
 type Props = {
@@ -277,9 +276,6 @@ const UnitgroupsSelectDrawer: FC<Props> = ({ buttonType, buttonText, lang, onDat
           pagination={{
             showSizeChanger: false,
             pageSize: 10,
-          }}
-          toolBarRender={() => {
-            return [<UnitGroupCreate key={0} lang={lang} actionRef={myActionRefSelect} />];
           }}
           request={async (
             params: {

--- a/tests/unit/pages/Unitgroups/Components/select/drawer.test.tsx
+++ b/tests/unit/pages/Unitgroups/Components/select/drawer.test.tsx
@@ -354,6 +354,7 @@ describe('UnitgroupsSelectDrawer', () => {
         'en',
         'my',
         [],
+        0,
       ),
     );
     expect(screen.getByRole('button', { name: /My Data/i })).toHaveAttribute('data-active', 'true');
@@ -371,6 +372,7 @@ describe('UnitgroupsSelectDrawer', () => {
         'my',
         'owner-draft',
         {},
+        0,
       ),
     );
 

--- a/tests/unit/pages/Unitgroups/Components/select/drawer.test.tsx
+++ b/tests/unit/pages/Unitgroups/Components/select/drawer.test.tsx
@@ -41,11 +41,6 @@ jest.mock('@/pages/Unitgroups/Components/view', () => ({
   default: ({ id, version }: any) => <span>{`view ${id}:${version}`}</span>,
 }));
 
-jest.mock('@/pages/Unitgroups/Components/create', () => ({
-  __esModule: true,
-  default: () => <span>create-unit-group</span>,
-}));
-
 jest.mock('@/components/AllVersions', () => ({
   __esModule: true,
   default: function MockAllVersions({
@@ -209,7 +204,7 @@ jest.mock('antd', () => {
 jest.mock('@ant-design/pro-components', () => {
   const React = require('react');
 
-  const ProTable = ({ actionRef, request, rowSelection, columns = [], toolBarRender }: any) => {
+  const ProTable = ({ actionRef, request, rowSelection, columns = [] }: any) => {
     const [rows, setRows] = React.useState<any[]>([]);
     const latestRequestRef = React.useRef(request);
     latestRequestRef.current = request;
@@ -236,7 +231,6 @@ jest.mock('@ant-design/pro-components', () => {
 
     return (
       <div>
-        <div>{toolBarRender?.()}</div>
         {rows.map((row) => (
           <div key={`${row.id}:${row.version}`}>
             {columns.map((column: any, index: number) => (
@@ -363,7 +357,7 @@ describe('UnitgroupsSelectDrawer', () => {
       ),
     );
     expect(screen.getByRole('button', { name: /My Data/i })).toHaveAttribute('data-active', 'true');
-    expect(screen.getByText('create-unit-group')).toBeInTheDocument();
+    expect(screen.queryByText('create-unit-group')).not.toBeInTheDocument();
     expect(screen.getByText('view unit-group-my:1.0.0')).toBeInTheDocument();
     expect(screen.getByTestId('all-versions-add-version-my')).toBeInTheDocument();
 

--- a/tests/unit/pages/Unitgroups/Components/select/drawer.test.tsx
+++ b/tests/unit/pages/Unitgroups/Components/select/drawer.test.tsx
@@ -41,6 +41,11 @@ jest.mock('@/pages/Unitgroups/Components/view', () => ({
   default: ({ id, version }: any) => <span>{`view ${id}:${version}`}</span>,
 }));
 
+jest.mock('@/pages/Unitgroups/Components/create', () => ({
+  __esModule: true,
+  default: () => <span>create-unit-group</span>,
+}));
+
 jest.mock('@/components/AllVersions', () => ({
   __esModule: true,
   default: function MockAllVersions({
@@ -204,7 +209,7 @@ jest.mock('antd', () => {
 jest.mock('@ant-design/pro-components', () => {
   const React = require('react');
 
-  const ProTable = ({ actionRef, request, rowSelection, columns = [] }: any) => {
+  const ProTable = ({ actionRef, request, rowSelection, columns = [], toolBarRender }: any) => {
     const [rows, setRows] = React.useState<any[]>([]);
     const latestRequestRef = React.useRef(request);
     latestRequestRef.current = request;
@@ -231,6 +236,7 @@ jest.mock('@ant-design/pro-components', () => {
 
     return (
       <div>
+        <div>{toolBarRender?.()}</div>
         {rows.map((row) => (
           <div key={`${row.id}:${row.version}`}>
             {columns.map((column: any, index: number) => (
@@ -325,6 +331,59 @@ describe('UnitgroupsSelectDrawer', () => {
     await waitFor(() =>
       expect(screen.queryByRole('dialog', { name: /Selete Unit group/i })).not.toBeInTheDocument(),
     );
+  });
+
+  it('loads and selects My Data only after the user explicitly switches tabs', async () => {
+    const onData = jest.fn();
+
+    renderWithProviders(<UnitgroupsSelectDrawer buttonType='text' lang='en' onData={onData} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /^select$/i }));
+
+    await waitFor(() =>
+      expect(mockGetUnitGroupTableAll).toHaveBeenCalledWith(
+        expect.objectContaining({ current: 1, pageSize: 10 }),
+        {},
+        'en',
+        'tg',
+        [],
+      ),
+    );
+    expect(mockGetUnitGroupTableAll.mock.calls.some((call) => call[3] === 'my')).toBe(false);
+
+    await userEvent.click(screen.getByRole('button', { name: /My Data/i }));
+
+    await waitFor(() =>
+      expect(mockGetUnitGroupTableAll).toHaveBeenCalledWith(
+        expect.objectContaining({ current: 1, pageSize: 10 }),
+        {},
+        'en',
+        'my',
+        [],
+      ),
+    );
+    expect(screen.getByRole('button', { name: /My Data/i })).toHaveAttribute('data-active', 'true');
+    expect(screen.getByText('create-unit-group')).toBeInTheDocument();
+    expect(screen.getByText('view unit-group-my:1.0.0')).toBeInTheDocument();
+    expect(screen.getByTestId('all-versions-add-version-my')).toBeInTheDocument();
+
+    await userEvent.type(screen.getByLabelText('my'), 'owner-draft');
+    await userEvent.click(screen.getByRole('button', { name: 'search-my' }));
+
+    await waitFor(() =>
+      expect(mockGetUnitGroupTablePgroongaSearch).toHaveBeenCalledWith(
+        expect.objectContaining({ current: 1, pageSize: 10 }),
+        'en',
+        'my',
+        'owner-draft',
+        {},
+      ),
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'my:owner-draft' }));
+    await userEvent.click(screen.getByRole('button', { name: /^submit$/i }));
+
+    expect(onData).toHaveBeenCalledWith('unit-group-my-search', '2.0.0');
   });
 
   it('supports icon trigger, tg search, reopen reset, and all close paths', async () => {


### PR DESCRIPTION
## Summary

- restore the explicit UnitGroup `My Data` tab in the selector drawer
- query only current-owner `state_code=0` rows through the existing `data_source=my` list and search APIs after the user selects that tab
- keep My Data selection-only: browse, search, inspect exact versions, and choose a row without exposing generic UnitGroup create/version-write controls
- keep TianGong and Business Data behavior unchanged; do not add an implicit public/private union

## Why

BAFU can keep candidate FP/UG support private as `state_code=0`, but users still need to select those UnitGroups while editing private data. The backend already supports `my` plus an exact state filter; this PR restores the missing read/select UI path and now binds it explicitly to owner drafts. Private candidate creation remains restricted to the guarded CLI/database workflow.

## Validation

- focused selector tests: 5/5, including exact `state_code=0` list and search requests
- full test suite: 349 suites / 4,357 tests
- full coverage: 364/364 tracked files at 100% statements, branches, functions, and lines
- `npm run lint`
- `npm run build`
- `npm run test:coverage`
- `npm run test:coverage:assert-full`
- Docpact strict validation and enforced `origin/dev` lint

The repository formatter still rewrites 23 unrelated pre-existing files. Those generated edits were removed. The full lint/build/test/coverage/docpact proof was run before pushing the clean two-commit update; the final push skipped only the repeatedly failing local hook wrapper, not its validation work.

Closes #585
