### PR TITLE
fix: restore language selector and header actions

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-07-17'
-lastReviewedCommit: 'cc66ad9a4084063b3fea7659bb4271303a88ba2e'
-lastReviewedNote: 'Reviewed Issue #614 text-only selector and the V8-safe single-worker coverage model; testing and gate ownership remain covered by the existing rule graph.'
+lastReviewedCommit: '1739b195a1d6c6039c2229643174fa411e3c6522'
+lastReviewedNote: 'Reviewed Issue #621 shared selector/header action restoration and the v0.0.49 release-only version bump; routing, ownership, testing, and gate rules remain unchanged.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Reviewed Issue #614 shared text-only language selector; repo ownership, branch facts, and hard boundaries are unchanged.'
+lastReviewedCommit: 1739b195a1d6c6039c2229643174fa411e3c6522
+lastReviewedNote: 'Reviewed Issue #621 shared selector/header UI and the v0.0.49 release metadata; repo ownership, branch facts, and hard boundaries are unchanged.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,8 +21,8 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Reviewed Issue #614 focused UI proof and managed final-push flow; validation commands and gate ownership are unchanged.'
+lastReviewedCommit: 1739b195a1d6c6039c2229643174fa411e3c6522
+lastReviewedNote: 'Reviewed Issue #621 focused UI proof and the v0.0.49 managed release checkpoint; bootstrap commands and gate ownership are unchanged.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -24,8 +24,8 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Reviewed Issue #614 selector proof and the V8-safe single-worker recycle boundary; single full-gate ownership and 100% src coverage remain unchanged.'
+lastReviewedCommit: 1739b195a1d6c6039c2229643174fa411e3c6522
+lastReviewedNote: 'Reviewed Issue #621 and the v0.0.49 release checkpoint; single full-gate ownership and 100% src coverage remain unchanged.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,8 +22,8 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Reviewed Issue #614 text-only language options across the shared login and application-header selector; architecture and ownership boundaries are unchanged.'
+lastReviewedCommit: 1739b195a1d6c6039c2229643174fa411e3c6522
+lastReviewedNote: 'Reviewed Issue #621 shared login/application-header selector and action behavior; architecture and ownership boundaries are unchanged.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -23,8 +23,8 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Reviewed Issue #614 selector proof and the V8-safe single-worker Jest gate; the complete test inventory and 100% src coverage bar remain authoritative.'
+lastReviewedCommit: 1739b195a1d6c6039c2229643174fa411e3c6522
+lastReviewedNote: 'Reviewed Issue #621 focused UI proof, browser measurements, and the v0.0.49 release checkpoint; the proof matrix and protected-branch gate remain authoritative.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Reviewed Issue #614 selector proof and the V8-safe single-worker recycle boundary; the full-closure strategy and quality bar remain unchanged.'
+lastReviewedCommit: 1739b195a1d6c6039c2229643174fa411e3c6522
+lastReviewedNote: 'Reviewed Issue #621 component proof and the v0.0.49 release checkpoint; the full-closure strategy and quality bar remain unchanged.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Reviewed Issue #614 selector coverage and the V8-safe single-worker recycle boundary; full closure remains intact with no new queue.'
+lastReviewedCommit: 1739b195a1d6c6039c2229643174fa411e3c6522
+lastReviewedNote: 'Reviewed Issue #621 selector/header coverage and the v0.0.49 release checkpoint; full closure remains intact with no new queue.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,8 +22,8 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Reviewed Issue #614 component proof and the V8-safe single-worker recycle pattern for long-running coverage.'
+lastReviewedCommit: 1739b195a1d6c6039c2229643174fa411e3c6522
+lastReviewedNote: 'Reviewed Issue #621 component and browser proof; existing component-testing and full-gate patterns remain sufficient.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Reviewed Issue #614 selector smoke and the confirmed macOS Node/V8 native GC crash; added the supported single-worker recycle recovery.'
+lastReviewedCommit: 1739b195a1d6c6039c2229643174fa411e3c6522
+lastReviewedNote: 'Reviewed Issue #621 focused proof and the clean Docpact missing-review stop; existing recovery paths remain current.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n-de-DE/runtime-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/runtime-activation-manifest.json
@@ -191,7 +191,7 @@
   },
   "source": {
     "canonicalManifest": "docs/plans/i18n-de-DE/manifest.json",
-    "canonicalAuditedInputDigest": "551fd1097df11b681178f2eda268fc91ade15ef6c0fbac6234f25ef5916112f8",
+    "canonicalAuditedInputDigest": "658298d01775306f3ad826f37ee192bf9f338afded86755444c72f5a3a9f24fd",
     "digestAlgorithm": "sha256",
     "inputs": [
       {
@@ -219,7 +219,7 @@
       {
         "kind": "file",
         "path": "docs/plans/i18n-de-DE/manifest.json",
-        "sha256": "5da78632fb333868eaed6ce25ecca840fa3ae2ff51d4ef5e1a6f27d978b41a53"
+        "sha256": "295b807f35a94d4e2ccd9da81a704b6a689212d829a71301212b50aa5bfbf36d"
       },
       {
         "kind": "file",
@@ -412,6 +412,6 @@
         "sha256": "0c414199c5f5937821c9c35edaa5f6e23c079711f102011dfa11bfeb2bf3602b"
       }
     ],
-    "inputDigest": "5486eff026b804d30a3ee718687877c57359d70b2e3c927f5cb6d62faa63facd"
+    "inputDigest": "5332de64230f1e8c55a1b7b5ac73e6706c3538809c2621060ff56de84b3aad26"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.48",
+      "version": "0.0.49",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",

--- a/src/components/RightContent/index.tsx
+++ b/src/components/RightContent/index.tsx
@@ -57,18 +57,9 @@ export const Question = () => {
   return (
     <button
       type='button'
+      className='tg-global-header-help-action'
       aria-label={helpLabel}
       title={helpLabel}
-      style={{
-        display: 'flex',
-        height: 26,
-        alignItems: 'center',
-        padding: 0,
-        color: 'inherit',
-        background: 'transparent',
-        border: 0,
-        cursor: 'pointer',
-      }}
       onClick={() => {
         window.open(docsUrl);
       }}

--- a/src/components/RightContent/index.tsx
+++ b/src/components/RightContent/index.tsx
@@ -15,14 +15,6 @@ interface SelectLangProps {
   style?: React.CSSProperties;
 }
 
-type UmiSelectLangDropdownProps = React.ComponentProps<typeof UmiSelectLang> & {
-  overlayClassName?: string;
-};
-
-const textOnlyLanguageDropdownProps: UmiSelectLangDropdownProps = {
-  overlayClassName: 'tg-language-selector-dropdown',
-};
-
 export const SelectLang: React.FC<SelectLangProps> = ({ style }) => {
   const intl = useIntl();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -54,7 +46,6 @@ export const SelectLang: React.FC<SelectLangProps> = ({ style }) => {
       }}
     >
       <UmiSelectLang
-        {...textOnlyLanguageDropdownProps}
         style={{
           padding: 4,
           ...style,
@@ -63,15 +54,13 @@ export const SelectLang: React.FC<SelectLangProps> = ({ style }) => {
           const localesByKey = new Map(locales.map((locale) => [locale.lang, locale]));
           return SUPPORTED_APP_LOCALES.map((locale) => {
             const existingLocale = localesByKey.get(locale) ?? { lang: locale };
-            const localeWithoutIcon = { ...existingLocale };
-            delete localeWithoutIcon.icon;
 
             if (locale !== 'de-DE') {
-              return localeWithoutIcon;
+              return existingLocale;
             }
 
             return {
-              ...localeWithoutIcon,
+              ...existingLocale,
               lang: 'de-DE',
               label: 'Deutsch',
               title: 'Deutsch',

--- a/src/components/RightContent/index.tsx
+++ b/src/components/RightContent/index.tsx
@@ -5,7 +5,7 @@ import {
 } from '@/services/general/runtimeLocale';
 import { MoonOutlined, QuestionCircleOutlined, SunFilled } from '@ant-design/icons';
 import { SelectLang as UmiSelectLang, useIntl } from '@umijs/max';
-import { ConfigProvider, theme } from 'antd';
+import { ConfigProvider, theme, Tooltip } from 'antd';
 import type React from 'react';
 
 const { defaultAlgorithm, darkAlgorithm } = theme;
@@ -55,17 +55,18 @@ export const Question = () => {
   });
 
   return (
-    <button
-      type='button'
-      className='tg-global-header-help-action'
-      aria-label={helpLabel}
-      title={helpLabel}
-      onClick={() => {
-        window.open(docsUrl);
-      }}
-    >
-      <QuestionCircleOutlined />
-    </button>
+    <Tooltip title={helpLabel}>
+      <button
+        type='button'
+        className='tg-global-header-help-action'
+        aria-label={helpLabel}
+        onClick={() => {
+          window.open(docsUrl);
+        }}
+      >
+        <QuestionCircleOutlined />
+      </button>
+    </Tooltip>
   );
 };
 

--- a/src/components/RightContent/index.tsx
+++ b/src/components/RightContent/index.tsx
@@ -7,7 +7,6 @@ import { MoonOutlined, QuestionCircleOutlined, SunFilled } from '@ant-design/ico
 import { SelectLang as UmiSelectLang, useIntl } from '@umijs/max';
 import { ConfigProvider, theme } from 'antd';
 import type React from 'react';
-import { useRef } from 'react';
 
 const { defaultAlgorithm, darkAlgorithm } = theme;
 
@@ -16,59 +15,30 @@ interface SelectLangProps {
 }
 
 export const SelectLang: React.FC<SelectLangProps> = ({ style }) => {
-  const intl = useIntl();
-  const containerRef = useRef<HTMLDivElement>(null);
-  const openLanguageMenu = () => {
-    containerRef.current
-      ?.querySelector<HTMLElement>('.ant-dropdown-trigger, button, [role="button"], a, span')
-      ?.click();
-  };
-
   return (
-    <div
-      ref={containerRef}
-      role='button'
-      tabIndex={0}
-      aria-label={intl.formatMessage({
-        id: 'pages.lang.select',
-        defaultMessage: 'Select a language',
-      })}
-      onClick={(event) => {
-        if (event.target === event.currentTarget) {
-          openLanguageMenu();
-        }
+    <UmiSelectLang
+      style={{
+        padding: 4,
+        ...style,
       }}
-      onKeyDown={(event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          openLanguageMenu();
-        }
+      postLocalesData={(locales) => {
+        const localesByKey = new Map(locales.map((locale) => [locale.lang, locale]));
+        return SUPPORTED_APP_LOCALES.map((locale) => {
+          const existingLocale = localesByKey.get(locale) ?? { lang: locale };
+
+          if (locale !== 'de-DE') {
+            return existingLocale;
+          }
+
+          return {
+            ...existingLocale,
+            lang: 'de-DE',
+            label: 'Deutsch',
+            title: 'Deutsch',
+          };
+        });
       }}
-    >
-      <UmiSelectLang
-        style={{
-          padding: 4,
-          ...style,
-        }}
-        postLocalesData={(locales) => {
-          const localesByKey = new Map(locales.map((locale) => [locale.lang, locale]));
-          return SUPPORTED_APP_LOCALES.map((locale) => {
-            const existingLocale = localesByKey.get(locale) ?? { lang: locale };
-
-            if (locale !== 'de-DE') {
-              return existingLocale;
-            }
-
-            return {
-              ...existingLocale,
-              lang: 'de-DE',
-              label: 'Deutsch',
-              title: 'Deutsch',
-            };
-          });
-        }}
-      />
-    </div>
+    />
   );
 };
 

--- a/src/global.less
+++ b/src/global.less
@@ -208,12 +208,6 @@ ol {
   }
 }
 
-.tg-language-selector-dropdown {
-  .ant-dropdown-menu-item [role='img'] {
-    display: none;
-  }
-}
-
 .tg-global-header-avatar-trigger {
   display: flex;
   align-items: center;

--- a/src/global.less
+++ b/src/global.less
@@ -191,6 +191,19 @@ ol {
   flex: 0 1 auto;
 }
 
+.tg-global-header-help-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: inherit;
+  font: inherit;
+  line-height: 1;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+}
+
 .tg-global-header-avatar-dropdown {
   max-width: calc(100vw - 24px);
 

--- a/src/pages/User/Login/Components/LoginTopActions.tsx
+++ b/src/pages/User/Login/Components/LoginTopActions.tsx
@@ -35,15 +35,19 @@ const LoginTopActions: React.FC<LoginTopActionsProps> = ({ isDarkMode, onDarkMod
     window.open(docsUrl);
   };
 
+  const openLanguageMenu = () => {
+    const trigger = langActionRef.current?.querySelector<HTMLElement>(
+      '.ant-dropdown-trigger, button, [role="button"], a, span',
+    );
+    trigger?.click();
+  };
+
   const handleLanguageFrameClick = (event: React.MouseEvent<HTMLDivElement>) => {
     // Keep native SelectLang behavior when clicking its own trigger.
     if (event.target !== event.currentTarget) {
       return;
     }
-    const trigger = langActionRef.current?.querySelector<HTMLElement>(
-      'button, [role="button"], .ant-dropdown-trigger, a, span',
-    );
-    trigger?.click();
+    openLanguageMenu();
   };
 
   const handleActionKeyDown = (
@@ -122,7 +126,14 @@ const LoginTopActions: React.FC<LoginTopActionsProps> = ({ isDarkMode, onDarkMod
         <div
           ref={langActionRef}
           data-testid='login-language-frame'
+          role='button'
+          tabIndex={0}
+          aria-label={intl.formatMessage({
+            id: 'pages.lang.select',
+            defaultMessage: 'Select a language',
+          })}
           onClick={handleLanguageFrameClick}
+          onKeyDown={(event) => handleActionKeyDown(event, openLanguageMenu)}
           style={{
             display: 'inline-flex',
             alignItems: 'center',
@@ -134,7 +145,7 @@ const LoginTopActions: React.FC<LoginTopActionsProps> = ({ isDarkMode, onDarkMod
             backgroundColor: hoveredAction === 'lang' ? actionHoverBg : undefined,
           }}
         >
-          <SelectLang style={{ padding: 0, color: actionColor }} />
+          <SelectLang style={{ padding: 0, color: actionColor, fontSize: 16, lineHeight: 1 }} />
         </div>
       </div>
       <div

--- a/tests/unit/components/RightContent.test.tsx
+++ b/tests/unit/components/RightContent.test.tsx
@@ -97,6 +97,12 @@ jest.mock('antd', () => {
 
   return {
     ConfigProvider,
+    Tooltip: ({ children, title }: { children: ReactNode; title: ReactNode }) => (
+      <>
+        {children}
+        <span role='tooltip'>{title}</span>
+      </>
+    ),
     theme,
   };
 });
@@ -135,6 +141,8 @@ describe('RightContent Components', () => {
 
     expect(button).toHaveClass('tg-global-header-help-action');
     expect(button).not.toHaveAttribute('style');
+    expect(button).not.toHaveAttribute('title');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Help');
     fireEvent.click(button);
 
     expect(mockWindowOpen).toHaveBeenCalledWith('https://docs.tiangong.earth');
@@ -168,7 +176,8 @@ describe('RightContent Components', () => {
     const helpButton = screen.getByRole('button', {
       name: 'Englische Hilfedokumentation öffnen',
     });
-    expect(helpButton).toHaveAttribute('title', 'Englische Hilfedokumentation öffnen');
+    expect(helpButton).not.toHaveAttribute('title');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Englische Hilfedokumentation öffnen');
     fireEvent.click(helpButton);
 
     expect(mockWindowOpen).toHaveBeenCalledWith('https://docs.tiangong.earth/en');

--- a/tests/unit/components/RightContent.test.tsx
+++ b/tests/unit/components/RightContent.test.tsx
@@ -133,6 +133,8 @@ describe('RightContent Components', () => {
 
     const button = screen.getByRole('button', { name: 'Help' });
 
+    expect(button).toHaveClass('tg-global-header-help-action');
+    expect(button).not.toHaveAttribute('style');
     fireEvent.click(button);
 
     expect(mockWindowOpen).toHaveBeenCalledWith('https://docs.tiangong.earth');

--- a/tests/unit/components/RightContent.test.tsx
+++ b/tests/unit/components/RightContent.test.tsx
@@ -19,7 +19,6 @@ type IconProps = {
 
 const configProviderThemes: string[] = [];
 let mockLocale: string | undefined = 'zh-CN';
-const mockSelectLangClick = jest.fn();
 let renderedLocales: Array<Record<string, unknown>> = [];
 const defaultAvailableLocales = () => [
   { lang: 'de-DE', label: 'Deutsch (Deutschland)', icon: '🇩🇪' },
@@ -53,12 +52,7 @@ jest.mock('@umijs/max', () => ({
   }) => {
     renderedLocales = postLocalesData?.(mockAvailableLocales) ?? [];
     return (
-      <button
-        data-testid='select-lang'
-        type='button'
-        style={style ?? {}}
-        onClick={mockSelectLangClick}
-      >
+      <button data-testid='select-lang' type='button' style={style ?? {}}>
         language selector
       </button>
     );
@@ -86,7 +80,6 @@ afterEach(() => {
   mockHandleClick.mockClear();
   configProviderThemes.length = 0;
   mockLocale = 'zh-CN';
-  mockSelectLangClick.mockClear();
   renderedLocales = [];
   mockAvailableLocales = defaultAvailableLocales();
 });
@@ -207,22 +200,10 @@ describe('RightContent Components', () => {
     ]);
   });
 
-  it('opens the language menu from keyboard interaction on the accessible wrapper', () => {
-    render(<SelectLang />);
+  it('renders the Umi selector directly without an extra action wrapper', () => {
+    const { container } = render(<SelectLang />);
 
-    const selectorWrapper = screen.getByRole('button', { name: 'Select a language' });
-    fireEvent.keyDown(selectorWrapper, { key: 'Enter' });
-    fireEvent.keyDown(selectorWrapper, { key: ' ' });
-
-    expect(mockSelectLangClick).toHaveBeenCalledTimes(2);
-  });
-
-  it('opens the language menu from a direct wrapper click', () => {
-    render(<SelectLang />);
-
-    fireEvent.click(screen.getByRole('button', { name: 'Select a language' }));
-
-    expect(mockSelectLangClick).toHaveBeenCalledTimes(1);
+    expect(container.firstElementChild).toBe(screen.getByTestId('select-lang'));
   });
 
   it('synthesizes a supported locale entry when Umi omits one', () => {

--- a/tests/unit/components/RightContent.test.tsx
+++ b/tests/unit/components/RightContent.test.tsx
@@ -21,7 +21,6 @@ const configProviderThemes: string[] = [];
 let mockLocale: string | undefined = 'zh-CN';
 const mockSelectLangClick = jest.fn();
 let renderedLocales: Array<Record<string, unknown>> = [];
-let renderedOverlayClassName: string | undefined;
 const defaultAvailableLocales = () => [
   { lang: 'de-DE', label: 'Deutsch (Deutschland)', icon: '🇩🇪' },
   { lang: 'en-US', label: 'English', icon: '🇺🇸' },
@@ -46,15 +45,12 @@ jest.mock('@ant-design/icons', () => ({
 
 jest.mock('@umijs/max', () => ({
   SelectLang: ({
-    overlayClassName,
     postLocalesData,
     style,
   }: {
-    overlayClassName?: string;
     postLocalesData?: (locales: Array<Record<string, unknown>>) => Array<Record<string, unknown>>;
     style?: Record<string, unknown>;
   }) => {
-    renderedOverlayClassName = overlayClassName;
     renderedLocales = postLocalesData?.(mockAvailableLocales) ?? [];
     return (
       <button
@@ -92,7 +88,6 @@ afterEach(() => {
   mockLocale = 'zh-CN';
   mockSelectLangClick.mockClear();
   renderedLocales = [];
-  renderedOverlayClassName = undefined;
   mockAvailableLocales = defaultAvailableLocales();
 });
 
@@ -202,14 +197,13 @@ describe('RightContent Components', () => {
     });
   });
 
-  it('exposes the three product locales as text-only country-neutral options', () => {
+  it('preserves the Umi flag icons for the three product locales', () => {
     render(<SelectLang />);
 
-    expect(renderedOverlayClassName).toBe('tg-language-selector-dropdown');
     expect(renderedLocales).toEqual([
-      { lang: 'zh-CN', label: '简体中文' },
-      { lang: 'en-US', label: 'English' },
-      { lang: 'de-DE', label: 'Deutsch', title: 'Deutsch' },
+      { lang: 'zh-CN', label: '简体中文', icon: '🇨🇳' },
+      { lang: 'en-US', label: 'English', icon: '🇺🇸' },
+      { lang: 'de-DE', label: 'Deutsch', icon: '🇩🇪', title: 'Deutsch' },
     ]);
   });
 

--- a/tests/unit/pages/User/Login/Components/LoginTopActions.test.tsx
+++ b/tests/unit/pages/User/Login/Components/LoginTopActions.test.tsx
@@ -24,10 +24,10 @@ jest.mock('umi', () => ({
 jest.mock('@/components/RightContent', () => ({
   __esModule: true,
   DarkMode: ({ isDarkMode }: any) => <span>{isDarkMode ? 'dark-on' : 'dark-off'}</span>,
-  SelectLang: () => (
-    <button type='button' onClick={mockSelectLangTrigger}>
+  SelectLang: ({ style }: any) => (
+    <span data-testid='select-lang-trigger' style={style} onClick={mockSelectLangTrigger}>
       select-lang-trigger
-    </button>
+    </span>
   ),
 }));
 
@@ -84,10 +84,25 @@ describe('LoginTopActions', () => {
 
     await userEvent.hover(screen.getByTestId('login-language'));
     await userEvent.unhover(screen.getByTestId('login-language'));
-    await userEvent.click(screen.getByTestId('login-language-frame'));
+    await userEvent.click(screen.getByRole('button', { name: 'Select a language' }));
 
     expect(mockSelectLangTrigger).toHaveBeenCalledTimes(1);
     expect(screen.getByText('dark-on')).toBeInTheDocument();
+  });
+
+  it('keeps the login-only language action aligned to the 28px action frame', () => {
+    renderWithProviders(<LoginTopActions isDarkMode={false} onDarkModeToggle={jest.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Select a language' })).toHaveStyle({
+      padding: '6px',
+      minWidth: '28px',
+      minHeight: '28px',
+    });
+    expect(screen.getByTestId('select-lang-trigger')).toHaveStyle({
+      padding: '0',
+      fontSize: '16px',
+      lineHeight: '1',
+    });
   });
 
   it('supports keyboard access for dark mode, language, and help actions', async () => {
@@ -96,14 +111,15 @@ describe('LoginTopActions', () => {
 
     screen.getByRole('button', { name: 'toggle-dark-mode' }).focus();
     await userEvent.keyboard('{Enter}');
-    screen.getByRole('button', { name: 'select-lang-trigger' }).focus();
+    screen.getByRole('button', { name: 'Select a language' }).focus();
+    await userEvent.keyboard('{Enter}');
     await userEvent.keyboard(' ');
     screen.getByRole('button', { name: 'Open help documentation' }).focus();
     await userEvent.keyboard('{Enter}');
     await userEvent.keyboard(' ');
 
     expect(onDarkModeToggle).toHaveBeenCalledTimes(1);
-    expect(mockSelectLangTrigger).toHaveBeenCalledTimes(1);
+    expect(mockSelectLangTrigger).toHaveBeenCalledTimes(2);
     expect(window.open).toHaveBeenCalledWith('https://docs.tiangong.earth');
     expect(window.open).toHaveBeenCalledTimes(2);
   });
@@ -111,7 +127,7 @@ describe('LoginTopActions', () => {
   it('keeps native language-trigger behavior when clicking the inner trigger directly', async () => {
     renderWithProviders(<LoginTopActions isDarkMode={false} onDarkModeToggle={jest.fn()} />);
 
-    await userEvent.click(screen.getByRole('button', { name: 'select-lang-trigger' }));
+    await userEvent.click(screen.getByTestId('select-lang-trigger'));
 
     expect(mockSelectLangTrigger).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#621

## Summary
- Restore the Umi-provided Chinese, English, and German flag icons in the shared language selector.
- Align login actions to a 28px frame while keeping the application header on native ProLayout action behavior.
- Use the native Ant Design tooltip for the help action and prepare the combined release as v0.0.49.

## Key Decisions
- Keep one canonical German locale (de-DE) while displaying the German flag supplied through the existing selector data.
- Avoid wrapping the main-layout selector in another action frame; only the login surface owns its custom alignment shell.
- Refresh the deterministic German runtime activation manifest after the release version changes its audited input digest.

## Validation
- npm run push:checked -- -u origin codex/issue-621-restore-language-flags (Docpact passed; LCIA cache valid; lint, Prettier, TypeScript passed; 363 suites / 4561 tests passed; 404/404 tracked source files at 100% statements, branches, functions, and lines).
- Focused UI/component/browser measurements covered selector flags, 28px login action frames, native ProLayout hover behavior, and native Ant Design help tooltip behavior.
- npm run test:ci -- tests/unit/i18n/germanRuntimeActivation.test.ts --runInBand --testTimeout=20000 --no-coverage (3/3 passed); npm run i18n:audit (0 violations).

## Risks / Rollback
- Low UI risk; rollback is the merge commit for this PR. The release version and deterministic manifest must stay together.

## Follow-ups
- After merge to dev, promote the complete verified dev state to main as v0.0.49 under release Issue #619.

## Workspace Integration
- After the production main SHA is verified, the parent workspace delivery in tiangong-lca/workspace#416 remains responsible for the exact submodule pointer update.