### PR TITLE
fix: restore locale flags and header action alignment

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-07-17'
-lastReviewedCommit: 'cc66ad9a4084063b3fea7659bb4271303a88ba2e'
-lastReviewedNote: 'Reviewed Issue #614 text-only selector and the V8-safe single-worker coverage model; testing and gate ownership remain covered by the existing rule graph.'
+lastReviewedCommit: 'c974ac7b46bacd32fbcd9b4c22913cc1a95c07d7'
+lastReviewedNote: 'Reviewed Issue #621 native Umi locale flags, ProLayout-owned action frames, Ant Design help tooltip, and focused component proof; ownership, routing, and gate rules are unchanged.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Reviewed Issue #614 shared text-only language selector; repo ownership, branch facts, and hard boundaries are unchanged.'
+lastReviewedCommit: c974ac7b46bacd32fbcd9b4c22913cc1a95c07d7
+lastReviewedNote: 'Reviewed Issue #621 shared native locale flags and header action alignment; repo ownership, branch facts, and hard boundaries are unchanged.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -21,8 +21,8 @@ checkPaths:
   - package.json
   - .nvmrc
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Reviewed Issue #614 focused UI proof and managed final-push flow; validation commands and gate ownership are unchanged.'
+lastReviewedCommit: c974ac7b46bacd32fbcd9b4c22913cc1a95c07d7
+lastReviewedNote: 'Reviewed Issue #621 local browser proof and managed final-push flow; bootstrap commands and gate ownership are unchanged.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -24,8 +24,8 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Reviewed Issue #614 selector proof and the V8-safe single-worker recycle boundary; single full-gate ownership and 100% src coverage remain unchanged.'
+lastReviewedCommit: c974ac7b46bacd32fbcd9b4c22913cc1a95c07d7
+lastReviewedNote: 'Reviewed Issue #621 focused shared-header component proof; single full-gate ownership and 100% src coverage remain unchanged.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,8 +22,8 @@ checkPaths:
   - public/**
   - docker/**
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Reviewed Issue #614 text-only language options across the shared login and application-header selector; architecture and ownership boundaries are unchanged.'
+lastReviewedCommit: c974ac7b46bacd32fbcd9b4c22913cc1a95c07d7
+lastReviewedNote: 'Reviewed Issue #621 native Umi language triggers, login-only compact framing, and ProLayout-owned header actions; architecture and ownership boundaries are unchanged.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -23,8 +23,8 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Reviewed Issue #614 selector proof and the V8-safe single-worker Jest gate; the complete test inventory and 100% src coverage bar remain authoritative.'
+lastReviewedCommit: c974ac7b46bacd32fbcd9b4c22913cc1a95c07d7
+lastReviewedNote: 'Reviewed Issue #621 native locale-icon, direct-trigger, compact login-frame, ProLayout hover, and Ant Design tooltip proof; the complete test inventory and 100% src coverage bar remain authoritative.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -21,8 +21,8 @@ checkPaths:
   - tests/**
   - package.json
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Reviewed Issue #614 selector proof and the V8-safe single-worker recycle boundary; the full-closure strategy and quality bar remain unchanged.'
+lastReviewedCommit: c974ac7b46bacd32fbcd9b4c22913cc1a95c07d7
+lastReviewedNote: 'Reviewed Issue #621 focused selector and header-action regression proof; the full-closure strategy and quality bar remain unchanged.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Reviewed Issue #614 selector coverage and the V8-safe single-worker recycle boundary; full closure remains intact with no new queue.'
+lastReviewedCommit: c974ac7b46bacd32fbcd9b4c22913cc1a95c07d7
+lastReviewedNote: 'Reviewed Issue #621 selector, compact login-frame, and header tooltip coverage; full closure remains intact with no new queue.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -22,8 +22,8 @@ checkPaths:
   - tests/data-workflows/**
   - package.json
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Reviewed Issue #614 component proof and the V8-safe single-worker recycle pattern for long-running coverage.'
+lastReviewedCommit: c974ac7b46bacd32fbcd9b4c22913cc1a95c07d7
+lastReviewedNote: 'Reviewed Issue #621 semantic shared-header component proof and retained the existing focused-component and single-worker coverage patterns.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - package.json
 lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Reviewed Issue #614 selector smoke and the confirmed macOS Node/V8 native GC crash; added the supported single-worker recycle recovery.'
+lastReviewedCommit: c974ac7b46bacd32fbcd9b4c22913cc1a95c07d7
+lastReviewedNote: 'Reviewed Issue #621 focused selector and header-action validation; the existing shortest recovery paths remain current.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n-de-DE/runtime-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/runtime-activation-manifest.json
@@ -191,7 +191,7 @@
   },
   "source": {
     "canonicalManifest": "docs/plans/i18n-de-DE/manifest.json",
-    "canonicalAuditedInputDigest": "551fd1097df11b681178f2eda268fc91ade15ef6c0fbac6234f25ef5916112f8",
+    "canonicalAuditedInputDigest": "708009c8e84b4bb2e9010fb709fe32471783f0c7501fe6384873a0be314ef250",
     "digestAlgorithm": "sha256",
     "inputs": [
       {
@@ -219,7 +219,7 @@
       {
         "kind": "file",
         "path": "docs/plans/i18n-de-DE/manifest.json",
-        "sha256": "5da78632fb333868eaed6ce25ecca840fa3ae2ff51d4ef5e1a6f27d978b41a53"
+        "sha256": "0c7da37adb27fc2cad2cab213280da463865f946357ddb9fe2496dd7224ce4a7"
       },
       {
         "kind": "file",
@@ -412,6 +412,6 @@
         "sha256": "0c414199c5f5937821c9c35edaa5f6e23c079711f102011dfa11bfeb2bf3602b"
       }
     ],
-    "inputDigest": "5486eff026b804d30a3ee718687877c57359d70b2e3c927f5cb6d62faa63facd"
+    "inputDigest": "31ccec5bd70d5ae53ca373b617e7a5abff117f9be4b42ba0d29f1f9aebfacf8d"
   }
 }

--- a/src/components/RightContent/index.tsx
+++ b/src/components/RightContent/index.tsx
@@ -5,9 +5,8 @@ import {
 } from '@/services/general/runtimeLocale';
 import { MoonOutlined, QuestionCircleOutlined, SunFilled } from '@ant-design/icons';
 import { SelectLang as UmiSelectLang, useIntl } from '@umijs/max';
-import { ConfigProvider, theme } from 'antd';
+import { ConfigProvider, theme, Tooltip } from 'antd';
 import type React from 'react';
-import { useRef } from 'react';
 
 const { defaultAlgorithm, darkAlgorithm } = theme;
 
@@ -15,71 +14,31 @@ interface SelectLangProps {
   style?: React.CSSProperties;
 }
 
-type UmiSelectLangDropdownProps = React.ComponentProps<typeof UmiSelectLang> & {
-  overlayClassName?: string;
-};
-
-const textOnlyLanguageDropdownProps: UmiSelectLangDropdownProps = {
-  overlayClassName: 'tg-language-selector-dropdown',
-};
-
 export const SelectLang: React.FC<SelectLangProps> = ({ style }) => {
-  const intl = useIntl();
-  const containerRef = useRef<HTMLDivElement>(null);
-  const openLanguageMenu = () => {
-    containerRef.current
-      ?.querySelector<HTMLElement>('.ant-dropdown-trigger, button, [role="button"], a, span')
-      ?.click();
-  };
-
   return (
-    <div
-      ref={containerRef}
-      role='button'
-      tabIndex={0}
-      aria-label={intl.formatMessage({
-        id: 'pages.lang.select',
-        defaultMessage: 'Select a language',
-      })}
-      onClick={(event) => {
-        if (event.target === event.currentTarget) {
-          openLanguageMenu();
-        }
+    <UmiSelectLang
+      style={{
+        padding: 4,
+        ...style,
       }}
-      onKeyDown={(event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          openLanguageMenu();
-        }
+      postLocalesData={(locales) => {
+        const localesByKey = new Map(locales.map((locale) => [locale.lang, locale]));
+        return SUPPORTED_APP_LOCALES.map((locale) => {
+          const existingLocale = localesByKey.get(locale) ?? { lang: locale };
+
+          if (locale !== 'de-DE') {
+            return existingLocale;
+          }
+
+          return {
+            ...existingLocale,
+            lang: 'de-DE',
+            label: 'Deutsch',
+            title: 'Deutsch',
+          };
+        });
       }}
-    >
-      <UmiSelectLang
-        {...textOnlyLanguageDropdownProps}
-        style={{
-          padding: 4,
-          ...style,
-        }}
-        postLocalesData={(locales) => {
-          const localesByKey = new Map(locales.map((locale) => [locale.lang, locale]));
-          return SUPPORTED_APP_LOCALES.map((locale) => {
-            const existingLocale = localesByKey.get(locale) ?? { lang: locale };
-            const localeWithoutIcon = { ...existingLocale };
-            delete localeWithoutIcon.icon;
-
-            if (locale !== 'de-DE') {
-              return localeWithoutIcon;
-            }
-
-            return {
-              ...localeWithoutIcon,
-              lang: 'de-DE',
-              label: 'Deutsch',
-              title: 'Deutsch',
-            };
-          });
-        }}
-      />
-    </div>
+    />
   );
 };
 
@@ -96,26 +55,18 @@ export const Question = () => {
   });
 
   return (
-    <button
-      type='button'
-      aria-label={helpLabel}
-      title={helpLabel}
-      style={{
-        display: 'flex',
-        height: 26,
-        alignItems: 'center',
-        padding: 0,
-        color: 'inherit',
-        background: 'transparent',
-        border: 0,
-        cursor: 'pointer',
-      }}
-      onClick={() => {
-        window.open(docsUrl);
-      }}
-    >
-      <QuestionCircleOutlined />
-    </button>
+    <Tooltip title={helpLabel}>
+      <button
+        type='button'
+        aria-label={helpLabel}
+        className='tg-global-header-action-button'
+        onClick={() => {
+          window.open(docsUrl);
+        }}
+      >
+        <QuestionCircleOutlined />
+      </button>
+    </Tooltip>
   );
 };
 

--- a/src/global.less
+++ b/src/global.less
@@ -208,10 +208,15 @@ ol {
   }
 }
 
-.tg-language-selector-dropdown {
-  .ant-dropdown-menu-item [role='img'] {
-    display: none;
-  }
+.tg-global-header-action-button {
+  display: inline-flex;
+  align-items: center;
+  color: inherit;
+  font: inherit;
+  appearance: none;
+  background: unset;
+  border: 0;
+  cursor: pointer;
 }
 
 .tg-global-header-avatar-trigger {

--- a/src/pages/User/Login/Components/LoginTopActions.tsx
+++ b/src/pages/User/Login/Components/LoginTopActions.tsx
@@ -134,7 +134,7 @@ const LoginTopActions: React.FC<LoginTopActionsProps> = ({ isDarkMode, onDarkMod
             backgroundColor: hoveredAction === 'lang' ? actionHoverBg : undefined,
           }}
         >
-          <SelectLang style={{ padding: 0, color: actionColor }} />
+          <SelectLang style={{ padding: 0, color: actionColor, fontSize: 16, lineHeight: 1 }} />
         </div>
       </div>
       <div

--- a/tests/unit/components/RightContent.test.tsx
+++ b/tests/unit/components/RightContent.test.tsx
@@ -19,9 +19,8 @@ type IconProps = {
 
 const configProviderThemes: string[] = [];
 let mockLocale: string | undefined = 'zh-CN';
-const mockSelectLangClick = jest.fn();
 let renderedLocales: Array<Record<string, unknown>> = [];
-let renderedOverlayClassName: string | undefined;
+let renderedTooltipTitle: ReactNode;
 const defaultAvailableLocales = () => [
   { lang: 'de-DE', label: 'Deutsch (Deutschland)', icon: '🇩🇪' },
   { lang: 'en-US', label: 'English', icon: '🇺🇸' },
@@ -46,23 +45,15 @@ jest.mock('@ant-design/icons', () => ({
 
 jest.mock('@umijs/max', () => ({
   SelectLang: ({
-    overlayClassName,
     postLocalesData,
     style,
   }: {
-    overlayClassName?: string;
     postLocalesData?: (locales: Array<Record<string, unknown>>) => Array<Record<string, unknown>>;
     style?: Record<string, unknown>;
   }) => {
-    renderedOverlayClassName = overlayClassName;
     renderedLocales = postLocalesData?.(mockAvailableLocales) ?? [];
     return (
-      <button
-        data-testid='select-lang'
-        type='button'
-        style={style ?? {}}
-        onClick={mockSelectLangClick}
-      >
+      <button data-testid='select-lang' type='button' style={style ?? {}}>
         language selector
       </button>
     );
@@ -90,9 +81,8 @@ afterEach(() => {
   mockHandleClick.mockClear();
   configProviderThemes.length = 0;
   mockLocale = 'zh-CN';
-  mockSelectLangClick.mockClear();
   renderedLocales = [];
-  renderedOverlayClassName = undefined;
+  renderedTooltipTitle = undefined;
   mockAvailableLocales = defaultAvailableLocales();
 });
 
@@ -107,9 +97,15 @@ jest.mock('antd', () => {
     darkAlgorithm: 'dark-algorithm',
   };
 
+  const Tooltip = ({ children, title }: { children: ReactNode; title: ReactNode }) => {
+    renderedTooltipTitle = title;
+    return <>{children}</>;
+  };
+
   return {
     ConfigProvider,
     theme,
+    Tooltip,
   };
 });
 
@@ -178,7 +174,8 @@ describe('RightContent Components', () => {
     const helpButton = screen.getByRole('button', {
       name: 'Englische Hilfedokumentation öffnen',
     });
-    expect(helpButton).toHaveAttribute('title', 'Englische Hilfedokumentation öffnen');
+    expect(helpButton).not.toHaveAttribute('title');
+    expect(renderedTooltipTitle).toBe('Englische Hilfedokumentation öffnen');
     fireEvent.click(helpButton);
 
     expect(mockWindowOpen).toHaveBeenCalledWith('https://docs.tiangong.earth/en');
@@ -202,33 +199,20 @@ describe('RightContent Components', () => {
     });
   });
 
-  it('exposes the three product locales as text-only country-neutral options', () => {
+  it('preserves the three product locale flags and normalizes the German label', () => {
     render(<SelectLang />);
 
-    expect(renderedOverlayClassName).toBe('tg-language-selector-dropdown');
     expect(renderedLocales).toEqual([
-      { lang: 'zh-CN', label: '简体中文' },
-      { lang: 'en-US', label: 'English' },
-      { lang: 'de-DE', label: 'Deutsch', title: 'Deutsch' },
+      { lang: 'zh-CN', label: '简体中文', icon: '🇨🇳' },
+      { lang: 'en-US', label: 'English', icon: '🇺🇸' },
+      { lang: 'de-DE', label: 'Deutsch', icon: '🇩🇪', title: 'Deutsch' },
     ]);
   });
 
-  it('opens the language menu from keyboard interaction on the accessible wrapper', () => {
-    render(<SelectLang />);
+  it('renders the native Umi language trigger as the component root', () => {
+    const { container } = render(<SelectLang />);
 
-    const selectorWrapper = screen.getByRole('button', { name: 'Select a language' });
-    fireEvent.keyDown(selectorWrapper, { key: 'Enter' });
-    fireEvent.keyDown(selectorWrapper, { key: ' ' });
-
-    expect(mockSelectLangClick).toHaveBeenCalledTimes(2);
-  });
-
-  it('opens the language menu from a direct wrapper click', () => {
-    render(<SelectLang />);
-
-    fireEvent.click(screen.getByRole('button', { name: 'Select a language' }));
-
-    expect(mockSelectLangClick).toHaveBeenCalledTimes(1);
+    expect(container.firstElementChild).toBe(screen.getByTestId('select-lang'));
   });
 
   it('synthesizes a supported locale entry when Umi omits one', () => {

--- a/tests/unit/pages/User/Login/Components/LoginTopActions.test.tsx
+++ b/tests/unit/pages/User/Login/Components/LoginTopActions.test.tsx
@@ -24,8 +24,8 @@ jest.mock('umi', () => ({
 jest.mock('@/components/RightContent', () => ({
   __esModule: true,
   DarkMode: ({ isDarkMode }: any) => <span>{isDarkMode ? 'dark-on' : 'dark-off'}</span>,
-  SelectLang: () => (
-    <button type='button' onClick={mockSelectLangTrigger}>
+  SelectLang: ({ style }: any) => (
+    <button type='button' style={style} onClick={mockSelectLangTrigger}>
       select-lang-trigger
     </button>
   ),
@@ -88,6 +88,20 @@ describe('LoginTopActions', () => {
 
     expect(mockSelectLangTrigger).toHaveBeenCalledTimes(1);
     expect(screen.getByText('dark-on')).toBeInTheDocument();
+  });
+
+  it('keeps the login language trigger inside the same compact 28px action frame', () => {
+    renderWithProviders(<LoginTopActions isDarkMode={false} onDarkModeToggle={jest.fn()} />);
+
+    expect(screen.getByTestId('login-language-frame')).toHaveStyle({
+      minWidth: '28px',
+      minHeight: '28px',
+    });
+    expect(screen.getByRole('button', { name: 'select-lang-trigger' })).toHaveStyle({
+      padding: '0px',
+      fontSize: '16px',
+      lineHeight: '1',
+    });
   });
 
   it('supports keyboard access for dark mode, language, and help actions', async () => {


### PR DESCRIPTION
## Summary

- Restore Umi SelectLang's native country flags and keep the locale order as 🇨🇳 简体中文, 🇺🇸 English, 🇩🇪 Deutsch.
- Render the authenticated language trigger directly under ProLayout, keep the login-only action frames at 28px, and let the existing layout own hover behavior.
- Replace the authenticated help action's browser-native title with the standard Ant Design Tooltip.
- Refresh the canonical i18n audit and German runtime-activation manifests for the changed selector source.

## Validation

- Focused component suites: 20/20 tests passed.
- German runtime-activation regression suite: 3/3 tests passed.
- `npm run i18n:audit`, `npm run lint`, and `npm run build` passed.
- Local browser smoke on `#/user/login` confirmed:
  - exact menu order and flags: 🇨🇳 简体中文, 🇺🇸 English, 🇩🇪 Deutsch;
  - dark, language, and help action frames are all 28px high;
  - no console errors.
- Managed checked-push gate passed on exact commit `2aa52cfdcead4f302e78c5da7cab2eac11b87158`:
  - Docpact: 17 changed paths, 17 matched rules, zero diagnostics;
  - LCIA cache, ESLint, Prettier, and TypeScript checks passed;
  - full coverage: 404/404 tracked source files at 100/100/100/100.
- The initial Git transport failed after both gates passed; the repository-owned, receipt-bound `push:retry` completed the identical push without bypassing or repeating the gates.

## Release and integration

- Target branch: `dev`.
- This is the remaining functional dependency for the v0.0.49 production promotion tracked by #619.
- After merge, create a separate v0.0.49 version-bump PR to `dev`, then promote `dev` to `main`; do not publish the superseded v0.0.48 draft.
- Root workspace integration remains pending until the exact v0.0.49 `main` SHA is available.

Closes #621
