### PR TITLE
chore: release private FP/UG selectors as v0.0.44

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-12"
-lastReviewedCommit: "fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31"
+lastReviewedCommit: "bb72522c0"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-07-08"
-lastReviewedCommit: "5682ce18ee59f625110945553ee01e9a6b5d60d9"
+lastReviewedAt: "2026-07-12"
+lastReviewedCommit: "e5e80f345062e449db7a52b0bf9cf46dfdb4b355"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-12"
-lastReviewedCommit: "bb72522c0"
+lastReviewedCommit: "7f4db1930"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-12"
-lastReviewedCommit: "e5e80f345062e449db7a52b0bf9cf46dfdb4b355"
+lastReviewedCommit: "fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31"
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
+lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
+lastReviewedCommit: bb72522c0
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: bb72522c0
+lastReviewedCommit: 7f4db1930
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
+lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
+lastReviewedCommit: bb72522c0
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -20,8 +20,8 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 5720aa816910678fca95f96fd2800b2a5c9417d1
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: bb72522c0
+lastReviewedCommit: 7f4db1930
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.js
   - .github/workflows/**
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
+lastReviewedCommit: bb72522c0
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: bb72522c0
+lastReviewedCommit: 7f4db1930
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/docpact-gate.js
   - .github/workflows/**
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
+lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
+lastReviewedCommit: bb72522c0
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - docker/**
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
+lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: bb72522c0
+lastReviewedCommit: 7f4db1930
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
+lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
+lastReviewedCommit: bb72522c0
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,7 +22,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: bb72522c0
+lastReviewedCommit: 7f4db1930
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -21,8 +21,8 @@ checkPaths:
   - jest.config.cjs
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -20,7 +20,7 @@ checkPaths:
   - src/services/**
   - docker/**
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: bb72522c0
+lastReviewedCommit: 7f4db1930
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -19,8 +19,8 @@ checkPaths:
   - config/supabaseEnv.ts
   - src/services/**
   - docker/**
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: c2b13d45239ff152272f4075a1a06f7a16593441
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: bb72522c0
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: bb72522c0
+lastReviewedCommit: 7f4db1930
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
+lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
+lastReviewedCommit: bb72522c0
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: bb72522c0
+lastReviewedCommit: 7f4db1930
 ---
 
 # Testing Execution State
@@ -32,7 +32,7 @@ lastReviewedCommit: bb72522c0
 
 - latest verified full run: `npm run prepush:gate`
 - suites: `349`
-- tests: `4357`
+- tests: `4358`
 - tracked source files: `364`
 - coverage: `100%` statements, branches, functions, and lines
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
+lastReviewedCommit: bb72522c0
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
+lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,8 +20,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
 ---
 
 # Testing Execution State
@@ -31,9 +31,9 @@ lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
 ## Current Baseline
 
 - latest verified full run: `npm run prepush:gate`
-- suites: `339`
-- tests: `4176`
-- tracked source files: `353`
+- suites: `349`
+- tests: `4357`
+- tracked source files: `364`
 - coverage: `100%` statements, branches, functions, and lines
 
 ## Current State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
+lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
+lastReviewedCommit: bb72522c0
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: bb72522c0
+lastReviewedCommit: 7f4db1930
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
+lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: bb72522c0
+lastReviewedCommit: 7f4db1930
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-07-08
-lastReviewedCommit: 5682ce18ee59f625110945553ee01e9a6b5d60d9
+lastReviewedAt: 2026-07-12
+lastReviewedCommit: e5e80f345062e449db7a52b0bf9cf46dfdb4b355
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-07-12
-lastReviewedCommit: fd2a065f0f48949bdd9cb44db5e7d272c9fc8a31
+lastReviewedCommit: bb72522c0
 ---
 
 # Testing Troubleshooting

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.43",
+      "version": "0.0.44",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",

--- a/src/components/AllVersions/index.tsx
+++ b/src/components/AllVersions/index.tsx
@@ -22,6 +22,7 @@ interface AllVersionsListProps {
   columns: ProColumns<any>[];
   lang: string;
   dataSource?: string;
+  stateCode?: number;
   disabled?: boolean;
   addVersionComponent?: ({ newVersion }: { newVersion: string }) => ReactElement;
   operationRender?: (
@@ -46,6 +47,7 @@ const AllVersionsList: FC<AllVersionsListProps> = ({
   columns,
   lang,
   dataSource: dataSourceOverride,
+  stateCode,
   disabled = false,
   addVersionComponent,
   operationRender,
@@ -233,6 +235,7 @@ const AllVersionsList: FC<AllVersionsListProps> = ({
                 sort,
                 lang,
                 dataSource,
+                stateCode,
               );
               tableDataRef.current = result.data ?? [];
               return result;

--- a/src/pages/Flowproperties/Components/select/drawer.tsx
+++ b/src/pages/Flowproperties/Components/select/drawer.tsx
@@ -17,9 +17,6 @@ import type { FC, Key, ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 import { getAllVersionsColumns } from '../../../Utils';
-import FlowpropertiesCreate from '../create';
-import FlowpropertiesDelete from '../delete';
-import FlowpropertiesEdit from '../edit';
 import FlowpropertyView from '../view';
 
 type Props = {
@@ -79,35 +76,11 @@ const FlowpropertiesSelectDrawer: FC<Props> = ({ buttonType, lang, onData, butto
   };
 
   const renderVersionSelectActions = (row: FlowpropertyTable) => {
-    if (activeTabKey === 'tg') {
-      return [
-        <Space size={'small'} key={0}>
-          <FlowpropertyView lang={lang} buttonType={'icon'} id={row.id} version={row.version} />
-        </Space>,
-      ];
-    }
-    if (activeTabKey === 'my') {
-      return [
-        <Space size={'small'} key={0}>
-          <FlowpropertyView lang={lang} buttonType={'icon'} id={row.id} version={row.version} />
-          <FlowpropertiesEdit
-            lang={lang}
-            id={row.id}
-            version={row.version}
-            buttonType={'icon'}
-            actionRef={myActionRefSelect}
-          />
-          <FlowpropertiesDelete
-            id={row.id}
-            version={row.version}
-            buttonType={'icon'}
-            actionRef={myActionRefSelect}
-            setViewDrawerVisible={() => {}}
-          />
-        </Space>,
-      ];
-    }
-    return [];
+    return [
+      <Space size={'small'} key={0}>
+        <FlowpropertyView lang={lang} buttonType={'icon'} id={row.id} version={row.version} />
+      </Space>,
+    ];
   };
 
   const onTabChange = async (key: string) => {
@@ -241,11 +214,11 @@ const FlowpropertiesSelectDrawer: FC<Props> = ({ buttonType, lang, onData, butto
             <AllVersionsList
               lang={lang}
               dataSource={activeTabKey}
+              stateCode={activeTabKey === 'my' ? 0 : undefined}
               searchTableName='flowproperties'
               columns={getAllVersionsColumns(FlowpropertyColumns, 4)}
               searchColume={flowpropertyAllVersionsSearchColumn}
               id={row.id}
-              addVersionComponent={() => <></>}
               operationRender={(versionRow) =>
                 renderVersionSelectActions(versionRow as FlowpropertyTable)
               }
@@ -481,9 +454,6 @@ const FlowpropertiesSelectDrawer: FC<Props> = ({ buttonType, lang, onData, butto
         <ProTable<FlowpropertyTable, ListPagination>
           actionRef={myActionRefSelect}
           search={false}
-          toolBarRender={() => {
-            return [<FlowpropertiesCreate lang={lang} key={0} actionRef={myActionRefSelect} />];
-          }}
           pagination={{
             showSizeChanger: false,
             pageSize: 10,
@@ -496,7 +466,7 @@ const FlowpropertiesSelectDrawer: FC<Props> = ({ buttonType, lang, onData, butto
             sort,
           ) => {
             if (myKeyWord.length > 0) {
-              return getFlowpropertyTablePgroongaSearch(params, lang, 'my', myKeyWord, {}).then(
+              return getFlowpropertyTablePgroongaSearch(params, lang, 'my', myKeyWord, {}, 0).then(
                 (res) => {
                   return getUnitData('unitgroup', res?.data).then((unitRes) => {
                     return {
@@ -508,7 +478,7 @@ const FlowpropertiesSelectDrawer: FC<Props> = ({ buttonType, lang, onData, butto
                 },
               );
             }
-            return getFlowpropertyTableAll(params, sort, lang, 'my', []).then((res) => {
+            return getFlowpropertyTableAll(params, sort, lang, 'my', [], 0).then((res) => {
               return getUnitData('unitgroup', res?.data).then((unitRes) => {
                 return {
                   ...res,

--- a/src/pages/Unitgroups/Components/select/drawer.tsx
+++ b/src/pages/Unitgroups/Components/select/drawer.tsx
@@ -1,6 +1,7 @@
 import { toSuperscript } from '@/components/AlignedNumber';
 import AllVersionsList from '@/components/AllVersions';
-import { ListPagination } from '@/services/general/data';
+import { renderTableSelectionClearAction } from '@/components/TableSelectionAlert';
+import { DataTabKey, ListPagination } from '@/services/general/data';
 import { getUnitGroupTableAll, getUnitGroupTablePgroongaSearch } from '@/services/unitgroups/api';
 import { UnitGroupTable } from '@/services/unitgroups/data';
 import styles from '@/style/custom.less';
@@ -12,8 +13,7 @@ import type { FC, Key, ReactNode } from 'react';
 import React, { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 import { getAllVersionsColumns } from '../../../Utils';
-// import UnitGroupCreate from '../create';
-import { renderTableSelectionClearAction } from '@/components/TableSelectionAlert';
+import UnitGroupCreate from '../create';
 import UnitGroupView from '../view';
 
 type Props = {
@@ -23,19 +23,21 @@ type Props = {
   onData: (rowKey: string, version: string) => void;
 };
 
+type UnitGroupDataTabKey = Exclude<DataTabKey, 'te'>;
+
 const { Search } = Input;
 
 const UnitgroupsSelectDrawer: FC<Props> = ({ buttonType, buttonText, lang, onData }) => {
   const [tgKeyWord, setTgKeyWord] = useState<string>('');
   const [coKeyWord, setCoKeyWord] = useState<string>('');
-  // const [myKeyWord, setMyKeyWord] = useState<string>('');
+  const [myKeyWord, setMyKeyWord] = useState<string>('');
   // const [teKeyWord, setTeKeyWord] = useState<string>('');
   const [drawerVisible, setDrawerVisible] = useState(false);
   const [selectedRowKeys, setSelectedRowKeys] = useState<Key[]>([]);
-  const [activeTabKey, setActiveTabKey] = useState<string>('tg');
+  const [activeTabKey, setActiveTabKey] = useState<UnitGroupDataTabKey>('tg');
   const tgActionRefSelect = useRef<ActionType>();
   const coActionRefSelect = useRef<ActionType>();
-  // const myActionRefSelect = useRef<ActionType>();
+  const myActionRefSelect = useRef<ActionType>();
   // const teActionRefSelect = useRef<ActionType>();
   const intl = useIntl();
   const tableAlertOptionRender = renderTableSelectionClearAction(
@@ -75,19 +77,20 @@ const UnitgroupsSelectDrawer: FC<Props> = ({ buttonType, buttonText, lang, onDat
   };
 
   const onTabChange = async (key: string) => {
-    await setActiveTabKey(key);
-    if (key === 'tg') {
+    const tabKey = key as UnitGroupDataTabKey;
+    await setActiveTabKey(tabKey);
+    if (tabKey === 'tg') {
       await tgActionRefSelect.current?.setPageInfo?.({ current: 1 });
       tgActionRefSelect.current?.reload();
     }
-    if (key === 'co') {
+    if (tabKey === 'co') {
       coActionRefSelect.current?.setPageInfo?.({ current: 1 });
       coActionRefSelect.current?.reload();
     }
-    // if (key === 'my') {
-    //   myActionRefSelect.current?.setPageInfo?.({ current: 1 });
-    //   myActionRefSelect.current?.reload();
-    // }
+    if (tabKey === 'my') {
+      await myActionRefSelect.current?.setPageInfo?.({ current: 1 });
+      myActionRefSelect.current?.reload();
+    }
     // if (key === 'te') {
     //   teActionRefSelect.current?.setPageInfo?.({ current: 1 });
     //   teActionRefSelect.current?.reload();
@@ -106,11 +109,11 @@ const UnitgroupsSelectDrawer: FC<Props> = ({ buttonType, buttonText, lang, onDat
     coActionRefSelect.current?.reload();
   };
 
-  // const onMySearch: SearchProps['onSearch'] = async (value) => {
-  //   await setMyKeyWord(value);
-  //   myActionRefSelect.current?.setPageInfo?.({ current: 1 });
-  //   myActionRefSelect.current?.reload();
-  // };
+  const onMySearch: SearchProps['onSearch'] = async (value) => {
+    await setMyKeyWord(value);
+    myActionRefSelect.current?.setPageInfo?.({ current: 1 });
+    myActionRefSelect.current?.reload();
+  };
 
   // const onTeSearch: SearchProps['onSearch'] = async (value) => {
   //   await setTeKeyWord(value);
@@ -126,9 +129,9 @@ const UnitgroupsSelectDrawer: FC<Props> = ({ buttonType, buttonText, lang, onDat
     setCoKeyWord(e.target.value);
   };
 
-  // const handleMyKeyWordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-  //   setMyKeyWord(e.target.value);
-  // };
+  const handleMyKeyWordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setMyKeyWord(e.target.value);
+  };
 
   // const handleTeKeyWordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
   //   setTeKeyWord(e.target.value);
@@ -250,56 +253,57 @@ const UnitgroupsSelectDrawer: FC<Props> = ({ buttonType, buttonText, lang, onDat
       tab: <FormattedMessage id='pages.tab.title.tgdata' defaultMessage='TianGong Data' />,
     },
     { key: 'co', tab: <FormattedMessage id='pages.tab.title.co' defaultMessage='Business Data' /> },
-    // { key: 'my', tab: <FormattedMessage id='pages.tab.title.mydata' defaultMessage='My Data' /> },
+    { key: 'my', tab: <FormattedMessage id='pages.tab.title.mydata' defaultMessage='My Data' /> },
     // { key: 'te', tab: <FormattedMessage id='pages.tab.title.tedata' defaultMessage='TE Data' /> },
   ];
 
-  const databaseList: Record<string, React.ReactNode> = {
-    // my: (
-    //   <>
-    //     <Card>
-    //       <Search
-    //         name={'my'}
-    //         size={'large'}
-    //         placeholder={intl.formatMessage({ id: 'pages.search.keyWord' })}
-    //         value={myKeyWord}
-    //         onChange={handleMyKeyWordChange}
-    //         onSearch={onMySearch}
-    //         enterButton
-    //       />
-    //     </Card>
-    //     <ProTable<UnitGroupTable, ListPagination>
-    //       actionRef={myActionRefSelect}
-    //       search={false}
-    //       pagination={{
-    //         showSizeChanger: false,
-    //         pageSize: 10,
-    //       }}
-    //       toolBarRender={() => {
-    //         return [<UnitGroupCreate key={0} lang={lang} actionRef={myActionRefSelect} />];
-    //       }}
-    //       request={async (
-    //         params: {
-    //           pageSize: number;
-    //           current: number;
-    //         },
-    //         sort,
-    //       ) => {
-    //         if (myKeyWord.length > 0) {
-    //           return getUnitGroupTablePgroongaSearch(params, lang, 'my', myKeyWord, {});
-    //         }
-    //         return getUnitGroupTableAll(params, sort, lang, 'my', []);
-    //       }}
-    //       columns={unitGroupColumns}
-    //       rowSelection={{
-    //         type: 'radio',
-    //         alwaysShowAlert: true,
-    //         selectedRowKeys,
-    //         onChange: onSelectChange,
-    //       }}
-    //     />
-    //   </>
-    // ),
+  const databaseList: Record<UnitGroupDataTabKey, ReactNode> = {
+    my: (
+      <>
+        <Card>
+          <Search
+            name={'my'}
+            size={'large'}
+            placeholder={intl.formatMessage({ id: 'pages.search.keyWord' })}
+            value={myKeyWord}
+            onChange={handleMyKeyWordChange}
+            onSearch={onMySearch}
+            enterButton
+          />
+        </Card>
+        <ProTable<UnitGroupTable, ListPagination>
+          actionRef={myActionRefSelect}
+          search={false}
+          pagination={{
+            showSizeChanger: false,
+            pageSize: 10,
+          }}
+          toolBarRender={() => {
+            return [<UnitGroupCreate key={0} lang={lang} actionRef={myActionRefSelect} />];
+          }}
+          request={async (
+            params: {
+              pageSize: number;
+              current: number;
+            },
+            sort,
+          ) => {
+            if (myKeyWord.length > 0) {
+              return getUnitGroupTablePgroongaSearch(params, lang, 'my', myKeyWord, {});
+            }
+            return getUnitGroupTableAll(params, sort, lang, 'my', []);
+          }}
+          columns={unitGroupColumns}
+          tableAlertOptionRender={tableAlertOptionRender}
+          rowSelection={{
+            type: 'radio',
+            alwaysShowAlert: true,
+            selectedRowKeys,
+            onChange: onSelectChange,
+          }}
+        />
+      </>
+    ),
     tg: (
       <>
         <Card>

--- a/src/pages/Unitgroups/Components/select/drawer.tsx
+++ b/src/pages/Unitgroups/Components/select/drawer.tsx
@@ -193,6 +193,7 @@ const UnitgroupsSelectDrawer: FC<Props> = ({ buttonType, buttonText, lang, onDat
             <AllVersionsList
               lang={lang}
               dataSource={activeTabKey}
+              stateCode={activeTabKey === 'my' ? 0 : undefined}
               searchTableName='unitgroups'
               columns={getAllVersionsColumns(unitGroupColumns, 4)}
               searchColume={unitGroupAllVersionsSearchColumn}

--- a/src/pages/Unitgroups/Components/select/drawer.tsx
+++ b/src/pages/Unitgroups/Components/select/drawer.tsx
@@ -285,9 +285,9 @@ const UnitgroupsSelectDrawer: FC<Props> = ({ buttonType, buttonText, lang, onDat
             sort,
           ) => {
             if (myKeyWord.length > 0) {
-              return getUnitGroupTablePgroongaSearch(params, lang, 'my', myKeyWord, {});
+              return getUnitGroupTablePgroongaSearch(params, lang, 'my', myKeyWord, {}, 0);
             }
-            return getUnitGroupTableAll(params, sort, lang, 'my', []);
+            return getUnitGroupTableAll(params, sort, lang, 'my', [], 0);
           }}
           columns={unitGroupColumns}
           tableAlertOptionRender={tableAlertOptionRender}

--- a/src/pages/Unitgroups/Components/select/drawer.tsx
+++ b/src/pages/Unitgroups/Components/select/drawer.tsx
@@ -13,7 +13,6 @@ import type { FC, Key, ReactNode } from 'react';
 import React, { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'umi';
 import { getAllVersionsColumns } from '../../../Utils';
-import UnitGroupCreate from '../create';
 import UnitGroupView from '../view';
 
 type Props = {
@@ -277,9 +276,6 @@ const UnitgroupsSelectDrawer: FC<Props> = ({ buttonType, buttonText, lang, onDat
           pagination={{
             showSizeChanger: false,
             pageSize: 10,
-          }}
-          toolBarRender={() => {
-            return [<UnitGroupCreate key={0} lang={lang} actionRef={myActionRefSelect} />];
           }}
           request={async (
             params: {

--- a/src/services/general/api.ts
+++ b/src/services/general/api.ts
@@ -1229,6 +1229,7 @@ export async function getAllVersions(
   sort: Record<string, SortOrder>,
   lang: string,
   dataSource: string,
+  stateCode?: number,
 ) {
   const sortBy = Object.keys(sort)[0] ?? 'version';
   const orderBy = sort[sortBy] ?? 'descend';
@@ -1251,11 +1252,9 @@ export async function getAllVersions(
       (params.current ?? 1) * (params.pageSize ?? 10) - 1,
     );
 
-  if (dataSource === 'tg') {
-    query = query.eq('state_code', 100);
-  } else if (dataSource === 'co') {
-    query = query.eq('state_code', 200);
-  } else if (dataSource === 'my') {
+  const hasExactStateCode = typeof stateCode === 'number';
+
+  if (dataSource === 'my') {
     const session = await supabase.auth.getSession();
     if (session.data.session) {
       query = query.eq('user_id', session?.data?.session?.user?.id);
@@ -1277,6 +1276,14 @@ export async function getAllVersions(
         total: 0,
       });
     }
+  }
+
+  if (hasExactStateCode) {
+    query = query.eq('state_code', stateCode);
+  } else if (dataSource === 'tg') {
+    query = query.eq('state_code', 100);
+  } else if (dataSource === 'co') {
+    query = query.eq('state_code', 200);
   }
 
   const result = await query;

--- a/tests/unit/components/AllVersions.test.tsx
+++ b/tests/unit/components/AllVersions.test.tsx
@@ -582,6 +582,7 @@ describe('AllVersionsList Component', () => {
         expect.any(Object),
         'en',
         'test-datasource',
+        undefined,
       );
     });
   });
@@ -607,6 +608,33 @@ describe('AllVersionsList Component', () => {
         expect.any(Object),
         'en',
         'te',
+        undefined,
+      );
+    });
+  });
+
+  it('should pass an exact state-code filter for owner-draft selectors', async () => {
+    render(
+      <ConfigProvider>
+        <AllVersionsList {...defaultProps} dataSource='my' stateCode={0} />
+      </ConfigProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(mockGetAllVersions).toHaveBeenCalledWith(
+        'id',
+        'processes',
+        'test-id',
+        expect.objectContaining({
+          pageSize: 10,
+          current: 1,
+        }),
+        expect.any(Object),
+        'en',
+        'my',
+        0,
       );
     });
   });

--- a/tests/unit/pages/Flowproperties/Components/select/drawer.test.tsx
+++ b/tests/unit/pages/Flowproperties/Components/select/drawer.test.tsx
@@ -31,9 +31,19 @@ jest.mock('@/style/custom.less', () => ({
   default: { footer_right: 'footer-right' },
 }));
 
+const mockFlowpropertiesCreate = jest.fn(() => <span>create-flowproperty</span>);
+const mockFlowpropertiesEdit = jest.fn(({ id, version }: any) => (
+  <span>{`edit ${id}:${version}`}</span>
+));
+const mockFlowpropertiesDelete = jest.fn(({ id, version, setViewDrawerVisible }: any) => (
+  <button type='button' onClick={() => setViewDrawerVisible?.(false)}>
+    {`delete ${id}:${version}`}
+  </button>
+));
+
 jest.mock('@/pages/Flowproperties/Components/create', () => ({
   __esModule: true,
-  default: () => <span>create-flowproperty</span>,
+  default: (props: any) => mockFlowpropertiesCreate(props),
 }));
 
 jest.mock('@/pages/Flowproperties/Components/view', () => ({
@@ -43,22 +53,29 @@ jest.mock('@/pages/Flowproperties/Components/view', () => ({
 
 jest.mock('@/pages/Flowproperties/Components/edit', () => ({
   __esModule: true,
-  default: ({ id, version }: any) => <span>{`edit ${id}:${version}`}</span>,
+  default: (props: any) => mockFlowpropertiesEdit(props),
 }));
 
 jest.mock('@/pages/Flowproperties/Components/delete', () => ({
   __esModule: true,
-  default: ({ id, version, setViewDrawerVisible }: any) => (
-    <button type='button' onClick={() => setViewDrawerVisible?.(false)}>
-      {`delete ${id}:${version}`}
-    </button>
-  ),
+  default: (props: any) => mockFlowpropertiesDelete(props),
 }));
 
 jest.mock('@/components/AllVersions', () => ({
   __esModule: true,
-  default: ({ id, addVersionComponent, operationRender, onSelectVersion }: any) => (
-    <div data-testid='all-versions'>
+  default: ({
+    id,
+    addVersionComponent,
+    dataSource,
+    stateCode,
+    operationRender,
+    onSelectVersion,
+  }: any) => (
+    <div
+      data-testid='all-versions'
+      data-source={dataSource}
+      data-state-code={stateCode === undefined ? '' : String(stateCode)}
+    >
       <span>{`all versions `}</span>
       {addVersionComponent?.({ newVersion: '10.00.000' })}
       <button type='button' onClick={() => onSelectVersion?.({ id })}>
@@ -304,6 +321,8 @@ describe('FlowpropertySelectDrawer', () => {
     );
     expect(screen.getByText('view flowproperty-tg:1.0.0')).toBeInTheDocument();
     expect(screen.getByText((content) => content.includes('unitgroup'))).toBeInTheDocument();
+    expect(screen.getByTestId('all-versions')).toHaveAttribute('data-source', 'tg');
+    expect(screen.getByTestId('all-versions')).toHaveAttribute('data-state-code', '');
 
     await userEvent.click(screen.getByRole('button', { name: /My Data/i }));
 
@@ -314,13 +333,20 @@ describe('FlowpropertySelectDrawer', () => {
         'en',
         'my',
         [],
+        0,
       ),
     );
-    expect(screen.getByText('create-flowproperty')).toBeInTheDocument();
-    expect(screen.getByText('edit flowproperty-my:1.0.0')).toBeInTheDocument();
-    const deleteButton = screen.getByRole('button', { name: 'delete flowproperty-my:1.0.0' });
-    expect(deleteButton).toBeInTheDocument();
-    await userEvent.click(deleteButton);
+    expect(screen.getByTestId('all-versions')).toHaveAttribute('data-source', 'my');
+    expect(screen.getByTestId('all-versions')).toHaveAttribute('data-state-code', '0');
+    expect(screen.getByText('view flowproperty-my:1.0.0')).toBeInTheDocument();
+    expect(screen.queryByText('create-flowproperty')).not.toBeInTheDocument();
+    expect(screen.queryByText('edit flowproperty-my:1.0.0')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'delete flowproperty-my:1.0.0' }),
+    ).not.toBeInTheDocument();
+    expect(mockFlowpropertiesCreate).not.toHaveBeenCalled();
+    expect(mockFlowpropertiesEdit).not.toHaveBeenCalled();
+    expect(mockFlowpropertiesDelete).not.toHaveBeenCalled();
 
     await userEvent.type(screen.getByLabelText('my'), 'alpha');
     await userEvent.click(screen.getByRole('button', { name: 'search-my' }));
@@ -332,6 +358,7 @@ describe('FlowpropertySelectDrawer', () => {
         'my',
         'alpha',
         {},
+        0,
       ),
     );
 
@@ -452,6 +479,7 @@ describe('FlowpropertySelectDrawer', () => {
         'en',
         'my',
         [],
+        0,
       ),
     );
 

--- a/tests/unit/pages/Unitgroups/Components/select/drawer.test.tsx
+++ b/tests/unit/pages/Unitgroups/Components/select/drawer.test.tsx
@@ -46,6 +46,7 @@ jest.mock('@/components/AllVersions', () => ({
   default: function MockAllVersions({
     addVersionComponent,
     dataSource,
+    stateCode,
     onSelectVersion,
     operationRender,
   }: any) {
@@ -60,7 +61,11 @@ jest.mock('@/components/AllVersions', () => ({
     };
 
     return (
-      <div data-testid='all-versions'>
+      <div
+        data-testid='all-versions'
+        data-source={dataSource}
+        data-state-code={stateCode === undefined ? '' : String(stateCode)}
+      >
         <div data-testid={`all-versions-add-version-${dataSource}`}>
           {addVersionComponent?.({ newVersion: '01.00.001' })}
         </div>
@@ -292,6 +297,8 @@ describe('UnitgroupsSelectDrawer', () => {
     );
     expect(screen.getByText('view unit-group-tg:1.0.0')).toBeInTheDocument();
     expect(screen.getByText('sup:kg')).toBeInTheDocument();
+    expect(screen.getByTestId('all-versions')).toHaveAttribute('data-source', 'tg');
+    expect(screen.getByTestId('all-versions')).toHaveAttribute('data-state-code', '');
 
     await userEvent.click(screen.getByRole('button', { name: /Business Data/i }));
 
@@ -358,6 +365,8 @@ describe('UnitgroupsSelectDrawer', () => {
       ),
     );
     expect(screen.getByRole('button', { name: /My Data/i })).toHaveAttribute('data-active', 'true');
+    expect(screen.getByTestId('all-versions')).toHaveAttribute('data-source', 'my');
+    expect(screen.getByTestId('all-versions')).toHaveAttribute('data-state-code', '0');
     expect(screen.queryByText('create-unit-group')).not.toBeInTheDocument();
     expect(screen.getByText('view unit-group-my:1.0.0')).toBeInTheDocument();
     expect(screen.getByTestId('all-versions-add-version-my')).toBeInTheDocument();

--- a/tests/unit/pages/Unitgroups/Components/select/drawer.test.tsx
+++ b/tests/unit/pages/Unitgroups/Components/select/drawer.test.tsx
@@ -354,6 +354,7 @@ describe('UnitgroupsSelectDrawer', () => {
         'en',
         'my',
         [],
+        0,
       ),
     );
     expect(screen.getByRole('button', { name: /My Data/i })).toHaveAttribute('data-active', 'true');
@@ -371,6 +372,7 @@ describe('UnitgroupsSelectDrawer', () => {
         'my',
         'owner-draft',
         {},
+        0,
       ),
     );
 

--- a/tests/unit/pages/Unitgroups/Components/select/drawer.test.tsx
+++ b/tests/unit/pages/Unitgroups/Components/select/drawer.test.tsx
@@ -41,11 +41,6 @@ jest.mock('@/pages/Unitgroups/Components/view', () => ({
   default: ({ id, version }: any) => <span>{`view ${id}:${version}`}</span>,
 }));
 
-jest.mock('@/pages/Unitgroups/Components/create', () => ({
-  __esModule: true,
-  default: () => <span>create-unit-group</span>,
-}));
-
 jest.mock('@/components/AllVersions', () => ({
   __esModule: true,
   default: function MockAllVersions({
@@ -209,7 +204,7 @@ jest.mock('antd', () => {
 jest.mock('@ant-design/pro-components', () => {
   const React = require('react');
 
-  const ProTable = ({ actionRef, request, rowSelection, columns = [], toolBarRender }: any) => {
+  const ProTable = ({ actionRef, request, rowSelection, columns = [] }: any) => {
     const [rows, setRows] = React.useState<any[]>([]);
     const latestRequestRef = React.useRef(request);
     latestRequestRef.current = request;
@@ -236,7 +231,6 @@ jest.mock('@ant-design/pro-components', () => {
 
     return (
       <div>
-        <div>{toolBarRender?.()}</div>
         {rows.map((row) => (
           <div key={`${row.id}:${row.version}`}>
             {columns.map((column: any, index: number) => (
@@ -363,7 +357,7 @@ describe('UnitgroupsSelectDrawer', () => {
       ),
     );
     expect(screen.getByRole('button', { name: /My Data/i })).toHaveAttribute('data-active', 'true');
-    expect(screen.getByText('create-unit-group')).toBeInTheDocument();
+    expect(screen.queryByText('create-unit-group')).not.toBeInTheDocument();
     expect(screen.getByText('view unit-group-my:1.0.0')).toBeInTheDocument();
     expect(screen.getByTestId('all-versions-add-version-my')).toBeInTheDocument();
 

--- a/tests/unit/pages/Unitgroups/Components/select/drawer.test.tsx
+++ b/tests/unit/pages/Unitgroups/Components/select/drawer.test.tsx
@@ -41,6 +41,11 @@ jest.mock('@/pages/Unitgroups/Components/view', () => ({
   default: ({ id, version }: any) => <span>{`view ${id}:${version}`}</span>,
 }));
 
+jest.mock('@/pages/Unitgroups/Components/create', () => ({
+  __esModule: true,
+  default: () => <span>create-unit-group</span>,
+}));
+
 jest.mock('@/components/AllVersions', () => ({
   __esModule: true,
   default: function MockAllVersions({
@@ -204,7 +209,7 @@ jest.mock('antd', () => {
 jest.mock('@ant-design/pro-components', () => {
   const React = require('react');
 
-  const ProTable = ({ actionRef, request, rowSelection, columns = [] }: any) => {
+  const ProTable = ({ actionRef, request, rowSelection, columns = [], toolBarRender }: any) => {
     const [rows, setRows] = React.useState<any[]>([]);
     const latestRequestRef = React.useRef(request);
     latestRequestRef.current = request;
@@ -231,6 +236,7 @@ jest.mock('@ant-design/pro-components', () => {
 
     return (
       <div>
+        <div>{toolBarRender?.()}</div>
         {rows.map((row) => (
           <div key={`${row.id}:${row.version}`}>
             {columns.map((column: any, index: number) => (
@@ -325,6 +331,59 @@ describe('UnitgroupsSelectDrawer', () => {
     await waitFor(() =>
       expect(screen.queryByRole('dialog', { name: /Selete Unit group/i })).not.toBeInTheDocument(),
     );
+  });
+
+  it('loads and selects My Data only after the user explicitly switches tabs', async () => {
+    const onData = jest.fn();
+
+    renderWithProviders(<UnitgroupsSelectDrawer buttonType='text' lang='en' onData={onData} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /^select$/i }));
+
+    await waitFor(() =>
+      expect(mockGetUnitGroupTableAll).toHaveBeenCalledWith(
+        expect.objectContaining({ current: 1, pageSize: 10 }),
+        {},
+        'en',
+        'tg',
+        [],
+      ),
+    );
+    expect(mockGetUnitGroupTableAll.mock.calls.some((call) => call[3] === 'my')).toBe(false);
+
+    await userEvent.click(screen.getByRole('button', { name: /My Data/i }));
+
+    await waitFor(() =>
+      expect(mockGetUnitGroupTableAll).toHaveBeenCalledWith(
+        expect.objectContaining({ current: 1, pageSize: 10 }),
+        {},
+        'en',
+        'my',
+        [],
+      ),
+    );
+    expect(screen.getByRole('button', { name: /My Data/i })).toHaveAttribute('data-active', 'true');
+    expect(screen.getByText('create-unit-group')).toBeInTheDocument();
+    expect(screen.getByText('view unit-group-my:1.0.0')).toBeInTheDocument();
+    expect(screen.getByTestId('all-versions-add-version-my')).toBeInTheDocument();
+
+    await userEvent.type(screen.getByLabelText('my'), 'owner-draft');
+    await userEvent.click(screen.getByRole('button', { name: 'search-my' }));
+
+    await waitFor(() =>
+      expect(mockGetUnitGroupTablePgroongaSearch).toHaveBeenCalledWith(
+        expect.objectContaining({ current: 1, pageSize: 10 }),
+        'en',
+        'my',
+        'owner-draft',
+        {},
+      ),
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'my:owner-draft' }));
+    await userEvent.click(screen.getByRole('button', { name: /^submit$/i }));
+
+    expect(onData).toHaveBeenCalledWith('unit-group-my-search', '2.0.0');
   });
 
   it('supports icon trigger, tg search, reopen reset, and all close paths', async () => {

--- a/tests/unit/services/general/api.test.ts
+++ b/tests/unit/services/general/api.test.ts
@@ -2213,7 +2213,7 @@ describe('Edge Cases and Error Handling', () => {
       ]);
     });
 
-    it('should fetch versions for my dataSource with session', async () => {
+    it('should fetch only exact owner-draft versions for my dataSource with session', async () => {
       const mockData = [
         { id: sampleId, version: '01.00.000', created_at: '2024-01-01', modified_at: '2024-01-01' },
       ];
@@ -2230,9 +2230,13 @@ describe('Edge Cases and Error Handling', () => {
         {},
         'en',
         'my',
+        0,
       );
 
       expect(builder.eq).toHaveBeenCalledWith('user_id', 'user-1');
+      expect(builder.eq).toHaveBeenCalledWith('state_code', 0);
+      expect(builder.eq).not.toHaveBeenCalledWith('state_code', 100);
+      expect(builder.eq).not.toHaveBeenCalledWith('state_code', 200);
       expect(result).toBeDefined();
     });
 


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#588

## Summary
- Promote the exact #586 and #589 dev history into main as v0.0.44.
- Base the release on current main, preserving the committed lockfile and release workflow while making both origin/main and origin/dev ancestors of the release head.
- Ship exact current-owner state_code=0 FP/UG My Data selection and read-only FlowProperty selector behavior; no BAFU data mutation is included.

## Key Decisions
- Use a main-based merge commit instead of replacing main with the diverged dev tree (main had 44 unique commits and dev had 9).
- Keep package-lock.json from v0.0.43 and change only its package/root versions to 0.0.44; no dependencies or release workflows changed.
- Back-merge final main into dev after the release succeeds; root workspace integration remains a separate later step.

## Validation
- Node v24.13.0 / npm 11.6.2: npm ci passed with the committed lockfile.
- Canonical npm run test:ci passed: 335 unit suites/4292 tests plus 14 integration suites/66 tests (349 suites, 4358 tests total).
- npm run prepush:gate passed: 4358/4358 tests and 100% statements/branches/functions/lines for 364/364 tracked files.
- npm run build passed.
- npm run docpact:gate -- --base origin/main --head HEAD passed.
- Gitleaks 8.30.1 scanned origin/main..HEAD (9 commits): zero findings.
- Both origin/main@62d9c85c3 and origin/dev@6ddbab7e9 are ancestors; v0.0.44 is unused; package and lock versions are all 0.0.44.
- Local/mocked frontend validation only; no live Supabase request and no BAFU data write.

## Risks / Rollback
- The first diagnostic run appended --json to test:ci, which intentionally bypasses the repo's bounded two-phase runner and produced seven parallel-order failures; the two affected suites then passed 75/75 under runInBand, and the exact no-argument release command passed all 4358 tests.
- Historical Gitleaks debt is separate: scheduled run 29176611927 scanned 2388 old commits and reported 104 legacy findings, while this release diff has zero findings.
- npm ci reports the existing lockfile's 58 audit findings (9 low, 25 moderate, 23 high, 1 critical); this release changes no dependencies.

## Follow-ups
- After merge, verify the canonical main Build/release run creates v0.0.44, passes Release Gate, deploys EdgeOne web, and creates all Electron draft artifacts.
- Open and merge a tracked main-to-dev backmerge after release verification.

## Workspace Integration
- Workspace pointer remains pending and must use the verified released main SHA; this PR does not touch lca-workspace.