### PR TITLE
fix: preserve local release E2E CI boundary

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-07-22'
-lastReviewedCommit: '8d7d9ee4ed25b3f5226116d5e63244ba324bfdc9'
-lastReviewedNote: 'Updated for Issue #654; release E2E container, controller, runtime inputs, and local state now route through the repo testing/quality contract.'
+lastReviewedCommit: '3c267b24c6ecd7f78e4ec0bcd9e8d4068f29aa29'
+lastReviewedNote: 'Reviewed for Issue #660; the host/controller CI boundary remains covered by the existing bootstrap and testing/quality contracts, with no routing-rule change required.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 8d7d9ee4ed25b3f5226116d5e63244ba324bfdc9
-lastReviewedNote: 'Updated for Issue #654: local release proof now uses the isolated exact-candidate E2E controller while CI remains credential-free/read-only.'
+lastReviewedCommit: 3c267b24c6ecd7f78e4ec0bcd9e8d4068f29aa29
+lastReviewedNote: 'Updated for Issue #660: production-data release E2E now rejects host CI before clearing image-inherited CI markers for a local operator run.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -118,7 +118,7 @@ Do not start from additional governed source docs, proposal docs, or README-leve
 - data workflow result fixture relationships live in `tests/data-workflows/fixtures/result/README.md`; proof selection stays in `docs/agents/repo-validation.md`
 - run Umi-generating focused tests, coverage, and `npm run prepush:gate` serially; for normal delivery, use focused proof during iteration and let the push hook own the one full gate after the final controlled tracked change
 - new npm dependencies require human approval
-- production-writing E2E requires authenticated mode plus two write guards: `E2E_ALLOW_PRODUCTION_DATA=true` and `E2E_PRODUCTION_WRITE_CONFIRMATION=I_AUTHORIZE_ONE_CODEX_E2E_PRODUCTION_PROCESS`; verified tracked evidence additionally requires `E2E_WRITE_VERIFIED_EVIDENCE=true`. Before create it writes an intent ledger, and before delete it verifies the production row's UUID, authenticated owner, and all five multilingual fields across every registry authoring language, then proves `created=cleaned` and `leaked=0`
+- production-writing E2E requires a host without `CI` or `GITHUB_ACTIONS`; only after that check may the controller clear image-inherited CI markers for the local container. Authenticated mode plus two write guards remain mandatory: `E2E_ALLOW_PRODUCTION_DATA=true` and `E2E_PRODUCTION_WRITE_CONFIRMATION=I_AUTHORIZE_ONE_CODEX_E2E_PRODUCTION_PROCESS`; verified tracked evidence additionally requires `E2E_WRITE_VERIFIED_EVIDENCE=true`. Before create it writes an intent ledger, and before delete it verifies the production row's UUID, authenticated owner, and all five multilingual fields across every registry authoring language, then proves `created=cleaned` and `leaked=0`
 
 ## Minimal Execution Facts
 

--- a/DEV.md
+++ b/DEV.md
@@ -26,8 +26,8 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - .nvmrc
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 8d7d9ee4ed25b3f5226116d5e63244ba324bfdc9
-lastReviewedNote: 'Updated for Issue #654: added the repository-owned isolated release E2E installer, doctor, runner, diagnostics, and bounded resume workflow.'
+lastReviewedCommit: 3c267b24c6ecd7f78e4ec0bcd9e8d4068f29aa29
+lastReviewedNote: 'Updated for Issue #660: documented the host-CI refusal and local container CI-marker override for production-data E2E.'
 ---
 
 # Development Bootstrap
@@ -145,7 +145,7 @@ npm run e2e:release -- \
   --users-env-file .env.users.local
 ```
 
-The controller translates these explicit options into the existing production-write guards inside the isolated container. This command shape remains forbidden in semantic E2E GitHub Actions; CI keeps using the credential-free/read-only exact-SHA matrix.
+The controller first refuses this production-data command when the host has `CI` or `GITHUB_ACTIONS` set. After that local-operator check passes, it clears only the release image's inherited CI markers at container runtime so the unchanged in-container production-write guards can validate the explicit authorization. This command shape remains forbidden in semantic E2E GitHub Actions; CI keeps using the credential-free/read-only exact-SHA matrix.
 
 ## Command Rules
 
@@ -159,7 +159,7 @@ The controller translates these explicit options into the existing production-wr
 - race diagnosis may add `--project <browser> --spec <path>` or `--grep <pattern> --repeat-each <1-5>`; repeat is accepted only for a focused read-only scope and cannot write verified evidence
 - diagnostics retain the sanitized original error chain and emit stable phase/check IDs, coarse exit classes (`2`, `10`, `20`, `30`, `40`, `50`), cleanup state, output path, and one exact next command
 - semantic E2E GitHub Actions is credential-free and read-only: `workflow_dispatch` runs the three-browser public semantic/boundary matrix on demand, and the canonical release workflow calls the same matrix for the exact release SHA; routine PR/dev pushes do not trigger it
-- the full authenticated closure runs only in an explicitly authorized local operator session with runtime credentials and `E2E_AUTHENTICATED=true`; production write requires both `E2E_ALLOW_PRODUCTION_DATA=true` and the exact one-process confirmation token, while tracked evidence additionally requires `E2E_WRITE_VERIFIED_EVIDENCE=true`; never move that closure or its credentials into a semantic E2E GitHub job
+- the full authenticated closure runs only in an explicitly authorized local operator session with runtime credentials and `E2E_AUTHENTICATED=true`; the host controller refuses production-data mode when `CI` or `GITHUB_ACTIONS` is set, then an accepted local run overrides the image-inherited markers to empty inside the container; production write still requires both `E2E_ALLOW_PRODUCTION_DATA=true` and the exact one-process confirmation token, while tracked evidence additionally requires `E2E_WRITE_VERIFIED_EVIDENCE=true`; never move that closure or its credentials into a semantic E2E GitHub job
 - before any create, authenticated E2E writes a UUID-scoped `codex-e2e` intent ledger; before any delete, it must read the production row and verify the UUID, authenticated owner, and exact marker coverage for all five multilingual fields across every registry authoring language
 - use one protected `E2E_RECOVERY_LEDGER_PATH` per active invocation; recovery may proceed from the external copy alone after a crash, but a primary ledger without the configured recovery copy fails closed so a stale teardown cannot adopt another run
 - teardown deletes only the verified exact-ID rows, records created/cleaned counts, and must prove `created=cleaned` and `leaked=0`

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 8d7d9ee4ed25b3f5226116d5e63244ba324bfdc9
-lastReviewedNote: 'Reviewed for Issue #654: the isolated local release E2E controller remains separate from the protected pre-push and credential-free CI gates.'
+lastReviewedCommit: 3c267b24c6ecd7f78e4ec0bcd9e8d4068f29aa29
+lastReviewedNote: 'Updated for Issue #660: local production-data E2E now rejects host CI before overriding image-inherited CI markers.'
 ---
 
 # Pre-Push Gate Policy
@@ -95,7 +95,7 @@ It does not own:
 - any coverage collection exclusions must be explicit, reviewed, and paired with focused verification of the affected user-visible wrapper flows
 - data workflow fixture expansions stay under the existing `tests/**` docpact trigger; they do not change the protected-branch gate policy unless the actual hook, CI command, or coverage bar changes
 - semantic E2E keeps its local candidate frontend on a loopback URL, derives locales from registries, disables screenshot/trace/video/auth artifacts, and keeps every semantic E2E GitHub Actions run credential-free/read-only
-- an authorized local production-data run uses `E2E_AUTHENTICATED=true`, `E2E_ALLOW_PRODUCTION_DATA=true`, and the exact one-process confirmation token; `E2E_WRITE_VERIFIED_EVIDENCE=true` separately opts into tracked evidence. It writes its intent ledger before create; cleanup verifies the production row UUID, authenticated owner, and all five multilingual-field markers across registry authoring languages before exact-ID deletion, then proves `created=cleaned` and `leaked=0`
+- an authorized local production-data run is rejected before Docker when host `CI` or `GITHUB_ACTIONS` is set; after the local check passes, the controller clears only those image-inherited markers at container runtime and still requires `E2E_AUTHENTICATED=true`, `E2E_ALLOW_PRODUCTION_DATA=true`, and the exact one-process confirmation token; `E2E_WRITE_VERIFIED_EVIDENCE=true` separately opts into tracked evidence. It writes its intent ledger before create; cleanup verifies the production row UUID, authenticated owner, and all five multilingual-field markers across registry authoring languages before exact-ID deletion, then proves `created=cleaned` and `leaked=0`
 - Header Umi `SelectLang` remains `reload={false}` so same-document locale refresh and delayed old-response race behavior stay browser-verifiable
 - historical German review commands may remain explicit compatibility gates, but active locale/context/quality/correction/activation and `npm run prepush:gate` must never read ignored confirmation files
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 8d7d9ee4ed25b3f5226116d5e63244ba324bfdc9
-lastReviewedNote: 'Updated for Issue #654: release E2E now has isolated install/doctor/run/resume commands and ordered pre-fixture diagnostics.'
+lastReviewedCommit: 3c267b24c6ecd7f78e4ec0bcd9e8d4068f29aa29
+lastReviewedNote: 'Updated for Issue #660: added proof requirements for the host-CI refusal and local container CI-marker boundary.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -92,7 +92,7 @@ The independent `.github/workflows/i18n-semantic-e2e.yml` workflow is one creden
 - the canonical release workflow reuses it for the exact release SHA before any Web or Electron publication
 - every invocation uses no production credentials, permits no production writes, and runs only contract discovery plus the public semantic/boundary matrix in Chromium, Firefox, and WebKit
 
-The separate full authenticated closure is local-operator-only. It requires explicit user authorization, runtime credentials, the local candidate, `E2E_BACKEND_TARGET=production`, and `E2E_AUTHENTICATED=true`. Its two production-write guards are `E2E_ALLOW_PRODUCTION_DATA=true` and `E2E_PRODUCTION_WRITE_CONFIRMATION=I_AUTHORIZE_ONE_CODEX_E2E_PRODUCTION_PROCESS`; writing verified tracked evidence separately opts in with `E2E_WRITE_VERIFIED_EVIDENCE=true`. Semantic E2E GitHub Actions is never a transport for these credentials, flags, or writes.
+The separate full authenticated closure is local-operator-only. It requires explicit user authorization, runtime credentials, the local candidate, `E2E_BACKEND_TARGET=production`, and `E2E_AUTHENTICATED=true`. Before Docker execution, the host controller rejects production-data mode whenever `CI` or `GITHUB_ACTIONS` is set. Only after that local check passes does it override the release image's inherited CI markers to empty inside the container; the container's safety check remains unchanged. Its two production-write guards are `E2E_ALLOW_PRODUCTION_DATA=true` and `E2E_PRODUCTION_WRITE_CONFIRMATION=I_AUTHORIZE_ONE_CODEX_E2E_PRODUCTION_PROCESS`; writing verified tracked evidence separately opts in with `E2E_WRITE_VERIFIED_EVIDENCE=true`. Semantic E2E GitHub Actions is never a transport for these credentials, flags, or writes.
 
 The full route/view proof has 49 stable assertion IDs. Every ID requires its live route scenario plus any target-declared semantic scenarios; these cover anonymous fail-closed navigation, locale fallback/refresh, modal states, authoring options, responsive layout, persisted multilingual content, and reference refresh where applicable. Locales and authoring languages are derived from the typed registries, Chromium runs the entire route/view matrix, and the selector, team authoring, and process lifecycle critical scenarios run in all three browser engines. Adding a registry locale expands the expected locale sequence and invalidates any older evidence automatically.
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -25,8 +25,8 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - package.json
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 8d7d9ee4ed25b3f5226116d5e63244ba324bfdc9
-lastReviewedNote: 'Updated for Issue #654: release E2E environment discovery and safe pre-fixture reruns are now repository-owned rather than operator-assembled.'
+lastReviewedCommit: 3c267b24c6ecd7f78e4ec0bcd9e8d4068f29aa29
+lastReviewedNote: 'Updated for Issue #660: the local-operator strategy now distinguishes host CI refusal from image-inherited container markers.'
 ---
 
 # Testing Strategy
@@ -43,7 +43,7 @@ lastReviewedNote: 'Updated for Issue #654: release E2E environment discovery and
 - data workflow smoke coverage should grow through paired data/result fixtures and workflow-lib unit proof only when the workflow phase or backend-facing assertion changes
 - localization quality should combine deterministic topology, context, terminology-token, route-view, fallback, correction, and activation gates with a separately produced semantic/route/E2E proof; the deterministic structural artifact must not present itself as independent semantic review, and delivery does not create a human translation-approval state
 - the localization semantic E2E layer is deliberately bounded: 49 stable route/view assertion IDs, a Chromium full matrix, three-browser critical scenarios, registry-derived locale/content-language loops, and digest-bound evidence that invalidates itself when a locale or covered input changes
-- production-backed E2E uses a local candidate frontend and an explicitly authorized local operator trust boundary; GitHub Actions runs the credential-free/read-only browser matrix only on demand and for the exact release SHA, while the local run uses authenticated mode plus the two explicit production-write guards (and a separate verified-evidence opt-in), writes intent before create, verifies UUID/owner/five-field registry markers before delete, and ends with `created=cleaned`, `leaked=0`
+- production-backed E2E uses a local candidate frontend and an explicitly authorized local operator trust boundary; GitHub Actions runs the credential-free/read-only browser matrix only on demand and for the exact release SHA, while host `CI`/`GITHUB_ACTIONS` rejects production-data mode before Docker. After that local check passes, the controller clears only image-inherited CI markers and still requires authenticated mode plus the two explicit production-write guards (and a separate verified-evidence opt-in), writes intent before create, verifies UUID/owner/five-field registry markers before delete, and ends with `created=cleaned`, `leaked=0`
 - local release proof now treats environment setup as productized test infrastructure: a pinned-image installer, read-only doctor, archived clean candidate, one cached production build, ordered pre-fixture checks, phase-coded diagnostics, and exact one-hour continuation remove repeated environment exploration without weakening browser or cleanup evidence
 - browser/UI race repair remains a focused loop (`e2e:dev` with one project/spec/grep plus explicit readiness states); only after focused repeat stability should an operator spend the complete release matrix, and no blanket retry or fixed sleep may substitute for first-attempt release proof
 - same-document locale behavior is a first-class browser risk: Header Umi `SelectLang` stays `reload={false}`, and proof covers retained document identity plus stale-reference-response race rejection

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 8d7d9ee4ed25b3f5226116d5e63244ba324bfdc9
-lastReviewedNote: 'Updated for Issue #654: recorded the implemented isolated release E2E environment, preflight, diagnostics, and bounded continuation surface.'
+lastReviewedCommit: 3c267b24c6ecd7f78e4ec0bcd9e8d4068f29aa29
+lastReviewedNote: 'Updated for Issue #660: recorded the corrected host-CI/local-container boundary for authenticated release E2E.'
 ---
 
 # Testing Execution State
@@ -56,6 +56,7 @@ This is a checked-in reference, not a per-PR execution ledger. A delivery's post
 - Issue #635 adds a separate Playwright semantic localization proof surface: `npm run test:e2e:i18n` derives all locale/content-language expectations from registries, binds 49 stable route/view assertion IDs, runs Chromium across the complete matrix, and requires the login/selector, team authoring, and process lifecycle critical scenarios in Chromium, Firefox, and WebKit
 - semantic E2E GitHub Actions is credential-free/read-only and runs only contract discovery plus three-browser public semantics; it is optional through `workflow_dispatch`, mandatory for the exact release SHA, and absent from routine PR/dev triggers, while authenticated candidate-local/production-backend closure is restricted to an explicitly authorized local operator session with authenticated mode, both production-write guards, and an explicit verified-evidence opt-in
 - Issue #654 adds `e2e:env:install`, read-only `e2e:env:doctor`, exact-candidate `e2e:release`, argument-free bounded `e2e:release:resume`, owned cleanup, and focused `e2e:dev`; release mode archives only a clean Next commit, uses a digest-pinned container and cached production build, performs all safe checks before fixture intent, and never mounts the workspace
+- Issue #660 keeps production-data E2E fail-closed on real CI hosts while allowing an authorized local run to override only the release image's inherited `CI`/`GITHUB_ACTIONS` markers before the unchanged in-container authorization and ledger checks
 - tracked semantic evidence remains fail closed for production readiness until one full local authenticated execution closes every assertion, matches the declared source/test/route bindings, writes its intent ledger before create, verifies UUID + owner + all five multilingual field markers before delete, and reports `created=cleaned` with `leaked=0`; routine pre-push checks validate the record structurally without requiring current production-proof hashes, and adding a registry locale still invalidates older evidence rather than silently shrinking coverage
 - Header locale switching now keeps Umi `SelectLang` at `reload={false}`; focused proof covers same-document identity, URL retention, live reference-label refresh, and rejection of a delayed old-locale response
 - clean-checkout active German and new-locale suites require zero confirmation-file dependencies; only explicit historical compatibility tests may exercise generated private fixtures

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -26,8 +26,8 @@ checkPaths:
   - playwright.config.ts
   - package.json
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 8d7d9ee4ed25b3f5226116d5e63244ba324bfdc9
-lastReviewedNote: 'Updated for Issue #654: separated focused browser diagnosis from exact-candidate release proof and documented preflight/resume boundaries.'
+lastReviewedCommit: 3c267b24c6ecd7f78e4ec0bcd9e8d4068f29aa29
+lastReviewedNote: 'Updated for Issue #660: documented the two-sided host-CI and local container-marker production-write boundary.'
 ---
 
 # Testing Patterns Reference
@@ -119,7 +119,7 @@ Browser semantic E2E pattern:
 - retain the 15-second assertion budget for public/CI semantics, but allow the explicitly authenticated production-backed closure 45 seconds for remote Process drawers; this scoped budget must not weaken routine browser checks
 - derive locale and authoring-language loops from `LOCALE_REGISTRY` and `CONTENT_LANGUAGE_REGISTRY`; never copy the current locale list into a spec or reporter
 - run the complete 49-route/view matrix in Chromium, require every target-declared semantic scenario in the evidence record, and run the critical selector, team authoring, and process lifecycle scenarios in Chromium, Firefox, and WebKit
-- keep every semantic E2E GitHub Actions invocation credential-free and read-only; `workflow_dispatch` provides optional three-browser public semantics/contract proof and release reuses it for the exact candidate SHA, while routine PR/dev events do not trigger it and authenticated production writes are restricted to an explicitly authorized local operator session with `E2E_AUTHENTICATED=true` plus the two write guards (`E2E_ALLOW_PRODUCTION_DATA=true` and the exact one-process confirmation token); verified evidence is a separate explicit opt-in
+- keep every semantic E2E GitHub Actions invocation credential-free and read-only; `workflow_dispatch` provides optional three-browser public semantics/contract proof and release reuses it for the exact candidate SHA, while routine PR/dev events do not trigger it; host `CI` or `GITHUB_ACTIONS` must fail production-data mode before Docker, and only an accepted local operator run may clear the image-inherited markers inside the container while still requiring `E2E_AUTHENTICATED=true` plus the two write guards (`E2E_ALLOW_PRODUCTION_DATA=true` and the exact one-process confirmation token); verified evidence is a separate explicit opt-in
 - write an ignored UUID-scoped `codex-e2e` intent ledger before create; before delete, fetch the exact production row and verify its exact ILCD UUID path, authenticated owner, and per-language marker pairs at all five exact multilingual field paths
 - delete only verified exact-ID row versions and fail unless `created=cleaned` and `leaked=0`; an absent or unverifiable attempted row is not successful cleanup evidence
 - keep Header Umi `SelectLang` at `reload={false}` and prove locale switching within the same document: URL/document identity persist, mounted locale state refreshes, and a delayed old-locale reference response cannot overwrite the current selection

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -25,8 +25,8 @@ checkPaths:
   - tests/e2e/i18n/**
   - package.json
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 8d7d9ee4ed25b3f5226116d5e63244ba324bfdc9
-lastReviewedNote: 'Updated for Issue #654: added early release-E2E doctor, phase diagnostics, isolated candidate, and bounded resume recovery paths.'
+lastReviewedCommit: 3c267b24c6ecd7f78e4ec0bcd9e8d4068f29aa29
+lastReviewedNote: 'Updated for Issue #660: added diagnosis for host-CI refusal versus inherited container CI markers.'
 ---
 
 # Testing Troubleshooting
@@ -64,6 +64,7 @@ Canonical baseline and proof ownership stays with `DEV.md` and `docs/agents/repo
 | Playwright refuses `E2E_BASE_URL` | the browser target is not the local candidate frontend | use a loopback candidate URL and let `playwright.config.ts` start `npm run start:main`; never point the Playwright frontend target at production |
 | a public semantic browser job reports a flaky missing login control after cold startup | the global candidate probe passed, but a new page returned from `domcontentloaded` before its login route mounted | keep `failOnFlakyTests` enabled, make the page use the shared rendered-login readiness helper, move regenerable Umi/MFSU caches aside, and rerun the exact browser scope without a fixed sleep or global timeout increase |
 | authenticated semantic E2E skips or fails before setup | the authorized local session lacks a mode-`0600` users env file, explicit authenticated/write/evidence options, the production target proof, or a safe recovery-ledger path | keep GitHub Actions credential-free/read-only; run `npm run e2e:release -- --authenticated --allow-production-data --write-verified-evidence --users-env-file <path>` locally, and inspect the role-neutral auth/safety preflight check rather than assuming a required business role |
+| production-data release E2E reports `E2E_PRODUCTION_DATA_FORBIDDEN_IN_HOST_CI` | the host exported `CI` or `GITHUB_ACTIONS`, so the controller cannot prove a local operator boundary | run from a genuine local operator shell after removing only an accidentally inherited host marker; never clear a real CI marker or bypass the guard. The controller itself clears the release image's inherited markers only after this host check passes. |
 | explicit production locale readiness rejects semantic evidence | one of the 49 assertion IDs, registry locales, required browsers, current backend/package/runtime/route/test/source bindings, or cleanup counts is incomplete or stale | inspect the first mismatched contract field, rerun only the affected browser scope, then run the complete authenticated closure; never edit evidence to simulate execution. Routine activation/pre-push checks must not require current production-proof hashes. |
 | teardown refuses cleanup or reports a leaked `codex-e2e` process | the intent ledger is invalid, the production row UUID/owner/five-field registry marker closure does not match, or exact-ID deletion failed | preserve the ignored ledger; inspect only the exact UUID row, restore verifiable ownership/marker evidence or escalate, and never broaden deletion; do not create another record until `created=cleaned` and `leaked=0` |
 | teardown reports that the primary ledger has no matching recovery copy | another invocation is active, a stale teardown is reading a newer run's primary ledger, or the protected external recovery file was removed | stop every older E2E runner, verify the exact UUID through audit/read-only checks, and restore only the matching recovery copy; never let the orphaned primary ledger authorize deletion |

--- a/scripts/e2e/release-e2e.cjs
+++ b/scripts/e2e/release-e2e.cjs
@@ -505,6 +505,20 @@ function validateRunOptions(options) {
   }
 }
 
+function assertLocalOperatorHostEnvironment(options, environment = process.env) {
+  if (!options.allowProductionData) return;
+  if (environment.CI || environment.GITHUB_ACTIONS) {
+    throw new ReleaseE2EError(
+      'Production-data release E2E is forbidden when the host is CI or GitHub Actions.',
+      {
+        exitCode: EXIT.SAFETY,
+        failureCode: 'E2E_PRODUCTION_DATA_FORBIDDEN_IN_HOST_CI',
+        phase: 'safety',
+      },
+    );
+  }
+}
+
 function loadEnvironmentContractFromWorkingTree() {
   const contractPath = path.join(REPOSITORY_ROOT, ENVIRONMENT_CONTRACT_RELATIVE_PATH);
   const raw = fs.readFileSync(contractPath, 'utf8');
@@ -1205,6 +1219,7 @@ function prepareRuntimeInputs(context, options, runDirectory) {
 function dockerRunArguments(context, options, runDirectory, runtimeInputs) {
   const containerRecoveryLedger = `/e2e-recovery/${path.basename(runtimeInputs.recoveryLedger)}`;
   const environment = {
+    ...(options.allowProductionData ? { CI: '', GITHUB_ACTIONS: '' } : {}),
     E2E_ALLOW_PRODUCTION_DATA: String(options.allowProductionData),
     E2E_AUTHENTICATED: String(options.authenticated),
     E2E_AUTH_ROLE: options.role,
@@ -1261,6 +1276,7 @@ function readContainerResult(runDirectory) {
 
 function runRelease(options, state = {}) {
   validateRunOptions(options);
+  assertLocalOperatorHostEnvironment(options);
   const prerequisites = assertHostPrerequisites();
   const environment = loadEnvironmentContractFromWorkingTree();
   const candidate = requireCleanCommittedCandidate();
@@ -1726,6 +1742,7 @@ module.exports = {
   RECEIPT_SCHEMA_VERSION,
   ReleaseE2EError,
   acquireInvocationLock,
+  assertLocalOperatorHostEnvironment,
   commandHelp,
   createReceipt,
   dockerRunArguments,

--- a/tests/unit/e2e/releaseE2ERunner.test.ts
+++ b/tests/unit/e2e/releaseE2ERunner.test.ts
@@ -12,6 +12,10 @@ import { readVerifiedProductionBackendTarget } from '../../e2e/i18n/production-b
 const controller = require('../../../scripts/e2e/release-e2e.cjs') as {
   RECEIPT_SCHEMA_VERSION: number;
   acquireInvocationLock: (command: string, lockPath: string) => () => void;
+  assertLocalOperatorHostEnvironment: (
+    options: Record<string, any>,
+    environment?: Record<string, string | undefined>,
+  ) => void;
   commandHelp: () => string;
   createReceipt: (input: Record<string, any>, key: Buffer) => Record<string, any>;
   dockerRunArguments: (
@@ -119,6 +123,49 @@ describe('release E2E controller contracts', () => {
     );
   });
 
+  it('keeps production writes local while clearing only image-inherited CI markers', () => {
+    const readOnly = controller.parseOptions('run', []);
+    expect(() =>
+      controller.assertLocalOperatorHostEnvironment(readOnly, { CI: 'true' }),
+    ).not.toThrow();
+
+    const productionData = controller.parseOptions('run', [
+      '--authenticated',
+      '--allow-production-data',
+    ]);
+    expect(() =>
+      controller.assertLocalOperatorHostEnvironment(productionData, { CI: 'true' }),
+    ).toThrow('forbidden when the host is CI or GitHub Actions');
+    expect(() =>
+      controller.assertLocalOperatorHostEnvironment(productionData, { GITHUB_ACTIONS: 'true' }),
+    ).toThrow('forbidden when the host is CI or GitHub Actions');
+    expect(() => controller.assertLocalOperatorHostEnvironment(productionData, {})).not.toThrow();
+
+    const productionArgs = controller.dockerRunArguments(
+      { imageTag: 'candidate:test' },
+      productionData,
+      '/host/run',
+      {
+        recoveryLedger: '/host/recovery/ledger.json',
+        trackedMainEnvironmentPath: '/host/input/main.env',
+      },
+    );
+    expect(productionArgs).toContain('CI=');
+    expect(productionArgs).toContain('GITHUB_ACTIONS=');
+
+    const readOnlyArgs = controller.dockerRunArguments(
+      { imageTag: 'candidate:test' },
+      readOnly,
+      '/host/run',
+      {
+        recoveryLedger: '/host/recovery/ledger.json',
+        trackedMainEnvironmentPath: '/host/input/main.env',
+      },
+    );
+    expect(readOnlyArgs).not.toContain('CI=');
+    expect(readOnlyArgs).not.toContain('GITHUB_ACTIONS=');
+  });
+
   it('emits parseable JSON-only stdout and a coarse input exit code on refusal', () => {
     const result = spawnSync(
       process.execPath,
@@ -131,6 +178,22 @@ describe('release E2E controller contracts', () => {
       exitCode: 2,
       failureCode: 'E2E_PRODUCTION_DATA_REQUIRES_AUTH',
       phase: 'input',
+      status: 'failed',
+    });
+  });
+
+  it('refuses host CI production writes before checking Docker or credentials', () => {
+    const result = spawnSync(
+      process.execPath,
+      [controllerPath, 'run', '--format=json', '--authenticated', '--allow-production-data'],
+      { cwd: process.cwd(), encoding: 'utf8', env: { ...process.env, CI: 'true' } },
+    );
+    expect(result.status).toBe(30);
+    expect(result.stderr).toBe('');
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      exitCode: 30,
+      failureCode: 'E2E_PRODUCTION_DATA_FORBIDDEN_IN_HOST_CI',
+      phase: 'safety',
       status: 'failed',
     });
   });


### PR DESCRIPTION
## Summary

- fail closed before Docker when production-data release E2E is launched from a host with `CI` or `GITHUB_ACTIONS`
- clear only image-inherited CI markers for an already-authorized local production-data container run
- keep the in-container production authorization and ledger guard unchanged
- add regression coverage and align governed E2E documentation

## Validation

- `npm run test:ci -- tests/unit/e2e/releaseE2ERunner.test.ts tests/unit/e2e/productionDataLedger.test.ts --runInBand --testTimeout=10000 --no-coverage` — 88 passed
- `npm run lint` — passed
- `npm run docpact:gate` — passed
- full authenticated release E2E on exact candidate `ce5debbf9af750f79252ab9de9a9a197641ea3ef` — passed in 956.616s; Chromium/Firefox/WebKit; 49 stable assertion IDs; 9/9 preflight checks; `created=1`, `cleaned=1`, `leaked=0`
- checked-push gate — 398 suites / 5374 tests passed; 450/450 tracked source files at 100% statements, branches, functions, and lines

## Safety

Real CI hosts remain unable to request production writes. The runtime override is emitted only for `--allow-production-data` after the host-side CI refusal passes; the existing container-side guard is unchanged.

## Integration

After merge to `dev`, promote `dev -> main` before any root workspace pointer update.

Closes #660