### PR TITLE
chore(release): prepare v0.0.53

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-20"
-lastReviewedCommit: "9156b4baf8bfacb85d935ca45ed943654bd3e3f3"
-lastReviewedNote: 'Reviewed for Issue #635 and governed credential-free GitHub browser jobs, the explicitly authorized local production-data operator run, and digest-bound evidence.'
+lastReviewedCommit: "9b5bdeb11794f280b639212248b9816338923dd7"
+lastReviewedNote: 'Reviewed for v0.0.53 version-only release preparation; routing, ownership, and testing-gate contracts are unchanged.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: 9156b4baf8bfacb85d935ca45ed943654bd3e3f3
-lastReviewedNote: 'Reviewed for Issue #635: GitHub browser jobs are credential-free/read-only, while production-data semantic closure is restricted to an explicitly authorized local operator session.'
+lastReviewedCommit: 9b5bdeb11794f280b639212248b9816338923dd7
+lastReviewedNote: 'Reviewed for v0.0.53 version-only release preparation; repo, branch, delivery, and workspace-integration contracts are unchanged.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -24,8 +24,8 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - .nvmrc
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: 9156b4baf8bfacb85d935ca45ed943654bd3e3f3
-lastReviewedNote: 'Reviewed for Issue #635 and separated credential-free GitHub browser proof from the explicitly authorized local production-data operator run.'
+lastReviewedCommit: 9b5bdeb11794f280b639212248b9816338923dd7
+lastReviewedNote: 'Reviewed for v0.0.53 version-only release preparation; bootstrap and canonical command guidance are unchanged.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -56,8 +56,8 @@ checkPaths:
   - .github/workflows/build.yml
   - package.json
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: 9156b4baf8bfacb85d935ca45ed943654bd3e3f3
-lastReviewedNote: 'Closed the Issue #633 audit blind spots for logical/nullish locale defaults, exported full-document lang/dir metadata, and intentional fail-closed supported-language snapshot tests.'
+lastReviewedCommit: 9b5bdeb11794f280b639212248b9816338923dd7
+lastReviewedNote: 'Reviewed for the digest-bound v0.0.53 release candidate; the full authenticated semantic E2E contract remains satisfied with created=cleaned and leaked=0.'
 baselineObservedAt: 2026-07-18
 related:
   - ../../AGENTS.md

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: 9156b4baf8bfacb85d935ca45ed943654bd3e3f3
-lastReviewedNote: 'Reviewed for Issue #633: the full gate and local-operator-only semantic E2E boundary remain unchanged after the locale-hardcoding audit repair.'
+lastReviewedCommit: 9b5bdeb11794f280b639212248b9816338923dd7
+lastReviewedNote: 'Reviewed for v0.0.53 version-only release preparation; pre-push and release-gate behavior is unchanged.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: 9156b4baf8bfacb85d935ca45ed943654bd3e3f3
-lastReviewedNote: 'Updated for Issue #633: hardcoding proof now covers logical/nullish locale defaults, exported full-document lang/dir metadata, and intentional fail-closed language snapshot tests.'
+lastReviewedCommit: 9b5bdeb11794f280b639212248b9816338923dd7
+lastReviewedNote: 'Reviewed for v0.0.53 version-only release preparation; the existing proof matrix and production release gate remain sufficient.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -23,8 +23,8 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - package.json
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: 9156b4baf8bfacb85d935ca45ed943654bd3e3f3
-lastReviewedNote: 'Reviewed for Issue #633: the bounded browser strategy remains valid after regenerating digest-bound evidence for the locale-hardcoding repair.'
+lastReviewedCommit: 9b5bdeb11794f280b639212248b9816338923dd7
+lastReviewedNote: 'Reviewed for v0.0.53 version-only release preparation; the maintained testing strategy needs no change.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -24,8 +24,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: 9156b4baf8bfacb85d935ca45ed943654bd3e3f3
-lastReviewedNote: 'Reviewed for Issue #633: no coverage queue reopened; the locale-hardcoding repair reuses and refreshes the existing authenticated evidence contract.'
+lastReviewedCommit: 9b5bdeb11794f280b639212248b9816338923dd7
+lastReviewedNote: 'Reviewed for v0.0.53 version-only release preparation; no coverage or testing queue is reopened.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -24,8 +24,8 @@ checkPaths:
   - playwright.config.ts
   - package.json
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: 9156b4baf8bfacb85d935ca45ed943654bd3e3f3
-lastReviewedNote: 'Reviewed for Issue #633: documented registry-derived coverage alongside intentional fail-closed product-locale snapshot tests.'
+lastReviewedCommit: 9b5bdeb11794f280b639212248b9816338923dd7
+lastReviewedNote: 'Reviewed for v0.0.53 version-only release preparation; reusable test-selection and structure patterns are unchanged.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -23,8 +23,8 @@ checkPaths:
   - tests/e2e/i18n/**
   - package.json
 lastReviewedAt: 2026-07-20
-lastReviewedCommit: 9156b4baf8bfacb85d935ca45ed943654bd3e3f3
-lastReviewedNote: 'Reviewed for Issue #633: added the required out-of-worktree recovery-ledger boundary for authorized production-data E2E.'
+lastReviewedCommit: 9b5bdeb11794f280b639212248b9816338923dd7
+lastReviewedNote: 'Reviewed for v0.0.53 version-only release preparation; supported recovery paths are unchanged.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "96d03a2e2c0b8fe5a593b253868b6c3b3b07bcec6590ea24b3809f6e2048c06e",
+    "digest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "2cda631e69410264c55cb64642f067f329160eaf3d926ff6e2eb4dadc373f040",
+          "sha256": "e131897851657197f77e8ac2deb481bfa17ddef48b281cb991c555c6af3669bd",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "96d03a2e2c0b8fe5a593b253868b6c3b3b07bcec6590ea24b3809f6e2048c06e",
+    "docs/plans/i18n/route-view-coverage.json": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-de-DE/glossary.json": "a5fd4e759af2713fbec83f2b95171c7b32206d7218da0401d28d2eecefccce3a",
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "4e0a99256e76d10decffe8997fa78041558676cf8517170253c01b7569a895b6"
+  "contextDigest": "e81d11bf3b5ccf3f6f9b297ffd435e28a1269c697d76d65141bb1eca4de925f7"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4e0a99256e76d10decffe8997fa78041558676cf8517170253c01b7569a895b6",
-    "qualityDigest": "b7ca4331b1610f40dfbc3e4e12c7e3040ffc65ced9b3b4c24f213a554ad90742",
+    "contextDigest": "e81d11bf3b5ccf3f6f9b297ffd435e28a1269c697d76d65141bb1eca4de925f7",
+    "qualityDigest": "67fa1a26045bd1ba0ccb6e6756c3093cb5340bcabf581afd060c07f27e7bd556",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "96d03a2e2c0b8fe5a593b253868b6c3b3b07bcec6590ea24b3809f6e2048c06e",
+    "routeViewCoverageDigest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "91a5cef275dea1c061ad29618b4deb159807d1ec257f0f84b2c2915526bd67d7"
+  "activationDigest": "498c1c454711516b5efeffd0d4401d71ab5599cfe60b5f01df6bba7f1108872c"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "0ba964026db9c377e8c0ff9b281f2434c61879b671997b101a866855740ae92f",
-    "contextDigest": "4e0a99256e76d10decffe8997fa78041558676cf8517170253c01b7569a895b6"
+    "contextDigest": "e81d11bf3b5ccf3f6f9b297ffd435e28a1269c697d76d65141bb1eca4de925f7"
   },
   "catalog": {
     "messageCount": 3032,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "b7ca4331b1610f40dfbc3e4e12c7e3040ffc65ced9b3b4c24f213a554ad90742"
+  "qualityDigest": "67fa1a26045bd1ba0ccb6e6756c3093cb5340bcabf581afd060c07f27e7bd556"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "96d03a2e2c0b8fe5a593b253868b6c3b3b07bcec6590ea24b3809f6e2048c06e",
+    "digest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "2cda631e69410264c55cb64642f067f329160eaf3d926ff6e2eb4dadc373f040",
+          "sha256": "e131897851657197f77e8ac2deb481bfa17ddef48b281cb991c555c6af3669bd",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "96d03a2e2c0b8fe5a593b253868b6c3b3b07bcec6590ea24b3809f6e2048c06e",
+    "docs/plans/i18n/route-view-coverage.json": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-en-US/glossary.json": "4b8443ea3f91f15383683e9ece6221e40e24ceb75442ea830964b06c12559970",
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "5c21b90ebe2a5fbf52c8581e405aca9a08e4965d6408a4424e778c5db8146fe0"
+  "contextDigest": "9699b93f34b8fec338851c78ecb02790a5c0d607ae06ab894eb2b2c129e3843e"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "5c21b90ebe2a5fbf52c8581e405aca9a08e4965d6408a4424e778c5db8146fe0",
-    "qualityDigest": "41d1310f23f0155899e7bc2595e8c19cbd88ddd23de97b2ebe4d10eaf10a940e",
+    "contextDigest": "9699b93f34b8fec338851c78ecb02790a5c0d607ae06ab894eb2b2c129e3843e",
+    "qualityDigest": "f8b7a699baa93de97aa487f8e80aa46a9477522fb1112f5605927d358d6156e8",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "96d03a2e2c0b8fe5a593b253868b6c3b3b07bcec6590ea24b3809f6e2048c06e",
+    "routeViewCoverageDigest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "cf903b267df837eb9189014d37cfb3abeb0de425c1ed652c3fe71e6ece1db1ad"
+  "activationDigest": "1342b99b76bcf11190beceb0927d6a57aae65344c1d4e333fc34d64fc9c94a81"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "0ba964026db9c377e8c0ff9b281f2434c61879b671997b101a866855740ae92f",
-    "contextDigest": "5c21b90ebe2a5fbf52c8581e405aca9a08e4965d6408a4424e778c5db8146fe0"
+    "contextDigest": "9699b93f34b8fec338851c78ecb02790a5c0d607ae06ab894eb2b2c129e3843e"
   },
   "catalog": {
     "messageCount": 3032,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "41d1310f23f0155899e7bc2595e8c19cbd88ddd23de97b2ebe4d10eaf10a940e"
+  "qualityDigest": "f8b7a699baa93de97aa487f8e80aa46a9477522fb1112f5605927d358d6156e8"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "96d03a2e2c0b8fe5a593b253868b6c3b3b07bcec6590ea24b3809f6e2048c06e",
+    "digest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "2cda631e69410264c55cb64642f067f329160eaf3d926ff6e2eb4dadc373f040",
+          "sha256": "e131897851657197f77e8ac2deb481bfa17ddef48b281cb991c555c6af3669bd",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "96d03a2e2c0b8fe5a593b253868b6c3b3b07bcec6590ea24b3809f6e2048c06e",
+    "docs/plans/i18n/route-view-coverage.json": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-fr-FR/glossary.json": "057cb494f02d980106469f6a16befc102d26db5ac362b9777cd5f97c7729c91b",
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "d0a128698b9b505976bddc8f453e5e4815c1a01b9e284d96c92ac14afccf759c"
+  "contextDigest": "759c30c0bd11518a46eb7d4e55846286e3e38eb3338a79e53135efbca8798368"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "d0a128698b9b505976bddc8f453e5e4815c1a01b9e284d96c92ac14afccf759c",
-    "qualityDigest": "a93123d09fd7f726205becafcf37d50e526eb7ead490a75eeb6995675a1abb80",
+    "contextDigest": "759c30c0bd11518a46eb7d4e55846286e3e38eb3338a79e53135efbca8798368",
+    "qualityDigest": "478ae311ad117ecc6f112ff7093013902ebeb2e8dfdb132c0bcaa41241892852",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "96d03a2e2c0b8fe5a593b253868b6c3b3b07bcec6590ea24b3809f6e2048c06e",
+    "routeViewCoverageDigest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "daef77ec5c26f82ea629f12848d18456b05829513bd136b6c7407eb225ce0763"
+  "activationDigest": "030f90c064b5e4783b0bea46c75459fdba8a0391cb4747b9e486ab8b14c81ef0"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "0ba964026db9c377e8c0ff9b281f2434c61879b671997b101a866855740ae92f",
-    "contextDigest": "d0a128698b9b505976bddc8f453e5e4815c1a01b9e284d96c92ac14afccf759c"
+    "contextDigest": "759c30c0bd11518a46eb7d4e55846286e3e38eb3338a79e53135efbca8798368"
   },
   "catalog": {
     "messageCount": 3032,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "a93123d09fd7f726205becafcf37d50e526eb7ead490a75eeb6995675a1abb80"
+  "qualityDigest": "478ae311ad117ecc6f112ff7093013902ebeb2e8dfdb132c0bcaa41241892852"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "96d03a2e2c0b8fe5a593b253868b6c3b3b07bcec6590ea24b3809f6e2048c06e",
+    "digest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "2cda631e69410264c55cb64642f067f329160eaf3d926ff6e2eb4dadc373f040",
+          "sha256": "e131897851657197f77e8ac2deb481bfa17ddef48b281cb991c555c6af3669bd",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "96d03a2e2c0b8fe5a593b253868b6c3b3b07bcec6590ea24b3809f6e2048c06e",
+    "docs/plans/i18n/route-view-coverage.json": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-zh-CN/glossary.json": "c891add0ee4bd6d24c0213d0c839474e145d85867426df796763b8e038053d9b",
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "fe9c70636f1c065655c1fbfe0bcb222985e7936794ed23258844a8bf92e3ab88"
+  "contextDigest": "bd486101b04c6d7ddca0518f23fff4e8ce5129ea809e49f5cd80582fc5b07555"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "fe9c70636f1c065655c1fbfe0bcb222985e7936794ed23258844a8bf92e3ab88",
-    "qualityDigest": "0085a42512eaa0b0dcbc1aca9e6f1c261cb00c721fb3bcbce68d60463a1d01f0",
+    "contextDigest": "bd486101b04c6d7ddca0518f23fff4e8ce5129ea809e49f5cd80582fc5b07555",
+    "qualityDigest": "f23f80a1dbb43e69a73f40abb08dea49d5b1e0319c64bcad155c8a41e3878e74",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "96d03a2e2c0b8fe5a593b253868b6c3b3b07bcec6590ea24b3809f6e2048c06e",
+    "routeViewCoverageDigest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "0f3257c74bbf50f90a32b18918df2e7a4dfe170301d4f3b1adbd5916cc6844bf"
+  "activationDigest": "e37dd970189a3390769ff53f6833082a1a8e093d45fc0238c93b89fc167f1046"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "0ba964026db9c377e8c0ff9b281f2434c61879b671997b101a866855740ae92f",
-    "contextDigest": "fe9c70636f1c065655c1fbfe0bcb222985e7936794ed23258844a8bf92e3ab88"
+    "contextDigest": "bd486101b04c6d7ddca0518f23fff4e8ce5129ea809e49f5cd80582fc5b07555"
   },
   "catalog": {
     "messageCount": 3032,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "0085a42512eaa0b0dcbc1aca9e6f1c261cb00c721fb3bcbce68d60463a1d01f0"
+  "qualityDigest": "f23f80a1dbb43e69a73f40abb08dea49d5b1e0319c64bcad155c8a41e3878e74"
 }

--- a/docs/plans/i18n/route-view-coverage.json
+++ b/docs/plans/i18n/route-view-coverage.json
@@ -353,7 +353,7 @@
       "executedEvidence": [
         {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "2cda631e69410264c55cb64642f067f329160eaf3d926ff6e2eb4dadc373f040"
+          "sha256": "e131897851657197f77e8ac2deb481bfa17ddef48b281cb991c555c6af3669bd"
         }
       ]
     }

--- a/docs/plans/i18n/semantic-e2e-evidence.json
+++ b/docs/plans/i18n/semantic-e2e-evidence.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": "tiangong.i18n-semantic-e2e-evidence.v1",
   "status": "verified",
-  "generatedAt": "2026-07-20T06:49:37.572Z",
-  "runId": "local-5b1ee628-ce60-4a6a-bcab-64d0fda6e7da",
+  "generatedAt": "2026-07-20T08:15:36.565Z",
+  "runId": "local-77a53ac7-7125-42ae-9440-9252c707a6ac",
   "candidate": {
     "configTreeDigest": "a5f819459fba99fbf639dbbfd9c6b863672bb2356203113c736ba508b2c8a176",
-    "observedHeadCommit": "9156b4baf8bfacb85d935ca45ed943654bd3e3f3",
-    "packageManifestDigest": "f80ad3c2d30abe3f9c03bbc4cb17915b110d539a7f3ecd637696723706117009",
+    "observedHeadCommit": "9b5bdeb11794f280b639212248b9816338923dd7",
+    "packageManifestDigest": "4910623de8b46e2cc3efb74c665a6fb047fa4315759de0e22819535e7f72ac11",
     "sourceTreeDigest": "b4d9690cc7845351b1ea6ee338f4e5f3e13c937806652b01c43f1225e20118eb",
     "unitTestTreeDigest": "3c93914f11fb952cc1ba593d3bdd832518e4a68b9d62bf013dd03d21fc3782a1"
   },
@@ -34,7 +34,7 @@
   "digests": {
     "packageLock": {
       "path": "package-lock.json",
-      "sha256": "d909770f35048f325093cad75d93da86e3a9ff2521973e4373fac6007b1c051c"
+      "sha256": "c4ae4cce664d94a18b3618df3e0a33363d9dc9c29834e1a44fde8599f0fd90b0"
     },
     "runtimeAssets": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.52",
+      "version": "0.0.53",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
## Summary

- bump the application release version from 0.0.52 to 0.0.53 without changing dependencies
- refresh the digest-bound semantic E2E evidence and all four registry-locale activation artifacts
- record the required Docpact review metadata; governance and gate behavior are unchanged

Relates to #633. The issue remains open until promotion, production release, and workspace exact-SHA integration are complete.

## Validation

- authenticated candidate-local frontend + production backend semantic E2E: 48 passed, 24 policy-skipped, 0 failed; production data created=1, cleaned=1, leaked=0
- semantic evidence: 49/49 assertions, Chromium full matrix, Chromium/Firefox/WebKit critical scenarios; SHA-256 `e131897851657197f77e8ac2deb481bfa17ddef48b281cb991c555c6af3669bd`
- `npm run i18n:locale:all:production:check`
- `npm run reference-data:production:check`
- `npm run lint`
- `npm run build`
- Docpact strict config and enforced changed-path lint: 26/26 paths covered
- managed `push:checked` full gate: 397 suites / 5,343 tests; 450 source files at 100% statements, branches, functions, and lines

## Release boundary

This PR targets `dev` only. `v0.0.53` must remain absent until the later `dev -> main` promotion merge triggers the canonical release workflow.