### PR TITLE
fix: restore clean-runner German release gate

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-07-16"
-lastReviewedCommit: "a9524dbb33b272e1c5526f33a0b8c758e186d170"
-lastReviewedNote: 'Added Issue #602 German runtime, classified the shared locale-formatting helper, and retained bounded failure-activated pre-push transport-retry ownership without changing repository boundaries.'
+lastReviewedAt: '2026-07-17'
+lastReviewedCommit: '8ad1c1692ccf2bdac8b06762cf840185ab7a55bb'
+lastReviewedNote: 'Reviewed Issue #611 clean-runner release recovery; test-gate and i18n script ownership remain correctly covered by the existing rule graph.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,9 +212,6 @@ jobs:
           release_base="${{ needs.release-context.outputs.release_base }}"
           npm run docpact:gate -- --base "$release_base" --head "$release_head"
 
-      - name: Run CI tests
-        run: npm run test:ci
-
       - name: Run full release gate
         run: npm run prepush:gate
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -5,10 +5,24 @@ push_updates_file="$(mktemp "${TMPDIR:-/tmp}/tiangong-prepush-updates.XXXXXX")"
 trap 'rm -f "$push_updates_file"' 0 1 2 15
 cat >"$push_updates_file"
 
-export NVM_DIR="$HOME/.nvm"
-if [ -s "$NVM_DIR/nvm.sh" ]; then
-  . "$NVM_DIR/nvm.sh"
-  nvm use 24 >/dev/null
+node24_active() {
+  command -v node >/dev/null 2>&1 &&
+    node -e 'process.exit(Number(process.versions.node.split(".")[0]) === 24 ? 0 : 1)'
+}
+
+if ! node24_active; then
+  export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+  if [ -s "$NVM_DIR/nvm.sh" ]; then
+    . "$NVM_DIR/nvm.sh"
+    if ! nvm use 24 >/dev/null 2>&1; then
+      :
+    fi
+  fi
+fi
+
+if ! node24_active; then
+  echo "Node.js 24 is required for the pre-push gate." >&2
+  exit 1
 fi
 
 node scripts/prepush-gate-receipt.cjs hook-run \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,9 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-07-16
-lastReviewedCommit: a9524dbb33b272e1c5526f33a0b8c758e186d170
-lastReviewedNote: 'Reviewed Issue #601 scoped-first validation and single final-checkpoint gate ownership; repo ownership and branch facts are unchanged.'
+lastReviewedAt: 2026-07-17
+lastReviewedCommit: 8ad1c1692ccf2bdac8b06762cf840185ab7a55bb
+lastReviewedNote: 'Reviewed Issue #611 clean-runner release-gate recovery; repo ownership and branch facts are unchanged.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -20,9 +20,9 @@ checkPaths:
   - .docpact/config.yaml
   - package.json
   - .nvmrc
-lastReviewedAt: 2026-07-16
-lastReviewedCommit: a9524dbb33b272e1c5526f33a0b8c758e186d170
-lastReviewedNote: 'Aligned the shortest work loop with the active German runtime gates and the managed, failure-activated push-retry path.'
+lastReviewedAt: 2026-07-17
+lastReviewedCommit: 8ad1c1692ccf2bdac8b06762cf840185ab7a55bb
+lastReviewedNote: 'Documented the Issue #611 pre-push bootstrap path for both active Node 24 and the local NVM fallback.'
 ---
 
 # Development Bootstrap
@@ -107,6 +107,7 @@ If no push will occur and a standalone handoff needs final evidence, run `npm ru
 - use `npm run test:workflows -- --processes:create --frontend-url <url> --supabase-url <url> --supabase-publishable-key <key>` for one live data workflow script; use `--processes:all` or `--teams:all` when a full workflow suite is needed
 - run `npm run test:api:smoke -- <workflow-args>` only with a target Supabase environment and configured test users; inspect its summary because child workflow failures are reported without making the command exit non-zero
 - local pushes run the Husky pre-push hook, which runs `npm run docpact:gate` and then `npm run prepush:gate`
+- the hook keeps an already-active Node.js 24 from `PATH`, including a CI `setup-node` runtime; it sources local NVM and runs `nvm use 24` only when the active Node is absent or has another major version
 - treat `npm run prepush:gate` as the authoritative local test gate
 - during normal delivery, use `npm run push:checked -- <normal-git-push-args>` and do not run the full gate manually immediately before its ordinary hook repeats it; focused proof belongs in the edit loop and the hook owns the final committed checkpoint
 - ignored local confirmation edits and GitHub metadata do not invalidate repository full-gate evidence; a controlled tracked change, relevant Node/dependency change, or gate/configuration change does

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -23,9 +23,9 @@ checkPaths:
   - scripts/docpact-gate.js
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
-lastReviewedAt: 2026-07-16
-lastReviewedCommit: a9524dbb33b272e1c5526f33a0b8c758e186d170
-lastReviewedNote: 'Aligned the Issue #602 bounded, failure-activated push-retry contract with the managed push lifecycle.'
+lastReviewedAt: 2026-07-17
+lastReviewedCommit: 8ad1c1692ccf2bdac8b06762cf840185ab7a55bb
+lastReviewedNote: 'Aligned the pre-push Node 24 bootstrap with both local NVM and clean setup-node runners for Issue #611.'
 ---
 
 # Pre-Push Gate Policy
@@ -73,6 +73,7 @@ It does not own:
 
 ## Adoption Conditions
 
+- the hook accepts an already-active Node.js 24 from `PATH`; it falls back to local NVM only when the active Node is absent or has another major version, and fails clearly if Node 24 is still unavailable
 - hook behavior and release-gate behavior must match the documented policy
 - no release path may bypass the full gate
 - branch policy must stay aligned with `dev -> main`
@@ -83,6 +84,7 @@ It does not own:
 ## Short Rule Summary
 
 - keep one authoritative full gate
+- do not require an NVM-managed copy of Node 24 when the runner or operator already has Node 24 active on `PATH`
 - for a normal delivery, let the existing push hook own the single full-gate execution after the final controlled tracked change; do not invoke the same gate manually immediately before that push
 - use manual full-gate execution only when a no-push handoff needs the evidence
 - use `npm run push:checked -- <normal git push arguments>` for the final managed push; its ordinary Git hook runs both authoritative gates and returns a private gate-bound payload to the wrapper
@@ -96,6 +98,7 @@ It does not own:
 - never invoke `git push --no-verify` or `HUSKY=0` manually; a missing or invalidated receipt requires a new managed push and hook-owned gate run
 - run the lightweight docpact gate before the full local test gate so governed-doc review failures surface early
 - protect the actual local and release gates
+- keep one full Jest execution inside each production release workflow; `prepush:gate` already owns the coverage-enabled complete suite, so do not precede it with a second standalone `test:ci`
 - avoid spending GitHub Actions minutes on ordinary push-triggered test jobs
 - keep release automation in the same `main` push workflow after the tag is created; do not rely on a second tag-push workflow run from `GITHUB_TOKEN`
 - use `workflow_dispatch` with an existing `v*` tag when a release needs to be recovered with newer workflow code

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,9 +22,9 @@ checkPaths:
   - .husky/pre-push
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
-lastReviewedAt: 2026-07-16
-lastReviewedCommit: a9524dbb33b272e1c5526f33a0b8c758e186d170
-lastReviewedNote: 'Activated German runtime proof and aligned the bounded, failure-activated push-retry contract.'
+lastReviewedAt: 2026-07-17
+lastReviewedCommit: 8ad1c1692ccf2bdac8b06762cf840185ab7a55bb
+lastReviewedNote: 'Separated clean-runner structural German proof from private local approval and documented setup-node-compatible hook bootstrap for Issue #611.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -77,6 +77,8 @@ npm run prepush:gate
 
 The local `pre-push` hook always runs `npm run docpact:gate` first, then runs the full `npm run prepush:gate` local test gate on every branch. The docpact gate defaults to `origin/dev` and can be redirected with `DOCPACT_BASE_REF=<ref>` for promote or hotfix branches. For a normal delivery, commit the final controlled tracked change and let that hook own the one authoritative full-gate run; do not manually run the same full gate immediately before pushing. Manual full-gate execution is for a no-push evidence handoff.
 
+The hook uses an already-active Node.js 24 from `PATH`, including GitHub `setup-node`, before consulting NVM. It sources NVM and runs `nvm use 24` only when the active Node is missing or has another major version, then fails closed with an explicit version error if Node 24 is still unavailable.
+
 Run every Umi-generating `test:ci`, coverage, and `prepush:gate` command serially because they share `.umi-test`. The full gate already includes coverage; do not surround it with redundant broad test or coverage runs for the same checkpoint.
 
 Full-gate evidence binds the exact committed `HEAD`, tracked tree, Node/dependency state, and test/lint/build/coverage/Docpact/gate configuration. Ignored review content, GitHub body changes, and read-only checks do not create a new repository checkpoint. Any changed controlled tracked input does, and requires one new final full-gate run.
@@ -87,9 +89,15 @@ After that uncertain or failed transport, run `npm run push:retry` with no argum
 
 For deployment-only workflow changes under `.github/workflows/build.yml` or the manual `.github/workflows/ci.yml` fallback, validate the workflow shape directly with YAML parsing, formatter checks, and shell syntax checks for edited deploy scripts. For EdgeOne CLI dependency changes, also validate the pinned temporary install path locally without calling the live deploy command. Do not run production deploy commands locally or from PR validation unless the task explicitly requires exercising live deploy credentials; the automatic EdgeOne Pages deploy step runs from canonical `main` pushes by creating the matching `v*` tag from `package.json.version` and continuing release in the same workflow run, unchanged-version `main` workflow hotfix pushes skip release when the matching tag already belongs to an older `main` commit, manual `v*` tag pushes and `workflow_dispatch` recovery runs remain supported when the target commit is already on `main`, and Electron publication must pre-create exactly one tag-scoped draft before the parallel matrix and finish by verifying the exact 12 expected non-empty assets in that one draft. The manual deploy fallback is guarded to `refs/heads/main` and checks out `github.sha`, and ordinary non-release branch pushes belong to the local pre-push gate.
 
+The production Release Gate runs the coverage-enabled complete Jest suite exactly once through `npm run prepush:gate`. Do not add a preceding standalone `npm run test:ci`; it exercises the same suite without producing an independent release artifact. The separate early LCIA verification remains a lightweight fail-fast publication check and `prepush:gate` retains the authoritative complete quality bar.
+
 Treat dataset-validation work under `src/pages/*/sdkValidation.ts`, `src/pages/Utils/validation/**`, `src/components/ValidationIssueModal/index.tsx`, and localized validator copy under `src/locales/**` as shipped runtime work even when most of the change looks like error-message plumbing.
 
 Treat `npm run i18n:audit` as the deterministic structural proof for locale ownership and runtime message references. Linguistic and domain sign-off remain separate review evidence; a green structural audit does not prove translation quality.
+
+Canonical-manifest `--check` reuses the checked-in `source.baseRef` and immutable `source.baseCommit` unless `--base-ref` is explicitly supplied. Advancing an ambient branch such as `origin/dev` without changing audited locale/callsite inputs therefore does not stale a release checkout; `--write` and an explicit `--base-ref` still resolve and record the requested current commit.
+
+Clean-checkout Jest and release gates must pass explicit nonexistent German confirmation paths and assert that only the expected local-confirmation findings remain while every tracked structural finding is zero. Positive approval behavior stays covered by generated private temporary fixtures. These repository tests do not claim human approval, and `i18n:de:pilot`, `i18n:de:delta:review:check`, and enforced `i18n:de:audit` continue to fail closed when their local evidence is absent or stale.
 
 For the active German workflow, `i18n:de:pilot` only verifies that the frozen Issue #601 Pilot/catalog artifacts and existing ignored confirmations still match their immutable source; do not regenerate or reinterpret that baseline during Issue #602. After a controlled runtime or copy change, refresh the canonical manifest and runtime activation manifest, generate/check the separate private 28-item delta form, then enforce `i18n:de:audit`. The delta binds 24 new messages, 2 modified baseline messages, and 2 external report-prose items to their English/Chinese/context/runtime evidence without exposing reviewer identity or decisions. The completed file stays under `.local/i18n-de-DE/`, is ignored, and must not be quoted or attached to GitHub. Any changed frozen input blocks carry-forward; any changed delta-bound copy, context, family, policy, or renderer requires a fresh delta review. Missing, malformed, or stale evidence remains a structural failure, and automated output never substitutes for human linguistic approval.
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -20,9 +20,9 @@ checkPaths:
   - docs/agents/repo-validation.md
   - tests/**
   - package.json
-lastReviewedAt: 2026-07-16
-lastReviewedCommit: a9524dbb33b272e1c5526f33a0b8c758e186d170
-lastReviewedNote: 'Added risk-proportional scoped-first proof and one final-checkpoint full gate without reopening gate-infrastructure strategy.'
+lastReviewedAt: 2026-07-17
+lastReviewedCommit: 8ad1c1692ccf2bdac8b06762cf840185ab7a55bb
+lastReviewedNote: 'Reviewed Issue #611 clean-runner recovery without reopening the long-term testing strategy.'
 ---
 
 # Testing Strategy
@@ -38,8 +38,10 @@ lastReviewedNote: 'Added risk-proportional scoped-first proof and one final-chec
 - shared validation adapters and helper modules should stay unit-heavy; do not expand wrapper-only branch testing unless the user-visible contract actually changes
 - data workflow smoke coverage should grow through paired data/result fixtures and workflow-lib unit proof only when the workflow phase or backend-facing assertion changes
 - localization quality should combine deterministic topology/context/hash gates with local human language/domain confirmation; Jest validates form integrity and privacy boundaries but never claims that an automated audit proves fluency
+- clean-runner localization tests should prove tracked structure with explicitly absent private forms, while generated temporary approvals separately cover the fail-closed local human-evidence path
 - proof should be risk-proportional and scoped-first: micro-edits use focused checks, coherent batches use subsystem audits, and the repository full gate runs once for the final committed controlled checkpoint
 - gate ownership should prevent duplicate work: a normal delivery uses the push hook as the single full-gate owner, while a no-push handoff may run it manually instead
+- each production release workflow should also have one full-suite owner: coverage-enabled `prepush:gate`, without a preceding duplicate `test:ci`
 
 ## Operating Principles
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -20,9 +20,9 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-07-16
-lastReviewedCommit: a9524dbb33b272e1c5526f33a0b8c758e186d170
-lastReviewedNote: 'Retained the checked-in full-closure reference and recorded the Issue #602 German runtime and single-final-gate execution state.'
+lastReviewedAt: 2026-07-17
+lastReviewedCommit: 8ad1c1692ccf2bdac8b06762cf840185ab7a55bb
+lastReviewedNote: 'Retained the checked-in reference and recorded Issue #611 clean-runner privacy and Node-bootstrap regression coverage.'
 ---
 
 # Testing Execution State
@@ -48,6 +48,9 @@ This is a checked-in reference, not a per-PR execution ledger. A delivery's post
 - locale topology, message ownership, ICU placeholders, and dynamic families are additionally protected by `npm run i18n:audit`
 - the active German runtime preserves the frozen Issue #601 approval snapshot and adds exact runtime-manifest assembly plus a hash-bound, ignored local Issue #602 delta check; the 24 new messages, 2 modified baseline messages, and 2 external-family decisions are reviewed as one 28-item delta without recording reviewer details in Git or GitHub
 - German structural proof uses `i18n:audit`, the frozen `i18n:de:pilot` check, `i18n:de:runtime:manifest:check`, `i18n:de:delta:review:check`, and final `i18n:de:audit`; focused proof stays in the edit loop and each delivery gets one post-commit full gate through `push:checked`
+- clean-checkout German suites inject missing private confirmation paths and require every tracked structural finding to stay at zero; generated temporary forms retain positive and fail-closed approval coverage without making `.local` a repository-gate input
+- pre-push receipt coverage includes a setup-node-style active Node 24 with an unusable NVM install, so runner bootstrap cannot exit before the repo-owned hook coordinator
+- the production Release Gate delegates the complete coverage-enabled suite to one `prepush:gate` step and no longer repeats all Jest tests through an earlier standalone `test:ci`
 - a failed managed transport may be retried without repeating the full gate only through the ignored, exact-intent, one-hour receipt and argument-free `npm run push:retry`; any controlled-input drift requires a fresh managed push and gate
 - dataset SDK validation adapters, shared localized validation helpers, and validation-report navigation now ride on the maintained full-closure baseline
 - data workflow smoke fixtures now pair `fixtures/data/**` input JSON with `fixtures/result/**` expected-result Markdown; the current relationship map is in `tests/data-workflows/fixtures/result/README.md`

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -21,9 +21,9 @@ checkPaths:
   - tests/helpers/**
   - tests/data-workflows/**
   - package.json
-lastReviewedAt: 2026-07-16
-lastReviewedCommit: a9524dbb33b272e1c5526f33a0b8c758e186d170
-lastReviewedNote: 'Added the active German runtime delta pattern and the managed, failure-activated final-push boundary.'
+lastReviewedAt: 2026-07-17
+lastReviewedCommit: 8ad1c1692ccf2bdac8b06762cf840185ab7a55bb
+lastReviewedNote: 'Added clean-runner German evidence separation and active-Node hook bootstrap coverage for Issue #611.'
 ---
 
 # Testing Patterns Reference
@@ -100,6 +100,11 @@ Special cases:
 10. keep structural and linguistic evidence distinct: `i18n:audit` proves locale topology/ICU ownership, the frozen Pilot check proves the inherited approval snapshot, and runtime-manifest/delta checks prove only the declared active assembly; human German and LCA/TIDAS judgment stays in ignored local evidence
 11. validate each edit with the narrowest proof that covers its risk; accumulate coherent German runtime work into batch audits rather than running lint, build, coverage, or the repository full gate for every message
 12. bind the repository full gate to the final committed controlled checkpoint and use `push:checked` so the ordinary hook owns that one execution; only a failed transport after successful gates may activate the exact-intent receipt consumed by argument-free `push:retry`
+13. keep clean-runner structure proof independent from ignored human evidence: inject a guaranteed-missing confirmation path, assert only the expected confirmation findings, and cover approved behavior with a generated private temporary form
+
+Gate-bootstrap pattern:
+
+- when a hook supports both `PATH` and a version manager, test the already-correct active runtime while the version-manager fallback is deliberately unusable; the hook must not replace a compatible runner-provided runtime
 
 ## Focused Command Shapes
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -20,9 +20,9 @@ checkPaths:
   - docs/agents/repo-validation.md
   - scripts/test-runner.cjs
   - package.json
-lastReviewedAt: 2026-07-16
-lastReviewedCommit: a9524dbb33b272e1c5526f33a0b8c758e186d170
-lastReviewedNote: 'Added active German runtime/delta recovery and bounded managed-push retry guidance.'
+lastReviewedAt: 2026-07-17
+lastReviewedCommit: 8ad1c1692ccf2bdac8b06762cf840185ab7a55bb
+lastReviewedNote: 'Added Issue #611 clean-runner provenance, private-evidence, and setup-node hook recovery guidance.'
 ---
 
 # Testing Troubleshooting
@@ -46,12 +46,15 @@ Canonical baseline and proof ownership stays with `DEV.md` and `docs/agents/repo
 | timeout or maximum update depth | loop in effect, stale mock, unresolved async state | narrow to one file, then inspect effect triggers and mocked promises |
 | auth or session flow failing | missing provider, missing auth mock, stale route state | reuse existing auth wrapper and compare against nearby passing tests |
 | element not found | query too early, wrong role/text, render path not reached | assert the prerequisite state first, then switch to semantic query |
+| a visible action exists but the expected request never starts | the control is present but still disabled while prerequisite data loads | wait for the control to become enabled, then interact; do not replace the product guard with an arbitrary delay |
 | mock not hit | wrong import path or mock order | verify module path and set mocks before importing the subject |
 | provider or context error | missing wrapper or wrong test utility | use the repo helper that already provides the required wrapper |
 | data workflow smoke assertion mismatch | `fixtures/data/**`, `fixtures/result/**`, workflow default path, or last-run artifact drifted apart | compare the case in `tests/data-workflows/fixtures/result/README.md`, then update the paired input fixture, expected-result Markdown, workflow lib default, and unit proof together |
 | one gate fails only while another Umi-generating command is running locally | concurrent focused tests, coverage, or full gate regenerated shared `.umi-test` | stop or await every heavy command, then rerun only the narrow failed command serially; do not chain broad test, coverage, and full-gate reruns |
 | local `docpact:gate` or manual `ai-doc-lint` fails with `missing-review` after runtime, service, or test changes | required governed docs were not reviewed in the same PR | rerun `npm run docpact:gate`, inspect the required docs from `.docpact/config.yaml`, and touch the owning docs with a real review/update |
 | `i18n:audit` reports missing, duplicate, or computed message IDs | locale topology drift, one key has multiple owners, or a runtime family is not enumerated | inspect the reported key and callsites, update the canonical manifest/decision record, then rerun the audit before translating or adding an allowlist |
+| canonical manifest is stale only because `origin/dev` advanced | an old checker resolved the moving ambient branch instead of the manifest's recorded source commit | run the fixed default `--check`, which validates the recorded commit and audited-input digest; use explicit `--base-ref` or `--write` only when intentionally advancing provenance |
+| clean CI reports missing German confirmation files | a repository test implicitly read ignored `.local` evidence | pass an explicit nonexistent path and assert the expected confirmation-only findings; keep approved-form coverage in generated private fixtures and never add the real form to CI |
 | frozen German Pilot check reports context or `offlineReviewConfirmation` drift | the inherited Issue #601 snapshot, context ledger, producer evidence, or ignored approval no longer matches its frozen source | stop runtime activation work and inspect the frozen English, Chinese, German, callsites, and approval hashes; do not regenerate or silently reinterpret the approved baseline |
 | active German runtime manifest is stale | a controlled locale, runtime-family, context, policy, or activation input changed after generation | inspect the diff, then run `npm run i18n:de:runtime:manifest:write` only after the controlled change is final and rerun the manifest check |
 | Issue #602 delta review is missing, malformed, or stale | the ignored local form is incomplete, its normalized body/hash changed, or the 24 new, 2 modified, and 2 external-family item boundaries no longer match | regenerate with `npm run i18n:de:delta:review:generate`, obtain fresh human approval for the entire 28-item body, and run `npm run i18n:de:delta:review:check`; never commit or upload reviewer details |
@@ -60,6 +63,7 @@ Canonical baseline and proof ownership stays with `DEV.md` and `docs/agents/repo
 | active `i18n:de:audit` reports frozen-snapshot, delta-inventory, descriptor-family, or assembly drift | the active catalog no longer equals the frozen baseline plus the declared reviewed delta, or one closed runtime family disagrees with its formatter/callsites | fix the structural mismatch without broadening the approved delta, refresh the runtime manifest, obtain new local delta approval only when its reviewed body changed, then rerun the narrow German gates |
 | managed push transport fails after both gates pass | `push:checked` activated the ignored exact-intent receipt and the remote may or may not have accepted the commit | run argument-free `npm run push:retry`; it succeeds idempotently when the exact SHA already arrived and otherwise retries only while the remote and all bound inputs remain unchanged |
 | raw push fails after its hook passed but no receipt exists | only `push:checked` can bind the original push intent and activate bounded recovery after a failed transport | run a fresh `npm run push:checked -- <normal-git-push-args>` so its ordinary hook re-establishes evidence; never use `--no-verify` or `HUSKY=0` manually |
+| every hook-driven receipt test exits before either fake gate on GitHub Ubuntu | the hook forced `nvm use 24` even though `setup-node` had already activated Node 24 outside NVM | verify the active Node major first, use it when already 24, and consult NVM only as a fallback |
 
 ## Open-Handle Playbook
 

--- a/docs/plans/i18n-de-DE/README.md
+++ b/docs/plans/i18n-de-DE/README.md
@@ -10,6 +10,7 @@ This directory contains tracked candidate, context, terminology, and structural 
 - Active #602 delta: 24 new app-owned message IDs, 2 modified baseline API-doc messages, and 2 bundle-external import-report prose items.
 - Final active topology: `en-US`, `zh-CN`, and the single `de-DE` bundle, each with 2,689 messages and the same 30-module spread order.
 - `runtime-activation-manifest.json` binds the immutable #601 Git snapshot, current three-locale manifest, exact ordered delta inventory, final count, adapter policy, dataset-language fallback, and tracked prose digests.
+- Canonical-manifest checks reuse the checked-in source commit by default; a later movement of `origin/dev` does not invalidate unchanged locale/callsite evidence. `--write` or an explicit `--base-ref` is required to advance that provenance.
 - The local #602 approval scope binds only those 28 review items, their relevant direct/dynamic callsite evidence, the two runtime descriptor maps, and the deterministic renderer contract. Refreshing a structural manifest after an unrelated production or unrelated dynamic-family change does not by itself invalidate an otherwise unchanged human approval.
 - The old Pilot and 2,665-message catalog confirmations remain local and valid only while their frozen tracked inputs match the #601 commit.
 - The separate 28-item #602 delta form is local and ignored; its checker currently reports the generic approved state without exposing reviewer identity, date, decisions, response digest, or per-item notes.
@@ -29,6 +30,8 @@ Activation proceeds in five checkpoints:
 5. run focused runtime proof, then the single final repository gate on the immutable delivery HEAD.
 
 A generated delta form without a valid local approval block is useful review material but never satisfies the human checkpoint. Structural report mode remains runnable in that state, while enforcement fails closed; the current local form satisfies the checker.
+
+Repository Jest and clean-release gates exercise that structural report boundary with explicit nonexistent confirmation paths. They require zero tracked structural findings and the expected missing-local-evidence findings; separate generated temporary forms prove approved behavior. No clean runner infers or claims human approval.
 
 ## Privacy and evidence boundary
 

--- a/docs/plans/i18n-de-DE/runtime-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/runtime-activation-manifest.json
@@ -242,7 +242,7 @@
       {
         "kind": "file",
         "path": "scripts/i18n/audit-locales.mjs",
-        "sha256": "71788d1b91cddbf8941dc5544cf635e89f6e1e9ef739f1f9b91385f83f9d7cd7"
+        "sha256": "79f5200ef8baeaeff2ab47ee9906d3c240752e31720ace80137a2c0c89ea5ed3"
       },
       {
         "kind": "file",
@@ -420,6 +420,6 @@
         "sha256": "0c414199c5f5937821c9c35edaa5f6e23c079711f102011dfa11bfeb2bf3602b"
       }
     ],
-    "inputDigest": "bcd6dd8de7c11da355e9515c244a01ea1a1c5bd69c58c7017af640bf75c02b58"
+    "inputDigest": "8adf8d543b068f162be2a2de1af3ef26c375c70f2e539cdbab1713d12b878abc"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.46",
+      "version": "0.0.47",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",

--- a/scripts/i18n/audit-locales.mjs
+++ b/scripts/i18n/audit-locales.mjs
@@ -55,7 +55,8 @@ Options:
   --refresh-decisions      replace the generated decision register (requires --write)
   --check                  fail if the checked-in manifest differs from current output
   --root <path>            repository root (default: current working directory)
-  --base-ref <ref>         commit/ref recorded as the audited baseline (default: origin/dev)
+  --base-ref <ref>         commit/ref recorded as the audited baseline (default on write: origin/dev;
+                           check reuses checked-in provenance unless this option is explicit)
   --manifest <path>        manifest path relative to root
   --decisions <path>       decision-register path relative to root
   --dynamic-registry <path>
@@ -72,6 +73,7 @@ function parseArgs(argv) {
     check: false,
     root: process.cwd(),
     baseRef: 'origin/dev',
+    baseRefExplicit: false,
     manifest: DEFAULT_MANIFEST,
     decisions: DEFAULT_DECISIONS,
     dynamicRegistry: DEFAULT_DYNAMIC_REGISTRY,
@@ -106,6 +108,7 @@ function parseArgs(argv) {
         '--dynamic-registry': 'dynamicRegistry',
       }[argument];
       options[key] = value;
+      if (key === 'baseRef') options.baseRefExplicit = true;
     } else throw new Error(`Unknown argument: ${argument}`);
   }
   if (!['report', 'enforce'].includes(options.mode))
@@ -1006,7 +1009,7 @@ function auditInputDigest(root, paths) {
   return hash.digest('hex');
 }
 
-function buildManifest(root, baseRef, dynamicRegistryPath) {
+function buildManifest(root, baseRef, dynamicRegistryPath, pinnedBaseCommit = null) {
   const scanErrors = [];
   const unsupportedSyntax = [];
   const invalidIcuMessages = [];
@@ -1275,10 +1278,12 @@ function buildManifest(root, baseRef, dynamicRegistryPath) {
     Object.entries(findings).map(([key, values]) => [key, values.length]),
   );
   const violationCount = Object.values(violationCounts).reduce((sum, value) => sum + value, 0);
-  const baseCommit = execFileSync('git', ['rev-parse', '--verify', `${baseRef}^{commit}`], {
-    cwd: root,
-    encoding: 'utf8',
-  }).trim();
+  const baseCommit =
+    pinnedBaseCommit ??
+    execFileSync('git', ['rev-parse', '--verify', `${baseRef}^{commit}`], {
+      cwd: root,
+      encoding: 'utf8',
+    }).trim();
   const auditedInputPaths = [
     dynamicRegistry.path ?? dynamicRegistryPath,
     ...runtime.sourceFiles,
@@ -1500,10 +1505,53 @@ function writeFileEnsuringDirectory(filePath, content) {
   fs.writeFileSync(filePath, content);
 }
 
+function resolveBaseProvenance(options, manifestPath) {
+  if (options.check && !options.baseRefExplicit && fs.existsSync(manifestPath)) {
+    const checkedManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    const baseRef = checkedManifest?.source?.baseRef;
+    const baseCommit = checkedManifest?.source?.baseCommit;
+    if (typeof baseRef !== 'string' || !/^[0-9a-f]{40}$/u.test(baseCommit ?? '')) {
+      throw new Error('The checked-in manifest has invalid source base provenance.');
+    }
+    const resolvedCommit = execFileSync(
+      'git',
+      ['rev-parse', '--verify', `${baseCommit}^{commit}`],
+      {
+        cwd: options.root,
+        encoding: 'utf8',
+      },
+    ).trim();
+    if (resolvedCommit !== baseCommit) {
+      throw new Error('The checked-in manifest source commit does not resolve exactly.');
+    }
+    try {
+      execFileSync('git', ['merge-base', '--is-ancestor', baseCommit, 'HEAD'], {
+        cwd: options.root,
+        stdio: 'ignore',
+      });
+    } catch {
+      throw new Error('The checked-in manifest source commit must remain an ancestor of HEAD.');
+    }
+    return { baseRef, baseCommit };
+  }
+
+  const baseCommit = execFileSync('git', ['rev-parse', '--verify', `${options.baseRef}^{commit}`], {
+    cwd: options.root,
+    encoding: 'utf8',
+  }).trim();
+  return { baseRef: options.baseRef, baseCommit };
+}
+
 async function main() {
   const options = parseArgs(process.argv.slice(2));
-  const manifest = buildManifest(options.root, options.baseRef, options.dynamicRegistry);
   const manifestPath = path.resolve(options.root, options.manifest);
+  const baseProvenance = resolveBaseProvenance(options, manifestPath);
+  const manifest = buildManifest(
+    options.root,
+    baseProvenance.baseRef,
+    options.dynamicRegistry,
+    baseProvenance.baseCommit,
+  );
   const manifestText = await prettier.format(JSON.stringify(manifest), {
     ...(await prettier.resolveConfig(manifestPath)),
     filepath: manifestPath,

--- a/tests/unit/config/lciaCacheReleaseGate.test.ts
+++ b/tests/unit/config/lciaCacheReleaseGate.test.ts
@@ -21,9 +21,11 @@ describe('LCIA cache publication gates', () => {
       workflow.indexOf('  release-draft:'),
     );
     expect(releaseGate).toContain('run: npm run lcia-cache:verify');
+    expect(releaseGate).toContain('run: npm run prepush:gate');
     expect(releaseGate.indexOf('npm run lcia-cache:verify')).toBeLessThan(
-      releaseGate.indexOf('npm run test:ci'),
+      releaseGate.indexOf('npm run prepush:gate'),
     );
+    expect(releaseGate).not.toContain('run: npm run test:ci');
 
     const webDeploy = workflow.slice(
       workflow.indexOf('  web-deploy:'),

--- a/tests/unit/i18n/auditLocalesCli.test.ts
+++ b/tests/unit/i18n/auditLocalesCli.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -216,6 +216,90 @@ describe('locale audit CLI schema defaults', () => {
           ]),
         }),
       ]);
+    } finally {
+      fs.rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('keeps check provenance pinned when the ambient base branch moves', () => {
+    const root = initializeAuditFixture();
+    const manifestPath = path.join(root, 'manifest.json');
+    const gitEnvironment = createIsolatedGitEnvironment();
+    const git = (args: string[]) =>
+      execFileSync('git', args, { cwd: root, encoding: 'utf8', env: gitEnvironment }).trim();
+    const runAudit = (args: string[]) =>
+      spawnSync(process.execPath, [AUDIT_SCRIPT, '--root', root, ...args], {
+        encoding: 'utf8',
+        env: gitEnvironment,
+      });
+
+    try {
+      const originalBase = git(['rev-parse', 'HEAD']);
+      git(['update-ref', 'refs/remotes/origin/dev', originalBase]);
+      const written = runAudit([
+        '--base-ref',
+        'origin/dev',
+        '--mode',
+        'report',
+        '--write',
+        '--manifest',
+        manifestPath,
+      ]);
+      expect(written.status).toBe(0);
+
+      writeFixtureFile(root, 'unrelated.txt', 'unrelated checkpoint\n');
+      git(['add', 'unrelated.txt']);
+      git([
+        '-c',
+        'user.name=Locale Audit Test',
+        '-c',
+        'user.email=locale-audit@example.invalid',
+        'commit',
+        '--quiet',
+        '-m',
+        'unrelated checkpoint',
+      ]);
+      const movedBase = git(['rev-parse', 'HEAD']);
+      git(['update-ref', 'refs/remotes/origin/dev', movedBase]);
+
+      const pinnedCheck = runAudit(['--mode', 'report', '--check', '--manifest', manifestPath]);
+      expect(pinnedCheck.status).toBe(0);
+      expect(JSON.parse(pinnedCheck.stdout)).toEqual(
+        expect.objectContaining({
+          staleManifest: false,
+          source: expect.objectContaining({
+            baseRef: 'origin/dev',
+            baseCommit: originalBase,
+          }),
+        }),
+      );
+
+      const explicitMovingCheck = runAudit([
+        '--base-ref',
+        'origin/dev',
+        '--mode',
+        'report',
+        '--check',
+        '--manifest',
+        manifestPath,
+      ]);
+      expect(explicitMovingCheck.status).toBe(1);
+      expect(JSON.parse(explicitMovingCheck.stdout).staleManifest).toBe(true);
+
+      writeFixtureFile(
+        root,
+        'src/locales/de-DE.ts',
+        "export default { 'fixture.schema.required': 'Geänderter Validierungshinweis' };\n",
+      );
+      const auditedInputCheck = runAudit([
+        '--mode',
+        'report',
+        '--check',
+        '--manifest',
+        manifestPath,
+      ]);
+      expect(auditedInputCheck.status).toBe(1);
+      expect(JSON.parse(auditedInputCheck.stdout).staleManifest).toBe(true);
     } finally {
       fs.rmSync(root, { force: true, recursive: true });
     }

--- a/tests/unit/i18n/germanReviewWorkflow.test.ts
+++ b/tests/unit/i18n/germanReviewWorkflow.test.ts
@@ -83,10 +83,19 @@ function computeBodyDigest(file: string) {
 
 describe('German local human-review workflow', () => {
   it('builds a complete 90-message offline pilot scope without GitHub evidence fields', () => {
+    const missingConfirmation = `.local/i18n-de-DE/missing-pilot-${process.pid}-${Date.now()}.md`;
     const report = JSON.parse(
       execFileSync(
         process.execPath,
-        [FROZEN_REVIEW_SCRIPT, '--scope', 'pilot', '--mode', 'report'],
+        [
+          FROZEN_REVIEW_SCRIPT,
+          '--scope',
+          'pilot',
+          '--mode',
+          'report',
+          '--confirmation',
+          missingConfirmation,
+        ],
         {
           cwd: REPOSITORY_ROOT,
           encoding: 'utf8',
@@ -101,12 +110,13 @@ describe('German local human-review workflow', () => {
         schemaVersion: 'tiangong.i18n-de-frozen-review-check.v1',
         scope: 'pilot',
         snapshotMatches: true,
-        approved: true,
+        approved: false,
         counts: {
           pilotMessages: 90,
           blockedContextProposals: 9,
           blockedGlossaryTerms: 2,
         },
+        reasons: ['Local confirmation file is missing.'],
       }),
     );
     expect(pack.schemaVersion).toBe('tiangong.i18n-de-pilot-review-pack.v6');

--- a/tests/unit/i18n/germanRuntimeActivation.test.ts
+++ b/tests/unit/i18n/germanRuntimeActivation.test.ts
@@ -45,12 +45,27 @@ function approve(markdown: string, reviewer: string) {
 
 describe('German active-runtime evidence', () => {
   it('binds the immutable baseline, exact delta, and one active German locale without human data', () => {
+    const missingCatalogConfirmation = `.local/i18n-de-DE/missing-catalog-${process.pid}-${Date.now()}.md`;
+    const missingDeltaConfirmation = `.local/i18n-de-DE/missing-delta-${process.pid}-${Date.now()}.md`;
     const report = JSON.parse(
-      execFileSync(process.execPath, [ACTIVATION_SCRIPT, '--mode', 'report', '--check'], {
-        cwd: REPOSITORY_ROOT,
-        encoding: 'utf8',
-        maxBuffer: 20 * 1024 * 1024,
-      }),
+      execFileSync(
+        process.execPath,
+        [
+          ACTIVATION_SCRIPT,
+          '--mode',
+          'report',
+          '--check',
+          '--catalog-confirmation',
+          missingCatalogConfirmation,
+          '--delta-confirmation',
+          missingDeltaConfirmation,
+        ],
+        {
+          cwd: REPOSITORY_ROOT,
+          encoding: 'utf8',
+          maxBuffer: 20 * 1024 * 1024,
+        },
+      ),
     );
     const manifest = JSON.parse(fs.readFileSync(RUNTIME_MANIFEST, 'utf8'));
 
@@ -60,14 +75,24 @@ describe('German active-runtime evidence', () => {
         newMessageCount: 24,
         modifiedBaselineMessageCount: 2,
         finalMessageCount: 2689,
-        baselineCatalogReviewApproved: true,
+        baselineCatalogReviewApproved: false,
+        deltaReviewApproved: false,
       }),
     );
-    const nonDeltaFindingCounts = Object.entries(report.summary.findingCounts)
-      .filter(([category]) => category !== 'deltaReviewConfirmation')
+    const structuralFindingCounts = Object.entries(report.summary.findingCounts)
+      .filter(
+        ([category]) =>
+          !['baselineCatalogConfirmation', 'deltaReviewConfirmation'].includes(category),
+      )
       .map(([, count]) => count);
-    expect(nonDeltaFindingCounts.every((count) => count === 0)).toBe(true);
-    expect(report.summary.findingCount).toBe(report.summary.findingCounts.deltaReviewConfirmation);
+    expect(structuralFindingCounts.every((count) => count === 0)).toBe(true);
+    expect(report.summary.findingCounts).toEqual(
+      expect.objectContaining({
+        baselineCatalogConfirmation: 1,
+        deltaReviewConfirmation: 1,
+      }),
+    );
+    expect(report.summary.findingCount).toBe(2);
     expect(manifest.baseline).toEqual(
       expect.objectContaining({
         sourceCommit: '826f87a53032bfa9ab58baff2e4b8b7212671cdf',

--- a/tests/unit/pages/Processes/Analysis/index.test.tsx
+++ b/tests/unit/pages/Processes/Analysis/index.test.tsx
@@ -654,7 +654,9 @@ describe('LcaAnalysisPage', () => {
     });
     render(<LcaAnalysisPage />);
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Load LCIA profile' }));
+    const loadProfileButton = await screen.findByRole('button', { name: 'Load LCIA profile' });
+    await waitFor(() => expect(loadProfileButton).toBeEnabled());
+    fireEvent.click(loadProfileButton);
 
     expect(await screen.findByText('snapshot-with-evidence')).toBeInTheDocument();
     expect(await screen.findByTestId('calculation-evidence-notice')).toHaveTextContent(

--- a/tests/unit/scripts/prepushGateReceipt.test.ts
+++ b/tests/unit/scripts/prepushGateReceipt.test.ts
@@ -302,6 +302,50 @@ describe('bounded checked-push transport receipt', () => {
     expect(fixtureEnvironment).not.toHaveProperty('GIT_WORK_TREE');
   });
 
+  it('uses an already-active Node 24 without requiring an NVM-managed install', () => {
+    expect(process.versions.node.split('.')[0]).toBe('24');
+    const current = fixture();
+    const fakeHome = path.join(current.container, 'home');
+    writeExecutable(
+      path.join(fakeHome, '.nvm/nvm.sh'),
+      "#!/bin/sh\nnvm() { echo 'fixture nvm must not be used' >&2; return 42; }\n",
+    );
+
+    const result = checkedPush(current, 'refs/heads/main', {
+      HOME: fakeHome,
+      NVM_DIR: path.join(fakeHome, '.nvm'),
+    });
+
+    expect({ status: result.status, stdout: result.stdout, stderr: result.stderr }).toEqual(
+      expect.objectContaining({ status: 0 }),
+    );
+    expect(readGateLog(current)).toHaveLength(2);
+    expect(remoteSha(current)).toBe(current.head);
+  });
+
+  it('fails clearly when neither PATH nor NVM can provide Node 24', () => {
+    const current = fixture();
+    const fakeHome = path.join(current.container, 'home');
+    const fakeBin = path.join(current.container, 'fake-bin');
+    writeExecutable(path.join(fakeBin, 'node'), '#!/bin/sh\nexit 1\n');
+    writeExecutable(path.join(fakeHome, '.nvm/nvm.sh'), '#!/bin/sh\nnvm() { return 42; }\n');
+
+    const result = run(
+      current.root,
+      path.join(current.root, '.husky/pre-push'),
+      ['origin', current.remote],
+      {
+        HOME: fakeHome,
+        NVM_DIR: path.join(fakeHome, '.nvm'),
+        PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Node.js 24 is required for the pre-push gate.');
+    expect(readGateLog(current)).toEqual([]);
+  });
+
   it('does not activate a receipt after managed success, even if the remote is rolled back', () => {
     const current = fixture();
 


### PR DESCRIPTION
## Summary

- restores the German UI production release path after the v0.0.46 Release Gate failed on a clean GitHub runner
- bumps the immutable recovery version to 0.0.47; v0.0.46 remains untouched
- makes the pre-push hook accept setup-node Node 24 without requiring an NVM-managed install
- separates private local human approvals from reproducible clean-runner German audits while preserving fail-closed authoring checks
- pins default locale audit checks to the recorded immutable provenance, stabilizes the Analysis test, and removes the duplicate standalone test:ci from the production workflow

## Validation

Final managed gate ran against immutable range 8ad1c1692ccf2bdac8b06762cf840185ab7a55bb..8fc999ae8af5d09f085a8587e609931601bfbb84 and passed before the branch was pushed:

- Docpact strict config: 13 rules, 0 problems
- Docpact lint: 22 changed paths, 21 matched rules, coverage and freshness OK
- LCIA cache: valid, 25 methods, 0 errors
- ESLint, deprecated API lint, Prettier, and TypeScript: passed
- Jest coverage: 361 suites and 4567 tests passed
- coverage: statements 24026/24026, branches 15406/15406, functions 5416/5416, lines 23071/23071
- full coverage owner: 402/402 tracked source files at 100/100/100/100

The first attempted transport used an unnecessary DOCPACT_BASE_REF override and exposed test-environment inheritance; a later attempt was interrupted by the SSH connection idle timeout. Neither attempt changed tracked state or reached the remote. The successful managed gate used the repository automatic hotfix-to-main baseline selection plus SSH keepalive on the same immutable commit.

## Release and integration contract

- this PR targets main as an M2 production hotfix and requires separate merge authorization
- merging should create v0.0.47 and start the production Build/release workflow
- do not move or reuse v0.0.46
- after v0.0.47 succeeds, backmerge main into dev
- workspace issue tiangong-lca/workspace#404 remains blocked until the successful exact main release SHA is known
- completed human review forms and reviewer identity remain local-only and are not committed or copied into GitHub

## Risk and rollback

The changes are limited to release-gate portability, reproducible audit/test boundaries, one test timing wait, version metadata, and removal of a redundant full Jest invocation. If the release fails, do not retag; diagnose under a new tracked patch release.

Closes #611