### PR TITLE
test(i18n): stabilize per-page login route readiness

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-07-19'
-lastReviewedCommit: 'a3c63306da7f6e4665158aeb0744f578c0e32050'
+lastReviewedAt: '2026-07-20'
+lastReviewedCommit: 'd44bcac8c7839f0c29163485f43c61b71965a3b6'
 lastReviewedNote: 'Reviewed for Issue #635 and governed credential-free GitHub browser jobs, the explicitly authorized local production-data operator run, and digest-bound evidence.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-07-20'
-lastReviewedCommit: 'd44bcac8c7839f0c29163485f43c61b71965a3b6'
+lastReviewedCommit: '91973faef33baa3534490e47688f7a538dd41861'
 lastReviewedNote: 'Reviewed for Issue #635 and governed credential-free GitHub browser jobs, the explicitly authorized local production-data operator run, and digest-bound evidence.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: d44bcac8c7839f0c29163485f43c61b71965a3b6
+lastReviewedCommit: 91973faef33baa3534490e47688f7a538dd41861
 lastReviewedNote: 'Reviewed for Issue #635: GitHub browser jobs are credential-free/read-only, while production-data semantic closure is restricted to an explicitly authorized local operator session.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-07-19
-lastReviewedCommit: a3c63306da7f6e4665158aeb0744f578c0e32050
+lastReviewedAt: 2026-07-20
+lastReviewedCommit: d44bcac8c7839f0c29163485f43c61b71965a3b6
 lastReviewedNote: 'Reviewed for Issue #635: GitHub browser jobs are credential-free/read-only, while production-data semantic closure is restricted to an explicitly authorized local operator session.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -23,8 +23,8 @@ checkPaths:
   - tests/e2e/i18n/**
   - .github/workflows/i18n-semantic-e2e.yml
   - .nvmrc
-lastReviewedAt: 2026-07-19
-lastReviewedCommit: a3c63306da7f6e4665158aeb0744f578c0e32050
+lastReviewedAt: 2026-07-20
+lastReviewedCommit: d44bcac8c7839f0c29163485f43c61b71965a3b6
 lastReviewedNote: 'Reviewed for Issue #635 and separated credential-free GitHub browser proof from the explicitly authorized local production-data operator run.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -24,7 +24,7 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - .nvmrc
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: d44bcac8c7839f0c29163485f43c61b71965a3b6
+lastReviewedCommit: 91973faef33baa3534490e47688f7a538dd41861
 lastReviewedNote: 'Reviewed for Issue #635 and separated credential-free GitHub browser proof from the explicitly authorized local production-data operator run.'
 ---
 

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -56,7 +56,7 @@ checkPaths:
   - .github/workflows/build.yml
   - package.json
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: d44bcac8c7839f0c29163485f43c61b71965a3b6
+lastReviewedCommit: 91973faef33baa3534490e47688f7a538dd41861
 lastReviewedNote: 'Bound the reusable Goal to credential-free GitHub browser jobs, local-operator-only production data, pre-delete row attestation, and same-document locale race proof.'
 baselineObservedAt: 2026-07-18
 related:

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -55,8 +55,8 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - .github/workflows/build.yml
   - package.json
-lastReviewedAt: 2026-07-19
-lastReviewedCommit: a3c63306da7f6e4665158aeb0744f578c0e32050
+lastReviewedAt: 2026-07-20
+lastReviewedCommit: d44bcac8c7839f0c29163485f43c61b71965a3b6
 lastReviewedNote: 'Bound the reusable Goal to credential-free GitHub browser jobs, local-operator-only production data, pre-delete row attestation, and same-document locale race proof.'
 baselineObservedAt: 2026-07-18
 related:
@@ -795,7 +795,7 @@ tracked semantic evidence 只允许包含非秘密 assertion 结果与 digest。
 - 匿名登录流程和一个代表性已登录 shared Header browser smoke；匿名访问 `/`、`/welcome`、`/welcome?view=carbon-footprint` 及代表性未匹配/大小写变体路径时，必须逐项证明跳转 canonical login 且未挂载受保护内容；
 - 在有效会话下，对 Welcome overview 与 carbon-footprint guide 验证标题、正文、动作、步骤/schema、modal、媒体 loading/error/fallback、语言切换及带 query 刷新；
 - 对 route-view matrix 发现的其他静态页面执行同级 focused browser proof，不能只验证示例 URL；浏览器矩阵从 registry 遍历全部 active locale，而不是只测本次目标语言；
-- 以 `npm run test:e2e:i18n` 执行 `playwright.config.ts` 与 `tests/e2e/i18n/**`：Chromium 覆盖全部 49 个稳定 assertion ID，Chromium/Firefox/WebKit 共同覆盖关键登录/selector、team authoring 和 process lifecycle 场景；
+- 以 `npm run test:e2e:i18n` 执行 `playwright.config.ts` 与 `tests/e2e/i18n/**`：Chromium 覆盖全部 49 个稳定 assertion ID，Chromium/Firefox/WebKit 共同覆盖关键登录/selector、team authoring 和 process lifecycle 场景；除全局 candidate rendered probe 外，每个新登录 page/context 必须通过共享 route-ready marker 完成有界等待，保留 `failOnFlakyTests`，禁止 fixed sleep、全局 action timeout 放宽或重跑碰运气；
 - 所有 semantic E2E GitHub Actions event（包括 `workflow_dispatch`）只执行无生产凭据、无写入的三浏览器 public semantics/合同边界矩阵；完整已登录 proof 只允许明确授权的本地 operator session，并对 local `npm run start:main` candidate + production backend 设置 authenticated mode、两个 production-write guards 和 verified-evidence opt-in；
 - 生产数据仅创建 UUID-scoped `codex-e2e` tuple；create 前写 intent ledger，delete 前验证 production row UUID、authenticated owner 和五个 multilingual fields × 全部 registry authoring languages 的 exact marker closure，随后精确清理并证明 `created=cleaned`、`leaked=0`；禁止 screenshot/trace/video/auth artifact；
 - Header 的 Umi `SelectLang` 以 `reload={false}` 在同 document 内切换；验证 document identity/URL 保持、mounted reference label 刷新，以及延迟旧 locale 响应不会覆盖当前 locale；

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-07-19
-lastReviewedCommit: a3c63306da7f6e4665158aeb0744f578c0e32050
+lastReviewedAt: 2026-07-20
+lastReviewedCommit: d44bcac8c7839f0c29163485f43c61b71965a3b6
 lastReviewedNote: 'Reviewed for Issue #635: kept the full gate unchanged and made every GitHub semantic E2E run credential-free/read-only; authenticated closure is local-operator-only.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: d44bcac8c7839f0c29163485f43c61b71965a3b6
+lastReviewedCommit: 91973faef33baa3534490e47688f7a538dd41861
 lastReviewedNote: 'Reviewed for Issue #635: kept the full gate unchanged and made every GitHub semantic E2E run credential-free/read-only; authenticated closure is local-operator-only.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,7 +25,7 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: d44bcac8c7839f0c29163485f43c61b71965a3b6
+lastReviewedCommit: 91973faef33baa3534490e47688f7a538dd41861
 lastReviewedNote: 'Updated for Issue #635: all GitHub browser jobs are credential-free/read-only and the digest-bound production-data closure is local-operator-only.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -24,8 +24,8 @@ checkPaths:
   - .husky/pre-push
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
-lastReviewedAt: 2026-07-19
-lastReviewedCommit: a3c63306da7f6e4665158aeb0744f578c0e32050
+lastReviewedAt: 2026-07-20
+lastReviewedCommit: d44bcac8c7839f0c29163485f43c61b71965a3b6
 lastReviewedNote: 'Updated for Issue #635: all GitHub browser jobs are credential-free/read-only and the digest-bound production-data closure is local-operator-only.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -22,8 +22,8 @@ checkPaths:
   - playwright.config.ts
   - .github/workflows/i18n-semantic-e2e.yml
   - package.json
-lastReviewedAt: 2026-07-19
-lastReviewedCommit: a3c63306da7f6e4665158aeb0744f578c0e32050
+lastReviewedAt: 2026-07-20
+lastReviewedCommit: d44bcac8c7839f0c29163485f43c61b71965a3b6
 lastReviewedNote: 'Reviewed for Issue #635: retained bounded browser coverage while restricting authenticated production-data proof to an authorized local operator session.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -23,7 +23,7 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - package.json
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: d44bcac8c7839f0c29163485f43c61b71965a3b6
+lastReviewedCommit: 91973faef33baa3534490e47688f7a538dd41861
 lastReviewedNote: 'Reviewed for Issue #635: retained bounded browser coverage while restricting authenticated production-data proof to an authorized local operator session.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -24,7 +24,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: d44bcac8c7839f0c29163485f43c61b71965a3b6
+lastReviewedCommit: 91973faef33baa3534490e47688f7a538dd41861
 lastReviewedNote: 'Reviewed for Issue #635: recorded the local-operator-only authenticated closure and credential-free/read-only GitHub browser matrix.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -23,8 +23,8 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-07-19
-lastReviewedCommit: a3c63306da7f6e4665158aeb0744f578c0e32050
+lastReviewedAt: 2026-07-20
+lastReviewedCommit: d44bcac8c7839f0c29163485f43c61b71965a3b6
 lastReviewedNote: 'Reviewed for Issue #635: recorded the local-operator-only authenticated closure and credential-free/read-only GitHub browser matrix.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -24,7 +24,7 @@ checkPaths:
   - playwright.config.ts
   - package.json
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: d44bcac8c7839f0c29163485f43c61b71965a3b6
+lastReviewedCommit: 91973faef33baa3534490e47688f7a538dd41861
 lastReviewedNote: 'Reviewed for Issue #635 and separated credential-free GitHub browser proof from the local-operator-only authenticated production-data pattern.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -23,8 +23,8 @@ checkPaths:
   - tests/e2e/i18n/**
   - playwright.config.ts
   - package.json
-lastReviewedAt: 2026-07-19
-lastReviewedCommit: a3c63306da7f6e4665158aeb0744f578c0e32050
+lastReviewedAt: 2026-07-20
+lastReviewedCommit: d44bcac8c7839f0c29163485f43c61b71965a3b6
 lastReviewedNote: 'Reviewed for Issue #635 and separated credential-free GitHub browser proof from the local-operator-only authenticated production-data pattern.'
 ---
 
@@ -109,6 +109,7 @@ Browser semantic E2E pattern:
 
 - use `@playwright/test` `1.61.1` through `playwright.config.ts` and keep specs/helpers under `tests/e2e/i18n/**`
 - serve the candidate locally with `npm run start:main`; reject a non-loopback Playwright base URL even though the candidate uses the production backend configuration
+- keep the global rendered-candidate probe and require every new login page/context to await the shared route-specific visible marker before interaction; use a bounded readiness timeout, never a fixed sleep, broader action timeout, disabled retry accounting, or relaxed `failOnFlakyTests`
 - derive locale and authoring-language loops from `LOCALE_REGISTRY` and `CONTENT_LANGUAGE_REGISTRY`; never copy the current locale list into a spec or reporter
 - run the complete 49-route/view matrix in Chromium, require every target-declared semantic scenario in the evidence record, and run the critical selector, team authoring, and process lifecycle scenarios in Chromium, Firefox, and WebKit
 - keep every semantic E2E GitHub Actions event, including `workflow_dispatch`, credential-free and read-only; CI runs only three-browser public semantics/contract, while authenticated production writes are restricted to an explicitly authorized local operator session with `E2E_AUTHENTICATED=true` plus the two write guards (`E2E_ALLOW_PRODUCTION_DATA=true` and the exact one-process confirmation token); verified evidence is a separate explicit opt-in

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -22,8 +22,8 @@ checkPaths:
   - playwright.config.ts
   - tests/e2e/i18n/**
   - package.json
-lastReviewedAt: 2026-07-19
-lastReviewedCommit: a3c63306da7f6e4665158aeb0744f578c0e32050
+lastReviewedAt: 2026-07-20
+lastReviewedCommit: d44bcac8c7839f0c29163485f43c61b71965a3b6
 lastReviewedNote: 'Reviewed for Issue #635 and corrected semantic E2E recovery for credential-free GitHub jobs, local operator authorization, and pre-delete row verification.'
 ---
 
@@ -54,6 +54,7 @@ Canonical baseline and proof ownership stays with `DEV.md` and `docs/agents/repo
 | provider or context error | missing wrapper or wrong test utility | use the repo helper that already provides the required wrapper |
 | data workflow smoke assertion mismatch | `fixtures/data/**`, `fixtures/result/**`, workflow default path, or last-run artifact drifted apart | compare the case in `tests/data-workflows/fixtures/result/README.md`, then update the paired input fixture, expected-result Markdown, workflow lib default, and unit proof together |
 | Playwright refuses `E2E_BASE_URL` | the browser target is not the local candidate frontend | use a loopback candidate URL and let `playwright.config.ts` start `npm run start:main`; never point the Playwright frontend target at production |
+| a public semantic browser job reports a flaky missing login control after cold startup | the global candidate probe passed, but a new page returned from `domcontentloaded` before its login route mounted | keep `failOnFlakyTests` enabled, make the page use the shared rendered-login readiness helper, move regenerable Umi/MFSU caches aside, and rerun the exact browser scope without a fixed sleep or global timeout increase |
 | authenticated semantic E2E skips or fails before setup | the explicitly authorized local operator session lacks runtime credentials, authenticated mode, one of the two write guards, verified-evidence opt-in, or the production target proof | keep every semantic E2E GitHub Actions run unauthenticated/read-only; run the full closure only in the authorized local session with `E2E_AUTHENTICATED=true`, `E2E_ALLOW_PRODUCTION_DATA=true`, the exact one-process confirmation token, `E2E_WRITE_VERIFIED_EVIDENCE=true`, and the verified production backend target |
 | semantic evidence remains `failed` or activation rejects it | one of the 49 assertion IDs, registry locales, required browsers, route/test/source digests, or cleanup counts is incomplete or stale | inspect the first mismatched contract field, rerun only the affected browser scope, then run the complete authenticated closure; never edit evidence to simulate execution |
 | teardown refuses cleanup or reports a leaked `codex-e2e` process | the intent ledger is invalid, the production row UUID/owner/five-field registry marker closure does not match, or exact-ID deletion failed | preserve the ignored ledger; inspect only the exact UUID row, restore verifiable ownership/marker evidence or escalate, and never broaden deletion; do not create another record until `created=cleaned` and `leaked=0` |

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -23,7 +23,7 @@ checkPaths:
   - tests/e2e/i18n/**
   - package.json
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: d44bcac8c7839f0c29163485f43c61b71965a3b6
+lastReviewedCommit: 91973faef33baa3534490e47688f7a538dd41861
 lastReviewedNote: 'Reviewed for Issue #635 and corrected semantic E2E recovery for credential-free GitHub jobs, local operator authorization, and pre-delete row verification.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "1dfd9e71fe24c5d990b0407a8142445c498ccba73db90fe77e7e500e0cd31bb5",
+    "digest": "ea2cca1e196561ad60eba3217e219ad797599820562f83a0b45e94a3029f7652",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "8a5c6692f83c16c01fb0f00970889a6c907904eeeacf5641ac3ad72bfd3166d7",
+          "sha256": "7621a3295fbe0b63eacf0114990ba975fb8f55fae4c1b10d076b19dc19289bdc",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "1dfd9e71fe24c5d990b0407a8142445c498ccba73db90fe77e7e500e0cd31bb5",
+    "docs/plans/i18n/route-view-coverage.json": "ea2cca1e196561ad60eba3217e219ad797599820562f83a0b45e94a3029f7652",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-de-DE/glossary.json": "a5fd4e759af2713fbec83f2b95171c7b32206d7218da0401d28d2eecefccce3a",
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "86e28809d2b4444313165d1e77abf29fc4e2597123336a0d601c4e3ce97746c1"
+  "contextDigest": "5f4eec2630011e7c586db2c00d690922058cc24bcc4527d353b861e56f49a33d"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "86e28809d2b4444313165d1e77abf29fc4e2597123336a0d601c4e3ce97746c1",
-    "qualityDigest": "d2817d754adfad5eda0218fc6fd8ba3116a8836bacdd6b5b631e5612563d7920",
+    "contextDigest": "5f4eec2630011e7c586db2c00d690922058cc24bcc4527d353b861e56f49a33d",
+    "qualityDigest": "2d91357a88edca3176148c71d25bdd2670da76a871f81bec1a7dc5f95a96f235",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "1dfd9e71fe24c5d990b0407a8142445c498ccba73db90fe77e7e500e0cd31bb5",
+    "routeViewCoverageDigest": "ea2cca1e196561ad60eba3217e219ad797599820562f83a0b45e94a3029f7652",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "4d6731910838621ce174905ed209b7e887945599c9ee3016a7a402ef14cd2482"
+  "activationDigest": "78c6c0f7b01d0d190d543f6131f1c2db1536a5661e7fc02ab0321a4d488ff52b"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "43bf490c0d2b308be7e09c8d1c16fb099f67c4d1249601b7957e9b2bbfafb840",
-    "contextDigest": "86e28809d2b4444313165d1e77abf29fc4e2597123336a0d601c4e3ce97746c1"
+    "contextDigest": "5f4eec2630011e7c586db2c00d690922058cc24bcc4527d353b861e56f49a33d"
   },
   "catalog": {
     "messageCount": 3032,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "d2817d754adfad5eda0218fc6fd8ba3116a8836bacdd6b5b631e5612563d7920"
+  "qualityDigest": "2d91357a88edca3176148c71d25bdd2670da76a871f81bec1a7dc5f95a96f235"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "1dfd9e71fe24c5d990b0407a8142445c498ccba73db90fe77e7e500e0cd31bb5",
+    "digest": "ea2cca1e196561ad60eba3217e219ad797599820562f83a0b45e94a3029f7652",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "8a5c6692f83c16c01fb0f00970889a6c907904eeeacf5641ac3ad72bfd3166d7",
+          "sha256": "7621a3295fbe0b63eacf0114990ba975fb8f55fae4c1b10d076b19dc19289bdc",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "1dfd9e71fe24c5d990b0407a8142445c498ccba73db90fe77e7e500e0cd31bb5",
+    "docs/plans/i18n/route-view-coverage.json": "ea2cca1e196561ad60eba3217e219ad797599820562f83a0b45e94a3029f7652",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-en-US/glossary.json": "4b8443ea3f91f15383683e9ece6221e40e24ceb75442ea830964b06c12559970",
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "3d4deb20fb520651e571b8d14d38a4907ad1edb80f63061f988cceda8a031da3"
+  "contextDigest": "6f813d0ebd303fe0b0279d7ba3702b69eae5fce646e71d2a866438774d15cc9e"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "3d4deb20fb520651e571b8d14d38a4907ad1edb80f63061f988cceda8a031da3",
-    "qualityDigest": "3683a9ee6bd5e420a1ed369f4e1247209c0bb2b9ffef657d374da3868a704330",
+    "contextDigest": "6f813d0ebd303fe0b0279d7ba3702b69eae5fce646e71d2a866438774d15cc9e",
+    "qualityDigest": "98353a4864531a355a510a74501eadd3d2b835d6886463753a2dd24f227ed1a7",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "1dfd9e71fe24c5d990b0407a8142445c498ccba73db90fe77e7e500e0cd31bb5",
+    "routeViewCoverageDigest": "ea2cca1e196561ad60eba3217e219ad797599820562f83a0b45e94a3029f7652",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "98fa79b73840012ed666b7fd0988f6ba592c7b57512466b3d050892aa2297e54"
+  "activationDigest": "37b921f643e321b0a3ef440207bc62e83ca02fc9329ab1cc87b25273e0069924"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "43bf490c0d2b308be7e09c8d1c16fb099f67c4d1249601b7957e9b2bbfafb840",
-    "contextDigest": "3d4deb20fb520651e571b8d14d38a4907ad1edb80f63061f988cceda8a031da3"
+    "contextDigest": "6f813d0ebd303fe0b0279d7ba3702b69eae5fce646e71d2a866438774d15cc9e"
   },
   "catalog": {
     "messageCount": 3032,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "3683a9ee6bd5e420a1ed369f4e1247209c0bb2b9ffef657d374da3868a704330"
+  "qualityDigest": "98353a4864531a355a510a74501eadd3d2b835d6886463753a2dd24f227ed1a7"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "1dfd9e71fe24c5d990b0407a8142445c498ccba73db90fe77e7e500e0cd31bb5",
+    "digest": "ea2cca1e196561ad60eba3217e219ad797599820562f83a0b45e94a3029f7652",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "8a5c6692f83c16c01fb0f00970889a6c907904eeeacf5641ac3ad72bfd3166d7",
+          "sha256": "7621a3295fbe0b63eacf0114990ba975fb8f55fae4c1b10d076b19dc19289bdc",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "1dfd9e71fe24c5d990b0407a8142445c498ccba73db90fe77e7e500e0cd31bb5",
+    "docs/plans/i18n/route-view-coverage.json": "ea2cca1e196561ad60eba3217e219ad797599820562f83a0b45e94a3029f7652",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-fr-FR/glossary.json": "057cb494f02d980106469f6a16befc102d26db5ac362b9777cd5f97c7729c91b",
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "e243d05bf123f2a7b08bbe20fc363d4307c41e167933b080995af3924db6a86d"
+  "contextDigest": "ed72c68f444f408e0a0361992da791541b3d7c28472f04a6640c68b25758d4a8"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "e243d05bf123f2a7b08bbe20fc363d4307c41e167933b080995af3924db6a86d",
-    "qualityDigest": "62638cf5b9954e772732004e9a838d8279951a94881e5b23407deb606686dbaa",
+    "contextDigest": "ed72c68f444f408e0a0361992da791541b3d7c28472f04a6640c68b25758d4a8",
+    "qualityDigest": "14779d24a2a92aacaaa8b9618903374c7d18a9936152b895119f294477f91be5",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "1dfd9e71fe24c5d990b0407a8142445c498ccba73db90fe77e7e500e0cd31bb5",
+    "routeViewCoverageDigest": "ea2cca1e196561ad60eba3217e219ad797599820562f83a0b45e94a3029f7652",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "01a75435d65764e9ee193340048a91a2a6099e933988a8e9ac16bbf5a86a64e1"
+  "activationDigest": "f0341b45a7efdb3a26ad31a31a92de6a480a18343700c4a0006bad3464aab411"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "43bf490c0d2b308be7e09c8d1c16fb099f67c4d1249601b7957e9b2bbfafb840",
-    "contextDigest": "e243d05bf123f2a7b08bbe20fc363d4307c41e167933b080995af3924db6a86d"
+    "contextDigest": "ed72c68f444f408e0a0361992da791541b3d7c28472f04a6640c68b25758d4a8"
   },
   "catalog": {
     "messageCount": 3032,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "62638cf5b9954e772732004e9a838d8279951a94881e5b23407deb606686dbaa"
+  "qualityDigest": "14779d24a2a92aacaaa8b9618903374c7d18a9936152b895119f294477f91be5"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "1dfd9e71fe24c5d990b0407a8142445c498ccba73db90fe77e7e500e0cd31bb5",
+    "digest": "ea2cca1e196561ad60eba3217e219ad797599820562f83a0b45e94a3029f7652",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "8a5c6692f83c16c01fb0f00970889a6c907904eeeacf5641ac3ad72bfd3166d7",
+          "sha256": "7621a3295fbe0b63eacf0114990ba975fb8f55fae4c1b10d076b19dc19289bdc",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "1dfd9e71fe24c5d990b0407a8142445c498ccba73db90fe77e7e500e0cd31bb5",
+    "docs/plans/i18n/route-view-coverage.json": "ea2cca1e196561ad60eba3217e219ad797599820562f83a0b45e94a3029f7652",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-zh-CN/glossary.json": "c891add0ee4bd6d24c0213d0c839474e145d85867426df796763b8e038053d9b",
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "fc9ac1e747b1bf8ba9eb16488f39f531def5e6eeec573a66481c111d1a8d095c"
+  "contextDigest": "67a72f7800a3dc7999736f489514e5b6f9e5861d4315ecc531b7fe2d7d0523e6"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "fc9ac1e747b1bf8ba9eb16488f39f531def5e6eeec573a66481c111d1a8d095c",
-    "qualityDigest": "82860a84340f9cda5dc2d026dd983c57a0413389f500a66c7aa5596aee9f1b82",
+    "contextDigest": "67a72f7800a3dc7999736f489514e5b6f9e5861d4315ecc531b7fe2d7d0523e6",
+    "qualityDigest": "d4ebfa90c861f4b2a6aaed36d0c38f758c7468a9f5ce872a13f0255604d6fa6b",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "1dfd9e71fe24c5d990b0407a8142445c498ccba73db90fe77e7e500e0cd31bb5",
+    "routeViewCoverageDigest": "ea2cca1e196561ad60eba3217e219ad797599820562f83a0b45e94a3029f7652",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "25f05f6398f4538add892ec3f02c70754740647241781d329e483c65d446a6b6"
+  "activationDigest": "3af315a40cea03ba8055d73720a7432405623cee0f3ab562c2a341b8a5b2cafa"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "43bf490c0d2b308be7e09c8d1c16fb099f67c4d1249601b7957e9b2bbfafb840",
-    "contextDigest": "fc9ac1e747b1bf8ba9eb16488f39f531def5e6eeec573a66481c111d1a8d095c"
+    "contextDigest": "67a72f7800a3dc7999736f489514e5b6f9e5861d4315ecc531b7fe2d7d0523e6"
   },
   "catalog": {
     "messageCount": 3032,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "82860a84340f9cda5dc2d026dd983c57a0413389f500a66c7aa5596aee9f1b82"
+  "qualityDigest": "d4ebfa90c861f4b2a6aaed36d0c38f758c7468a9f5ce872a13f0255604d6fa6b"
 }

--- a/docs/plans/i18n/route-view-coverage.json
+++ b/docs/plans/i18n/route-view-coverage.json
@@ -353,7 +353,7 @@
       "executedEvidence": [
         {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "8a5c6692f83c16c01fb0f00970889a6c907904eeeacf5641ac3ad72bfd3166d7"
+          "sha256": "7621a3295fbe0b63eacf0114990ba975fb8f55fae4c1b10d076b19dc19289bdc"
         }
       ]
     }

--- a/docs/plans/i18n/semantic-e2e-evidence.json
+++ b/docs/plans/i18n/semantic-e2e-evidence.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": "tiangong.i18n-semantic-e2e-evidence.v1",
   "status": "verified",
-  "generatedAt": "2026-07-19T15:46:51.227Z",
-  "runId": "local-d12cd186-1e0f-4a3d-8a34-83c05f18dd29",
+  "generatedAt": "2026-07-19T16:53:13.372Z",
+  "runId": "local-81b2218a-4d3f-4bc8-a9d0-85fe60018b88",
   "candidate": {
     "configTreeDigest": "a5f819459fba99fbf639dbbfd9c6b863672bb2356203113c736ba508b2c8a176",
-    "observedHeadCommit": "3e40d5d63f5815b00dd041d2879c18922d2fc46d",
+    "observedHeadCommit": "91973faef33baa3534490e47688f7a538dd41861",
     "packageManifestDigest": "f80ad3c2d30abe3f9c03bbc4cb17915b110d539a7f3ecd637696723706117009",
     "sourceTreeDigest": "6d57f0320172a30374bd304a22ab627da1a19a48955bc130f33f4d31f016433d",
-    "unitTestTreeDigest": "56822f6edcab006a9a8604dc8d91691bda8ffc4c431e5614336e49dde18d41d8"
+    "unitTestTreeDigest": "91f3e7ffe38c075794d8e851813eaeadc672a993766514d307894c8a5fb46ec1"
   },
   "target": {
     "frontend": "candidate-local",
@@ -153,15 +153,15 @@
       },
       {
         "path": "tests/e2e/i18n/access-fallback.spec.ts",
-        "sha256": "494be03b58f399a3836b8b379c1e72426433eca39323f8a027af0a4d9d0a23d1"
+        "sha256": "709bac7281a50150bcf5e15c19b6b6b934d84ca1f3eb4e401d5cebe090695bc3"
       },
       {
         "path": "tests/e2e/i18n/auth.ts",
-        "sha256": "88208e7ab23f08dbc2527eccb87eb1c098e15ad036533f374f878a21cda490eb"
+        "sha256": "65b5528396835894644c9b80992edf1b62ccd00eca9a8ef7a236ec06f4b33349"
       },
       {
         "path": "tests/e2e/i18n/candidate-readiness.ts",
-        "sha256": "3e9de40d7e95cfe58bf77c3f5222601d834c7ee99c1c9c7ed9bdf7a34593df4b"
+        "sha256": "3c3caa4860092ef012301c6a2a099b32f17c071c8e9f1606521a6545ebc1b5f5"
       },
       {
         "path": "tests/e2e/i18n/carbon-footprint-guide.spec.ts",
@@ -200,6 +200,10 @@
         "sha256": "dcae1c20525749afd1ced26697540c6ceaba660291754c00d5e6e51036615f34"
       },
       {
+        "path": "tests/e2e/i18n/login-route-readiness.ts",
+        "sha256": "f7bc0e138d2801d8f1a0178cc4d1a43298822d604da7c19d09ef2e119a0b3e32"
+      },
+      {
         "path": "tests/e2e/i18n/process-lifecycle.spec.ts",
         "sha256": "2dbdcaa8d8690b9995200457fffccc2569205d98cc3a91c7a7910fcdbeb1daf4"
       },
@@ -225,7 +229,7 @@
       },
       {
         "path": "tests/e2e/i18n/query-responsive.spec.ts",
-        "sha256": "d2e7ca935cd174b2d8e13c54b8b2d3d8917928f505554b432f07879acce4ae66"
+        "sha256": "b5d8d0e504de3233c729df92741abb72c6f2d4e3aaca2c52ee14256cccc9f92c"
       },
       {
         "path": "tests/e2e/i18n/reference-fixture.ts",
@@ -253,7 +257,7 @@
       },
       {
         "path": "tests/e2e/i18n/semantic-critical.spec.ts",
-        "sha256": "e16867250b68c12e6bf99b12d73798ea03e262b5083531ae214251d9ab8be2cc"
+        "sha256": "0c77f45a2415fc3fcb72f3fcb90763f59c0eca1fc71d1183bf2e4b42574e7ca5"
       },
       {
         "path": "tests/e2e/i18n/state-semantics.spec.ts",

--- a/tests/e2e/i18n/access-fallback.spec.ts
+++ b/tests/e2e/i18n/access-fallback.spec.ts
@@ -16,6 +16,7 @@ import {
   routeToCandidateUrl,
   type ExecutableRouteAssertion,
 } from './contracts';
+import { waitForRenderedLoginControl } from './login-route-readiness';
 import { installVerifiedProductionReadOnlyGuard } from './production-backend-target';
 import { assertNoBlockedProductionRequests } from './production-request-guard';
 
@@ -72,12 +73,14 @@ async function expectLocalizedLogin(
   page: Page,
   localeDefinition: LocaleRegistryEntry,
 ): Promise<void> {
+  await waitForRenderedLoginControl(page);
   await expect.poll(() => readStoredAppLocale(page)).toBe(localeDefinition.canonicalLocale);
   await expectLocalizedLoginContent(page, localeDefinition);
 }
 
 async function selectLoginLocale(page: Page, localeDefinition: LocaleRegistryEntry): Promise<void> {
-  await page.getByTestId('login-language-frame').click();
+  const languageControl = await waitForRenderedLoginControl(page);
+  await languageControl.click();
   const menu = page.locator('.ant-dropdown-menu');
   await expect(menu).toBeVisible();
   await menu

--- a/tests/e2e/i18n/auth.ts
+++ b/tests/e2e/i18n/auth.ts
@@ -8,6 +8,7 @@ import {
   pickCredentialByRole,
 } from '../../data-workflows/workflows/workflow-shared';
 import { getLocaleMessage } from './contracts';
+import { waitForRenderedLoginControl } from './login-route-readiness';
 
 const LOGIN_FORM_LOCALE = 'en-US' as const;
 
@@ -37,6 +38,7 @@ export async function loadE2ECredential() {
 export async function signInViaUi(page: Page): Promise<void> {
   const credential = await loadE2ECredential();
   await page.goto('/#/user/login', { waitUntil: 'domcontentloaded' });
+  await waitForRenderedLoginControl(page);
   const loginForm = getLoginFormControls(page);
   await expect(loginForm.email).toBeVisible();
   await loginForm.email.fill(credential.email);

--- a/tests/e2e/i18n/candidate-readiness.ts
+++ b/tests/e2e/i18n/candidate-readiness.ts
@@ -1,6 +1,7 @@
 import type { Browser, BrowserContext, BrowserType } from '@playwright/test';
 
 import { assertCandidateFrontendTarget, PLAYWRIGHT_BROWSER_PROJECTS } from './contracts';
+import { waitForRenderedLoginControl } from './login-route-readiness';
 import { installVerifiedProductionReadOnlyGuard } from './production-backend-target';
 import {
   assertNoBlockedProductionRequests,
@@ -64,10 +65,7 @@ export async function waitForCandidateFrontendReady(
       timeout: timeoutMs,
       waitUntil: 'domcontentloaded',
     });
-    await page.getByTestId('login-language-frame').waitFor({
-      state: 'visible',
-      timeout: timeoutMs,
-    });
+    await waitForRenderedLoginControl(page, timeoutMs);
     dependencies.assertNoBlockedRequests(guard);
   } catch {
     throw new Error(

--- a/tests/e2e/i18n/login-route-readiness.ts
+++ b/tests/e2e/i18n/login-route-readiness.ts
@@ -1,0 +1,15 @@
+import type { Locator, Page } from '@playwright/test';
+
+export const LOGIN_ROUTE_READY_TIMEOUT_MS = 60_000;
+
+export async function waitForRenderedLoginControl(
+  page: Pick<Page, 'getByTestId'>,
+  timeoutMs = LOGIN_ROUTE_READY_TIMEOUT_MS,
+): Promise<Locator> {
+  const languageControl = page.getByTestId('login-language-frame');
+  await languageControl.waitFor({
+    state: 'visible',
+    timeout: timeoutMs,
+  });
+  return languageControl;
+}

--- a/tests/e2e/i18n/query-responsive.spec.ts
+++ b/tests/e2e/i18n/query-responsive.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from './fixtures';
 
 import { LOCALE_REGISTRY } from '../../../src/services/general/localeRegistry';
 import { annotateEvidence, findRouteAssertion, readStoredAppLocale } from './contracts';
+import { waitForRenderedLoginControl } from './login-route-readiness';
 
 const loginAssertion = findRouteAssertion('/user/login');
 
@@ -9,16 +10,17 @@ test('locale switching preserves hash query at a narrow viewport', async ({ page
   annotateEvidence(testInfo, loginAssertion, 'query-responsive');
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto('/#/user/login?codex-e2e=query-preserved', { waitUntil: 'domcontentloaded' });
-  await expect(page.getByTestId('login-language-frame')).toBeVisible();
+  await waitForRenderedLoginControl(page);
 
   for (const localeDefinition of LOCALE_REGISTRY) {
-    await page.getByTestId('login-language-frame').click();
+    const languageControl = await waitForRenderedLoginControl(page);
+    await languageControl.click();
     await page
       .locator('.ant-dropdown-menu-item')
       .filter({ hasText: localeDefinition.nativeLabel })
       .click();
     await expect.poll(() => readStoredAppLocale(page)).toBe(localeDefinition.canonicalLocale);
     expect(new URL(page.url()).hash).toContain('codex-e2e=query-preserved');
-    await expect(page.getByTestId('login-language-frame')).toBeVisible();
+    await waitForRenderedLoginControl(page);
   }
 });

--- a/tests/e2e/i18n/semantic-critical.spec.ts
+++ b/tests/e2e/i18n/semantic-critical.spec.ts
@@ -7,11 +7,13 @@ import {
   findRouteAssertion,
   readStoredAppLocale,
 } from './contracts';
+import { waitForRenderedLoginControl } from './login-route-readiness';
 
 const loginAssertion = findRouteAssertion('/user/login');
 
 async function openLanguageMenu(page: Page) {
-  await page.getByTestId('login-language-frame').click();
+  const languageControl = await waitForRenderedLoginControl(page);
+  await languageControl.click();
   await expect(page.locator('.ant-dropdown-menu')).toBeVisible();
 }
 

--- a/tests/unit/e2e/loginRouteReadiness.test.ts
+++ b/tests/unit/e2e/loginRouteReadiness.test.ts
@@ -1,0 +1,34 @@
+import {
+  LOGIN_ROUTE_READY_TIMEOUT_MS,
+  waitForRenderedLoginControl,
+} from '../../../tests/e2e/i18n/login-route-readiness';
+
+describe('login route readiness', () => {
+  it('waits for the rendered language control with the bounded page timeout', async () => {
+    const waitFor = jest.fn().mockResolvedValue(undefined);
+    const languageControl = { waitFor };
+    const getByTestId = jest.fn().mockReturnValue(languageControl);
+
+    await expect(waitForRenderedLoginControl({ getByTestId } as never)).resolves.toBe(
+      languageControl,
+    );
+
+    expect(getByTestId).toHaveBeenCalledWith('login-language-frame');
+    expect(waitFor).toHaveBeenCalledWith({
+      state: 'visible',
+      timeout: LOGIN_ROUTE_READY_TIMEOUT_MS,
+    });
+  });
+
+  it('honors the longer candidate-startup timeout supplied by global setup', async () => {
+    const waitFor = jest.fn().mockResolvedValue(undefined);
+    const getByTestId = jest.fn().mockReturnValue({ waitFor });
+
+    await waitForRenderedLoginControl({ getByTestId } as never, 180_000);
+
+    expect(waitFor).toHaveBeenCalledWith({
+      state: 'visible',
+      timeout: 180_000,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add one shared, bounded login-route readiness helper and use it in global candidate setup plus every page/context that interacts with the login language control
- keep zero fixed sleeps, the existing 20s action timeout, CI retry accounting, and `failOnFlakyTests` unchanged
- refresh the verified four-locale / three-browser semantic evidence and all derived locale manifests

## Root cause
After #639 merged to `dev`, the WebKit push workflow had one first-attempt timeout in `semantic-critical.spec.ts` while waiting for `login-language-frame`; the retry passed. The PR head tree and the `dev` merge tree were identical, so this was not a merge-source regression. The global candidate probe had completed, but a newly-created page could return from `domcontentloaded` before its login route mounted.

## Validation
- focused readiness unit tests: 6/6 passed
- cold-cache exact WebKit public-job scope: 6/6 passed on the first attempt
- Chromium + Firefox public-job scope: 12/12 passed on the first attempt
- authorized candidate-local / production-backend semantic E2E: 48 passed, 24 policy-skipped, 0 failed, local retries=0 across Chromium, Firefox, and WebKit
- production fixture closure: created=1, cleaned=1, leaked=0; primary/recovery ledgers, auth state, screenshots, traces, video, HAR, and reports were not retained
- verified evidence SHA-256: `7621a3295fbe0b63eacf0114990ba975fb8f55fae4c1b10d076b19dc19289bdc`
- checked-push gate: 397/397 suites, 5340/5340 tests, 450/450 tracked source files at 100% statements/branches/functions/lines
- Docpact, ESLint, Prettier, TypeScript, locale production readiness, and reference-resource checks passed

## Risk controls
- no production credentials are stored in GitHub or repository artifacts
- no fixed sleep, global action-timeout expansion, worker reduction, disabled retry accounting, or relaxed flaky policy
- the production test created only one UUID-scoped `codex-e2e` process and deleted that exact row after owner/version/marker verification

Closes #635
