### PR TITLE
fix: verify and save calculation bundle downloads

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-07-17'
-lastReviewedCommit: '7e2c5267aa1ee87e5c3986ea7cdf8ffb4b5fd0ea'
+lastReviewedCommit: 'cc66ad9a4084063b3fea7659bb4271303a88ba2e'
 lastReviewedNote: 'Reviewed Issue #614 text-only selector and the V8-safe single-worker coverage model; testing and gate ownership remain covered by the existing rule graph.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: 7e2c5267aa1ee87e5c3986ea7cdf8ffb4b5fd0ea
+lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
 lastReviewedNote: 'Reviewed Issue #614 shared text-only language selector; repo ownership, branch facts, and hard boundaries are unchanged.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -21,7 +21,7 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: 7e2c5267aa1ee87e5c3986ea7cdf8ffb4b5fd0ea
+lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
 lastReviewedNote: 'Reviewed Issue #614 focused UI proof and managed final-push flow; validation commands and gate ownership are unchanged.'
 ---
 

--- a/docs/agents/lcia-calculation-evidence.md
+++ b/docs/agents/lcia-calculation-evidence.md
@@ -27,8 +27,8 @@ checkPaths:
   - src/services/processes/api.ts
   - .github/workflows/ci.yml
   - .github/workflows/build.yml
-lastReviewedAt: 2026-07-16
-lastReviewedCommit: e112fa85f4138b5094c965bd010825d8267ee75d
+lastReviewedAt: 2026-07-17
+lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
 lastReviewedNote: 'Added the persisted Calculation Bundle and canonical release readback contract for Issue #606 without changing the reviewed static LCIA method bundle.'
 ---
 
@@ -85,6 +85,8 @@ Both normal listing and keyword search use that exact database predicate. This s
 ## Persisted Calculation Bundle And Release Readback
 
 `tiangong.calculation-bundle.v1` is the private, package-level read model for Worker-produced LCI, LCIA, coverage, and calculation evidence. Data Processing loads it by package identity through the authenticated user session. It does not reconstruct LCI or LCIA in the browser. Process-axis and fixed process-range artifacts select the exact records to display; parsed preview artifacts must match their declared byte size and SHA-256 before their NDJSON is trusted. Oversized chunks remain downloadable evidence and are not parsed inline.
+
+Raw Calculation Bundle downloads use the same fail-closed boundary: each click resolves a fresh authenticated bundle projection, requires its path, media type, stored byte size, and SHA-256 to match the already displayed immutable metadata, fetches the short-lived signed URL without credentials, and only then exposes a local Blob for saving. A `401`, `403`, `404`, or `410` object response refreshes the projection once and retries; other network, size, or digest failures create no local file. The UI must not rely on cross-origin `<a download>` behavior, because browsers may navigate to the signed object instead of downloading it, and keeps a failed action visible for manual secure-link refresh.
 
 Published release readback is a separate sanitized projection. It becomes anonymously readable only when Database marks one release current and Edge exposes its release, validation, artifact, and source-Process identity projection. A source Process maps to the exact Unit Process plus generated LifecycleModel and Result Process UUID/version identities. The Unit Process package remains result-free; the Model/Result package carries the LCI exchanges and LCIA results without changing TIDAS schema.
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -24,7 +24,7 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: 7e2c5267aa1ee87e5c3986ea7cdf8ffb4b5fd0ea
+lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
 lastReviewedNote: 'Reviewed Issue #614 selector proof and the V8-safe single-worker recycle boundary; single full-gate ownership and 100% src coverage remain unchanged.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: 7e2c5267aa1ee87e5c3986ea7cdf8ffb4b5fd0ea
+lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
 lastReviewedNote: 'Reviewed Issue #614 text-only language options across the shared login and application-header selector; architecture and ownership boundaries are unchanged.'
 related:
   - ../AGENTS.md
@@ -102,7 +102,7 @@ The public release read paths are:
 
 `src/pages/Processes/Components/view.tsx -> src/components/LcaReleaseReadPanel/index.tsx -> src/services/lcaReleases/api.ts -> public current Process projection`
 
-Next owns read orchestration, exact UUID/version deep links, directional LCI/LCIA rendering, integrity checks before parsing preview artifacts, and fresh signed-download requests. The Calculation Bundle read requires the current user session. A public release projection may be anonymous only after Database and Edge expose it as the current published release. Next never approves or publishes a release, receives a service-role credential, or treats a private storage locator as public data.
+Next owns read orchestration, exact UUID/version deep links, directional LCI/LCIA rendering, integrity checks before parsing preview artifacts or saving raw Calculation Bundle downloads, and fresh signed-download requests. Verified raw downloads are saved through a local Blob instead of a cross-origin download anchor. The Calculation Bundle read requires the current user session. A public release projection may be anonymous only after Database and Edge expose it as the current published release. Next never approves or publishes a release, receives a service-role credential, or treats a private storage locator as public data.
 
 ## Current Hotspots
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -23,7 +23,7 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: 7e2c5267aa1ee87e5c3986ea7cdf8ffb4b5fd0ea
+lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
 lastReviewedNote: 'Reviewed Issue #614 selector proof and the V8-safe single-worker Jest gate; the complete test inventory and 100% src coverage bar remain authoritative.'
 related:
   - ../AGENTS.md
@@ -64,7 +64,7 @@ npm run prepush:gate
 | --- | --- | --- | --- |
 | routes, pages, app runtime, shared UI | `npm run lint`; focused `npm run test:ci -- <jest-args>`; `npm run build` | `npm run prepush:gate` | shared UX changes often affect multiple entrypoints |
 | services or env selection | `npm run lint`; focused `npm run test:ci -- <jest-args>`; `npm run build` | `npm run prepush:gate` | companion proof may live in another repo if schema or Edge runtime changed |
-| persisted Calculation Bundle or public release readback | `npm run lint`; focused `lcaReleases`, `CalculationBundlePanel`, `LcaReleaseReadPanel`, Data Processing, Process view, and locale tests; `npm run i18n:audit`; `npm run build` | `npm run prepush:gate`; paired Database RPC, Edge projection, Worker bundle, and deterministic package proof; live smoke only when a deployed environment and user credentials are available | private bundle reads use the user session; public release reads expose sanitized projections and short-lived artifact downloads only |
+| persisted Calculation Bundle or public release readback | `npm run lint`; focused `lcaReleases`, `CalculationBundlePanel`, `LcaReleaseReadPanel`, Data Processing, Process view, and locale tests; `npm run i18n:audit`; `npm run build` | `npm run prepush:gate`; paired Database RPC, Edge projection, Worker bundle, and deterministic package proof; live smoke only when a deployed environment and user credentials are available | private bundle reads use the user session; raw downloads must verify stored byte size and SHA-256 before Blob save; public release reads expose sanitized projections and short-lived artifact downloads only |
 | process review-submit gate/job UI or service contract | `npm run lint`; focused review/gate/job tests such as `npm run test:ci -- tests/unit/services/workerJobs/api.test.ts tests/unit/services/reviews/taskCenter.test.ts tests/unit/components/LcaTaskCenter.test.tsx tests/unit/services/reviews/api.test.ts tests/unit/utils/review.test.ts tests/unit/pages/Processes/Components/edit.test.tsx --runInBand --testTimeout=30000`; `npm run build` | smoke `app_worker_jobs`, `app_dataset_review_submit_jobs`, the worker, and final process submit-review against a safe dev environment when credentials and a queued job are available | Next must render backend job states and gate evidence, enqueue/read submit jobs instead of calling final submit-review from the browser, recover task-center state from service-backed worker jobs, prefer the canonical root `review_submit.submit` worker job for task identity/actions, and avoid duplicating worker blocker heuristics or browser-authoritative checksum logic. |
 | reviewed LCIA bundle under `public/lciamethods/**` or its validator | `npm run lcia-cache:verify`; `npm run lint`; focused LCIA cache/evidence tests; `npm run build` | `npm run prepush:gate` | verification must run before any web or Electron publication |
 | other static bundles under `public/**` | `npm run lint`; `npm run build` | focused tests near the consuming feature | check both the asset and its readers |

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -19,8 +19,8 @@ checkPaths:
   - config/supabaseEnv.ts
   - src/services/**
   - docker/**
-lastReviewedAt: 2026-07-16
-lastReviewedCommit: 3b716e00577a5fc4e235b65d71f9a0c15082a034
+lastReviewedAt: 2026-07-17
+lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
 lastReviewedNote: 'Reviewed Issue #606 release reads: Next keeps user-session and anonymous public projections in src/services/lcaReleases without taking schema, publication, or service-role ownership.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,7 +21,7 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: 7e2c5267aa1ee87e5c3986ea7cdf8ffb4b5fd0ea
+lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
 lastReviewedNote: 'Reviewed Issue #614 selector proof and the V8-safe single-worker recycle boundary; the full-closure strategy and quality bar remain unchanged.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: 7e2c5267aa1ee87e5c3986ea7cdf8ffb4b5fd0ea
+lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
 lastReviewedNote: 'Reviewed Issue #614 selector coverage and the V8-safe single-worker recycle boundary; full closure remains intact with no new queue.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,7 +22,7 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: 7e2c5267aa1ee87e5c3986ea7cdf8ffb4b5fd0ea
+lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
 lastReviewedNote: 'Reviewed Issue #614 component proof and the V8-safe single-worker recycle pattern for long-running coverage.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: 7e2c5267aa1ee87e5c3986ea7cdf8ffb4b5fd0ea
+lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
 lastReviewedNote: 'Reviewed Issue #614 selector smoke and the confirmed macOS Node/V8 native GC crash; added the supported single-worker recycle recovery.'
 ---
 

--- a/docs/plans/i18n-de-DE/runtime-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/runtime-activation-manifest.json
@@ -191,7 +191,7 @@
   },
   "source": {
     "canonicalManifest": "docs/plans/i18n-de-DE/manifest.json",
-    "canonicalAuditedInputDigest": "e09825c1df69ab6146397e6efb698b106faffbad198897d07e922a15df1e0d6c",
+    "canonicalAuditedInputDigest": "551fd1097df11b681178f2eda268fc91ade15ef6c0fbac6234f25ef5916112f8",
     "digestAlgorithm": "sha256",
     "inputs": [
       {
@@ -219,7 +219,7 @@
       {
         "kind": "file",
         "path": "docs/plans/i18n-de-DE/manifest.json",
-        "sha256": "38f297699de956b74144c7c6e1362ea29727c051840522875264174c64de2c32"
+        "sha256": "5da78632fb333868eaed6ce25ecca840fa3ae2ff51d4ef5e1a6f27d978b41a53"
       },
       {
         "kind": "file",
@@ -412,6 +412,6 @@
         "sha256": "0c414199c5f5937821c9c35edaa5f6e23c079711f102011dfa11bfeb2bf3602b"
       }
     ],
-    "inputDigest": "50fc68e13579bc81839d3fa7543c67261743566da44bf5b0f1a202fc7e176cdf"
+    "inputDigest": "5486eff026b804d30a3ee718687877c57359d70b2e3c927f5cb6d62faa63facd"
   }
 }

--- a/src/pages/DataProcessing/CalculationBundlePanel.tsx
+++ b/src/pages/DataProcessing/CalculationBundlePanel.tsx
@@ -1,12 +1,14 @@
 import {
   fetchCalculationBundleArtifactText,
   fetchCalculationBundleRecords,
+  fetchFreshCalculationBundleDownloadBlob,
   getCalculationBundle,
   type CalculationBundleArtifact,
   type CalculationBundleLciRecord,
   type CalculationBundleLciaRecord,
   type CalculationBundleProcessRecord,
   type CalculationBundleProjection,
+  type CalculationBundleSignedDownload,
 } from '@/services/lcaReleases';
 import { DownloadOutlined, ReloadOutlined } from '@ant-design/icons';
 import { useIntl } from '@umijs/max';
@@ -63,15 +65,22 @@ export function recordsToCsv(headers: string[], rows: unknown[][]): string {
   return `${[headers, ...rows].map((row) => row.map(csvCell).join(',')).join('\n')}\n`;
 }
 
-function downloadText(filename: string, text: string, mediaType: string): void {
-  const url = URL.createObjectURL(new Blob([text], { type: mediaType }));
+export function saveBlobDownload(filename: string, blob: Blob): void {
+  const url = URL.createObjectURL(blob);
   const link = document.createElement('a');
-  link.href = url;
-  link.download = filename;
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
-  URL.revokeObjectURL(url);
+  try {
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+  } finally {
+    link.remove();
+    URL.revokeObjectURL(url);
+  }
+}
+
+function downloadText(filename: string, text: string, mediaType: string): void {
+  saveBlobDownload(filename, new Blob([text], { type: mediaType }));
 }
 
 function hashValue(value: unknown): string {
@@ -100,6 +109,8 @@ const CalculationBundlePanel = ({ packageId, initialProcessId, initialProcessVer
   const [recordsLoading, setRecordsLoading] = useState(false);
   const [issue, setIssue] = useState<BundleIssue | null>(null);
   const [recordsIssue, setRecordsIssue] = useState<string | null>(null);
+  const [downloadIssue, setDownloadIssue] = useState<string | null>(null);
+  const [downloadingPath, setDownloadingPath] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
   const [activeResultTab, setActiveResultTab] = useState('lci');
 
@@ -112,6 +123,7 @@ const CalculationBundlePanel = ({ packageId, initialProcessId, initialProcessVer
       setProcesses([]);
       setSelectedProcessIndex(undefined);
       setCoverage(null);
+      setDownloadIssue(null);
       const result = await getCalculationBundle(packageId);
       if (cancelled) return;
       if (result.error || !result.data) {
@@ -250,6 +262,27 @@ const CalculationBundlePanel = ({ packageId, initialProcessId, initialProcessVer
       `${JSON.stringify(rows, null, 2)}\n`,
       'application/json',
     );
+
+  const downloadVerifiedArtifact = async (
+    key: string,
+    artifactPath: string | null,
+    filename: string,
+    download: Pick<
+      CalculationBundleSignedDownload,
+      'signedDownloadUrl' | 'sha256' | 'byteSize' | 'mediaType'
+    >,
+  ) => {
+    setDownloadIssue(null);
+    setDownloadingPath(key);
+    try {
+      const blob = await fetchFreshCalculationBundleDownloadBlob(packageId, artifactPath, download);
+      saveBlobDownload(filename, blob);
+    } catch (error) {
+      setDownloadIssue(error instanceof Error ? error.message : String(error));
+    } finally {
+      setDownloadingPath(null);
+    }
+  };
 
   const lciColumns = useMemo(
     () => [
@@ -472,39 +505,69 @@ const CalculationBundlePanel = ({ packageId, initialProcessId, initialProcessVer
                 key: 'downloads',
                 label: t('pages.dataProcessing.bundle.downloads', 'Downloads'),
                 children: (
-                  <div className={styles.bundleDownloadGrid}>
-                    <section className={styles.bundleDownloadItem}>
-                      <strong>calculation-bundle.json</strong>
-                      <code>{bundleData.manifestSha256}</code>
-                      <a
-                        href={bundleData.manifestDownload.signedDownloadUrl}
-                        download='calculation-bundle.json'
-                        rel='noreferrer'
-                      >
-                        <Button size='small' icon={<DownloadOutlined />}>
+                  <Space direction='vertical' size='middle' className={styles.previewDetails}>
+                    {downloadIssue ? (
+                      <Alert
+                        type='error'
+                        message={downloadIssue}
+                        action={
+                          <Button size='small' onClick={() => setReloadToken((value) => value + 1)}>
+                            {t('pages.dataProcessing.bundle.refresh', 'Refresh secure links')}
+                          </Button>
+                        }
+                      />
+                    ) : null}
+                    <div className={styles.bundleDownloadGrid}>
+                      <section className={styles.bundleDownloadItem}>
+                        <strong>calculation-bundle.json</strong>
+                        <code>{bundleData.manifestSha256}</code>
+                        <Button
+                          size='small'
+                          icon={<DownloadOutlined />}
+                          loading={downloadingPath === 'calculation-bundle.json'}
+                          disabled={downloadingPath !== null}
+                          onClick={() =>
+                            void downloadVerifiedArtifact(
+                              'calculation-bundle.json',
+                              null,
+                              'calculation-bundle.json',
+                              bundleData.manifestDownload,
+                            )
+                          }
+                        >
                           {t('pages.dataProcessing.bundle.download', 'Download')}
                         </Button>
-                      </a>
-                    </section>
-                    {bundleData.artifacts.map((artifact) => (
-                      <section key={artifact.path} className={styles.bundleDownloadItem}>
-                        <strong>{artifact.path}</strong>
-                        <span>
-                          {artifact.kind} · {artifact.recordCount} records
-                        </span>
-                        <code>{artifact.sha256}</code>
-                        <a
-                          href={artifact.signedDownloadUrl}
-                          download={artifact.path.split('/').pop()}
-                          rel='noreferrer'
-                        >
-                          <Button size='small' icon={<DownloadOutlined />}>
-                            {t('pages.dataProcessing.bundle.download', 'Download')}
-                          </Button>
-                        </a>
                       </section>
-                    ))}
-                  </div>
+                      {bundleData.artifacts.map((artifact) => {
+                        const filename = artifact.path.split('/').pop() || artifact.path;
+                        return (
+                          <section key={artifact.path} className={styles.bundleDownloadItem}>
+                            <strong>{artifact.path}</strong>
+                            <span>
+                              {artifact.kind} · {artifact.recordCount} records
+                            </span>
+                            <code>{artifact.sha256}</code>
+                            <Button
+                              size='small'
+                              icon={<DownloadOutlined />}
+                              loading={downloadingPath === artifact.path}
+                              disabled={downloadingPath !== null}
+                              onClick={() =>
+                                void downloadVerifiedArtifact(
+                                  artifact.path,
+                                  artifact.path,
+                                  filename,
+                                  artifact,
+                                )
+                              }
+                            >
+                              {t('pages.dataProcessing.bundle.download', 'Download')}
+                            </Button>
+                          </section>
+                        );
+                      })}
+                    </div>
+                  </Space>
                 ),
               },
             ]}

--- a/src/services/lcaReleases/api.ts
+++ b/src/services/lcaReleases/api.ts
@@ -311,6 +311,82 @@ async function sha256Hex(bytes: ArrayBuffer): Promise<string> {
     .join('');
 }
 
+export async function fetchCalculationBundleDownloadBlob(
+  download: Pick<
+    CalculationBundleSignedDownload,
+    'signedDownloadUrl' | 'sha256' | 'byteSize' | 'mediaType'
+  >,
+): Promise<Blob> {
+  const response = await fetch(download.signedDownloadUrl, { credentials: 'omit' });
+  if (!response.ok) {
+    const error = new Error(`Calculation artifact download failed (${response.status})`);
+    Object.assign(error, { status: response.status });
+    throw error;
+  }
+  const bytes = await response.arrayBuffer();
+  if (bytes.byteLength !== download.byteSize) {
+    throw new Error(
+      `Calculation artifact size mismatch: expected ${download.byteSize}, received ${bytes.byteLength}`,
+    );
+  }
+  const digest = await sha256Hex(bytes);
+  if (digest !== download.sha256) {
+    throw new Error('Calculation artifact SHA-256 mismatch');
+  }
+  return new Blob([bytes], { type: download.mediaType || 'application/octet-stream' });
+}
+
+type CalculationBundleDownloadExpectation = Pick<
+  CalculationBundleSignedDownload,
+  'sha256' | 'byteSize' | 'mediaType'
+>;
+
+function isRefreshableSignedDownloadFailure(error: unknown): boolean {
+  const status = (error as { status?: unknown } | null)?.status;
+  return status === 401 || status === 403 || status === 404 || status === 410;
+}
+
+async function resolveFreshCalculationBundleDownload(
+  packageId: string,
+  artifactPath: string | null,
+  expected: CalculationBundleDownloadExpectation,
+): Promise<CalculationBundleSignedDownload> {
+  const result = await getCalculationBundle(packageId);
+  if (result.error || !result.data) {
+    throw new Error(result.error?.message || 'Calculation Bundle secure links are unavailable.');
+  }
+  const download =
+    artifactPath === null
+      ? result.data.calculationBundle.manifestDownload
+      : result.data.calculationBundle.artifacts.find((artifact) => artifact.path === artifactPath);
+  if (!download) {
+    throw new Error(`Calculation artifact is no longer available: ${artifactPath ?? 'manifest'}`);
+  }
+  if (
+    download.sha256 !== expected.sha256 ||
+    download.byteSize !== expected.byteSize ||
+    download.mediaType !== expected.mediaType
+  ) {
+    throw new Error('Calculation artifact metadata changed; refresh the Calculation Bundle.');
+  }
+  return download;
+}
+
+export async function fetchFreshCalculationBundleDownloadBlob(
+  packageId: string,
+  artifactPath: string | null,
+  expected: CalculationBundleDownloadExpectation,
+): Promise<Blob> {
+  let download = await resolveFreshCalculationBundleDownload(packageId, artifactPath, expected);
+  try {
+    return await fetchCalculationBundleDownloadBlob(download);
+  } catch (error) {
+    if (!isRefreshableSignedDownloadFailure(error)) throw error;
+    download = await resolveFreshCalculationBundleDownload(packageId, artifactPath, expected);
+    return fetchCalculationBundleDownloadBlob(download);
+  }
+}
+
 async function decodeArtifactBytes(bytes: ArrayBuffer, compression: string): Promise<string> {
   const view = new Uint8Array(bytes);
   const hasGzipHeader = view.length >= 2 && view[0] === 0x1f && view[1] === 0x8b;

--- a/tests/unit/pages/DataProcessing/CalculationBundlePanel.test.tsx
+++ b/tests/unit/pages/DataProcessing/CalculationBundlePanel.test.tsx
@@ -21,12 +21,14 @@ jest.mock('@umijs/max', () => ({
 const mockGetCalculationBundle = jest.fn();
 const mockFetchRecords = jest.fn();
 const mockFetchText = jest.fn();
+const mockFetchFreshDownloadBlob = jest.fn();
 
 jest.mock('@/services/lcaReleases', () => ({
   __esModule: true,
   getCalculationBundle: (...args: any[]) => mockGetCalculationBundle(...args),
   fetchCalculationBundleRecords: (...args: any[]) => mockFetchRecords(...args),
   fetchCalculationBundleArtifactText: (...args: any[]) => mockFetchText(...args),
+  fetchFreshCalculationBundleDownloadBlob: (...args: any[]) => mockFetchFreshDownloadBlob(...args),
 }));
 
 const processRows = [
@@ -123,6 +125,9 @@ describe('CalculationBundlePanel', () => {
     jest.clearAllMocks();
     mockGetCalculationBundle.mockResolvedValue({ data: bundleProjection(), error: null });
     mockFetchText.mockResolvedValue(JSON.stringify({ complete: true }));
+    mockFetchFreshDownloadBlob.mockResolvedValue(
+      new Blob(['verified artifact'], { type: 'application/octet-stream' }),
+    );
     mockFetchRecords.mockImplementation(async (item: any) => {
       if (item.kind === 'process_axis') return processRows;
       if (item.kind === 'lci') {
@@ -201,12 +206,35 @@ describe('CalculationBundlePanel', () => {
     fireEvent.click(screen.getByTestId('tab-downloads'));
     expect(screen.getByText('calculation-bundle.json')).toBeInTheDocument();
     expect(screen.getByText('lci.ndjson.gz')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+
+    const downloadButtons = screen.getAllByRole('button', { name: 'Download' });
+    expect(downloadButtons).toHaveLength(bundleProjection().calculationBundle.artifacts.length + 1);
+    for (const [index, button] of downloadButtons.entries()) {
+      await waitFor(() => expect(button).not.toBeDisabled());
+      fireEvent.click(button);
+      await waitFor(() => expect(mockFetchFreshDownloadBlob).toHaveBeenCalledTimes(index + 1));
+      await waitFor(() => expect(URL.createObjectURL).toHaveBeenCalledTimes(index + 1));
+    }
+    expect(mockFetchFreshDownloadBlob).toHaveBeenNthCalledWith(
+      1,
+      '33333333-3333-4333-8333-333333333333',
+      null,
+      bundleProjection().calculationBundle.manifestDownload,
+    );
+    expect(mockFetchFreshDownloadBlob).toHaveBeenNthCalledWith(
+      2,
+      '33333333-3333-4333-8333-333333333333',
+      bundleProjection().calculationBundle.artifacts[0].path,
+      bundleProjection().calculationBundle.artifacts[0],
+    );
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('tab-lci'));
     fireEvent.click(screen.getByRole('button', { name: 'Export CSV' }));
     fireEvent.click(screen.getByRole('button', { name: 'Export JSON' }));
-    expect(URL.createObjectURL).toHaveBeenCalledTimes(2);
-    expect(HTMLAnchorElement.prototype.click).toHaveBeenCalledTimes(2);
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(downloadButtons.length + 2);
+    expect(HTMLAnchorElement.prototype.click).toHaveBeenCalledTimes(downloadButtons.length + 2);
 
     fireEvent.change(screen.getByLabelText('Process'), { target: { value: '0' } });
     await waitFor(() => expect(screen.getByText('flow-0')).toBeInTheDocument());
@@ -214,6 +242,21 @@ describe('CalculationBundlePanel', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Refresh secure links' }));
     await waitFor(() => expect(mockGetCalculationBundle).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows verified download failures without creating a local download', async () => {
+    mockFetchFreshDownloadBlob.mockRejectedValueOnce(
+      new Error('Calculation artifact SHA-256 mismatch'),
+    );
+    render(<CalculationBundlePanel packageId='download-failure' />);
+
+    expect(await screen.findByText('Calculation Bundle')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('tab-downloads'));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Download' })[0]);
+
+    expect(await screen.findByText('Calculation artifact SHA-256 mismatch')).toBeInTheDocument();
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+    expect(HTMLAnchorElement.prototype.click).not.toHaveBeenCalled();
   });
 
   it('renders legacy and generic load failures with a retry path', async () => {

--- a/tests/unit/pages/LifeCycleModels/Components/optiondata.test.tsx
+++ b/tests/unit/pages/LifeCycleModels/Components/optiondata.test.tsx
@@ -3,12 +3,16 @@ import {
   licenseTypeOptions,
 } from '@/pages/LifeCycleModels/Components/optiondata';
 
-jest.mock('umi', () => ({
-  __esModule: true,
-  FormattedMessage: ({ defaultMessage, id }: any) => ({
-    props: { defaultMessage, id },
+jest.mock(
+  'umi',
+  () => ({
+    __esModule: true,
+    FormattedMessage: ({ defaultMessage, id }: any) => ({
+      props: { defaultMessage, id },
+    }),
   }),
-}));
+  { virtual: true },
+);
 
 describe('LifeCycleModels optiondata', () => {
   it('exposes the expected copyright choices', () => {

--- a/tests/unit/services/lcaReleases/api.test.ts
+++ b/tests/unit/services/lcaReleases/api.test.ts
@@ -19,7 +19,9 @@ jest.mock('@/services/supabase', () => ({
 import {
   createLcaReleaseArtifactDownload,
   fetchCalculationBundleArtifactText,
+  fetchCalculationBundleDownloadBlob,
   fetchCalculationBundleRecords,
+  fetchFreshCalculationBundleDownloadBlob,
   getCalculationBundle,
   getCurrentLcaRelease,
   getCurrentLcaReleaseForProcess,
@@ -275,6 +277,223 @@ describe('lcaReleases api', () => {
     expect(global.fetch).toHaveBeenCalledWith('https://download.example/lci', {
       credentials: 'omit',
     });
+  });
+
+  it('downloads and verifies raw artifacts before exposing a browser Blob', async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    setCryptoDigest(3);
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      arrayBuffer: async () => bytes.buffer,
+    })) as any;
+
+    const blob = await fetchCalculationBundleDownloadBlob({
+      signedDownloadUrl: 'https://download.example/raw',
+      sha256: '03'.repeat(32),
+      byteSize: bytes.byteLength,
+      mediaType: 'application/x-ndjson',
+    });
+
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.size).toBe(bytes.byteLength);
+    expect(blob.type).toBe('application/x-ndjson');
+    expect(global.fetch).toHaveBeenCalledWith('https://download.example/raw', {
+      credentials: 'omit',
+    });
+
+    const fallbackTypeBlob = await fetchCalculationBundleDownloadBlob({
+      signedDownloadUrl: 'https://download.example/raw',
+      sha256: '03'.repeat(32),
+      byteSize: bytes.byteLength,
+      mediaType: '',
+    });
+    expect(fallbackTypeBlob.type).toBe('application/octet-stream');
+  });
+
+  it('fails closed before exposing an invalid raw download', async () => {
+    const oneByte = new Uint8Array([1]);
+    const twoBytes = new Uint8Array([1, 2]);
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 403 })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => oneByte.buffer,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => twoBytes.buffer,
+      }) as any;
+    const download = {
+      signedDownloadUrl: 'https://download.example/raw',
+      sha256: '00'.repeat(32),
+      byteSize: twoBytes.byteLength,
+      mediaType: 'application/octet-stream',
+    };
+
+    await expect(fetchCalculationBundleDownloadBlob(download)).rejects.toThrow('(403)');
+    await expect(fetchCalculationBundleDownloadBlob(download)).rejects.toThrow('size mismatch');
+    setCryptoDigest(9);
+    await expect(fetchCalculationBundleDownloadBlob(download)).rejects.toThrow('SHA-256 mismatch');
+  });
+
+  it('refreshes secure links per click and retries one expired signed URL', async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const expected = {
+      sha256: '03'.repeat(32),
+      byteSize: bytes.byteLength,
+      mediaType: 'application/x-ndjson',
+    };
+    const projection = (signedDownloadUrl: string) => ({
+      calculationBundle: {
+        manifestDownload: { ...expected, signedDownloadUrl, signedDownloadExpiresInSeconds: 900 },
+        artifacts: [
+          {
+            ...expected,
+            path: 'results/lci.ndjson.gz',
+            signedDownloadUrl,
+            signedDownloadExpiresInSeconds: 900,
+          },
+        ],
+      },
+    });
+    mockFunctionsInvoke
+      .mockResolvedValueOnce({
+        data: { ok: true, data: projection('https://download.example/expired') },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { ok: true, data: projection('https://download.example/fresh') },
+        error: null,
+      });
+    setCryptoDigest(3);
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 410 })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => bytes.buffer,
+      }) as any;
+
+    await expect(
+      fetchFreshCalculationBundleDownloadBlob(
+        '11111111-1111-4111-8111-111111111111',
+        'results/lci.ndjson.gz',
+        expected,
+      ),
+    ).resolves.toMatchObject({ size: bytes.byteLength, type: expected.mediaType });
+    expect(mockFunctionsInvoke).toHaveBeenCalledTimes(2);
+    expect(global.fetch).toHaveBeenNthCalledWith(1, 'https://download.example/expired', {
+      credentials: 'omit',
+    });
+    expect(global.fetch).toHaveBeenNthCalledWith(2, 'https://download.example/fresh', {
+      credentials: 'omit',
+    });
+  });
+
+  it('rejects missing, denied, or drifted fresh Calculation Bundle downloads before saving', async () => {
+    const expected = {
+      sha256: '00'.repeat(32),
+      byteSize: 2,
+      mediaType: 'application/octet-stream',
+    };
+    mockFunctionsInvoke
+      .mockResolvedValueOnce({
+        data: { ok: false, code: 'access_denied', message: 'Access denied' },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: {
+          ok: true,
+          data: { calculationBundle: { manifestDownload: expected, artifacts: [] } },
+        },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: {
+          ok: true,
+          data: {
+            calculationBundle: {
+              manifestDownload: expected,
+              artifacts: [
+                {
+                  ...expected,
+                  path: 'results/lci.ndjson.gz',
+                  sha256: 'ff'.repeat(32),
+                },
+              ],
+            },
+          },
+        },
+        error: null,
+      });
+    global.fetch = jest.fn() as any;
+
+    await expect(
+      fetchFreshCalculationBundleDownloadBlob('package', null, expected),
+    ).rejects.toThrow('Access denied');
+    await expect(
+      fetchFreshCalculationBundleDownloadBlob('package', 'missing.ndjson.gz', expected),
+    ).rejects.toThrow('no longer available');
+    await expect(
+      fetchFreshCalculationBundleDownloadBlob('package', 'results/lci.ndjson.gz', expected),
+    ).rejects.toThrow('metadata changed');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for unavailable manifests and non-refreshable verified download failures', async () => {
+    const bytes = new Uint8Array([1, 2]);
+    const expected = {
+      sha256: '00'.repeat(32),
+      byteSize: bytes.byteLength,
+      mediaType: 'application/octet-stream',
+    };
+    mockFunctionsInvoke
+      .mockResolvedValueOnce({ data: { ok: true, data: null }, error: null })
+      .mockResolvedValueOnce({
+        data: {
+          ok: true,
+          data: { calculationBundle: { artifacts: [] } },
+        },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: {
+          ok: true,
+          data: {
+            calculationBundle: {
+              manifestDownload: {
+                ...expected,
+                signedDownloadUrl: 'https://download.example/manifest',
+              },
+              artifacts: [],
+            },
+          },
+        },
+        error: null,
+      });
+    setCryptoDigest(9);
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      arrayBuffer: async () => bytes.buffer,
+    })) as any;
+
+    await expect(
+      fetchFreshCalculationBundleDownloadBlob('package', null, expected),
+    ).rejects.toThrow('secure links are unavailable');
+    await expect(
+      fetchFreshCalculationBundleDownloadBlob('package', null, expected),
+    ).rejects.toThrow('no longer available: manifest');
+    await expect(
+      fetchFreshCalculationBundleDownloadBlob('package', null, expected),
+    ).rejects.toThrow('SHA-256 mismatch');
+    expect(mockFunctionsInvoke).toHaveBeenCalledTimes(3);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
   it('decompresses verified gzip records and tolerates already-decoded responses', async () => {


### PR DESCRIPTION
## Summary

- refresh the authenticated Calculation Bundle projection for every artifact click
- verify the fresh path, media type, byte size, SHA-256 digest, and downloaded bytes before exposing a file
- fetch signed cross-origin URLs without ambient credentials and save verified bytes through a browser Blob
- retry one expired or rotated signed URL on 401, 403, 404, or 410
- fail closed with stable UI guidance when artifact metadata or bytes drift
- isolate the lifecycle option-data test from transient generated Umi files discovered by the full gate

## Validation

- focused release API and panel suites: 17 tests passed
- release API coverage: 100% statements, branches, functions, and lines
- German runtime activation: 3 tests passed
- LCIA static cache verification passed
- ESLint, Prettier, TypeScript, and production build passed
- i18n audit and runtime manifest checks passed
- Docpact strict validation and enforced lint passed
- checked pre-push gate: 363/363 suites and 4,561/4,561 tests passed
- full coverage: 404/404 tracked source files at 100% statements, branches, functions, and lines

## Risk and rollback

Downloads now fail closed if a fresh server projection no longer matches the rendered immutable artifact metadata. This can surface stale UI state as an explicit refresh error instead of silently saving unverified bytes. Rollback is the two commits in this PR; no schema or backend rollback is required.

## Release and UAT

After merge to dev, #619 bumps the release line to v0.0.49 and promotes the exact verified state to main. Deployed browser UAT must cover calculation, persisted LCI/LCIA display, and every artifact type before the draft release is published.

Closes #618