### PR TITLE
chore: release v0.0.46

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-07-16'
-lastReviewedCommit: 'e112fa85f4138b5094c965bd010825d8267ee75d'
+lastReviewedAt: "2026-07-16"
+lastReviewedCommit: "a9524dbb33b272e1c5526f33a0b8c758e186d170"
 lastReviewedNote: 'Added Issue #602 German runtime, classified the shared locale-formatting helper, and retained bounded failure-activated pre-push transport-retry ownership without changing repository boundaries.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: e112fa85f4138b5094c965bd010825d8267ee75d
+lastReviewedCommit: a9524dbb33b272e1c5526f33a0b8c758e186d170
 lastReviewedNote: 'Reviewed Issue #601 scoped-first validation and single final-checkpoint gate ownership; repo ownership and branch facts are unchanged.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: e112fa85f4138b5094c965bd010825d8267ee75d
+lastReviewedCommit: a9524dbb33b272e1c5526f33a0b8c758e186d170
 lastReviewedNote: 'Aligned the shortest work loop with the active German runtime gates and the managed, failure-activated push-retry path.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -24,7 +24,7 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: e112fa85f4138b5094c965bd010825d8267ee75d
+lastReviewedCommit: a9524dbb33b272e1c5526f33a0b8c758e186d170
 lastReviewedNote: 'Aligned the Issue #602 bounded, failure-activated push-retry contract with the managed push lifecycle.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: e112fa85f4138b5094c965bd010825d8267ee75d
+lastReviewedCommit: a9524dbb33b272e1c5526f33a0b8c758e186d170
 lastReviewedNote: 'Activated German runtime proof and aligned the bounded, failure-activated push-retry contract.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: bb7c8da76e2bd0581f7f32e1bc00c4a166fa4581
+lastReviewedCommit: a9524dbb33b272e1c5526f33a0b8c758e186d170
 lastReviewedNote: 'Added risk-proportional scoped-first proof and one final-checkpoint full gate without reopening gate-infrastructure strategy.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: e112fa85f4138b5094c965bd010825d8267ee75d
+lastReviewedCommit: a9524dbb33b272e1c5526f33a0b8c758e186d170
 lastReviewedNote: 'Retained the checked-in full-closure reference and recorded the Issue #602 German runtime and single-final-gate execution state.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: e112fa85f4138b5094c965bd010825d8267ee75d
+lastReviewedCommit: a9524dbb33b272e1c5526f33a0b8c758e186d170
 lastReviewedNote: 'Added the active German runtime delta pattern and the managed, failure-activated final-push boundary.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-07-16
-lastReviewedCommit: e112fa85f4138b5094c965bd010825d8267ee75d
+lastReviewedCommit: a9524dbb33b272e1c5526f33a0b8c758e186d170
 lastReviewedNote: 'Added active German runtime/delta recovery and bounded managed-push retry guidance.'
 ---
 

--- a/docs/plans/i18n-de-DE/runtime-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/runtime-activation-manifest.json
@@ -227,7 +227,7 @@
       {
         "kind": "file",
         "path": "docs/plans/i18n-de-DE/manifest.json",
-        "sha256": "1ecfb2632a33ffe66b7b82372931877bac8a9e691624890c648702458dd0cc3e"
+        "sha256": "f661c8d85269e2bd8fb4450478796d838bd4815289d14a44bf0672179f88af38"
       },
       {
         "kind": "file",
@@ -420,6 +420,6 @@
         "sha256": "0c414199c5f5937821c9c35edaa5f6e23c079711f102011dfa11bfeb2bf3602b"
       }
     ],
-    "inputDigest": "d272eeb79e57f2cd8af93d13de853071053207425dc0233d45be7eff3dad0754"
+    "inputDigest": "bcd6dd8de7c11da355e9515c244a01ea1a1c5bd69c58c7017af640bf75c02b58"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.45",
+      "version": "0.0.46",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
## Summary

- bump `package.json` and the root package entries in `package-lock.json` from `0.0.45` to `0.0.46`
- refresh the canonical and German runtime manifests to the current merged `dev` base
- record the Docpact review evidence required by the release/version input change
- keep all German copy, context, locale topology, and private human-review content unchanged

## Release intent

This is the controlled release-preparation change for Draft PR #608 (`dev -> main`). The `v0.0.46` tag and release do not exist before promotion. After this PR reaches `dev`, merging #608 into `main` is expected to create `v0.0.46` and run the release gate, Web deployment, and Electron release workflow.

PR #608 remains Draft and must not be merged without separate authorization.

## Validation

Final managed push on immutable checkpoint:

- head: `c1343f9ecc41872c010a87f5c62d0012f7a5865e`
- tree: `d41f59888dfe2e692a92e17c8a2944d5b8529424`
- command: `npm run push:checked -- origin codex/release-german-v0.0.46`
- Docpact: 13 changed paths, 12 matched rules, 0 findings
- LCIA static-cache verification: passed
- lint / Prettier / TypeScript: passed
- Jest: 361/361 suites and 4564/4564 tests passed
- tracked source files: 402/402 at 100% statements, branches, functions, and lines
- German runtime audit: 0 findings; frozen baseline and existing private 28-item delta approval remain valid
- focused regression proof after manifest refresh: 2/2 suites and 12/12 tests passed

## Change boundary

The manifest refresh only advances the recorded canonical base from the pre-merge feature baseline to current `dev`; it does not alter translations or their review scope. No dependency was added or upgraded.

Refs #602