### PR TITLE
chore: prepare v0.0.48 release

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-07-17'
-lastReviewedCommit: '8ad1c1692ccf2bdac8b06762cf840185ab7a55bb'
-lastReviewedNote: 'Reviewed Issue #611 clean-runner release recovery; test-gate and i18n script ownership remain correctly covered by the existing rule graph.'
+lastReviewedCommit: 'ba30c48a4157e5a30e3ab57b23263ae021923668'
+lastReviewedNote: 'Reviewed the v0.0.48 version-only release checkpoint; ownership, routing, and the test-gate rule graph are unchanged.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: f6f5cfaf79361e58dd20a01b5b3108a4e3eb4f56
-lastReviewedNote: 'Reviewed Issue #606 Calculation Bundle and Release-read UI after merging the Issue #611 clean-runner release-gate recovery; repo ownership, branch facts, and hard boundaries are unchanged.'
+lastReviewedCommit: f86df7f273c4975a66bd04d74181ca8f31224979
+lastReviewedNote: 'Reviewed the v0.0.48 version-only release checkpoint; repo ownership, branch facts, release automation, and hard boundaries are unchanged.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,8 +21,8 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: f6f5cfaf79361e58dd20a01b5b3108a4e3eb4f56
-lastReviewedNote: 'Reviewed Issue #606 against the active German delta workflow and the Issue #611 clean-runner Node 24 bootstrap; the shortest managed final-push loop is unchanged.'
+lastReviewedCommit: f86df7f273c4975a66bd04d74181ca8f31224979
+lastReviewedNote: 'Reviewed the v0.0.48 version-only release checkpoint; bootstrap commands and the shortest managed final-push loop are unchanged.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -24,8 +24,8 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: f6f5cfaf79361e58dd20a01b5b3108a4e3eb4f56
-lastReviewedNote: 'Reviewed Issue #606 merge and retry handling with the Issue #611 clean-runner Node 24 bootstrap; hook ownership, full-coverage policy, and bounded managed-push recovery are unchanged.'
+lastReviewedCommit: ba30c48a4157e5a30e3ab57b23263ae021923668
+lastReviewedNote: 'Reviewed the v0.0.48 version-only release checkpoint; hook ownership, full-coverage policy, and bounded managed-push recovery are unchanged.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -23,8 +23,8 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: f6f5cfaf79361e58dd20a01b5b3108a4e3eb4f56
-lastReviewedNote: 'Retained focused Calculation Bundle and Release-read proof while adapting the Issue #606 48-message German delta to the Issue #611 clean-runner and setup-node-compatible gate.'
+lastReviewedCommit: ba30c48a4157e5a30e3ab57b23263ae021923668
+lastReviewedNote: 'Reviewed the v0.0.48 version-only release checkpoint; Calculation Bundle, Release-read, German delta, and clean-runner proof requirements are unchanged.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: f6f5cfaf79361e58dd20a01b5b3108a4e3eb4f56
-lastReviewedNote: 'Retained Issue #606 service/read-panel and scoped-first proof while adopting the Issue #611 clean-runner recovery, without reopening the long-term testing strategy.'
+lastReviewedCommit: ba30c48a4157e5a30e3ab57b23263ae021923668
+lastReviewedNote: 'Reviewed the v0.0.48 version-only release checkpoint without reopening the long-term testing strategy.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: f6f5cfaf79361e58dd20a01b5b3108a4e3eb4f56
-lastReviewedNote: 'Retained the checked-in full-closure reference and recorded Issue #606 release proof together with Issue #611 clean-runner privacy and Node-bootstrap regression coverage.'
+lastReviewedCommit: ba30c48a4157e5a30e3ab57b23263ae021923668
+lastReviewedNote: 'Reviewed the v0.0.48 version-only release checkpoint; the checked-in full-closure reference and current execution state are unchanged.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,8 +22,8 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: f6f5cfaf79361e58dd20a01b5b3108a4e3eb4f56
-lastReviewedNote: 'Retained Issue #606 transport, integrity, component, and 48-message delta proof while adopting Issue #611 clean-runner evidence separation and active-Node hook coverage.'
+lastReviewedCommit: ba30c48a4157e5a30e3ab57b23263ae021923668
+lastReviewedNote: 'Reviewed the v0.0.48 version-only release checkpoint; testing, localization, and managed-push patterns are unchanged.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: f6f5cfaf79361e58dd20a01b5b3108a4e3eb4f56
-lastReviewedNote: 'Retained Issue #606 focused-suite and active-delta recovery guidance while adopting Issue #611 clean-runner provenance, private-evidence, and setup-node hook recovery.'
+lastReviewedCommit: ba30c48a4157e5a30e3ab57b23263ae021923668
+lastReviewedNote: 'Reviewed the v0.0.48 version-only release checkpoint; focused-test, localization, and managed-push recovery guidance is unchanged.'
 ---
 
 # Testing Troubleshooting

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.47",
+      "version": "0.0.48",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
## Summary

- bump the Next release version from `0.0.47` to `0.0.48`
- keep `package.json` and `package-lock.json` aligned
- record the required Docpact review of the unchanged release and test-gate contracts

This PR prepares the version consumed by the canonical `main` release workflow. It does not deploy production by itself.

## Validation

- Node.js `v24.16.0`
- `npm run lint`
- managed `npm run push:checked -- -u fork codex/issue-606-release-v0.0.48`
- Docpact strict validation and enforced lint: passed
- LCIA static cache verification: passed
- Jest coverage: 364 suites and 4,584 tests passed
- coverage assertion: 404/404 tracked source files at 100% statements, branches, functions, and lines

No live environment was changed by this PR.

## Release Gate

The private 48-message German/LCA human review required by #606 remains a separate production-promotion decision and stays outside Git and GitHub.

Refs #606