### PR TITLE
fix: remove Release tab from Process detail

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-21"
-lastReviewedCommit: "05fa44f8d1a95662b18a44ecd267a7e7b1306905"
+lastReviewedCommit: "5c1723b98f005b40f913f1ed6e174d064388efcc"
 lastReviewedNote: 'Reviewed for Issue #647; routing and ownership remain unchanged after making browser semantic E2E manual on demand and release-required.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 05fa44f8d1a95662b18a44ecd267a7e7b1306905
+lastReviewedCommit: 5c1723b98f005b40f913f1ed6e174d064388efcc
 lastReviewedNote: 'Updated for Issue #647: browser semantic E2E is manual on demand and mandatory for the exact release SHA, while authenticated production proof remains local-only.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -24,7 +24,7 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - .nvmrc
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 05fa44f8d1a95662b18a44ecd267a7e7b1306905
+lastReviewedCommit: 5c1723b98f005b40f913f1ed6e174d064388efcc
 lastReviewedNote: 'Updated for Issue #647: documented the manual and exact-release-SHA semantic E2E entrypoints.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 05fa44f8d1a95662b18a44ecd267a7e7b1306905
+lastReviewedCommit: 5c1723b98f005b40f913f1ed6e174d064388efcc
 lastReviewedNote: 'Updated for Issue #647: routine branches skip browser E2E, which remains optional manually and required for release.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -23,9 +23,9 @@ checkPaths:
   - docker/**
   - playwright.config.ts
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-07-20
-lastReviewedCommit: 9156b4baf8bfacb85d935ca45ed943654bd3e3f3
-lastReviewedNote: 'Reviewed for Issue #633: locale consumers remain registry-derived, with fixed locale arrays limited to explicit fail-closed product-contract tests.'
+lastReviewedAt: 2026-07-21
+lastReviewedCommit: db144da244dc905edac60fb2b4cc774209059187
+lastReviewedNote: 'Reviewed for Issue #645: public release readback remains in Data Processing and is no longer mounted in Process detail.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -106,13 +106,11 @@ The persisted calculation read path is:
 
 `src/pages/DataProcessing/CalculationBundlePanel.tsx -> src/services/lcaReleases/api.ts -> authenticated Edge projection -> signed Calculation Bundle artifacts`
 
-The public release read paths are:
+The public release read path is:
 
 `src/pages/DataProcessing/index.tsx -> src/components/LcaReleaseReadPanel/index.tsx -> src/services/lcaReleases/api.ts -> public current-release projection`
 
-`src/pages/Processes/Components/view.tsx -> src/components/LcaReleaseReadPanel/index.tsx -> src/services/lcaReleases/api.ts -> public current Process projection`
-
-Next owns read orchestration, exact UUID/version deep links, directional LCI/LCIA rendering, integrity checks before parsing preview artifacts or saving raw Calculation Bundle downloads, and fresh signed-download requests. Verified raw downloads are saved through a local Blob instead of a cross-origin download anchor. The Calculation Bundle read requires the current user session. A public release projection may be anonymous only after Database and Edge expose it as the current published release. Next never approves or publishes a release, receives a service-role credential, or treats a private storage locator as public data.
+Next owns read orchestration, release dataset identity display, directional LCI/LCIA rendering, integrity checks before parsing preview artifacts or saving raw Calculation Bundle downloads, and fresh signed-download requests. Verified raw downloads are saved through a local Blob instead of a cross-origin download anchor. The Calculation Bundle read requires the current user session. A public release projection may be anonymous only after Database and Edge expose it as the current published release. Next never approves or publishes a release, receives a service-role credential, or treats a private storage locator as public data.
 
 ## Current Hotspots
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -24,7 +24,7 @@ checkPaths:
   - playwright.config.ts
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: db144da244dc905edac60fb2b4cc774209059187
+lastReviewedCommit: 5c1723b98f005b40f913f1ed6e174d064388efcc
 lastReviewedNote: 'Reviewed for Issue #645: public release readback remains in Data Processing and is no longer mounted in Process detail.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,7 +25,7 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 05fa44f8d1a95662b18a44ecd267a7e7b1306905
+lastReviewedCommit: 5c1723b98f005b40f913f1ed6e174d064388efcc
 lastReviewedNote: 'Updated for Issue #647: browser semantic E2E is manual for daily work and mandatory for the exact release SHA.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -23,7 +23,7 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - package.json
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 05fa44f8d1a95662b18a44ecd267a7e7b1306905
+lastReviewedCommit: 5c1723b98f005b40f913f1ed6e174d064388efcc
 lastReviewedNote: 'Updated for Issue #647: the semantic browser matrix is risk-proportional on demand and mandatory at release.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -24,7 +24,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 05fa44f8d1a95662b18a44ecd267a7e7b1306905
+lastReviewedCommit: 5c1723b98f005b40f913f1ed6e174d064388efcc
 lastReviewedNote: 'Updated for Issue #647: recorded manual-on-demand and release-required browser semantic E2E.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -24,7 +24,7 @@ checkPaths:
   - playwright.config.ts
   - package.json
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 05fa44f8d1a95662b18a44ecd267a7e7b1306905
+lastReviewedCommit: 5c1723b98f005b40f913f1ed6e174d064388efcc
 lastReviewedNote: 'Updated for Issue #647: manual and exact-release-SHA browser execution now share one read-only reusable workflow.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -23,7 +23,7 @@ checkPaths:
   - tests/e2e/i18n/**
   - package.json
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 05fa44f8d1a95662b18a44ecd267a7e7b1306905
+lastReviewedCommit: 5c1723b98f005b40f913f1ed6e174d064388efcc
 lastReviewedNote: 'Reviewed for Issue #647: failure recovery remains valid after moving browser semantic E2E to manual and release-only triggers.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "0ba964026db9c377e8c0ff9b281f2434c61879b671997b101a866855740ae92f",
-    "auditedInputDigest": "dbd7e52e372f1a21e4c646202447442d5e79198fcdea3afea44b82f411d5dffa"
+    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
+    "auditedInputDigest": "1f36e04a72cba4ee610c9786573782863254836566773fc7108e29faa29dffbb"
   },
   "inventory": {
     "sourceMessageCount": 3032,
@@ -47,7 +47,7 @@
     "messageCount": 3032,
     "completeCount": 3032,
     "blockedCount": 0,
-    "dossierDigest": "3e6ea62d89d6025dc45640013e454f4fe06b22f15e109e63ab2059a0beab935f",
+    "dossierDigest": "3a8130948bdc355e27deb65b8057212aca5552439a1653dc6beb763d91285097",
     "catalogDigest": "7cd0bc0d30b733154b34642a79ddbc173919ffc6f3ad1115e45ceea9d4537224",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -55,9 +55,9 @@
       "error-or-validation": 342,
       "explanatory-copy": 110,
       "field-guidance": 49,
-      "label-or-body-copy": 1224,
+      "label-or-body-copy": 1223,
       "navigation-or-tab": 224,
-      "reserved-catalog-copy": 274,
+      "reserved-catalog-copy": 275,
       "status-or-empty-state": 92,
       "success-notification": 176,
       "title-or-heading": 237,
@@ -67,9 +67,9 @@
       "destructive-or-rejecting-action": 43,
       "failure-or-invalid-input": 342,
       "interactive-ready": 512,
-      "retained-not-currently-reachable": 353,
+      "retained-not-currently-reachable": 354,
       "successful-completion": 176,
-      "visible": 1606
+      "visible": 1605
     },
     "riskCounts": { "high": 1341, "low": 1474, "medium": 217 },
     "highRiskMessageCount": 1341,
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4018,
+    "literalReferenceCount": 4017,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale de-DE --message <MESSAGE_ID>"
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "cd30f97e4654d4aeb30114f92d6141cb4629f64957a3a1ecb94068e379c6bf64"
+  "contextDigest": "11ba03a50319445637ba884539327242e08415930089448793419932954723a0"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0ba964026db9c377e8c0ff9b281f2434c61879b671997b101a866855740ae92f"
+    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "cd30f97e4654d4aeb30114f92d6141cb4629f64957a3a1ecb94068e379c6bf64",
-    "qualityDigest": "1c265620ddc6011008d11d69800dd00c934a9a375b77c772d544982d10d29edb",
+    "contextDigest": "11ba03a50319445637ba884539327242e08415930089448793419932954723a0",
+    "qualityDigest": "fec526482df726291d9abd9a8a603fc206cac9bcd2d365b5622b055cf8424348",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
     "routeViewCoverageDigest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "1f19dae209fe3bd835e3fddea3000a7fe13705aee2afe7ec8a12793757e06de3"
+  "activationDigest": "ba6347608835fdf32e7780358d2731b377ea674fbeb91733df2859b6eee2f550"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0ba964026db9c377e8c0ff9b281f2434c61879b671997b101a866855740ae92f",
-    "contextDigest": "cd30f97e4654d4aeb30114f92d6141cb4629f64957a3a1ecb94068e379c6bf64"
+    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
+    "contextDigest": "11ba03a50319445637ba884539327242e08415930089448793419932954723a0"
   },
   "catalog": {
     "messageCount": 3032,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "b67840b6fca2bb62dbf4fdf66177e2d7944fea3c94173d82c4572ad23c9b0644",
-    "validationDigest": "ca5a3752e945cfafb05402d7561252741ed6ce8cfc64e4b911eb5c78eabdb800",
+    "digest": "05fefea4d47642cc6c24b805ba69664bea07c7110ea28d5711a8602dd015660a",
+    "validationDigest": "fc206a1e6208dbbee2f9d6c144532bb966baaae858521cd0bdc8daf9c5957227",
     "laneCount": 1,
     "validatedMessageCount": 3032,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "1c265620ddc6011008d11d69800dd00c934a9a375b77c772d544982d10d29edb"
+  "qualityDigest": "fec526482df726291d9abd9a8a603fc206cac9bcd2d365b5622b055cf8424348"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "dbd7e52e372f1a21e4c646202447442d5e79198fcdea3afea44b82f411d5dffa",
+    "auditedInputDigest": "1f36e04a72cba4ee610c9786573782863254836566773fc7108e29faa29dffbb",
     "validatedMessageCount": 3032,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1341,
     "highRiskMessageDigest": "3ce9911e5333fd9b7c85174693a78c7c8cf37e92835241c23e4f820a4c7b558e",
     "catalogDigest": "7cd0bc0d30b733154b34642a79ddbc173919ffc6f3ad1115e45ceea9d4537224",
-    "dossierDigest": "3e6ea62d89d6025dc45640013e454f4fe06b22f15e109e63ab2059a0beab935f",
+    "dossierDigest": "3a8130948bdc355e27deb65b8057212aca5552439a1653dc6beb763d91285097",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "0d8f89a5513c86639283cdf3b553007ec0227341f0b1bff75ac1f465c834506a",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "5ef93647a266ce23461d659b85cd8d1f1c8ccf437a689b159c423155d210580c",
         "highRiskMessageCount": 1341,
         "highRiskMessageDigest": "3ce9911e5333fd9b7c85174693a78c7c8cf37e92835241c23e4f820a4c7b558e",
-        "dossierDigest": "3e6ea62d89d6025dc45640013e454f4fe06b22f15e109e63ab2059a0beab935f",
+        "dossierDigest": "3a8130948bdc355e27deb65b8057212aca5552439a1653dc6beb763d91285097",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "ca5a3752e945cfafb05402d7561252741ed6ce8cfc64e4b911eb5c78eabdb800"
+  "validationDigest": "fc206a1e6208dbbee2f9d6c144532bb966baaae858521cd0bdc8daf9c5957227"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "0ba964026db9c377e8c0ff9b281f2434c61879b671997b101a866855740ae92f",
-    "auditedInputDigest": "dbd7e52e372f1a21e4c646202447442d5e79198fcdea3afea44b82f411d5dffa"
+    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
+    "auditedInputDigest": "1f36e04a72cba4ee610c9786573782863254836566773fc7108e29faa29dffbb"
   },
   "inventory": {
     "sourceMessageCount": 3032,
@@ -47,7 +47,7 @@
     "messageCount": 3032,
     "completeCount": 3032,
     "blockedCount": 0,
-    "dossierDigest": "ae9a66a206675dfcbf302ce5240a9ac736c23de44ca71a70adf2315587fc6754",
+    "dossierDigest": "1a8555b52e279fe8bc8e71f7990209a9f61cfdccb1825d34a93de1ef881c0a79",
     "catalogDigest": "d93ed39831164b98edc60b1961375fe4aa11c9ec5c446ad564b5b8742398e21d",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -55,9 +55,9 @@
       "error-or-validation": 342,
       "explanatory-copy": 110,
       "field-guidance": 49,
-      "label-or-body-copy": 1224,
+      "label-or-body-copy": 1223,
       "navigation-or-tab": 224,
-      "reserved-catalog-copy": 274,
+      "reserved-catalog-copy": 275,
       "status-or-empty-state": 92,
       "success-notification": 176,
       "title-or-heading": 237,
@@ -67,9 +67,9 @@
       "destructive-or-rejecting-action": 43,
       "failure-or-invalid-input": 342,
       "interactive-ready": 512,
-      "retained-not-currently-reachable": 353,
+      "retained-not-currently-reachable": 354,
       "successful-completion": 176,
-      "visible": 1606
+      "visible": 1605
     },
     "riskCounts": { "high": 1341, "low": 1493, "medium": 198 },
     "highRiskMessageCount": 1341,
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4018,
+    "literalReferenceCount": 4017,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale en-US --message <MESSAGE_ID>"
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "714c5543b5035f1aff6af05f9fe0abcf02775f274d7757c19e2395d9d5f547f8"
+  "contextDigest": "252e744d0034b2f1cac2a922c376e70fd342a1ea6f5ae98fe6254cf7940ce916"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0ba964026db9c377e8c0ff9b281f2434c61879b671997b101a866855740ae92f"
+    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "714c5543b5035f1aff6af05f9fe0abcf02775f274d7757c19e2395d9d5f547f8",
-    "qualityDigest": "c7cfae40a9a090c11c6b6a39bd396c831857319430103f398b9f40e99a0aa5c5",
+    "contextDigest": "252e744d0034b2f1cac2a922c376e70fd342a1ea6f5ae98fe6254cf7940ce916",
+    "qualityDigest": "bf45767a6e913628079f6d6b4dc9de4831c16800e6c7d2df970a049c49ed9612",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
     "routeViewCoverageDigest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "a3ca5cb4fc633fb757aee3c355c299eb5ff72f3e695b3fda6981bf803c91b73f"
+  "activationDigest": "79cc10a29d7b8d25effff274ce7924ac4018db688121cd6585b386c2586f4e46"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0ba964026db9c377e8c0ff9b281f2434c61879b671997b101a866855740ae92f",
-    "contextDigest": "714c5543b5035f1aff6af05f9fe0abcf02775f274d7757c19e2395d9d5f547f8"
+    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
+    "contextDigest": "252e744d0034b2f1cac2a922c376e70fd342a1ea6f5ae98fe6254cf7940ce916"
   },
   "catalog": {
     "messageCount": 3032,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "ef265ed817f19b104defc02f4e4fbf5ce826e4c9bddd0d672bb22f59dc081c1d",
-    "validationDigest": "4c0b679c87726908f8a34c6e529fb0716328e785a77dfebfaeab9e92c08fc53a",
+    "digest": "b70fd94b456cd1a7dc84117b329bc12a71239ac5c6fdff959b88d97d7397956b",
+    "validationDigest": "abeebe3f3e65708ec2efe3a9e1f67fd5bd80578379b4cfe32c8e16d46f6c2250",
     "laneCount": 1,
     "validatedMessageCount": 3032,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "c7cfae40a9a090c11c6b6a39bd396c831857319430103f398b9f40e99a0aa5c5"
+  "qualityDigest": "bf45767a6e913628079f6d6b4dc9de4831c16800e6c7d2df970a049c49ed9612"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "dbd7e52e372f1a21e4c646202447442d5e79198fcdea3afea44b82f411d5dffa",
+    "auditedInputDigest": "1f36e04a72cba4ee610c9786573782863254836566773fc7108e29faa29dffbb",
     "validatedMessageCount": 3032,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1341,
     "highRiskMessageDigest": "3ce9911e5333fd9b7c85174693a78c7c8cf37e92835241c23e4f820a4c7b558e",
     "catalogDigest": "d93ed39831164b98edc60b1961375fe4aa11c9ec5c446ad564b5b8742398e21d",
-    "dossierDigest": "ae9a66a206675dfcbf302ce5240a9ac736c23de44ca71a70adf2315587fc6754",
+    "dossierDigest": "1a8555b52e279fe8bc8e71f7990209a9f61cfdccb1825d34a93de1ef881c0a79",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "0d8f89a5513c86639283cdf3b553007ec0227341f0b1bff75ac1f465c834506a",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "5ef93647a266ce23461d659b85cd8d1f1c8ccf437a689b159c423155d210580c",
         "highRiskMessageCount": 1341,
         "highRiskMessageDigest": "3ce9911e5333fd9b7c85174693a78c7c8cf37e92835241c23e4f820a4c7b558e",
-        "dossierDigest": "ae9a66a206675dfcbf302ce5240a9ac736c23de44ca71a70adf2315587fc6754",
+        "dossierDigest": "1a8555b52e279fe8bc8e71f7990209a9f61cfdccb1825d34a93de1ef881c0a79",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "4c0b679c87726908f8a34c6e529fb0716328e785a77dfebfaeab9e92c08fc53a"
+  "validationDigest": "abeebe3f3e65708ec2efe3a9e1f67fd5bd80578379b4cfe32c8e16d46f6c2250"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "0ba964026db9c377e8c0ff9b281f2434c61879b671997b101a866855740ae92f",
-    "auditedInputDigest": "dbd7e52e372f1a21e4c646202447442d5e79198fcdea3afea44b82f411d5dffa"
+    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
+    "auditedInputDigest": "1f36e04a72cba4ee610c9786573782863254836566773fc7108e29faa29dffbb"
   },
   "inventory": {
     "sourceMessageCount": 3032,
@@ -47,7 +47,7 @@
     "messageCount": 3032,
     "completeCount": 3032,
     "blockedCount": 0,
-    "dossierDigest": "ac02d8db021b9065707961a6b95fd7d63ad4262fce413c0bc51067f0f8ff7741",
+    "dossierDigest": "6692befb10ab699ab299db391553104385856439ee23f524e078f8a288190050",
     "catalogDigest": "fe762b9712f0e81eab9a0befa1fd0f820986ef430556ff6491148c6a2f30e6a2",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -55,9 +55,9 @@
       "error-or-validation": 342,
       "explanatory-copy": 110,
       "field-guidance": 49,
-      "label-or-body-copy": 1224,
+      "label-or-body-copy": 1223,
       "navigation-or-tab": 224,
-      "reserved-catalog-copy": 274,
+      "reserved-catalog-copy": 275,
       "status-or-empty-state": 92,
       "success-notification": 176,
       "title-or-heading": 237,
@@ -67,9 +67,9 @@
       "destructive-or-rejecting-action": 43,
       "failure-or-invalid-input": 342,
       "interactive-ready": 512,
-      "retained-not-currently-reachable": 353,
+      "retained-not-currently-reachable": 354,
       "successful-completion": 176,
-      "visible": 1606
+      "visible": 1605
     },
     "riskCounts": { "high": 1341, "low": 1473, "medium": 218 },
     "highRiskMessageCount": 1341,
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4018,
+    "literalReferenceCount": 4017,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale fr-FR --message <MESSAGE_ID>"
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "b7ef3704774b223cae361f566698043b8d116eeb51fa7d1179d934fac178ef42"
+  "contextDigest": "38f3b5fdee5ec580fec770d6153bcf0c00691c152058695404c55d631555a308"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0ba964026db9c377e8c0ff9b281f2434c61879b671997b101a866855740ae92f"
+    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "b7ef3704774b223cae361f566698043b8d116eeb51fa7d1179d934fac178ef42",
-    "qualityDigest": "336b818475176551af242d17ede92c7967c4a72ef0fb66d1aeb8e33054b562f1",
+    "contextDigest": "38f3b5fdee5ec580fec770d6153bcf0c00691c152058695404c55d631555a308",
+    "qualityDigest": "d6cd52e9be6995fa323ca51865d8e018460b370d08564bf69cbeb128f794553a",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
     "routeViewCoverageDigest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "8f510ebdf6af08224e2d79b1591b135d62a8c6500c1f9916355e4e446c63836b"
+  "activationDigest": "4379122c67557d79139a5dabe59607e870395fda6bb5166ec5ef2c1f26265e36"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0ba964026db9c377e8c0ff9b281f2434c61879b671997b101a866855740ae92f",
-    "contextDigest": "b7ef3704774b223cae361f566698043b8d116eeb51fa7d1179d934fac178ef42"
+    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
+    "contextDigest": "38f3b5fdee5ec580fec770d6153bcf0c00691c152058695404c55d631555a308"
   },
   "catalog": {
     "messageCount": 3032,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "ae96d0b0b8ca1628f04eedb3e63c295a17f4776b46ffaf78ed6b5cb049acebf5",
-    "validationDigest": "594b71bc023216a08c1507528975ca5344e3244c8c8c499ab4a17c2fa2dddad8",
+    "digest": "8ade887dab1376ff282476a708a09c22c7a83d6d0b5678ee4245007c3a489410",
+    "validationDigest": "fe3429376d5154c22f6fcab287d32288c740f271708984910cc3035c38219ef4",
     "laneCount": 1,
     "validatedMessageCount": 3032,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "336b818475176551af242d17ede92c7967c4a72ef0fb66d1aeb8e33054b562f1"
+  "qualityDigest": "d6cd52e9be6995fa323ca51865d8e018460b370d08564bf69cbeb128f794553a"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "dbd7e52e372f1a21e4c646202447442d5e79198fcdea3afea44b82f411d5dffa",
+    "auditedInputDigest": "1f36e04a72cba4ee610c9786573782863254836566773fc7108e29faa29dffbb",
     "validatedMessageCount": 3032,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1341,
     "highRiskMessageDigest": "3ce9911e5333fd9b7c85174693a78c7c8cf37e92835241c23e4f820a4c7b558e",
     "catalogDigest": "fe762b9712f0e81eab9a0befa1fd0f820986ef430556ff6491148c6a2f30e6a2",
-    "dossierDigest": "ac02d8db021b9065707961a6b95fd7d63ad4262fce413c0bc51067f0f8ff7741",
+    "dossierDigest": "6692befb10ab699ab299db391553104385856439ee23f524e078f8a288190050",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "0d8f89a5513c86639283cdf3b553007ec0227341f0b1bff75ac1f465c834506a",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "5ef93647a266ce23461d659b85cd8d1f1c8ccf437a689b159c423155d210580c",
         "highRiskMessageCount": 1341,
         "highRiskMessageDigest": "3ce9911e5333fd9b7c85174693a78c7c8cf37e92835241c23e4f820a4c7b558e",
-        "dossierDigest": "ac02d8db021b9065707961a6b95fd7d63ad4262fce413c0bc51067f0f8ff7741",
+        "dossierDigest": "6692befb10ab699ab299db391553104385856439ee23f524e078f8a288190050",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "594b71bc023216a08c1507528975ca5344e3244c8c8c499ab4a17c2fa2dddad8"
+  "validationDigest": "fe3429376d5154c22f6fcab287d32288c740f271708984910cc3035c38219ef4"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "0ba964026db9c377e8c0ff9b281f2434c61879b671997b101a866855740ae92f",
-    "auditedInputDigest": "dbd7e52e372f1a21e4c646202447442d5e79198fcdea3afea44b82f411d5dffa"
+    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
+    "auditedInputDigest": "1f36e04a72cba4ee610c9786573782863254836566773fc7108e29faa29dffbb"
   },
   "inventory": {
     "sourceMessageCount": 3032,
@@ -47,7 +47,7 @@
     "messageCount": 3032,
     "completeCount": 3032,
     "blockedCount": 0,
-    "dossierDigest": "5d61b644bd0603f50eb54d872687763609fec78b9b8650e287f21d7c3dd4c464",
+    "dossierDigest": "3407227e20f4861c8e5f6695a75416d5bb961aaab3d98f987e75f530dd571909",
     "catalogDigest": "d2ba7bc81f8aca97f5075283d3509c63fb7ff370a6bec1d4a439c8737b19106e",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -55,9 +55,9 @@
       "error-or-validation": 342,
       "explanatory-copy": 110,
       "field-guidance": 49,
-      "label-or-body-copy": 1224,
+      "label-or-body-copy": 1223,
       "navigation-or-tab": 224,
-      "reserved-catalog-copy": 274,
+      "reserved-catalog-copy": 275,
       "status-or-empty-state": 92,
       "success-notification": 176,
       "title-or-heading": 237,
@@ -67,9 +67,9 @@
       "destructive-or-rejecting-action": 43,
       "failure-or-invalid-input": 342,
       "interactive-ready": 512,
-      "retained-not-currently-reachable": 353,
+      "retained-not-currently-reachable": 354,
       "successful-completion": 176,
-      "visible": 1606
+      "visible": 1605
     },
     "riskCounts": { "high": 1341, "low": 1523, "medium": 168 },
     "highRiskMessageCount": 1341,
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4018,
+    "literalReferenceCount": 4017,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale zh-CN --message <MESSAGE_ID>"
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "cc8eb69d58b2bf490843e070ac53e5bc58f5d5620d3cbaeb36d24d9168f53f4a"
+  "contextDigest": "4cc36fa9c46c38d58f06383f83f60fdb48cb16429490728248465143c220c408"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0ba964026db9c377e8c0ff9b281f2434c61879b671997b101a866855740ae92f"
+    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "cc8eb69d58b2bf490843e070ac53e5bc58f5d5620d3cbaeb36d24d9168f53f4a",
-    "qualityDigest": "fa7a64727121e8b8dbcc4f34bd43eda84ddceb12e63b227c67384dde812f9304",
+    "contextDigest": "4cc36fa9c46c38d58f06383f83f60fdb48cb16429490728248465143c220c408",
+    "qualityDigest": "32819db751759b265560673549ea939ee3ddc477ff1f9172134c045fb10056f0",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
     "routeViewCoverageDigest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "48e065492e90e6cf2344dad0171d2674309aad0540f776d7f465bcb21a2c46f4"
+  "activationDigest": "397a77bff89880a741564752318af9b1aff9b973228c69589f3d0476d13669ad"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0ba964026db9c377e8c0ff9b281f2434c61879b671997b101a866855740ae92f",
-    "contextDigest": "cc8eb69d58b2bf490843e070ac53e5bc58f5d5620d3cbaeb36d24d9168f53f4a"
+    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
+    "contextDigest": "4cc36fa9c46c38d58f06383f83f60fdb48cb16429490728248465143c220c408"
   },
   "catalog": {
     "messageCount": 3032,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "7a0429cb489c42703709e3d277db9c4eaaca6dfb212ec786187c5c43899e8628",
-    "validationDigest": "d966e4ab9fbe745f612757bd96b145f7b6a089bf3dd097356830dc9d6b8e0106",
+    "digest": "0af9f48dcb4dadbe1689e7aabb5b325c6f605739f5b2c0794d5a5e8b7b2640b6",
+    "validationDigest": "609908cb70903fbd11c564cef5c32a13629726b10c4af1c0335aa902aa319534",
     "laneCount": 1,
     "validatedMessageCount": 3032,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "fa7a64727121e8b8dbcc4f34bd43eda84ddceb12e63b227c67384dde812f9304"
+  "qualityDigest": "32819db751759b265560673549ea939ee3ddc477ff1f9172134c045fb10056f0"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "dbd7e52e372f1a21e4c646202447442d5e79198fcdea3afea44b82f411d5dffa",
+    "auditedInputDigest": "1f36e04a72cba4ee610c9786573782863254836566773fc7108e29faa29dffbb",
     "validatedMessageCount": 3032,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1341,
     "highRiskMessageDigest": "3ce9911e5333fd9b7c85174693a78c7c8cf37e92835241c23e4f820a4c7b558e",
     "catalogDigest": "d2ba7bc81f8aca97f5075283d3509c63fb7ff370a6bec1d4a439c8737b19106e",
-    "dossierDigest": "5d61b644bd0603f50eb54d872687763609fec78b9b8650e287f21d7c3dd4c464",
+    "dossierDigest": "3407227e20f4861c8e5f6695a75416d5bb961aaab3d98f987e75f530dd571909",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "0d8f89a5513c86639283cdf3b553007ec0227341f0b1bff75ac1f465c834506a",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "5ef93647a266ce23461d659b85cd8d1f1c8ccf437a689b159c423155d210580c",
         "highRiskMessageCount": 1341,
         "highRiskMessageDigest": "3ce9911e5333fd9b7c85174693a78c7c8cf37e92835241c23e4f820a4c7b558e",
-        "dossierDigest": "5d61b644bd0603f50eb54d872687763609fec78b9b8650e287f21d7c3dd4c464",
+        "dossierDigest": "3407227e20f4861c8e5f6695a75416d5bb961aaab3d98f987e75f530dd571909",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "d966e4ab9fbe745f612757bd96b145f7b6a089bf3dd097356830dc9d6b8e0106"
+  "validationDigest": "609908cb70903fbd11c564cef5c32a13629726b10c4af1c0335aa902aa319534"
 }

--- a/src/pages/Processes/Components/view.tsx
+++ b/src/pages/Processes/Components/view.tsx
@@ -1,5 +1,4 @@
 import LangTextItemDescription from '@/components/LangTextItem/description';
-import LcaReleaseReadPanel from '@/components/LcaReleaseReadPanel';
 import LevelTextItemDescription from '@/components/LevelTextItem/description';
 import LocationTextItemDescription from '@/components/LocationTextItem/description';
 import ContactSelectDescription from '@/pages/Contacts/Components/select/description';
@@ -212,10 +211,6 @@ const ProcessView: FC<Props> = ({
     {
       key: 'lciaResults',
       tab: <FormattedMessage id='pages.process.view.lciaresults' defaultMessage='LCIA Results' />,
-    },
-    {
-      key: 'releases',
-      tab: <FormattedMessage id='pages.process.view.releases' defaultMessage='Releases' />,
     },
     {
       key: 'validation',
@@ -1666,7 +1661,6 @@ const ProcessView: FC<Props> = ({
         processVersion={version}
       />
     ),
-    releases: <LcaReleaseReadPanel compact processId={id} processVersion={version} />,
     validation: (
       <ReviewItemView data={initData?.modellingAndValidation?.validation?.review ?? []} />
     ),

--- a/tests/unit/pages/Processes/Components/view.test.tsx
+++ b/tests/unit/pages/Processes/Components/view.test.tsx
@@ -136,13 +136,6 @@ jest.mock('@/components/AlignedNumber', () => ({
   default: ({ value }: any) => <span data-testid='aligned-number'>{value}</span>,
 }));
 
-jest.mock('@/components/LcaReleaseReadPanel', () => ({
-  __esModule: true,
-  default: ({ processId, processVersion }: any) => (
-    <div data-testid='release-read-panel'>{`${processId}:${processVersion}`}</div>
-  ),
-}));
-
 jest.mock('@/pages/Processes/Components/Exchange/view', () => ({
   __esModule: true,
   default: (props: any) => {
@@ -600,13 +593,12 @@ describe('ProcessView component', () => {
     });
   });
 
-  it('links the Process drawer to its Model and Result release projection', async () => {
+  it('does not expose release controls from the Process drawer', async () => {
     render(<ProcessView {...defaultProps} />);
     fireEvent.click(screen.getByRole('button'));
-    fireEvent.click(screen.getByRole('button', { name: 'Releases' }));
 
-    expect(await screen.findByTestId('release-read-panel')).toHaveTextContent('process-1:1.0.0');
-    expect(screen.getAllByTestId('card')[0]).toHaveAttribute('data-active-key', 'releases');
+    await waitFor(() => expect(mockGetProcessDetail).toHaveBeenCalled());
+    expect(screen.queryByRole('button', { name: 'Releases' })).not.toBeInTheDocument();
   });
 
   it('disables the view button when disabled prop is true', () => {


### PR DESCRIPTION
Closes #645

## Summary
- remove the Release tab and LcaReleaseReadPanel mount from Process detail
- keep release-package browsing in Data Processing
- update the Process detail unit contract and regenerate locale audit/activation artifacts

## Validation
- ProcessView focused unit test: 38/38 passed
- locale delivery contract test: 16/16 passed
- npm run i18n:audit
- npm run i18n:locale:all:check
- npm run lint
- npm run build
- Docpact lint: pass
- push:checked: 397 suites / 5344 tests passed, 100% statements, branches, functions, and lines

Browser E2E was not run because routine PR validation is now manual/optional under #647; it remains available for release validation.