### PR TITLE
chore(release): prepare v0.0.54

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-21"
-lastReviewedCommit: "5c1723b98f005b40f913f1ed6e174d064388efcc"
+lastReviewedCommit: "804a44c0816076fd5166a6f36764483c7f37aaa8"
 lastReviewedNote: 'Reviewed for Issue #647; routing and ownership remain unchanged after making browser semantic E2E manual on demand and release-required.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 5c1723b98f005b40f913f1ed6e174d064388efcc
+lastReviewedCommit: 804a44c0816076fd5166a6f36764483c7f37aaa8
 lastReviewedNote: 'Updated for Issue #647: browser semantic E2E is manual on demand and mandatory for the exact release SHA, while authenticated production proof remains local-only.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -24,8 +24,8 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - .nvmrc
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 5c1723b98f005b40f913f1ed6e174d064388efcc
-lastReviewedNote: 'Updated for Issue #647: documented the manual and exact-release-SHA semantic E2E entrypoints.'
+lastReviewedCommit: 804a44c0816076fd5166a6f36764483c7f37aaa8
+lastReviewedNote: 'Updated for Issue #651: production cleanup now requires the configured recovery copy before adopting a primary ledger.'
 ---
 
 # Development Bootstrap
@@ -140,6 +140,7 @@ This command shape is forbidden in semantic E2E GitHub Actions; CI uses the same
 - semantic E2E GitHub Actions is credential-free and read-only: `workflow_dispatch` runs the three-browser public semantic/boundary matrix on demand, and the canonical release workflow calls the same matrix for the exact release SHA; routine PR/dev pushes do not trigger it
 - the full authenticated closure runs only in an explicitly authorized local operator session with runtime credentials and `E2E_AUTHENTICATED=true`; production write requires both `E2E_ALLOW_PRODUCTION_DATA=true` and the exact one-process confirmation token, while tracked evidence additionally requires `E2E_WRITE_VERIFIED_EVIDENCE=true`; never move that closure or its credentials into a semantic E2E GitHub job
 - before any create, authenticated E2E writes a UUID-scoped `codex-e2e` intent ledger; before any delete, it must read the production row and verify the UUID, authenticated owner, and exact marker coverage for all five multilingual fields across every registry authoring language
+- use one protected `E2E_RECOVERY_LEDGER_PATH` per active invocation; recovery may proceed from the external copy alone after a crash, but a primary ledger without the configured recovery copy fails closed so a stale teardown cannot adopt another run
 - teardown deletes only the verified exact-ID rows, records created/cleaned counts, and must prove `created=cleaned` and `leaked=0`
 - shared Header language switching uses Umi `SelectLang` with `reload={false}`; semantic proof must retain the same document identity while refreshing locale-dependent state and reject a delayed old-locale reference response
 - never persist or upload credentials, auth state, screenshots, traces, or video; the digest-bound semantic evidence contains assertions and non-secret digests only

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -56,7 +56,7 @@ checkPaths:
   - .github/workflows/build.yml
   - package.json
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 05fa44f8d1a95662b18a44ecd267a7e7b1306905
+lastReviewedCommit: 804a44c0816076fd5166a6f36764483c7f37aaa8
 lastReviewedNote: 'Updated for Issue #647: semantic browser E2E is manual on demand, required for the exact release SHA, and authenticated only in local operator sessions.'
 baselineObservedAt: 2026-07-18
 related:

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 5c1723b98f005b40f913f1ed6e174d064388efcc
+lastReviewedCommit: 804a44c0816076fd5166a6f36764483c7f37aaa8
 lastReviewedNote: 'Updated for Issue #647: routine branches skip browser E2E, which remains optional manually and required for release.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -24,7 +24,7 @@ checkPaths:
   - playwright.config.ts
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 5c1723b98f005b40f913f1ed6e174d064388efcc
+lastReviewedCommit: 804a44c0816076fd5166a6f36764483c7f37aaa8
 lastReviewedNote: 'Reviewed for Issue #645: public release readback remains in Data Processing and is no longer mounted in Process detail.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 5c1723b98f005b40f913f1ed6e174d064388efcc
-lastReviewedNote: 'Updated for Issue #647: browser semantic E2E is manual for daily work and mandatory for the exact release SHA.'
+lastReviewedCommit: 804a44c0816076fd5166a6f36764483c7f37aaa8
+lastReviewedNote: 'Updated for Issue #652: authenticated production E2E has a scoped 45-second assertion budget while public/CI remains at 15 seconds.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -23,7 +23,7 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - package.json
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 5c1723b98f005b40f913f1ed6e174d064388efcc
+lastReviewedCommit: 804a44c0816076fd5166a6f36764483c7f37aaa8
 lastReviewedNote: 'Updated for Issue #647: the semantic browser matrix is risk-proportional on demand and mandatory at release.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -24,7 +24,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 5c1723b98f005b40f913f1ed6e174d064388efcc
+lastReviewedCommit: 804a44c0816076fd5166a6f36764483c7f37aaa8
 lastReviewedNote: 'Updated for Issue #647: recorded manual-on-demand and release-required browser semantic E2E.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -24,8 +24,8 @@ checkPaths:
   - playwright.config.ts
   - package.json
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 5c1723b98f005b40f913f1ed6e174d064388efcc
-lastReviewedNote: 'Updated for Issue #647: manual and exact-release-SHA browser execution now share one read-only reusable workflow.'
+lastReviewedCommit: 804a44c0816076fd5166a6f36764483c7f37aaa8
+lastReviewedNote: 'Updated for Issue #652: documented deterministic cache staging, focused menu dismissal, and authenticated production wait budgets.'
 ---
 
 # Testing Patterns Reference
@@ -110,12 +110,14 @@ Browser semantic E2E pattern:
 - use `@playwright/test` `1.61.1` through `playwright.config.ts` and keep specs/helpers under `tests/e2e/i18n/**`
 - serve the candidate locally with `npm run start:main`; reject a non-loopback Playwright base URL even though the candidate uses the production backend configuration
 - keep the global rendered-candidate probe and require every new login page/context to await the shared route-specific visible marker before interaction; use a bounded readiness timeout, never a fixed sleep, broader action timeout, disabled retry accounting, or relaxed `failOnFlakyTests`
+- retain the 15-second assertion budget for public/CI semantics, but allow the explicitly authenticated production-backed closure 45 seconds for remote Process drawers; this scoped budget must not weaken routine browser checks
 - derive locale and authoring-language loops from `LOCALE_REGISTRY` and `CONTENT_LANGUAGE_REGISTRY`; never copy the current locale list into a spec or reporter
 - run the complete 49-route/view matrix in Chromium, require every target-declared semantic scenario in the evidence record, and run the critical selector, team authoring, and process lifecycle scenarios in Chromium, Firefox, and WebKit
 - keep every semantic E2E GitHub Actions invocation credential-free and read-only; `workflow_dispatch` provides optional three-browser public semantics/contract proof and release reuses it for the exact candidate SHA, while routine PR/dev events do not trigger it and authenticated production writes are restricted to an explicitly authorized local operator session with `E2E_AUTHENTICATED=true` plus the two write guards (`E2E_ALLOW_PRODUCTION_DATA=true` and the exact one-process confirmation token); verified evidence is a separate explicit opt-in
 - write an ignored UUID-scoped `codex-e2e` intent ledger before create; before delete, fetch the exact production row and verify its exact ILCD UUID path, authenticated owner, and per-language marker pairs at all five exact multilingual field paths
 - delete only verified exact-ID row versions and fail unless `created=cleaned` and `leaked=0`; an absent or unverifiable attempted row is not successful cleanup evidence
 - keep Header Umi `SelectLang` at `reload={false}` and prove locale switching within the same document: URL/document identity persist, mounted locale state refreshes, and a delayed old-locale reference response cannot overwrite the current selection
+- stage deliberately stale IndexedDB/localStorage fixtures on a same-origin static document before navigating to the tested deep link, and send menu-dismissal keys to the visible menu/trigger rather than ambient page focus; Firefox may retry one exact navigation only after its known cancellation failed to commit that target
 - disable screenshot, trace, video, and persisted/uploaded auth state; evidence contains only non-secret assertion results and content digests
 - treat adding a registry locale or changing a bound route/source/test as evidence invalidation, not as a request to reuse the old result
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -23,8 +23,8 @@ checkPaths:
   - tests/e2e/i18n/**
   - package.json
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 5c1723b98f005b40f913f1ed6e174d064388efcc
-lastReviewedNote: 'Reviewed for Issue #647: failure recovery remains valid after moving browser semantic E2E to manual and release-only triggers.'
+lastReviewedCommit: 804a44c0816076fd5166a6f36764483c7f37aaa8
+lastReviewedNote: 'Updated for Issue #651: added the fail-closed recovery-copy rule for stale or concurrent production E2E teardown.'
 ---
 
 # Testing Troubleshooting
@@ -58,6 +58,7 @@ Canonical baseline and proof ownership stays with `DEV.md` and `docs/agents/repo
 | authenticated semantic E2E skips or fails before setup | the explicitly authorized local operator session lacks runtime credentials, authenticated mode, one of the two write guards, verified-evidence opt-in, the production target proof, or an absolute recovery-ledger path outside the candidate worktree | keep every semantic E2E GitHub Actions run unauthenticated/read-only; run the full closure only in the authorized local session with `E2E_AUTHENTICATED=true`, `E2E_ALLOW_PRODUCTION_DATA=true`, the exact one-process confirmation token, `E2E_WRITE_VERIFIED_EVIDENCE=true`, the verified production backend target, and `E2E_RECOVERY_LEDGER_PATH` set to a protected absolute path outside the candidate worktree |
 | explicit production locale readiness rejects semantic evidence | one of the 49 assertion IDs, registry locales, required browsers, current backend/package/runtime/route/test/source bindings, or cleanup counts is incomplete or stale | inspect the first mismatched contract field, rerun only the affected browser scope, then run the complete authenticated closure; never edit evidence to simulate execution. Routine activation/pre-push checks must not require current production-proof hashes. |
 | teardown refuses cleanup or reports a leaked `codex-e2e` process | the intent ledger is invalid, the production row UUID/owner/five-field registry marker closure does not match, or exact-ID deletion failed | preserve the ignored ledger; inspect only the exact UUID row, restore verifiable ownership/marker evidence or escalate, and never broaden deletion; do not create another record until `created=cleaned` and `leaked=0` |
+| teardown reports that the primary ledger has no matching recovery copy | another invocation is active, a stale teardown is reading a newer run's primary ledger, or the protected external recovery file was removed | stop every older E2E runner, verify the exact UUID through audit/read-only checks, and restore only the matching recovery copy; never let the orphaned primary ledger authorize deletion |
 | Header locale changes reload the document or an old reference label returns after switching | Umi `SelectLang` lost `reload={false}` or an old-locale async response won the race | restore in-document switching, then rerun the same-document identity/URL proof and the delayed old-response race test before accepting the locale refresh |
 | Playwright browser executable is missing | the pinned dependency is installed but browser binaries are not | run `npx playwright install chromium firefox webkit` locally, or use the workflow's per-browser `--with-deps` install step |
 | one gate fails only while another Umi-generating command is running locally | concurrent focused tests, coverage, or full gate regenerated shared `.umi-test` | stop or await every heavy command, then rerun only the narrow failed command serially; do not chain broad test, coverage, and full-gate reruns |

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
+    "digest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "e131897851657197f77e8ac2deb481bfa17ddef48b281cb991c555c6af3669bd",
+          "sha256": "048201d12bb912ee2421dcdf3a104bcee571239c62e4e6a20b3594c6d7cec075",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -611,7 +611,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "1e7b75e1d22383a09659785235603f31ba5c7a73ea8d7bf9b7a188a8dea0d94f",
-          "focusedTestDigest": "7fe881d320f73ca12d5d25ef8fd0394d1e898606b11dc8a98f50dd998bb8c9eb",
+          "focusedTestDigest": "ce5709e006c325f9e68e241fd9ecc6b2724656607d2c1454f8b12f3ce113a151",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -629,7 +629,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "1e7b75e1d22383a09659785235603f31ba5c7a73ea8d7bf9b7a188a8dea0d94f",
-          "focusedTestDigest": "7fe881d320f73ca12d5d25ef8fd0394d1e898606b11dc8a98f50dd998bb8c9eb",
+          "focusedTestDigest": "ce5709e006c325f9e68e241fd9ecc6b2724656607d2c1454f8b12f3ce113a151",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -647,7 +647,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "1e7b75e1d22383a09659785235603f31ba5c7a73ea8d7bf9b7a188a8dea0d94f",
-          "focusedTestDigest": "7fe881d320f73ca12d5d25ef8fd0394d1e898606b11dc8a98f50dd998bb8c9eb",
+          "focusedTestDigest": "ce5709e006c325f9e68e241fd9ecc6b2724656607d2c1454f8b12f3ce113a151",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -665,7 +665,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "1e7b75e1d22383a09659785235603f31ba5c7a73ea8d7bf9b7a188a8dea0d94f",
-          "focusedTestDigest": "7fe881d320f73ca12d5d25ef8fd0394d1e898606b11dc8a98f50dd998bb8c9eb",
+          "focusedTestDigest": "ce5709e006c325f9e68e241fd9ecc6b2724656607d2c1454f8b12f3ce113a151",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "0d8f89a5513c86639283cdf3b553007ec0227341f0b1bff75ac1f465c834506a",
+      "rowEvidenceDigest": "a61bdfc486511211c05a9c6109c854b091ec794d74a817aaaa2dfb097da77336",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
+    "docs/plans/i18n/route-view-coverage.json": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-de-DE/glossary.json": "a5fd4e759af2713fbec83f2b95171c7b32206d7218da0401d28d2eecefccce3a",
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "11ba03a50319445637ba884539327242e08415930089448793419932954723a0"
+  "contextDigest": "19a60094f0000133231287357fdf3cf83a4a5e7e1c75157030023c48a6ca5ad0"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "11ba03a50319445637ba884539327242e08415930089448793419932954723a0",
-    "qualityDigest": "fec526482df726291d9abd9a8a603fc206cac9bcd2d365b5622b055cf8424348",
+    "contextDigest": "19a60094f0000133231287357fdf3cf83a4a5e7e1c75157030023c48a6ca5ad0",
+    "qualityDigest": "a16448522e042f3c02dc6a862b065f59fcaf5a744f6e00be4b234eac1ed9acdd",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
+    "routeViewCoverageDigest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "ba6347608835fdf32e7780358d2731b377ea674fbeb91733df2859b6eee2f550"
+  "activationDigest": "e52a75820229e65c6fb83776a8c97c69088bb04290a75ce625ec2b647385dd88"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
-    "contextDigest": "11ba03a50319445637ba884539327242e08415930089448793419932954723a0"
+    "contextDigest": "19a60094f0000133231287357fdf3cf83a4a5e7e1c75157030023c48a6ca5ad0"
   },
   "catalog": {
     "messageCount": 3032,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "05fefea4d47642cc6c24b805ba69664bea07c7110ea28d5711a8602dd015660a",
-    "validationDigest": "fc206a1e6208dbbee2f9d6c144532bb966baaae858521cd0bdc8daf9c5957227",
+    "digest": "41106ab89e3b8b8ad030858531b1626ac7aafd9fb5b8372a5c2e410250c1a3c3",
+    "validationDigest": "5f2992b80e52975fcc758d52afe584fe3eaac48bbaf58a23b1637f66368f6fab",
     "laneCount": 1,
     "validatedMessageCount": 3032,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "fec526482df726291d9abd9a8a603fc206cac9bcd2d365b5622b055cf8424348"
+  "qualityDigest": "a16448522e042f3c02dc6a862b065f59fcaf5a744f6e00be4b234eac1ed9acdd"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "7cd0bc0d30b733154b34642a79ddbc173919ffc6f3ad1115e45ceea9d4537224",
     "dossierDigest": "3a8130948bdc355e27deb65b8057212aca5552439a1653dc6beb763d91285097",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "0d8f89a5513c86639283cdf3b553007ec0227341f0b1bff75ac1f465c834506a",
+    "routeEvidenceDigest": "a61bdfc486511211c05a9c6109c854b091ec794d74a817aaaa2dfb097da77336",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "fc206a1e6208dbbee2f9d6c144532bb966baaae858521cd0bdc8daf9c5957227"
+  "validationDigest": "5f2992b80e52975fcc758d52afe584fe3eaac48bbaf58a23b1637f66368f6fab"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
+    "digest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "e131897851657197f77e8ac2deb481bfa17ddef48b281cb991c555c6af3669bd",
+          "sha256": "048201d12bb912ee2421dcdf3a104bcee571239c62e4e6a20b3594c6d7cec075",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -611,7 +611,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "1e7b75e1d22383a09659785235603f31ba5c7a73ea8d7bf9b7a188a8dea0d94f",
-          "focusedTestDigest": "7fe881d320f73ca12d5d25ef8fd0394d1e898606b11dc8a98f50dd998bb8c9eb",
+          "focusedTestDigest": "ce5709e006c325f9e68e241fd9ecc6b2724656607d2c1454f8b12f3ce113a151",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -629,7 +629,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "1e7b75e1d22383a09659785235603f31ba5c7a73ea8d7bf9b7a188a8dea0d94f",
-          "focusedTestDigest": "7fe881d320f73ca12d5d25ef8fd0394d1e898606b11dc8a98f50dd998bb8c9eb",
+          "focusedTestDigest": "ce5709e006c325f9e68e241fd9ecc6b2724656607d2c1454f8b12f3ce113a151",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -647,7 +647,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "1e7b75e1d22383a09659785235603f31ba5c7a73ea8d7bf9b7a188a8dea0d94f",
-          "focusedTestDigest": "7fe881d320f73ca12d5d25ef8fd0394d1e898606b11dc8a98f50dd998bb8c9eb",
+          "focusedTestDigest": "ce5709e006c325f9e68e241fd9ecc6b2724656607d2c1454f8b12f3ce113a151",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -665,7 +665,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "1e7b75e1d22383a09659785235603f31ba5c7a73ea8d7bf9b7a188a8dea0d94f",
-          "focusedTestDigest": "7fe881d320f73ca12d5d25ef8fd0394d1e898606b11dc8a98f50dd998bb8c9eb",
+          "focusedTestDigest": "ce5709e006c325f9e68e241fd9ecc6b2724656607d2c1454f8b12f3ce113a151",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "0d8f89a5513c86639283cdf3b553007ec0227341f0b1bff75ac1f465c834506a",
+      "rowEvidenceDigest": "a61bdfc486511211c05a9c6109c854b091ec794d74a817aaaa2dfb097da77336",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
+    "docs/plans/i18n/route-view-coverage.json": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-en-US/glossary.json": "4b8443ea3f91f15383683e9ece6221e40e24ceb75442ea830964b06c12559970",
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "252e744d0034b2f1cac2a922c376e70fd342a1ea6f5ae98fe6254cf7940ce916"
+  "contextDigest": "bc4d9c90dad9a51f8f88f73684ee0b5f181ab90c2a49cbd6d3cd4c68070be7e7"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "252e744d0034b2f1cac2a922c376e70fd342a1ea6f5ae98fe6254cf7940ce916",
-    "qualityDigest": "bf45767a6e913628079f6d6b4dc9de4831c16800e6c7d2df970a049c49ed9612",
+    "contextDigest": "bc4d9c90dad9a51f8f88f73684ee0b5f181ab90c2a49cbd6d3cd4c68070be7e7",
+    "qualityDigest": "d540250bdb6e4d304b75eed29d55816b4dd4cebef8b2e2cf2a5dde3b8010450e",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
+    "routeViewCoverageDigest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "79cc10a29d7b8d25effff274ce7924ac4018db688121cd6585b386c2586f4e46"
+  "activationDigest": "b6b5a6ef81f7078bfe22f564572904463a85c594f9de940dd66746f6a4457f8c"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
-    "contextDigest": "252e744d0034b2f1cac2a922c376e70fd342a1ea6f5ae98fe6254cf7940ce916"
+    "contextDigest": "bc4d9c90dad9a51f8f88f73684ee0b5f181ab90c2a49cbd6d3cd4c68070be7e7"
   },
   "catalog": {
     "messageCount": 3032,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "b70fd94b456cd1a7dc84117b329bc12a71239ac5c6fdff959b88d97d7397956b",
-    "validationDigest": "abeebe3f3e65708ec2efe3a9e1f67fd5bd80578379b4cfe32c8e16d46f6c2250",
+    "digest": "467c4efc20bce94db7e5b89e93ffaebaf1279fa56a4b272c89266cacf92c0f60",
+    "validationDigest": "7dd179287ac356e549cf9b8661381749efe56dc7fd9b61bb7bc297a5fbc9df84",
     "laneCount": 1,
     "validatedMessageCount": 3032,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "bf45767a6e913628079f6d6b4dc9de4831c16800e6c7d2df970a049c49ed9612"
+  "qualityDigest": "d540250bdb6e4d304b75eed29d55816b4dd4cebef8b2e2cf2a5dde3b8010450e"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "d93ed39831164b98edc60b1961375fe4aa11c9ec5c446ad564b5b8742398e21d",
     "dossierDigest": "1a8555b52e279fe8bc8e71f7990209a9f61cfdccb1825d34a93de1ef881c0a79",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "0d8f89a5513c86639283cdf3b553007ec0227341f0b1bff75ac1f465c834506a",
+    "routeEvidenceDigest": "a61bdfc486511211c05a9c6109c854b091ec794d74a817aaaa2dfb097da77336",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "abeebe3f3e65708ec2efe3a9e1f67fd5bd80578379b4cfe32c8e16d46f6c2250"
+  "validationDigest": "7dd179287ac356e549cf9b8661381749efe56dc7fd9b61bb7bc297a5fbc9df84"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
+    "digest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "e131897851657197f77e8ac2deb481bfa17ddef48b281cb991c555c6af3669bd",
+          "sha256": "048201d12bb912ee2421dcdf3a104bcee571239c62e4e6a20b3594c6d7cec075",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -611,7 +611,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "1e7b75e1d22383a09659785235603f31ba5c7a73ea8d7bf9b7a188a8dea0d94f",
-          "focusedTestDigest": "7fe881d320f73ca12d5d25ef8fd0394d1e898606b11dc8a98f50dd998bb8c9eb",
+          "focusedTestDigest": "ce5709e006c325f9e68e241fd9ecc6b2724656607d2c1454f8b12f3ce113a151",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -629,7 +629,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "1e7b75e1d22383a09659785235603f31ba5c7a73ea8d7bf9b7a188a8dea0d94f",
-          "focusedTestDigest": "7fe881d320f73ca12d5d25ef8fd0394d1e898606b11dc8a98f50dd998bb8c9eb",
+          "focusedTestDigest": "ce5709e006c325f9e68e241fd9ecc6b2724656607d2c1454f8b12f3ce113a151",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -647,7 +647,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "1e7b75e1d22383a09659785235603f31ba5c7a73ea8d7bf9b7a188a8dea0d94f",
-          "focusedTestDigest": "7fe881d320f73ca12d5d25ef8fd0394d1e898606b11dc8a98f50dd998bb8c9eb",
+          "focusedTestDigest": "ce5709e006c325f9e68e241fd9ecc6b2724656607d2c1454f8b12f3ce113a151",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -665,7 +665,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "1e7b75e1d22383a09659785235603f31ba5c7a73ea8d7bf9b7a188a8dea0d94f",
-          "focusedTestDigest": "7fe881d320f73ca12d5d25ef8fd0394d1e898606b11dc8a98f50dd998bb8c9eb",
+          "focusedTestDigest": "ce5709e006c325f9e68e241fd9ecc6b2724656607d2c1454f8b12f3ce113a151",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "0d8f89a5513c86639283cdf3b553007ec0227341f0b1bff75ac1f465c834506a",
+      "rowEvidenceDigest": "a61bdfc486511211c05a9c6109c854b091ec794d74a817aaaa2dfb097da77336",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
+    "docs/plans/i18n/route-view-coverage.json": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-fr-FR/glossary.json": "057cb494f02d980106469f6a16befc102d26db5ac362b9777cd5f97c7729c91b",
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "38f3b5fdee5ec580fec770d6153bcf0c00691c152058695404c55d631555a308"
+  "contextDigest": "9c976d78b1542b3bd74cc8ae06e7e7bdb341813782d47539e322a0b69bb28206"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "38f3b5fdee5ec580fec770d6153bcf0c00691c152058695404c55d631555a308",
-    "qualityDigest": "d6cd52e9be6995fa323ca51865d8e018460b370d08564bf69cbeb128f794553a",
+    "contextDigest": "9c976d78b1542b3bd74cc8ae06e7e7bdb341813782d47539e322a0b69bb28206",
+    "qualityDigest": "4ad21063430f1691228f4d3faefa7500305a5b8055fa84a9ea65136cb4605b27",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
+    "routeViewCoverageDigest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "4379122c67557d79139a5dabe59607e870395fda6bb5166ec5ef2c1f26265e36"
+  "activationDigest": "4c4a9cfdd2cad949e9e43cd0e174ef2b7a841c5ee3463a58cec1516b358f0b69"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
-    "contextDigest": "38f3b5fdee5ec580fec770d6153bcf0c00691c152058695404c55d631555a308"
+    "contextDigest": "9c976d78b1542b3bd74cc8ae06e7e7bdb341813782d47539e322a0b69bb28206"
   },
   "catalog": {
     "messageCount": 3032,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "8ade887dab1376ff282476a708a09c22c7a83d6d0b5678ee4245007c3a489410",
-    "validationDigest": "fe3429376d5154c22f6fcab287d32288c740f271708984910cc3035c38219ef4",
+    "digest": "d1083c5a5ef909eb569235a2265ca434c411da9970ef6e1e345a6dd9ef16e986",
+    "validationDigest": "789e90256308b7e5a2379a28a84f929d8ce00bc6ffcd33e7c0b73f2f42df6404",
     "laneCount": 1,
     "validatedMessageCount": 3032,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "d6cd52e9be6995fa323ca51865d8e018460b370d08564bf69cbeb128f794553a"
+  "qualityDigest": "4ad21063430f1691228f4d3faefa7500305a5b8055fa84a9ea65136cb4605b27"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "fe762b9712f0e81eab9a0befa1fd0f820986ef430556ff6491148c6a2f30e6a2",
     "dossierDigest": "6692befb10ab699ab299db391553104385856439ee23f524e078f8a288190050",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "0d8f89a5513c86639283cdf3b553007ec0227341f0b1bff75ac1f465c834506a",
+    "routeEvidenceDigest": "a61bdfc486511211c05a9c6109c854b091ec794d74a817aaaa2dfb097da77336",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "fe3429376d5154c22f6fcab287d32288c740f271708984910cc3035c38219ef4"
+  "validationDigest": "789e90256308b7e5a2379a28a84f929d8ce00bc6ffcd33e7c0b73f2f42df6404"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
+    "digest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "e131897851657197f77e8ac2deb481bfa17ddef48b281cb991c555c6af3669bd",
+          "sha256": "048201d12bb912ee2421dcdf3a104bcee571239c62e4e6a20b3594c6d7cec075",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -611,7 +611,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "1e7b75e1d22383a09659785235603f31ba5c7a73ea8d7bf9b7a188a8dea0d94f",
-          "focusedTestDigest": "7fe881d320f73ca12d5d25ef8fd0394d1e898606b11dc8a98f50dd998bb8c9eb",
+          "focusedTestDigest": "ce5709e006c325f9e68e241fd9ecc6b2724656607d2c1454f8b12f3ce113a151",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -629,7 +629,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "1e7b75e1d22383a09659785235603f31ba5c7a73ea8d7bf9b7a188a8dea0d94f",
-          "focusedTestDigest": "7fe881d320f73ca12d5d25ef8fd0394d1e898606b11dc8a98f50dd998bb8c9eb",
+          "focusedTestDigest": "ce5709e006c325f9e68e241fd9ecc6b2724656607d2c1454f8b12f3ce113a151",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -647,7 +647,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "1e7b75e1d22383a09659785235603f31ba5c7a73ea8d7bf9b7a188a8dea0d94f",
-          "focusedTestDigest": "7fe881d320f73ca12d5d25ef8fd0394d1e898606b11dc8a98f50dd998bb8c9eb",
+          "focusedTestDigest": "ce5709e006c325f9e68e241fd9ecc6b2724656607d2c1454f8b12f3ce113a151",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -665,7 +665,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "1e7b75e1d22383a09659785235603f31ba5c7a73ea8d7bf9b7a188a8dea0d94f",
-          "focusedTestDigest": "7fe881d320f73ca12d5d25ef8fd0394d1e898606b11dc8a98f50dd998bb8c9eb",
+          "focusedTestDigest": "ce5709e006c325f9e68e241fd9ecc6b2724656607d2c1454f8b12f3ce113a151",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "0d8f89a5513c86639283cdf3b553007ec0227341f0b1bff75ac1f465c834506a",
+      "rowEvidenceDigest": "a61bdfc486511211c05a9c6109c854b091ec794d74a817aaaa2dfb097da77336",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
+    "docs/plans/i18n/route-view-coverage.json": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-zh-CN/glossary.json": "c891add0ee4bd6d24c0213d0c839474e145d85867426df796763b8e038053d9b",
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "4cc36fa9c46c38d58f06383f83f60fdb48cb16429490728248465143c220c408"
+  "contextDigest": "4217ffb8c21026515d45e3fb12269806f8407ef6e25c2791c470bff47db68c98"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4cc36fa9c46c38d58f06383f83f60fdb48cb16429490728248465143c220c408",
-    "qualityDigest": "32819db751759b265560673549ea939ee3ddc477ff1f9172134c045fb10056f0",
+    "contextDigest": "4217ffb8c21026515d45e3fb12269806f8407ef6e25c2791c470bff47db68c98",
+    "qualityDigest": "bd30f8d3357f4908428ed92a113171985f5794a882916bb37d628ee592409828",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "0404ec6b2a4c6c83f97f2a56154c980b82317d41bafaa8d10dec72474cf27a13",
+    "routeViewCoverageDigest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "397a77bff89880a741564752318af9b1aff9b973228c69589f3d0476d13669ad"
+  "activationDigest": "ef6fbff3205e72feeb82c07872f70b54f74d4f8850d971d9fe64e0f0c793e84d"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
-    "contextDigest": "4cc36fa9c46c38d58f06383f83f60fdb48cb16429490728248465143c220c408"
+    "contextDigest": "4217ffb8c21026515d45e3fb12269806f8407ef6e25c2791c470bff47db68c98"
   },
   "catalog": {
     "messageCount": 3032,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "0af9f48dcb4dadbe1689e7aabb5b325c6f605739f5b2c0794d5a5e8b7b2640b6",
-    "validationDigest": "609908cb70903fbd11c564cef5c32a13629726b10c4af1c0335aa902aa319534",
+    "digest": "c2244d591dc2a3541b5561bf25f802491ef31859a98f2a366db1c63d4c20b12e",
+    "validationDigest": "42e48090d8aea2f89d7e950fcf67eb2d37763a92b3b635b773f90c2db1fa90fb",
     "laneCount": 1,
     "validatedMessageCount": 3032,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "32819db751759b265560673549ea939ee3ddc477ff1f9172134c045fb10056f0"
+  "qualityDigest": "bd30f8d3357f4908428ed92a113171985f5794a882916bb37d628ee592409828"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "d2ba7bc81f8aca97f5075283d3509c63fb7ff370a6bec1d4a439c8737b19106e",
     "dossierDigest": "3407227e20f4861c8e5f6695a75416d5bb961aaab3d98f987e75f530dd571909",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "0d8f89a5513c86639283cdf3b553007ec0227341f0b1bff75ac1f465c834506a",
+    "routeEvidenceDigest": "a61bdfc486511211c05a9c6109c854b091ec794d74a817aaaa2dfb097da77336",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "609908cb70903fbd11c564cef5c32a13629726b10c4af1c0335aa902aa319534"
+  "validationDigest": "42e48090d8aea2f89d7e950fcf67eb2d37763a92b3b635b773f90c2db1fa90fb"
 }

--- a/docs/plans/i18n/route-view-coverage.json
+++ b/docs/plans/i18n/route-view-coverage.json
@@ -353,7 +353,7 @@
       "executedEvidence": [
         {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "e131897851657197f77e8ac2deb481bfa17ddef48b281cb991c555c6af3669bd"
+          "sha256": "048201d12bb912ee2421dcdf3a104bcee571239c62e4e6a20b3594c6d7cec075"
         }
       ]
     }

--- a/docs/plans/i18n/semantic-e2e-evidence.json
+++ b/docs/plans/i18n/semantic-e2e-evidence.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": "tiangong.i18n-semantic-e2e-evidence.v1",
   "status": "verified",
-  "generatedAt": "2026-07-20T08:15:36.565Z",
-  "runId": "local-77a53ac7-7125-42ae-9440-9252c707a6ac",
+  "generatedAt": "2026-07-21T13:16:30.855Z",
+  "runId": "local-16685da0-f047-467b-826e-4a14a4722909",
   "candidate": {
     "configTreeDigest": "a5f819459fba99fbf639dbbfd9c6b863672bb2356203113c736ba508b2c8a176",
-    "observedHeadCommit": "9b5bdeb11794f280b639212248b9816338923dd7",
-    "packageManifestDigest": "4910623de8b46e2cc3efb74c665a6fb047fa4315759de0e22819535e7f72ac11",
-    "sourceTreeDigest": "b4d9690cc7845351b1ea6ee338f4e5f3e13c937806652b01c43f1225e20118eb",
-    "unitTestTreeDigest": "3c93914f11fb952cc1ba593d3bdd832518e4a68b9d62bf013dd03d21fc3782a1"
+    "observedHeadCommit": "804a44c0816076fd5166a6f36764483c7f37aaa8",
+    "packageManifestDigest": "4de95641ba4877d61901bf9f67cfe1f83cd788721b39b74972d302ba2e4a2486",
+    "sourceTreeDigest": "8939ba3cc13c25997f75bb616fbb16e62e57852ae57ab80e8a95e6672051b58b",
+    "unitTestTreeDigest": "0f9266215df76d748c0dacd4bc3151e4d32c250ad03232fcaa83211ab0737c83"
   },
   "target": {
     "frontend": "candidate-local",
@@ -19,7 +19,7 @@
       "backendTrackedOriginSha256": "bf39ee1b65b9f4b508e97aeb69b704b9fc172f20b7d74e7f24ccfbc515161495",
       "backendTrackedPublishableKeySha256": "f48ee2a57a2e550f6a43fee565727d28865ec821b3cf8e5e08854bd7cc33ba9e",
       "candidateEnvironmentSha256": "e8e821970e6b99bc30b13f7b142b6db5afce7480238f7b178dd67d32fadb4174",
-      "frontendOriginSha256": "63767aa5615dabadd32b93fdf0db0c7190c850062ba568114ea4f28b6cdc9e71",
+      "frontendOriginSha256": "aea53e7b670632001d67f90ba2fc0bc6c1ad315c8b88bf5019e01594bfa84966",
       "freshPlaywrightServer": true,
       "observer": "chromium-auth-request",
       "trackedMainEnvironmentSha256": "e8e821970e6b99bc30b13f7b142b6db5afce7480238f7b178dd67d32fadb4174"
@@ -34,7 +34,7 @@
   "digests": {
     "packageLock": {
       "path": "package-lock.json",
-      "sha256": "c4ae4cce664d94a18b3618df3e0a33363d9dc9c29834e1a44fde8599f0fd90b0"
+      "sha256": "05311df9e31427d52d6bf45e2445850315e23a22ad0489f9a07c6af6ce9f5f43"
     },
     "runtimeAssets": [
       {
@@ -133,15 +133,15 @@
     "tests": [
       {
         "path": "docs/plans/i18n/semantic-e2e-evidence.schema.json",
-        "sha256": "dc9c76ea778e408be8f692ba0cd373bfaba0201de0d0572c40e4e7377d73e1d6"
+        "sha256": "0ad8af33b8a158f5f368435395205e6a824e19070ea4f6eeb0187e5c17aebe12"
       },
       {
         "path": "playwright.config.ts",
-        "sha256": "90f3b6d1e0a2437979f5fedd43ecd1bdb2790de4a14318fead36661a691042c1"
+        "sha256": "131ac48a2a5cac438d0cca681da4ceee014dead9ca641a31c97ed46fc738c9a3"
       },
       {
         "path": "scripts/i18n/locale-delivery.mjs",
-        "sha256": "7bcf9d0c0ec0147ff900c3b836bc3a6c6948adf64cff607a809e21e9fd4760e0"
+        "sha256": "0357f20b041722e07c53d65eb25d40909f0b784fdc1d81775628a4e6fc6e9aa9"
       },
       {
         "path": "tests/data-workflows/data-workflow-paths.ts",
@@ -173,7 +173,7 @@
       },
       {
         "path": "tests/e2e/i18n/contracts.ts",
-        "sha256": "d217b79cd222872eb328ac1c1d12fc4355ec5a0c83a3385e0bed39b998862674"
+        "sha256": "d6d43ed4e2147b7a3cc7f203f6cb313b8bcb856bb8432969d67b781487bafaee"
       },
       {
         "path": "tests/e2e/i18n/evidence-reporter.ts",
@@ -221,11 +221,11 @@
       },
       {
         "path": "tests/e2e/i18n/production-data-safety.ts",
-        "sha256": "bd28d61d9d6a2f92bcc20c50699867688ee9c98d3f6172b8c3c7864017e7162e"
+        "sha256": "31e1393ad2c8228a2134049e050ea50b6562f52019d2402fdff741d272018b8b"
       },
       {
         "path": "tests/e2e/i18n/production-request-guard.ts",
-        "sha256": "35c59de65c93bf3a17fba286ff6ba6a350d8619ba68eb69a7d6fc36a938f0fbe"
+        "sha256": "1f6330390333c142823d00c9c2d5dfdb31a46c32464f1709559754e98008e871"
       },
       {
         "path": "tests/e2e/i18n/query-responsive.spec.ts",
@@ -237,7 +237,7 @@
       },
       {
         "path": "tests/e2e/i18n/reference-refresh.spec.ts",
-        "sha256": "7124f65ce6fd87ba19994542c20a4b03bb03bea226629f8680e39ad200c95c43"
+        "sha256": "97a631d4d4d2c6e37230e6b839e5efced1d745af98baf52fc619e3afe7c7bf6f"
       },
       {
         "path": "tests/e2e/i18n/responsive-layout.spec.ts",
@@ -269,7 +269,7 @@
       },
       {
         "path": "tests/e2e/i18n/typed-view-variants.spec.ts",
-        "sha256": "ff229804f5b0b26d235a211464c78094cc662ca05bd91387739c869b45a67b44"
+        "sha256": "79180299393bf3f97789477ae586775025c802be5f186f4d7345bf21c5aba1d0"
       },
       {
         "path": "tests/unit/app.test.tsx",
@@ -325,19 +325,19 @@
       },
       {
         "path": "tests/unit/e2e/productionDataLedger.test.ts",
-        "sha256": "20bf46725a67ad2e5a709165377e70064103ce837f51666676070972bfdd5b70"
+        "sha256": "a6f3ab5e107ebb039d9d0388a1589514e34b92e0a9d5270166394ecb6254fade"
       },
       {
         "path": "tests/unit/e2e/productionRequestGuard.test.ts",
-        "sha256": "ad91f5be37717309c144b0b6ea5e09536c6d202ceb49a6e7ee75be71a9da7b5a"
+        "sha256": "68a890f057722adfde3be6cb781808ff7694e0715f5a687c1aa8d10257c68e58"
       },
       {
         "path": "tests/unit/e2e/referenceRefreshContract.test.ts",
-        "sha256": "a99ecbaa23056488375e1cdceb1a944ff4cea2e4db566e4aa9bbce0c17a954f3"
+        "sha256": "12e7b526cac4447bc848c6f5eb3f151d35155e65da1b55a24433b02465ffe853"
       },
       {
         "path": "tests/unit/i18n/localeDeliveryContracts.test.ts",
-        "sha256": "f654ac82a08968d4e4d0b433f406d28a6f618b0cb7e8e6fa6d5eca49ac027336"
+        "sha256": "df14008044560c174f3613365002d7424a277e75d9dc6437d964b04a9be9a486"
       },
       {
         "path": "tests/unit/pages/404.test.tsx",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.53",
+      "version": "0.0.54",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,6 +15,7 @@ assertCandidateFrontendTarget(baseURL);
 
 const authenticatedRun = process.env.E2E_AUTHENTICATED === 'true';
 const verifiedEvidenceRun = process.env.E2E_WRITE_VERIFIED_EVIDENCE === 'true';
+const expectTimeout = authenticatedRun ? 45_000 : 15_000;
 if (
   verifiedEvidenceRun &&
   (!authenticatedRun ||
@@ -36,7 +37,7 @@ export default defineConfig({
   workers: authenticatedRun ? 1 : process.env.CI ? 2 : 1,
   timeout: 120_000,
   expect: {
-    timeout: 15_000,
+    timeout: expectTimeout,
   },
   globalSetup: './tests/e2e/i18n/global-setup.ts',
   globalTeardown: './tests/e2e/i18n/global-teardown.ts',

--- a/tests/e2e/i18n/contracts.ts
+++ b/tests/e2e/i18n/contracts.ts
@@ -480,9 +480,16 @@ export async function selectAppLocaleThroughUi(
     key: UMI_LOCALE_STORAGE_KEY,
     value: locale,
   });
-  if ((await activeMenu.count()) > 0) {
-    await page.keyboard.press('Escape');
-  }
+  await page.keyboard.press('Escape');
+  await page.evaluate(() => {
+    const visibleMenuExists = [...document.querySelectorAll<HTMLElement>('[role="menu"]')].some(
+      (menu) => menu.getClientRects().length > 0 && getComputedStyle(menu).visibility !== 'hidden',
+    );
+    if (visibleMenuExists) {
+      document.querySelector<HTMLElement>('.tg-global-language-selector')?.click();
+    }
+  });
+  await page.keyboard.press('Escape');
   await waitForLocatorCount(
     page,
     activeMenu,

--- a/tests/e2e/i18n/production-data-safety.ts
+++ b/tests/e2e/i18n/production-data-safety.ts
@@ -204,10 +204,18 @@ export function reconcileProductionLedgerCopies(
   if (!primary && !recovery) {
     return undefined;
   }
+  if (primary && !recovery) {
+    assertLedgerScope(primary);
+    throw new Error(
+      'The primary codex-e2e ledger has no matching recovery copy; refusing cross-run adoption.',
+    );
+  }
+  if (!primary && recovery) {
+    assertLedgerScope(recovery);
+    return recovery;
+  }
   if (!primary || !recovery) {
-    const survivingCopy = primary ?? recovery!;
-    assertLedgerScope(survivingCopy);
-    return survivingCopy;
+    throw new Error('Codex E2E ledger reconciliation reached an impossible copy state.');
   }
   assertLedgerScope(primary);
   assertLedgerScope(recovery);

--- a/tests/e2e/i18n/production-request-guard.ts
+++ b/tests/e2e/i18n/production-request-guard.ts
@@ -14,6 +14,9 @@ const PUBLIC_AUTH_READ_PATHS = new Set(['/auth/v1/.well-known/jwks.json']);
 const AUTHENTICATED_AUTH_READ_PATHS = new Set(['/auth/v1/user']);
 const AUTH_TOKEN_GRANT_TYPES = new Set(['password', 'refresh_token']);
 const LEDGER_CONTROLLED_SAVE_DRAFT_SEARCH_ENTRIES = [['forceFunctionRegion', 'us-east-1']] as const;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+const PROCESS_VERSION_PATTERN = /^\d{2}[.]\d{2}[.]\d{3}$/u;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/iu;
 const STATIC_STORAGE_READ_PATH =
   /^\/storage\/v1\/(?:object|render\/image)\/(?:public|sign)\/[^/]+\/.+/u;
 const AUTHENTICATED_STORAGE_READ_PATH =
@@ -148,6 +151,41 @@ function isExactWorkerReadBody(postData: string | null | undefined): boolean {
   }
 }
 
+function isExactReviewSubmitJobReadBody(postData: string | null | undefined): boolean {
+  try {
+    const body = JSON.parse(postData ?? '');
+    if (body.action === 'read') {
+      return (
+        hasExactObjectKeys(body, ['action', 'reviewSubmitJobId']) &&
+        typeof body.reviewSubmitJobId === 'string' &&
+        UUID_PATTERN.test(body.reviewSubmitJobId)
+      );
+    }
+    if (body.action !== 'read_latest') {
+      return false;
+    }
+    const hasRevisionChecksum = Object.prototype.hasOwnProperty.call(body, 'revisionChecksum');
+    return (
+      hasExactObjectKeys(body, [
+        'action',
+        'table',
+        'id',
+        'version',
+        ...(hasRevisionChecksum ? ['revisionChecksum'] : []),
+      ]) &&
+      body.table === 'processes' &&
+      typeof body.id === 'string' &&
+      UUID_PATTERN.test(body.id) &&
+      typeof body.version === 'string' &&
+      PROCESS_VERSION_PATTERN.test(body.version) &&
+      (!hasRevisionChecksum ||
+        (typeof body.revisionChecksum === 'string' && SHA256_PATTERN.test(body.revisionChecksum)))
+    );
+  } catch {
+    return false;
+  }
+}
+
 function isExactPublicationListBody(postData: string | null | undefined): boolean {
   try {
     const body = JSON.parse(postData ?? '');
@@ -269,6 +307,9 @@ export function classifyProductionRequest(
     }
     if (functionName === 'app_worker_jobs') {
       return isExactWorkerReadBody(postData) ? 'allow' : 'block';
+    }
+    if (functionName === 'app_dataset_review_submit_jobs') {
+      return isExactReviewSubmitJobReadBody(postData) ? 'allow' : 'block';
     }
     if (functionName === 'app_data_product_commands') {
       return isExactPublicationListBody(postData) ? 'allow' : 'block';

--- a/tests/e2e/i18n/reference-refresh.spec.ts
+++ b/tests/e2e/i18n/reference-refresh.spec.ts
@@ -220,6 +220,37 @@ async function expectProcessDeepLink(
     });
 }
 
+async function gotoCandidateUrl(page: Page, browserName: string, targetUrl: string): Promise<void> {
+  const maxNavigationAttempts = browserName === 'firefox' ? 2 : 1;
+  let navigationError: unknown;
+  for (let attempt = 0; attempt < maxNavigationAttempts; attempt += 1) {
+    try {
+      await page.goto(targetUrl, { timeout: 45_000, waitUntil: 'domcontentloaded' });
+      navigationError = undefined;
+      break;
+    } catch (error) {
+      const isKnownFirefoxCancellation =
+        browserName === 'firefox' &&
+        error instanceof Error &&
+        (error.message.includes('NS_ERROR_FAILURE') ||
+          error.message.includes('NS_BINDING_ABORTED'));
+      if (!isKnownFirefoxCancellation) {
+        throw error;
+      }
+      if (page.url() === targetUrl) {
+        navigationError = undefined;
+        break;
+      }
+      navigationError = error;
+    }
+  }
+  if (navigationError) throw navigationError;
+
+  // A known Firefox cancellation may receive one exact-target retry only when the first attempt
+  // did not commit. Every caller must still prove that its exact URL committed.
+  await expect.poll(() => page.url(), { timeout: 45_000 }).toBe(targetUrl);
+}
+
 async function gotoCandidateDocument(
   page: Page,
   browserName: string,
@@ -229,21 +260,7 @@ async function gotoCandidateDocument(
   options: { mode?: 'edit' | 'view'; waitForDrawerIdle?: boolean } = {},
 ): Promise<void> {
   const { mode = 'view', waitForDrawerIdle = true } = options;
-  try {
-    await page.goto(targetUrl, { timeout: 45_000, waitUntil: 'domcontentloaded' });
-  } catch (error) {
-    const isCommittedFirefoxCancellation =
-      browserName === 'firefox' &&
-      error instanceof Error &&
-      (error.message.includes('NS_ERROR_FAILURE') || error.message.includes('NS_BINDING_ABORTED'));
-    if (!isCommittedFirefoxCancellation) {
-      throw error;
-    }
-  }
-
-  // Known Firefox cancellations are accepted only when the exact authenticated Process mount
-  // committed. No second navigation may hide a Welcome/login redirect or wrong query state.
-  await expect.poll(() => page.url(), { timeout: 45_000 }).toBe(targetUrl);
+  await gotoCandidateUrl(page, browserName, targetUrl);
   await expectProcessDeepLink(page, ledger, state, mode);
   await expect(page.locator('.tg-global-header-avatar-trigger')).toBeAttached({ timeout: 45_000 });
   await expect(page.locator('.tg-global-language-selector')).toBeVisible({ timeout: 45_000 });
@@ -727,6 +744,9 @@ test('previous-revision browser caches fail closed and process deep links surviv
       }
 
       try {
+        const cacheStagingUrl = new URL('/privacy_notice.html', baseURL!);
+        cacheStagingUrl.searchParams.set('codexE2EReferenceState', state);
+        await gotoCandidateUrl(page, browserName, cacheStagingUrl.toString());
         const injectedEntries = await injectPreviousRevisionEntries(
           page,
           fixtures,
@@ -734,8 +754,7 @@ test('previous-revision browser caches fail closed and process deep links surviv
           staleMarker,
         );
         await expectPreviousRevisionEntriesInjected(page, injectedEntries);
-        await page.reload({ waitUntil: 'domcontentloaded' });
-        expect(page.url()).toBe(targetUrl);
+        await gotoCandidateUrl(page, browserName, targetUrl);
         await expectProcessDeepLink(page, ledger!, state);
         await expect.poll(() => readStoredAppLocale(page)).toBe(definition.appLocale);
         await expect

--- a/tests/e2e/i18n/typed-view-variants.spec.ts
+++ b/tests/e2e/i18n/typed-view-variants.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page, type Route } from './fixtures';
+import { expect, test, type Locator, type Page, type Route } from './fixtures';
 
 import { signInViaUi } from './auth';
 import {
@@ -350,25 +350,38 @@ test('Data Processing typed tabs survive locale switches and reloads', async ({
   }
 });
 
-async function expectProcessDrawer(
+async function expectProcessDrawerMounted(
   page: Page,
-  locale: (typeof APP_LOCALES)[number],
   mode: 'edit' | 'view',
   required: 'optional' | 'required' | undefined,
-): Promise<void> {
-  const titleMessageId = `pages.process.drawer.title.${mode}`;
-  const drawer = page.locator('.ant-drawer-content:visible').filter({
-    has: page.getByText(getLocaleMessage(locale, titleMessageId), { exact: true }),
-  });
-  await expect(drawer).toHaveCount(1);
-  await expect(drawer).toBeVisible();
-  const state = drawer.getByTestId('process-deep-link-state');
+): Promise<Locator> {
+  const state = page.getByTestId('process-deep-link-state');
+  await expect(state).toBeAttached();
   await expect(state).toHaveAttribute('data-route-mode', mode);
   if (required) {
     await expect(state).toHaveAttribute('data-auto-check-required', required);
   } else {
     await expect(state).not.toHaveAttribute('data-auto-check-required');
   }
+  const drawer = page.locator('.ant-drawer-content:visible').filter({ has: state });
+  await expect(drawer).toHaveCount(1);
+  await expect(drawer).toBeVisible();
+  await expect(drawer.locator('.ant-spin-spinning')).toHaveCount(0);
+  return drawer;
+}
+
+async function expectProcessDrawer(
+  page: Page,
+  locale: (typeof APP_LOCALES)[number],
+  mode: 'edit' | 'view',
+  required: 'optional' | 'required' | undefined,
+): Promise<void> {
+  const drawer = await expectProcessDrawerMounted(page, mode, required);
+  await expect(
+    drawer.getByText(getLocaleMessage(locale, `pages.process.drawer.title.${mode}`), {
+      exact: true,
+    }),
+  ).toBeVisible();
 }
 
 async function expectProcessDeepLinkMountSettled(input: {
@@ -436,6 +449,8 @@ test('Process edit and view deep links survive locale switches and reloads', asy
         await page.goto(spaLocationToCandidateUrl(baseURL!, location), {
           waitUntil: 'domcontentloaded',
         });
+        await expectSpaLocation(page, location);
+        await expectProcessDrawerMounted(page, mode, mode === 'edit' ? 'optional' : undefined);
         await selectAppLocaleThroughUi(page, locale, { forceTrigger: true });
         await expectSpaLocation(page, location);
         await expect.poll(() => readStoredAppLocale(page)).toBe(locale);

--- a/tests/unit/e2e/productionDataLedger.test.ts
+++ b/tests/unit/e2e/productionDataLedger.test.ts
@@ -774,12 +774,18 @@ describe('production data ledger safety contract', () => {
     );
   });
 
-  it('reconciles only the atomic cleanup-prepared transition between ledger copies', () => {
+  it('reconciles only recovery-backed ledger states and the atomic cleanup transition', () => {
     const primary = makeLedger();
     const recovery = makeLedgerAtState('cleanup-prepared');
     expect(reconcileProductionLedgerCopies(primary, recovery)).toEqual(recovery);
     expect(reconcileProductionLedgerCopies(recovery, primary)).toEqual(recovery);
-    expect(reconcileProductionLedgerCopies(primary, undefined)).toEqual(primary);
+    expect(reconcileProductionLedgerCopies(undefined, primary)).toEqual(primary);
+  });
+
+  it('refuses to let a stale run adopt a primary ledger without its recovery copy', () => {
+    expect(() => reconcileProductionLedgerCopies(makeLedger(), undefined)).toThrow(
+      /no matching recovery copy/u,
+    );
   });
 
   it('refuses ledger-copy disagreement outside the cleanup-prepared transition', () => {

--- a/tests/unit/e2e/productionMutationAuthorizationContract.test.ts
+++ b/tests/unit/e2e/productionMutationAuthorizationContract.test.ts
@@ -19,6 +19,8 @@ describe('production semantic E2E mutation authorization contract', () => {
     const config = read('playwright.config.ts');
     expect(config).toContain('failOnFlakyTests: Boolean(process.env.CI)');
     expect(config).toContain('retries: process.env.CI ? 1 : 0');
+    expect(config).toContain('const expectTimeout = authenticatedRun ? 45_000 : 15_000;');
+    expect(config).toContain('timeout: expectTimeout');
   });
 
   it('revalidates the complete operator envelope at create and exact-delete boundaries', () => {

--- a/tests/unit/e2e/productionRequestGuard.test.ts
+++ b/tests/unit/e2e/productionRequestGuard.test.ts
@@ -467,6 +467,110 @@ describe('production browser request guard', () => {
   });
 
   it.each([
+    [
+      'read',
+      {
+        action: 'read',
+        reviewSubmitJobId: '33333333-3333-4333-8333-333333333333',
+      },
+    ],
+    [
+      'read_latest',
+      {
+        action: 'read_latest',
+        table: 'processes',
+        id: '11111111-1111-4111-8111-111111111111',
+        version: '01.00.000',
+      },
+    ],
+    [
+      'read_latest with revision checksum',
+      {
+        action: 'read_latest',
+        table: 'processes',
+        id: '11111111-1111-4111-8111-111111111111',
+        version: '01.00.000',
+        revisionChecksum: 'a'.repeat(64),
+      },
+    ],
+  ])('allows the exact read-only review-submit %s action', (_name, body) => {
+    expect(
+      classify('POST', '/functions/v1/app_dataset_review_submit_jobs', JSON.stringify(body)),
+    ).toBe('allow');
+  });
+
+  it.each([
+    [
+      'enqueue',
+      {
+        action: 'enqueue',
+        table: 'processes',
+        id: '11111111-1111-4111-8111-111111111111',
+        version: '01.00.000',
+      },
+    ],
+    [
+      'read with an extra key',
+      { action: 'read', reviewSubmitJobId: '33333333-3333-4333-8333-333333333333', write: true },
+    ],
+    ['read with a non-UUID id', { action: 'read', reviewSubmitJobId: 'latest' }],
+    [
+      'read_latest for another table',
+      {
+        action: 'read_latest',
+        table: 'flows',
+        id: '11111111-1111-4111-8111-111111111111',
+        version: '01.00.000',
+      },
+    ],
+    [
+      'read_latest with a non-UUID id',
+      { action: 'read_latest', table: 'processes', id: 'latest', version: '01.00.000' },
+    ],
+    [
+      'read_latest with an invalid version',
+      {
+        action: 'read_latest',
+        table: 'processes',
+        id: '11111111-1111-4111-8111-111111111111',
+        version: '1',
+      },
+    ],
+    [
+      'read_latest with an invalid checksum',
+      {
+        action: 'read_latest',
+        table: 'processes',
+        id: '11111111-1111-4111-8111-111111111111',
+        version: '01.00.000',
+        revisionChecksum: 'latest',
+      },
+    ],
+    [
+      'read_latest with an extra key',
+      {
+        action: 'read_latest',
+        table: 'processes',
+        id: '11111111-1111-4111-8111-111111111111',
+        version: '01.00.000',
+        write: true,
+      },
+    ],
+    [
+      'missing action',
+      { table: 'processes', id: '11111111-1111-4111-8111-111111111111', version: '01.00.000' },
+    ],
+  ])('blocks the write-capable or invalid review-submit %s request', (_name, body) => {
+    expect(
+      classify('POST', '/functions/v1/app_dataset_review_submit_jobs', JSON.stringify(body)),
+    ).toBe('block');
+  });
+
+  it('blocks a malformed review-submit request body', () => {
+    expect(classify('POST', '/functions/v1/app_dataset_review_submit_jobs', '{')).toBe('block');
+  });
+
+  it.each([
     ['POST', '/rest/v1/teams'],
     ['PATCH', '/rest/v1/processes?id=eq.codex-e2e'],
     ['DELETE', '/rest/v1/processes?id=eq.codex-e2e'],

--- a/tests/unit/e2e/referenceRefreshContract.test.ts
+++ b/tests/unit/e2e/referenceRefreshContract.test.ts
@@ -55,6 +55,16 @@ describe('reference refresh semantic E2E contract', () => {
 
   it('drives both real resource scopes without screenshots, traces, video, or writes', () => {
     const source = fs.readFileSync(path.join(REPOSITORY_ROOT, SPEC_PATH), 'utf8');
+    const cacheScenarioStart = source.indexOf(
+      "test('previous-revision browser caches fail closed and process deep links survive locale reloads'",
+    );
+    const cacheScenario = source.slice(cacheScenarioStart);
+    const staticStaging = cacheScenario.indexOf("new URL('/privacy_notice.html', baseURL!)");
+    const staleInjection = cacheScenario.indexOf('await injectPreviousRevisionEntries(');
+    const injectionProof = cacheScenario.indexOf('await expectPreviousRevisionEntriesInjected(');
+    const targetNavigation = cacheScenario.indexOf(
+      'await gotoCandidateUrl(page, browserName, targetUrl);',
+    );
     expect(source).toContain("id: 'classification'");
     expect(source).toContain("id: 'location'");
     expect(source).toContain("'reference-refresh-cache'");
@@ -67,64 +77,84 @@ describe('reference refresh semantic E2E contract', () => {
     expect(source).toContain(
       'await gotoCandidateDocument(page, browserName, targetUrl, ledger!, state);',
     );
-    expect(source).toContain("page.reload({ waitUntil: 'domcontentloaded' })");
+    expect(source).toContain("new URL('/privacy_notice.html', baseURL!)");
+    expect(source).toContain(
+      'await gotoCandidateUrl(page, browserName, cacheStagingUrl.toString());',
+    );
+    expect(source).toContain('await gotoCandidateUrl(page, browserName, targetUrl);');
     expect(source).toContain("locator('.ant-select-dropdown:visible')");
     expect(source).not.toContain("getByRole('option'");
     expect(source.indexOf('await expectCurrentReferenceCacheBaseline')).toBeLessThan(
       source.indexOf('await injectPreviousRevisionEntries'),
     );
+    expect(staticStaging).toBeGreaterThan(-1);
+    expect(staleInjection).toBeGreaterThan(staticStaging);
+    expect(injectionProof).toBeGreaterThan(staleInjection);
+    expect(targetNavigation).toBeGreaterThan(injectionProof);
     expect(source).not.toMatch(/page\.screenshot|ariaSnapshot|context\.tracing|recordVideo/gu);
     expect(source).not.toMatch(/updateProcess|insert\(|delete\(|upsert\(/gu);
   });
 
-  it('uses one candidate navigation and accepts Firefox cancellation only after exact mount readiness', () => {
+  it('bounds Firefox cancellation recovery to one exact-target retry for every candidate URL', () => {
     const source = fs.readFileSync(path.join(REPOSITORY_ROOT, SPEC_PATH), 'utf8');
-    const helperStart = source.indexOf('async function gotoCandidateDocument(');
+    const urlHelperStart = source.indexOf('async function gotoCandidateUrl(');
+    const documentHelperStart = source.indexOf('async function gotoCandidateDocument(');
     const helperEnd = source.indexOf(
       '\n}\n\nasync function selectLocaleThroughHeader(',
-      helperStart,
+      documentHelperStart,
     );
-    const helperSource = source.slice(helperStart, helperEnd);
-    const detailReadyGuard = helperSource.indexOf("if (mode === 'view')");
-    const detailReady = helperSource.indexOf(
+    const urlHelperSource = source.slice(urlHelperStart, documentHelperStart);
+    const documentHelperSource = source.slice(documentHelperStart, helperEnd);
+    const detailReadyGuard = documentHelperSource.indexOf("if (mode === 'view')");
+    const detailReady = documentHelperSource.indexOf(
       "toHaveAttribute('data-detail-ready', 'true'",
       detailReadyGuard,
     );
-    const idleGuard = helperSource.indexOf('if (waitForDrawerIdle)', detailReady);
-    const nestedIdleWait = helperSource.indexOf("drawer.locator('.ant-spin-spinning')", idleGuard);
+    const idleGuard = documentHelperSource.indexOf('if (waitForDrawerIdle)', detailReady);
+    const nestedIdleWait = documentHelperSource.indexOf(
+      "drawer.locator('.ant-spin-spinning')",
+      idleGuard,
+    );
 
-    expect(helperStart).toBeGreaterThan(-1);
-    expect(helperEnd).toBeGreaterThan(helperStart);
-    expect(helperSource).toContain("browserName === 'firefox'");
-    expect(helperSource).toContain("error.message.includes('NS_ERROR_FAILURE')");
-    expect(helperSource).toContain("error.message.includes('NS_BINDING_ABORTED')");
-    expect(helperSource).toContain('throw error;');
-    expect(helperSource).toContain(
+    expect(urlHelperStart).toBeGreaterThan(-1);
+    expect(documentHelperStart).toBeGreaterThan(urlHelperStart);
+    expect(helperEnd).toBeGreaterThan(documentHelperStart);
+    expect(urlHelperSource).toContain("browserName === 'firefox'");
+    expect(urlHelperSource).toContain("browserName === 'firefox' ? 2 : 1");
+    expect(urlHelperSource).toContain("error.message.includes('NS_ERROR_FAILURE')");
+    expect(urlHelperSource).toContain("error.message.includes('NS_BINDING_ABORTED')");
+    expect(urlHelperSource).toContain('throw error;');
+    expect(urlHelperSource).toContain(
       "await page.goto(targetUrl, { timeout: 45_000, waitUntil: 'domcontentloaded' });",
     );
-    expect(helperSource.match(/page[.]goto[(]/gu)).toHaveLength(1);
-    expect(helperSource).toContain(
+    expect(urlHelperSource.match(/page[.]goto[(]/gu)).toHaveLength(1);
+    expect(urlHelperSource).toContain(
       'expect.poll(() => page.url(), { timeout: 45_000 }).toBe(targetUrl)',
     );
-    expect(helperSource).toContain('await expectProcessDeepLink(page, ledger, state, mode);');
-    expect(helperSource).toContain("const { mode = 'view', waitForDrawerIdle = true } = options;");
+    expect(documentHelperSource).toContain('await gotoCandidateUrl(page, browserName, targetUrl);');
+    expect(documentHelperSource).toContain(
+      'await expectProcessDeepLink(page, ledger, state, mode);',
+    );
+    expect(documentHelperSource).toContain(
+      "const { mode = 'view', waitForDrawerIdle = true } = options;",
+    );
     expect(detailReadyGuard).toBeGreaterThan(-1);
     expect(detailReady).toBeGreaterThan(detailReadyGuard);
     expect(idleGuard).toBeGreaterThan(detailReady);
     expect(nestedIdleWait).toBeGreaterThan(idleGuard);
-    expect(helperSource).toContain("page.locator('.tg-global-header-avatar-trigger')");
-    expect(helperSource).toContain("page.locator('.tg-global-language-selector')");
-    expect(helperSource).toContain("page.locator('.ant-result-403')");
-    expect(helperSource).toContain("page.getByTestId('process-deep-link-state')");
-    expect(helperSource).toContain("toHaveAttribute('data-route-mode', mode");
-    expect(helperSource).toContain(
+    expect(documentHelperSource).toContain("page.locator('.tg-global-header-avatar-trigger')");
+    expect(documentHelperSource).toContain("page.locator('.tg-global-language-selector')");
+    expect(documentHelperSource).toContain("page.locator('.ant-result-403')");
+    expect(documentHelperSource).toContain("page.getByTestId('process-deep-link-state')");
+    expect(documentHelperSource).toContain("toHaveAttribute('data-route-mode', mode");
+    expect(documentHelperSource).toContain(
       "page.locator('.ant-drawer-content:visible').filter({ has: deepLinkState })",
     );
     expect(source).not.toContain('isAuthenticatedWelcomeBootRedirect');
-    expect(source).not.toContain('MAX_CANDIDATE_NAVIGATION_ATTEMPTS');
-    expect(helperSource).not.toContain('selectLocaleThroughHeader');
-    expect(helperSource).not.toContain('staleRequestsStarted');
-    expect(helperSource).not.toContain('releaseOldResponseOnce');
+    expect(urlHelperSource).toContain('for (let attempt = 0; attempt < maxNavigationAttempts;');
+    expect(urlHelperSource).not.toContain('selectLocaleThroughHeader');
+    expect(urlHelperSource).not.toContain('staleRequestsStarted');
+    expect(urlHelperSource).not.toContain('releaseOldResponseOnce');
   });
 
   it('settles the delayed-response race through mounted localized text, not a required network miss', () => {

--- a/tests/unit/e2e/responsiveSurfaceMatrixContract.test.ts
+++ b/tests/unit/e2e/responsiveSurfaceMatrixContract.test.ts
@@ -110,7 +110,17 @@ describe('responsive surface evidence contract', () => {
     const targetMenuFilter = helperSource.indexOf('.filter({ has: targetIcon })');
     const scopedMenuItem = helperSource.indexOf("activeMenu.getByRole('menuitem')");
     const keyboardActivation = helperSource.indexOf("await target.press('Enter')");
-    const explicitMenuClose = helperSource.indexOf("await page.keyboard.press('Escape')");
+    const firstEscape = helperSource.indexOf("await page.keyboard.press('Escape')");
+    const atomicVisibleMenuCheck = helperSource.indexOf(
+      'document.querySelectorAll<HTMLElement>(\'[role="menu"]\')',
+    );
+    const atomicTriggerToggle = helperSource.indexOf(
+      "document.querySelector<HTMLElement>('.tg-global-language-selector')?.click()",
+    );
+    const secondEscape = helperSource.indexOf(
+      "await page.keyboard.press('Escape')",
+      firstEscape + 1,
+    );
     expect(spinnerWait?.index).toBeGreaterThan(-1);
     expect(storedLocaleEarlyReturn).toBeGreaterThan(spinnerWait!.index);
     expect(programmaticTriggerClick).toBeGreaterThan(storedLocaleEarlyReturn);
@@ -119,7 +129,10 @@ describe('responsive surface evidence contract', () => {
     expect(targetMenuFilter).toBeGreaterThan(activeMenuScope);
     expect(scopedMenuItem).toBeGreaterThan(activeMenuScope);
     expect(keyboardActivation).toBeGreaterThan(scopedMenuItem);
-    expect(explicitMenuClose).toBeGreaterThan(keyboardActivation);
+    expect(firstEscape).toBeGreaterThan(keyboardActivation);
+    expect(atomicVisibleMenuCheck).toBeGreaterThan(firstEscape);
+    expect(atomicTriggerToggle).toBeGreaterThan(atomicVisibleMenuCheck);
+    expect(secondEscape).toBeGreaterThan(atomicTriggerToggle);
     expect(helperSource).not.toContain('trigger.click({ force:');
     expect(helperSource).not.toContain('await target.click(');
   });

--- a/tests/unit/e2e/typedViewReadOnlyContract.test.ts
+++ b/tests/unit/e2e/typedViewReadOnlyContract.test.ts
@@ -211,4 +211,24 @@ describe('typed Process required-state read-only trap contract', () => {
       'expect(readTrappedValidationDrafts()).toBe(trappedValidationDraftsBeforeMount);',
     );
   });
+
+  it('settles each Process drawer before changing locale and proves localized copy afterward', () => {
+    const source = readFileSync(
+      path.join(REPOSITORY_ROOT, 'tests/e2e/i18n/typed-view-variants.spec.ts'),
+      'utf8',
+    );
+    const scenarioStart = source.indexOf("test('Process edit and view deep links");
+    const scenarioEnd = source.indexOf('PROCESS_REQUIRED_VARIANTS.forEach(', scenarioStart);
+    const scenario = source.slice(scenarioStart, scenarioEnd);
+    const navigation = scenario.indexOf('await page.goto(');
+    const initialMount = scenario.indexOf('await expectProcessDrawerMounted(', navigation);
+    const localeChange = scenario.indexOf('await selectAppLocaleThroughUi(', initialMount);
+    const localizedDrawer = scenario.indexOf('await expectProcessDrawer(', localeChange);
+
+    expect(navigation).toBeGreaterThan(-1);
+    expect(initialMount).toBeGreaterThan(navigation);
+    expect(localeChange).toBeGreaterThan(initialMount);
+    expect(localizedDrawer).toBeGreaterThan(localeChange);
+    expect(source).toContain("drawer.locator('.ant-spin-spinning')");
+  });
 });


### PR DESCRIPTION
## Summary

- bump the application release from v0.0.53 to v0.0.54
- enforce exact production request and ledger guards for review-submit semantic E2E
- harden authenticated Process/static navigation determinism and bind the final release evidence

## Validation

- authoritative checked-push gate: 397/397 test suites and 5359/5359 tests passed; statements, branches, functions, and lines all 100%
- production semantic E2E: 48 passed, 24 designed skips across Chromium, Firefox, and WebKit; fixture accounting created=1, cleaned=1, leaked=0
- production build, all production locale/reference checks, LCIA cache verification, and Docpact gate passed
- release evidence SHA-256: 048201d12bb912ee2421dcdf3a104bcee571239c62e4e6a20b3594c6d7cec075

Closes #650
Closes #651
Closes #652
Refs #645
Refs #647