### PR TITLE
release: promote dev to main for v0.0.55

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-22"
-lastReviewedCommit: "0e23b8ed92a72d5d6554b8eefeb26c549e4e7191"
+lastReviewedCommit: "b7f2b671323ced00de79b5424cd3d3747b5b0d7f"
 lastReviewedNote: 'Reviewed for Issue #660; the host/controller CI boundary remains covered by the existing bootstrap and testing/quality contracts, with no routing-rule change required.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-07-22'
-lastReviewedCommit: '3c267b24c6ecd7f78e4ec0bcd9e8d4068f29aa29'
+lastReviewedAt: "2026-07-22"
+lastReviewedCommit: "0e23b8ed92a72d5d6554b8eefeb26c549e4e7191"
 lastReviewedNote: 'Reviewed for Issue #660; the host/controller CI boundary remains covered by the existing bootstrap and testing/quality contracts, with no routing-rule change required.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 3c267b24c6ecd7f78e4ec0bcd9e8d4068f29aa29
+lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
 lastReviewedNote: 'Updated for Issue #660: production-data release E2E now rejects host CI before clearing image-inherited CI markers for a local operator run.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
+lastReviewedCommit: b7f2b671323ced00de79b5424cd3d3747b5b0d7f
 lastReviewedNote: 'Updated for Issue #660: production-data release E2E now rejects host CI before clearing image-inherited CI markers for a local operator run.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -26,7 +26,7 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - .nvmrc
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: bcbb1e9031a76a6bc68fb3cd4d559d37501fdba9
+lastReviewedCommit: b7f2b671323ced00de79b5424cd3d3747b5b0d7f
 lastReviewedNote: 'Updated for Issue #660: documented the host-CI refusal and local container CI-marker override for production-data E2E.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -26,7 +26,7 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - .nvmrc
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 3c267b24c6ecd7f78e4ec0bcd9e8d4068f29aa29
+lastReviewedCommit: bcbb1e9031a76a6bc68fb3cd4d559d37501fdba9
 lastReviewedNote: 'Updated for Issue #660: documented the host-CI refusal and local container CI-marker override for production-data E2E.'
 ---
 

--- a/docs/agents/contribution-path-analysis-design.md
+++ b/docs/agents/contribution-path-analysis-design.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-07-19
-lastReviewedCommit: a3c63306da7f6e4665158aeb0744f578c0e32050
+lastReviewedAt: 2026-07-22
+lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
 lastReviewedNote: 'Reviewed for Issue #633: localized lifecycle-model labels and reference-resource resolution do not change the proposed async contribution-path result contract.'
 ---
 

--- a/docs/agents/lca-analysis-visualization-plan.md
+++ b/docs/agents/lca-analysis-visualization-plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-07-19
-lastReviewedCommit: a3c63306da7f6e4665158aeb0744f578c0e32050
+lastReviewedAt: 2026-07-22
+lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
 lastReviewedNote: 'Reviewed for Issue #633: registry-driven lifecycle-model labels do not change the proposed analysis views, chart rules, or traceability contract.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
+lastReviewedCommit: b7f2b671323ced00de79b5424cd3d3747b5b0d7f
 lastReviewedNote: 'Updated for Issue #660: local production-data E2E now rejects host CI before overriding image-inherited CI markers.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 3c267b24c6ecd7f78e4ec0bcd9e8d4068f29aa29
+lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
 lastReviewedNote: 'Updated for Issue #660: local production-data E2E now rejects host CI before overriding image-inherited CI markers.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,7 +25,7 @@ checkPaths:
   - playwright.config.ts
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 8d7d9ee4ed25b3f5226116d5e63244ba324bfdc9
+lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
 lastReviewedNote: 'Updated for Issue #654: mapped the isolated release-E2E controller/container while preserving the test-only Supabase and shipped-service ownership boundaries.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
+lastReviewedCommit: b7f2b671323ced00de79b5424cd3d3747b5b0d7f
 lastReviewedNote: 'Updated for Issue #660: added proof requirements for the host-CI refusal and local container CI-marker boundary.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 3c267b24c6ecd7f78e4ec0bcd9e8d4068f29aa29
+lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
 lastReviewedNote: 'Updated for Issue #660: added proof requirements for the host-CI refusal and local container CI-marker boundary.'
 related:
   - ../AGENTS.md

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -23,7 +23,7 @@ checkPaths:
   - playwright.config.ts
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 8d7d9ee4ed25b3f5226116d5e63244ba324bfdc9
+lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
 lastReviewedNote: 'Updated for Issue #654: isolated release E2E consumes a read-only tracked-main environment proof and exact external recovery ledger without changing schema, Edge, role, or user-scoped cleanup ownership.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -25,7 +25,7 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - package.json
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 3c267b24c6ecd7f78e4ec0bcd9e8d4068f29aa29
+lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
 lastReviewedNote: 'Updated for Issue #660: the local-operator strategy now distinguishes host CI refusal from image-inherited container markers.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -25,7 +25,7 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - package.json
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
+lastReviewedCommit: b7f2b671323ced00de79b5424cd3d3747b5b0d7f
 lastReviewedNote: 'Updated for Issue #660: the local-operator strategy now distinguishes host CI refusal from image-inherited container markers.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 3c267b24c6ecd7f78e4ec0bcd9e8d4068f29aa29
+lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
 lastReviewedNote: 'Updated for Issue #660: recorded the corrected host-CI/local-container boundary for authenticated release E2E.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
+lastReviewedCommit: b7f2b671323ced00de79b5424cd3d3747b5b0d7f
 lastReviewedNote: 'Updated for Issue #660: recorded the corrected host-CI/local-container boundary for authenticated release E2E.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -26,7 +26,7 @@ checkPaths:
   - playwright.config.ts
   - package.json
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 3c267b24c6ecd7f78e4ec0bcd9e8d4068f29aa29
+lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
 lastReviewedNote: 'Updated for Issue #660: documented the two-sided host-CI and local container-marker production-write boundary.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -26,7 +26,7 @@ checkPaths:
   - playwright.config.ts
   - package.json
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
+lastReviewedCommit: b7f2b671323ced00de79b5424cd3d3747b5b0d7f
 lastReviewedNote: 'Updated for Issue #660: documented the two-sided host-CI and local container-marker production-write boundary.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -25,7 +25,7 @@ checkPaths:
   - tests/e2e/i18n/**
   - package.json
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
+lastReviewedCommit: b7f2b671323ced00de79b5424cd3d3747b5b0d7f
 lastReviewedNote: 'Updated for Issue #660: added diagnosis for host-CI refusal versus inherited container CI markers.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -25,7 +25,7 @@ checkPaths:
   - tests/e2e/i18n/**
   - package.json
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 3c267b24c6ecd7f78e4ec0bcd9e8d4068f29aa29
+lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
 lastReviewedNote: 'Updated for Issue #660: added diagnosis for host-CI refusal versus inherited container CI markers.'
 ---
 

--- a/docs/agents/util_calculate.md
+++ b/docs/agents/util_calculate.md
@@ -20,8 +20,8 @@ checkPaths:
   - src/services/lca/**
   - src/components/LcaTaskCenter/**
   - src/pages/Processes/Analysis/**
-lastReviewedAt: 2026-07-19
-lastReviewedCommit: a3c63306da7f6e4665158aeb0744f578c0e32050
+lastReviewedAt: 2026-07-22
+lastReviewedCommit: 0e23b8ed92a72d5d6554b8eefeb26c549e4e7191
 lastReviewedNote: 'Updated for Issue #635: generated subproduct labels now derive every authoring-enabled language and its reviewed prefix from the content-language registry; allocation and LCIA semantics are unchanged.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
-    "auditedInputDigest": "1f36e04a72cba4ee610c9786573782863254836566773fc7108e29faa29dffbb"
+    "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed",
+    "auditedInputDigest": "1fd128936af6d62dced37eaed46cf07e3d1a7513727545985051a2d817de47c1"
   },
   "inventory": {
     "sourceMessageCount": 3032,
@@ -47,7 +47,7 @@
     "messageCount": 3032,
     "completeCount": 3032,
     "blockedCount": 0,
-    "dossierDigest": "3a8130948bdc355e27deb65b8057212aca5552439a1653dc6beb763d91285097",
+    "dossierDigest": "e6ea5070ad4191376011990f69f2993fec9403a242c6f54c27c086ef740ec7d5",
     "catalogDigest": "7cd0bc0d30b733154b34642a79ddbc173919ffc6f3ad1115e45ceea9d4537224",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "19a60094f0000133231287357fdf3cf83a4a5e7e1c75157030023c48a6ca5ad0"
+  "contextDigest": "a469726ac0d7ed0095e2dab5189ce3fb72118abc2e117f10278989972d0f2fcf"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00"
+    "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "19a60094f0000133231287357fdf3cf83a4a5e7e1c75157030023c48a6ca5ad0",
-    "qualityDigest": "a16448522e042f3c02dc6a862b065f59fcaf5a744f6e00be4b234eac1ed9acdd",
+    "contextDigest": "a469726ac0d7ed0095e2dab5189ce3fb72118abc2e117f10278989972d0f2fcf",
+    "qualityDigest": "d716a096b77bbf2734b353ee01c12520be9f3da1e564660f1333056b0a8ef8bf",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
     "routeViewCoverageDigest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "e52a75820229e65c6fb83776a8c97c69088bb04290a75ce625ec2b647385dd88"
+  "activationDigest": "66e258ac7ce73d99649a44f4e6564b9cdbb4e7867e6c7d886a640df7dd13d07c"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
-    "contextDigest": "19a60094f0000133231287357fdf3cf83a4a5e7e1c75157030023c48a6ca5ad0"
+    "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed",
+    "contextDigest": "a469726ac0d7ed0095e2dab5189ce3fb72118abc2e117f10278989972d0f2fcf"
   },
   "catalog": {
     "messageCount": 3032,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "41106ab89e3b8b8ad030858531b1626ac7aafd9fb5b8372a5c2e410250c1a3c3",
-    "validationDigest": "5f2992b80e52975fcc758d52afe584fe3eaac48bbaf58a23b1637f66368f6fab",
+    "digest": "cab129c99f31b000656663047e9cf745dd03ece59c34a9a0d92052e911562f95",
+    "validationDigest": "fc5a5e15b9cc4c5ba3f6873727413ad17d7e83a4d40ec3af455b5b9cbccc7347",
     "laneCount": 1,
     "validatedMessageCount": 3032,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "a16448522e042f3c02dc6a862b065f59fcaf5a744f6e00be4b234eac1ed9acdd"
+  "qualityDigest": "d716a096b77bbf2734b353ee01c12520be9f3da1e564660f1333056b0a8ef8bf"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "1f36e04a72cba4ee610c9786573782863254836566773fc7108e29faa29dffbb",
+    "auditedInputDigest": "1fd128936af6d62dced37eaed46cf07e3d1a7513727545985051a2d817de47c1",
     "validatedMessageCount": 3032,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1341,
     "highRiskMessageDigest": "3ce9911e5333fd9b7c85174693a78c7c8cf37e92835241c23e4f820a4c7b558e",
     "catalogDigest": "7cd0bc0d30b733154b34642a79ddbc173919ffc6f3ad1115e45ceea9d4537224",
-    "dossierDigest": "3a8130948bdc355e27deb65b8057212aca5552439a1653dc6beb763d91285097",
+    "dossierDigest": "e6ea5070ad4191376011990f69f2993fec9403a242c6f54c27c086ef740ec7d5",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "a61bdfc486511211c05a9c6109c854b091ec794d74a817aaaa2dfb097da77336",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "5ef93647a266ce23461d659b85cd8d1f1c8ccf437a689b159c423155d210580c",
         "highRiskMessageCount": 1341,
         "highRiskMessageDigest": "3ce9911e5333fd9b7c85174693a78c7c8cf37e92835241c23e4f820a4c7b558e",
-        "dossierDigest": "3a8130948bdc355e27deb65b8057212aca5552439a1653dc6beb763d91285097",
+        "dossierDigest": "e6ea5070ad4191376011990f69f2993fec9403a242c6f54c27c086ef740ec7d5",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "5f2992b80e52975fcc758d52afe584fe3eaac48bbaf58a23b1637f66368f6fab"
+  "validationDigest": "fc5a5e15b9cc4c5ba3f6873727413ad17d7e83a4d40ec3af455b5b9cbccc7347"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
-    "auditedInputDigest": "1f36e04a72cba4ee610c9786573782863254836566773fc7108e29faa29dffbb"
+    "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed",
+    "auditedInputDigest": "1fd128936af6d62dced37eaed46cf07e3d1a7513727545985051a2d817de47c1"
   },
   "inventory": {
     "sourceMessageCount": 3032,
@@ -47,7 +47,7 @@
     "messageCount": 3032,
     "completeCount": 3032,
     "blockedCount": 0,
-    "dossierDigest": "1a8555b52e279fe8bc8e71f7990209a9f61cfdccb1825d34a93de1ef881c0a79",
+    "dossierDigest": "9fcffc0f4370cd72f61f164d20451729b37ad01320df9f6b79669080ef8f7e47",
     "catalogDigest": "d93ed39831164b98edc60b1961375fe4aa11c9ec5c446ad564b5b8742398e21d",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "bc4d9c90dad9a51f8f88f73684ee0b5f181ab90c2a49cbd6d3cd4c68070be7e7"
+  "contextDigest": "4e18877c7c2094b5d8da2ec09161f1d22c77e0f2d7c5fe117e5ec26d7c488c20"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00"
+    "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "bc4d9c90dad9a51f8f88f73684ee0b5f181ab90c2a49cbd6d3cd4c68070be7e7",
-    "qualityDigest": "d540250bdb6e4d304b75eed29d55816b4dd4cebef8b2e2cf2a5dde3b8010450e",
+    "contextDigest": "4e18877c7c2094b5d8da2ec09161f1d22c77e0f2d7c5fe117e5ec26d7c488c20",
+    "qualityDigest": "66ee956e052eb525a95fcb39131633c4872633ecd771e173fa135b11a392a14e",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
     "routeViewCoverageDigest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "b6b5a6ef81f7078bfe22f564572904463a85c594f9de940dd66746f6a4457f8c"
+  "activationDigest": "0fb47adf5275fb8dd8577bc7bd6ee94d9d33df607ceea8f363186d488b39a141"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
-    "contextDigest": "bc4d9c90dad9a51f8f88f73684ee0b5f181ab90c2a49cbd6d3cd4c68070be7e7"
+    "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed",
+    "contextDigest": "4e18877c7c2094b5d8da2ec09161f1d22c77e0f2d7c5fe117e5ec26d7c488c20"
   },
   "catalog": {
     "messageCount": 3032,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "467c4efc20bce94db7e5b89e93ffaebaf1279fa56a4b272c89266cacf92c0f60",
-    "validationDigest": "7dd179287ac356e549cf9b8661381749efe56dc7fd9b61bb7bc297a5fbc9df84",
+    "digest": "3ac8be180b585ad3fe5ba0f0fee42137ab2b3c4d27d7698bbc69eb049cc234b3",
+    "validationDigest": "b482f34c16790e2ad51408ce854ed874386e523f3231f0ab31a36e7d739e7a9b",
     "laneCount": 1,
     "validatedMessageCount": 3032,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "d540250bdb6e4d304b75eed29d55816b4dd4cebef8b2e2cf2a5dde3b8010450e"
+  "qualityDigest": "66ee956e052eb525a95fcb39131633c4872633ecd771e173fa135b11a392a14e"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "1f36e04a72cba4ee610c9786573782863254836566773fc7108e29faa29dffbb",
+    "auditedInputDigest": "1fd128936af6d62dced37eaed46cf07e3d1a7513727545985051a2d817de47c1",
     "validatedMessageCount": 3032,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1341,
     "highRiskMessageDigest": "3ce9911e5333fd9b7c85174693a78c7c8cf37e92835241c23e4f820a4c7b558e",
     "catalogDigest": "d93ed39831164b98edc60b1961375fe4aa11c9ec5c446ad564b5b8742398e21d",
-    "dossierDigest": "1a8555b52e279fe8bc8e71f7990209a9f61cfdccb1825d34a93de1ef881c0a79",
+    "dossierDigest": "9fcffc0f4370cd72f61f164d20451729b37ad01320df9f6b79669080ef8f7e47",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "a61bdfc486511211c05a9c6109c854b091ec794d74a817aaaa2dfb097da77336",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "5ef93647a266ce23461d659b85cd8d1f1c8ccf437a689b159c423155d210580c",
         "highRiskMessageCount": 1341,
         "highRiskMessageDigest": "3ce9911e5333fd9b7c85174693a78c7c8cf37e92835241c23e4f820a4c7b558e",
-        "dossierDigest": "1a8555b52e279fe8bc8e71f7990209a9f61cfdccb1825d34a93de1ef881c0a79",
+        "dossierDigest": "9fcffc0f4370cd72f61f164d20451729b37ad01320df9f6b79669080ef8f7e47",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "7dd179287ac356e549cf9b8661381749efe56dc7fd9b61bb7bc297a5fbc9df84"
+  "validationDigest": "b482f34c16790e2ad51408ce854ed874386e523f3231f0ab31a36e7d739e7a9b"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
-    "auditedInputDigest": "1f36e04a72cba4ee610c9786573782863254836566773fc7108e29faa29dffbb"
+    "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed",
+    "auditedInputDigest": "1fd128936af6d62dced37eaed46cf07e3d1a7513727545985051a2d817de47c1"
   },
   "inventory": {
     "sourceMessageCount": 3032,
@@ -47,7 +47,7 @@
     "messageCount": 3032,
     "completeCount": 3032,
     "blockedCount": 0,
-    "dossierDigest": "6692befb10ab699ab299db391553104385856439ee23f524e078f8a288190050",
+    "dossierDigest": "64d85c02a0157f90d9f61acadf2e5379db363cb9b87297817082914814b4dc2a",
     "catalogDigest": "fe762b9712f0e81eab9a0befa1fd0f820986ef430556ff6491148c6a2f30e6a2",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "9c976d78b1542b3bd74cc8ae06e7e7bdb341813782d47539e322a0b69bb28206"
+  "contextDigest": "4bc996bb340fa885f8c9502b3510906f94a21eb04c560830c2cf9d3420eca280"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00"
+    "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "9c976d78b1542b3bd74cc8ae06e7e7bdb341813782d47539e322a0b69bb28206",
-    "qualityDigest": "4ad21063430f1691228f4d3faefa7500305a5b8055fa84a9ea65136cb4605b27",
+    "contextDigest": "4bc996bb340fa885f8c9502b3510906f94a21eb04c560830c2cf9d3420eca280",
+    "qualityDigest": "0bc0a74cff6d7e7aecef5e9a8d0e812d13047e9fa2df525c3fcf6ee41040d838",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
     "routeViewCoverageDigest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "4c4a9cfdd2cad949e9e43cd0e174ef2b7a841c5ee3463a58cec1516b358f0b69"
+  "activationDigest": "4eac43ec91e3e92ee11e86e58303f7561ddccf3d4def38a050ef1062bfb8683c"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
-    "contextDigest": "9c976d78b1542b3bd74cc8ae06e7e7bdb341813782d47539e322a0b69bb28206"
+    "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed",
+    "contextDigest": "4bc996bb340fa885f8c9502b3510906f94a21eb04c560830c2cf9d3420eca280"
   },
   "catalog": {
     "messageCount": 3032,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "d1083c5a5ef909eb569235a2265ca434c411da9970ef6e1e345a6dd9ef16e986",
-    "validationDigest": "789e90256308b7e5a2379a28a84f929d8ce00bc6ffcd33e7c0b73f2f42df6404",
+    "digest": "f0682a069790814dbb2ad038b4ddaa1a7e7327181f6d3f9b992209fe0a5e6307",
+    "validationDigest": "75cbdb3742a3b4a6fe4dd9ff0f935c30783e34b7339d3d3329e0ea20465114d7",
     "laneCount": 1,
     "validatedMessageCount": 3032,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "4ad21063430f1691228f4d3faefa7500305a5b8055fa84a9ea65136cb4605b27"
+  "qualityDigest": "0bc0a74cff6d7e7aecef5e9a8d0e812d13047e9fa2df525c3fcf6ee41040d838"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "1f36e04a72cba4ee610c9786573782863254836566773fc7108e29faa29dffbb",
+    "auditedInputDigest": "1fd128936af6d62dced37eaed46cf07e3d1a7513727545985051a2d817de47c1",
     "validatedMessageCount": 3032,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1341,
     "highRiskMessageDigest": "3ce9911e5333fd9b7c85174693a78c7c8cf37e92835241c23e4f820a4c7b558e",
     "catalogDigest": "fe762b9712f0e81eab9a0befa1fd0f820986ef430556ff6491148c6a2f30e6a2",
-    "dossierDigest": "6692befb10ab699ab299db391553104385856439ee23f524e078f8a288190050",
+    "dossierDigest": "64d85c02a0157f90d9f61acadf2e5379db363cb9b87297817082914814b4dc2a",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "a61bdfc486511211c05a9c6109c854b091ec794d74a817aaaa2dfb097da77336",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "5ef93647a266ce23461d659b85cd8d1f1c8ccf437a689b159c423155d210580c",
         "highRiskMessageCount": 1341,
         "highRiskMessageDigest": "3ce9911e5333fd9b7c85174693a78c7c8cf37e92835241c23e4f820a4c7b558e",
-        "dossierDigest": "6692befb10ab699ab299db391553104385856439ee23f524e078f8a288190050",
+        "dossierDigest": "64d85c02a0157f90d9f61acadf2e5379db363cb9b87297817082914814b4dc2a",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "789e90256308b7e5a2379a28a84f929d8ce00bc6ffcd33e7c0b73f2f42df6404"
+  "validationDigest": "75cbdb3742a3b4a6fe4dd9ff0f935c30783e34b7339d3d3329e0ea20465114d7"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
-    "auditedInputDigest": "1f36e04a72cba4ee610c9786573782863254836566773fc7108e29faa29dffbb"
+    "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed",
+    "auditedInputDigest": "1fd128936af6d62dced37eaed46cf07e3d1a7513727545985051a2d817de47c1"
   },
   "inventory": {
     "sourceMessageCount": 3032,
@@ -47,7 +47,7 @@
     "messageCount": 3032,
     "completeCount": 3032,
     "blockedCount": 0,
-    "dossierDigest": "3407227e20f4861c8e5f6695a75416d5bb961aaab3d98f987e75f530dd571909",
+    "dossierDigest": "9bb55123e0773a8417ea542ae58f8986bb3792b545ce52a0af940d486c56eed5",
     "catalogDigest": "d2ba7bc81f8aca97f5075283d3509c63fb7ff370a6bec1d4a439c8737b19106e",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "4217ffb8c21026515d45e3fb12269806f8407ef6e25c2791c470bff47db68c98"
+  "contextDigest": "4d4b2052788a6d32f5815d60eb3e0c7628f32b82c7c32a326f174ec95f31c10a"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00"
+    "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4217ffb8c21026515d45e3fb12269806f8407ef6e25c2791c470bff47db68c98",
-    "qualityDigest": "bd30f8d3357f4908428ed92a113171985f5794a882916bb37d628ee592409828",
+    "contextDigest": "4d4b2052788a6d32f5815d60eb3e0c7628f32b82c7c32a326f174ec95f31c10a",
+    "qualityDigest": "e97e496d5287a8eef9732063c9e45258ea4cfc9a1a9d8d9db3f9e7f532eb6027",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
     "routeViewCoverageDigest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "ef6fbff3205e72feeb82c07872f70b54f74d4f8850d971d9fe64e0f0c793e84d"
+  "activationDigest": "3a95fd6210f1306fff263fe67165e2d6f5d45b021faaa94cfce59f8b906c3b07"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e3c4985ae2a250796856e941cc17a44d13d389e2ee05712fa57a5ed8a0cebf00",
-    "contextDigest": "4217ffb8c21026515d45e3fb12269806f8407ef6e25c2791c470bff47db68c98"
+    "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed",
+    "contextDigest": "4d4b2052788a6d32f5815d60eb3e0c7628f32b82c7c32a326f174ec95f31c10a"
   },
   "catalog": {
     "messageCount": 3032,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "c2244d591dc2a3541b5561bf25f802491ef31859a98f2a366db1c63d4c20b12e",
-    "validationDigest": "42e48090d8aea2f89d7e950fcf67eb2d37763a92b3b635b773f90c2db1fa90fb",
+    "digest": "03f476b7bced68f7c50049ef1c393bac318a1d3320fef4ebb3b41f6066284469",
+    "validationDigest": "ac4e7a81f4e61e34368f461859e9c705bc0f4ff12fe110888c2c73702eaeff30",
     "laneCount": 1,
     "validatedMessageCount": 3032,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "bd30f8d3357f4908428ed92a113171985f5794a882916bb37d628ee592409828"
+  "qualityDigest": "e97e496d5287a8eef9732063c9e45258ea4cfc9a1a9d8d9db3f9e7f532eb6027"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "1f36e04a72cba4ee610c9786573782863254836566773fc7108e29faa29dffbb",
+    "auditedInputDigest": "1fd128936af6d62dced37eaed46cf07e3d1a7513727545985051a2d817de47c1",
     "validatedMessageCount": 3032,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1341,
     "highRiskMessageDigest": "3ce9911e5333fd9b7c85174693a78c7c8cf37e92835241c23e4f820a4c7b558e",
     "catalogDigest": "d2ba7bc81f8aca97f5075283d3509c63fb7ff370a6bec1d4a439c8737b19106e",
-    "dossierDigest": "3407227e20f4861c8e5f6695a75416d5bb961aaab3d98f987e75f530dd571909",
+    "dossierDigest": "9bb55123e0773a8417ea542ae58f8986bb3792b545ce52a0af940d486c56eed5",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "a61bdfc486511211c05a9c6109c854b091ec794d74a817aaaa2dfb097da77336",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "5ef93647a266ce23461d659b85cd8d1f1c8ccf437a689b159c423155d210580c",
         "highRiskMessageCount": 1341,
         "highRiskMessageDigest": "3ce9911e5333fd9b7c85174693a78c7c8cf37e92835241c23e4f820a4c7b558e",
-        "dossierDigest": "3407227e20f4861c8e5f6695a75416d5bb961aaab3d98f987e75f530dd571909",
+        "dossierDigest": "9bb55123e0773a8417ea542ae58f8986bb3792b545ce52a0af940d486c56eed5",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "42e48090d8aea2f89d7e950fcf67eb2d37763a92b3b635b773f90c2db1fa90fb"
+  "validationDigest": "ac4e7a81f4e61e34368f461859e9c705bc0f4ff12fe110888c2c73702eaeff30"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.54",
+      "version": "0.0.55",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",

--- a/src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx
+++ b/src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx
@@ -32,6 +32,7 @@ import {
   genLifeCycleModelData,
   genLifeCycleModelInfoFromData,
   genPortLabel,
+  getLifeCycleModelPortFlowVersion,
 } from '@/services/lifeCycleModels/util';
 import {
   getProcessDetail,
@@ -1182,14 +1183,30 @@ const ToolbarEdit: FC<Props> = ({
       const targetProcessVersion = targetNode?.data?.version;
       const sourcePortIDs = sourcePortID.split(':');
       const targetPortIDs = targetPortID.split(':');
+      const sourceFlowUUID = sourcePortIDs?.[sourcePortIDs?.length - 1];
+      const targetFlowUUID = targetPortIDs?.[targetPortIDs?.length - 1];
+      const sourceFlowVersion = getLifeCycleModelPortFlowVersion(
+        sourceNode,
+        sourcePortID,
+        sourceFlowUUID,
+        'groupOutput',
+      );
+      const targetFlowVersion = getLifeCycleModelPortFlowVersion(
+        targetNode,
+        targetPortID,
+        targetFlowUUID,
+        'groupInput',
+      );
 
       updateEdge(edge.id, {
         data: {
           connection: {
             outputExchange: {
-              '@flowUUID': sourcePortIDs?.[sourcePortIDs?.length - 1],
+              '@flowUUID': sourceFlowUUID,
+              '@version': sourceFlowVersion,
               downstreamProcess: {
-                '@flowUUID': targetPortIDs?.[targetPortIDs?.length - 1],
+                '@flowUUID': targetFlowUUID,
+                '@version': targetFlowVersion,
               },
             },
           },

--- a/src/services/lifeCycleModels/api.ts
+++ b/src/services/lifeCycleModels/api.ts
@@ -47,7 +47,10 @@ import {
   buildReviewUpdateLifeCycleModelPersistencePlan,
   buildSaveLifeCycleModelPersistencePlan,
 } from './persistencePlan';
-import { genLifeCycleModelJsonOrdered } from './util';
+import {
+  genLifeCycleModelJsonOrdered,
+  MISSING_LIFECYCLE_MODEL_FLOW_VERSION_ERROR_CODE,
+} from './util';
 import { genLifeCycleModelProcesses } from './util_calculate';
 
 type LifeCycleModelListRpcRow = {
@@ -183,6 +186,42 @@ function buildMutationError(
     message,
     details,
   };
+}
+
+function buildFlowVersionMutationError(error: unknown): LifeCycleModelMutationResult | undefined {
+  if (
+    typeof error !== 'object' ||
+    error === null ||
+    !('code' in error) ||
+    error.code !== MISSING_LIFECYCLE_MODEL_FLOW_VERSION_ERROR_CODE ||
+    !('message' in error) ||
+    typeof error.message !== 'string'
+  ) {
+    return undefined;
+  }
+
+  return buildMutationError(
+    MISSING_LIFECYCLE_MODEL_FLOW_VERSION_ERROR_CODE,
+    error.message,
+    'details' in error ? error.details : undefined,
+  );
+}
+
+function serializeLifeCycleModelForMutation(
+  id: string,
+  data: any,
+):
+  | { success: true; jsonOrdered: any }
+  | { success: false; mutationError: LifeCycleModelMutationResult } {
+  try {
+    return { success: true, jsonOrdered: genLifeCycleModelJsonOrdered(id, data) };
+  } catch (error) {
+    const flowVersionError = buildFlowVersionMutationError(error);
+    if (flowVersionError) {
+      return { success: false, mutationError: flowVersionError };
+    }
+    throw error;
+  }
 }
 
 function buildLangValidationError(validationError: string): LifeCycleModelMutationResult {
@@ -346,7 +385,11 @@ export async function createLifeCycleModel(
   options?: NormalizeLangPayloadForSaveOptions,
   createVersionOptions?: { sourceVersion: string },
 ): Promise<LifeCycleModelMutationResult> {
-  const rawLifeCycleModelJsonOrdered = genLifeCycleModelJsonOrdered(data.id, data);
+  const serializationResult = serializeLifeCycleModelForMutation(data.id, data);
+  if (!serializationResult.success) {
+    return serializationResult.mutationError;
+  }
+  const rawLifeCycleModelJsonOrdered = serializationResult.jsonOrdered;
   const normalizedCreateResult = await normalizeLangPayloadForSave(
     rawLifeCycleModelJsonOrdered,
     options,
@@ -408,7 +451,11 @@ export async function updateLifeCycleModel(
   data: any,
   options?: NormalizeLangPayloadForSaveOptions,
 ): Promise<LifeCycleModelMutationResult> {
-  const rawLifeCycleModelJsonOrdered = genLifeCycleModelJsonOrdered(data.id, data);
+  const serializationResult = serializeLifeCycleModelForMutation(data.id, data);
+  if (!serializationResult.success) {
+    return serializationResult.mutationError;
+  }
+  const rawLifeCycleModelJsonOrdered = serializationResult.jsonOrdered;
   const normalizedUpdateResult = await normalizeLangPayloadForSave(
     rawLifeCycleModelJsonOrdered,
     options,

--- a/src/services/lifeCycleModels/data.ts
+++ b/src/services/lifeCycleModels/data.ts
@@ -125,9 +125,11 @@ export type LifeCycleModelGraphNode = {
 export type LifeCycleModelEdgeConnection = {
   outputExchange?: {
     '@flowUUID'?: string;
+    '@version'?: string;
     downstreamProcess?: {
       '@flowUUID'?: string;
       '@id'?: string;
+      '@version'?: string;
     };
   };
   isBalanced?: boolean;

--- a/src/services/lifeCycleModels/util.ts
+++ b/src/services/lifeCycleModels/util.ts
@@ -15,8 +15,112 @@ import {
   removeEmptyObjects,
 } from '../general/util';
 import { genProcessName, genProcessNameJson } from '../processes/util';
-import { FormLifeCycleModel } from './data';
+import type {
+  FormLifeCycleModel,
+  LifeCycleModelGraphEdge,
+  LifeCycleModelGraphNode,
+  LifeCycleModelPortGroup,
+} from './data';
 import { toReferenceProcessKey, toReferenceProcessNumber } from './referenceProcess';
+
+export const MISSING_LIFECYCLE_MODEL_FLOW_VERSION_ERROR_CODE = 'MISSING_FLOW_VERSION';
+
+type LifeCycleModelConnectionFlowRole = 'outputExchange' | 'downstreamProcess';
+
+export type MissingLifeCycleModelFlowVersionDetails = {
+  edgeId?: string;
+  fieldPath: 'outputExchange.@version' | 'outputExchange.downstreamProcess.@version';
+  flowUUID: string;
+  nodeId?: string;
+  portId?: string;
+  role: LifeCycleModelConnectionFlowRole;
+};
+
+export class MissingLifeCycleModelFlowVersionError extends Error {
+  readonly code = MISSING_LIFECYCLE_MODEL_FLOW_VERSION_ERROR_CODE;
+  readonly details: MissingLifeCycleModelFlowVersionDetails;
+
+  constructor(details: MissingLifeCycleModelFlowVersionDetails) {
+    super(
+      `Missing Flow dataset version for ${details.fieldPath} on edge "${details.edgeId ?? 'unknown'}" ` +
+        `(Flow "${details.flowUUID}", node "${details.nodeId ?? 'unknown'}", port "${details.portId ?? 'unknown'}"). ` +
+        'Re-select the Flow or restore referenceToFlowDataSet.@version before saving.',
+    );
+    this.name = 'MissingLifeCycleModelFlowVersionError';
+    this.details = details;
+  }
+}
+
+const normalizeFlowVersion = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+};
+
+export const getLifeCycleModelPortFlowVersion = (
+  node: LifeCycleModelGraphNode | undefined,
+  portId: string | undefined,
+  flowUUID: string | undefined,
+  group: LifeCycleModelPortGroup,
+): string | undefined => {
+  const ports = node?.ports?.items ?? [];
+  const direction = group === 'groupOutput' ? 'OUTPUT' : 'INPUT';
+  const exactPort = portId ? ports.find((port) => port.id === portId) : undefined;
+  const flowPort = flowUUID
+    ? ports.find(
+        (port) =>
+          port.group === group &&
+          (port.data?.flowId === flowUUID || port.id === `${direction}:${flowUUID}`),
+      )
+    : undefined;
+
+  return normalizeFlowVersion((exactPort ?? flowPort)?.data?.flowVersion);
+};
+
+const resolveConnectionFlowVersion = ({
+  edge,
+  flowUUID,
+  nodes,
+  role,
+}: {
+  edge: LifeCycleModelGraphEdge;
+  flowUUID: unknown;
+  nodes: LifeCycleModelGraphNode[];
+  role: LifeCycleModelConnectionFlowRole;
+}): string | undefined => {
+  const isOutputExchange = role === 'outputExchange';
+  const nodeId = isOutputExchange ? edge?.source?.cell : edge?.target?.cell;
+  const portId = isOutputExchange ? edge?.source?.port : edge?.target?.port;
+  const edgeVersion = isOutputExchange
+    ? edge?.data?.connection?.outputExchange?.['@version']
+    : edge?.data?.connection?.outputExchange?.downstreamProcess?.['@version'];
+  const version =
+    normalizeFlowVersion(edgeVersion) ??
+    getLifeCycleModelPortFlowVersion(
+      nodes.find((node) => node.id === nodeId),
+      portId,
+      typeof flowUUID === 'string' ? flowUUID : undefined,
+      isOutputExchange ? 'groupOutput' : 'groupInput',
+    );
+
+  if (typeof flowUUID !== 'string' || flowUUID.trim().length === 0 || version) {
+    return version;
+  }
+
+  throw new MissingLifeCycleModelFlowVersionError({
+    edgeId: edge?.id,
+    fieldPath: isOutputExchange
+      ? 'outputExchange.@version'
+      : 'outputExchange.downstreamProcess.@version',
+    flowUUID,
+    nodeId,
+    portId,
+    role,
+  });
+};
 
 export function genNodeLabel(label: string, lang: string, nodeWidth: number) {
   const labelSub = label?.substring(0, nodeWidth / getContentGraphTextWidthDivisor(lang) - 4);
@@ -54,7 +158,7 @@ export const genReferenceToResultingProcess = (
   return data;
 };
 export function genLifeCycleModelJsonOrdered(id: string, data: any) {
-  const nodes = data?.model?.nodes;
+  const nodes = data?.model?.nodes as LifeCycleModelGraphNode[] | undefined;
 
   let referenceToReferenceProcess: number | undefined;
   const processInstance = nodes?.map((n: any) => {
@@ -62,7 +166,9 @@ export function genLifeCycleModelJsonOrdered(id: string, data: any) {
       referenceToReferenceProcess = toReferenceProcessNumber(n?.data?.index);
     }
 
-    const sourceEdges = data?.model?.edges?.filter((e: any) => e?.source?.cell === n?.id);
+    const sourceEdges = ((data?.model?.edges ?? []) as LifeCycleModelGraphEdge[]).filter(
+      (edge) => edge?.source?.cell === n?.id,
+    );
 
     const sourceEdgeGroupeds = sourceEdges.reduce((acc: any, edge: any) => {
       const key = edge?.data?.connection?.outputExchange?.['@flowUUID'];
@@ -73,16 +179,34 @@ export function genLifeCycleModelJsonOrdered(id: string, data: any) {
       return acc;
     }, {});
 
-    const outputExchange = Object.entries(sourceEdgeGroupeds).map(([key, edges]) => {
-      const downstreamProcesses = jsonToList(edges)?.map((e: any) => {
-        const targetNode = nodes?.find((n: any) => n?.id === e?.target?.cell);
+    const outputExchange = Object.entries(sourceEdgeGroupeds).map(([key, groupedEdges]) => {
+      const edges = groupedEdges as LifeCycleModelGraphEdge[];
+      const firstEdge = edges[0];
+      const outputFlowUUID = firstEdge?.data?.connection?.outputExchange?.['@flowUUID'];
+      const outputFlowVersion = resolveConnectionFlowVersion({
+        edge: firstEdge,
+        flowUUID: outputFlowUUID,
+        nodes,
+        role: 'outputExchange',
+      });
+      const downstreamProcesses = edges.map((edge) => {
+        const targetNode = nodes?.find((node) => node?.id === edge?.target?.cell);
+        const downstreamFlowUUID =
+          edge?.data?.connection?.outputExchange?.downstreamProcess?.['@flowUUID'];
         return {
-          '@flowUUID': e?.data?.connection?.outputExchange?.downstreamProcess?.['@flowUUID'],
+          '@flowUUID': downstreamFlowUUID,
+          '@version': resolveConnectionFlowVersion({
+            edge,
+            flowUUID: downstreamFlowUUID,
+            nodes,
+            role: 'downstreamProcess',
+          }),
           '@id': targetNode?.data?.index,
         };
       });
       return {
         '@flowUUID': key,
+        '@version': outputFlowVersion,
         downstreamProcess: listToJson(downstreamProcesses),
       };
     });

--- a/tests/unit/pages/LifeCycleModels/Components/toolbar/editIndex.test.tsx
+++ b/tests/unit/pages/LifeCycleModels/Components/toolbar/editIndex.test.tsx
@@ -367,6 +367,9 @@ const mockGenLifeCycleModelData = jest.fn().mockReturnValue({ json: {} });
 const mockGenLifeCycleModelInfoFromData = jest.fn().mockReturnValue({});
 const mockGenNodeLabel = jest.fn().mockReturnValue('Node Label');
 const mockGenPortLabel = jest.fn().mockReturnValue('Port Label');
+const resolveMockPortFlowVersion = (node: any, portId: string) =>
+  node?.ports?.items?.find((port: any) => port.id === portId)?.data?.flowVersion;
+const mockGetLifeCycleModelPortFlowVersion = jest.fn(resolveMockPortFlowVersion);
 
 jest.mock('@/services/lifeCycleModels/util', () => ({
   __esModule: true,
@@ -374,6 +377,8 @@ jest.mock('@/services/lifeCycleModels/util', () => ({
   genLifeCycleModelInfoFromData: (...args: any[]) => mockGenLifeCycleModelInfoFromData(...args),
   genNodeLabel: (...args: any[]) => mockGenNodeLabel(...args),
   genPortLabel: (...args: any[]) => mockGenPortLabel(...args),
+  getLifeCycleModelPortFlowVersion: (...args: any[]) =>
+    mockGetLifeCycleModelPortFlowVersion(...args),
 }));
 
 const mockGetProcessDetail = jest.fn();
@@ -480,6 +485,7 @@ beforeEach(() => {
   mockUseGraphEvent.mockClear();
   mockGenNodeLabel.mockReset().mockReturnValue('Node Label');
   mockGenPortLabel.mockReset().mockReturnValue('Port Label');
+  mockGetLifeCycleModelPortFlowVersion.mockReset().mockImplementation(resolveMockPortFlowVersion);
   mockGetProcessDetail.mockReset().mockResolvedValue({
     data: {
       version: '2.0',
@@ -2920,6 +2926,21 @@ describe('ToolbarEdit', () => {
       { ignoreHistory: true },
     );
 
+    mockGraphStoreState.nodes[0].ports.items = [
+      {
+        id: 'OUTPUT:flow-a',
+        group: 'groupOutput',
+        data: { flowId: 'flow-a', flowVersion: '01.02.003' },
+      },
+    ];
+    mockGraphStoreState.nodes[1].ports.items = [
+      {
+        id: 'INPUT:flow-a',
+        group: 'groupInput',
+        data: { flowId: 'flow-a', flowVersion: '04.05.006' },
+      },
+    ];
+
     const validEdge = {
       id: 'edge-valid',
       getSourcePortId: () => 'OUTPUT:flow-a',
@@ -2932,7 +2953,16 @@ describe('ToolbarEdit', () => {
       'edge-valid',
       expect.objectContaining({
         data: expect.objectContaining({
-          connection: expect.any(Object),
+          connection: {
+            outputExchange: {
+              '@flowUUID': 'flow-a',
+              '@version': '01.02.003',
+              downstreamProcess: {
+                '@flowUUID': 'flow-a',
+                '@version': '04.05.006',
+              },
+            },
+          },
         }),
       }),
     );

--- a/tests/unit/services/lifeCycleModels/api.test.ts
+++ b/tests/unit/services/lifeCycleModels/api.test.ts
@@ -101,11 +101,21 @@ jest.mock('@/services/auth', () => ({
 
 const mockGenLifeCycleModelJsonOrdered = jest.fn();
 const mockGenReferenceToResultingProcess = jest.fn();
+class MockMissingLifeCycleModelFlowVersionError extends Error {
+  readonly code = 'MISSING_FLOW_VERSION';
+  readonly details: Record<string, unknown>;
+
+  constructor(details: Record<string, unknown>) {
+    super('Missing Flow dataset version for outputExchange.@version');
+    this.details = details;
+  }
+}
 
 jest.mock('@/services/lifeCycleModels/util', () => ({
   __esModule: true,
   genLifeCycleModelJsonOrdered: (...args: any[]) => mockGenLifeCycleModelJsonOrdered(...args),
   genReferenceToResultingProcess: (...args: any[]) => mockGenReferenceToResultingProcess(...args),
+  MISSING_LIFECYCLE_MODEL_FLOW_VERSION_ERROR_CODE: 'MISSING_FLOW_VERSION',
 }));
 
 const mockGenLifeCycleModelProcesses = jest.fn();
@@ -874,6 +884,67 @@ describe('deleteLifeCycleModel', () => {
 });
 
 describe('createLifeCycleModel', () => {
+  it('returns a targeted error before persistence when a connection Flow version is missing', async () => {
+    const details = {
+      edgeId: 'edge-1',
+      fieldPath: 'outputExchange.@version',
+      flowUUID: 'flow-1',
+      role: 'outputExchange',
+    };
+    mockGenLifeCycleModelJsonOrdered.mockImplementationOnce(() => {
+      throw new MockMissingLifeCycleModelFlowVersionError(details);
+    });
+
+    const result = await lifeCycleModelsApi.createLifeCycleModel({
+      id: sampleModelId,
+      model: { nodes: [], edges: [] },
+    });
+
+    expect(mockNormalizeLangPayloadForSave).not.toHaveBeenCalled();
+    expect(mockGenLifeCycleModelProcesses).not.toHaveBeenCalled();
+    expect(mockFunctionsInvoke).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      ok: false,
+      code: 'MISSING_FLOW_VERSION',
+      message: 'Missing Flow dataset version for outputExchange.@version',
+      details,
+    });
+  });
+
+  it('does not mask unexpected serialization errors', async () => {
+    mockGenLifeCycleModelJsonOrdered.mockImplementationOnce(() => {
+      throw new Error('unexpected serialization failure');
+    });
+
+    await expect(
+      lifeCycleModelsApi.createLifeCycleModel({
+        id: sampleModelId,
+        model: { nodes: [], edges: [] },
+      }),
+    ).rejects.toThrow('unexpected serialization failure');
+  });
+
+  it('returns a targeted Flow version error when structured details are unavailable', async () => {
+    mockGenLifeCycleModelJsonOrdered.mockImplementationOnce(() => {
+      throw {
+        code: 'MISSING_FLOW_VERSION',
+        message: 'Missing Flow dataset version',
+      };
+    });
+
+    const result = await lifeCycleModelsApi.createLifeCycleModel({
+      id: sampleModelId,
+      model: { nodes: [], edges: [] },
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'MISSING_FLOW_VERSION',
+      message: 'Missing Flow dataset version',
+    });
+    expect(result.details).toBeUndefined();
+  });
+
   it('returns a language validation error when normalization fails', async () => {
     mockNormalizeLangPayloadForSave.mockResolvedValueOnce({
       payload: { ignored: true },
@@ -1147,6 +1218,32 @@ describe('createLifeCycleModel', () => {
 });
 
 describe('updateLifeCycleModel', () => {
+  it('returns a targeted Flow version error before querying the current model', async () => {
+    const details = {
+      edgeId: 'edge-2',
+      fieldPath: 'outputExchange.downstreamProcess.@version',
+      flowUUID: 'flow-2',
+      role: 'downstreamProcess',
+    };
+    mockGenLifeCycleModelJsonOrdered.mockImplementationOnce(() => {
+      throw new MockMissingLifeCycleModelFlowVersionError(details);
+    });
+
+    const result = await lifeCycleModelsApi.updateLifeCycleModel({
+      id: sampleModelId,
+      version: sampleVersion,
+      model: { nodes: [], edges: [] },
+    });
+
+    expect(mockFrom).not.toHaveBeenCalled();
+    expect(mockFunctionsInvoke).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'MISSING_FLOW_VERSION',
+      details,
+    });
+  });
+
   it('returns MODEL_LOOKUP_FAILED when the current lifecycle model query errors', async () => {
     mockFrom.mockReturnValueOnce(
       createQueryBuilder({

--- a/tests/unit/services/lifeCycleModels/api.test.ts
+++ b/tests/unit/services/lifeCycleModels/api.test.ts
@@ -942,6 +942,10 @@ describe('createLifeCycleModel', () => {
       code: 'MISSING_FLOW_VERSION',
       message: 'Missing Flow dataset version',
     });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('Expected lifecycle model creation to fail');
+    }
     expect(result.details).toBeUndefined();
   });
 

--- a/tests/unit/services/lifeCycleModels/util.test.ts
+++ b/tests/unit/services/lifeCycleModels/util.test.ts
@@ -12,7 +12,10 @@ import {
   genNodeLabel,
   genPortLabel,
   genReferenceToResultingProcess,
+  getLifeCycleModelPortFlowVersion,
+  MissingLifeCycleModelFlowVersionError,
 } from '@/services/lifeCycleModels/util';
+import { createLifeCycleModel as createTidasLifeCycleModel } from '@tiangong-lca/tidas-sdk/core';
 
 const createLangText = (text: string, lang = 'en') => ({ '@xml:lang': lang, '#text': text });
 
@@ -211,8 +214,10 @@ const baseModelData = {
           connection: {
             outputExchange: {
               '@flowUUID': 'flow-1',
+              '@version': '01.01.000',
               downstreamProcess: {
                 '@flowUUID': 'flow-2',
+                '@version': '02.02.000',
               },
             },
           },
@@ -356,8 +361,186 @@ describe('genLifeCycleModelJsonOrdered', () => {
 
     const firstOutput = processes[0].connections.outputExchange;
     expect(firstOutput['@flowUUID']).toBe('flow-1');
+    expect(firstOutput['@version']).toBe('01.01.000');
     expect(firstOutput.downstreamProcess['@id']).toBe('1');
     expect(firstOutput.downstreamProcess['@flowUUID']).toBe('flow-2');
+    expect(firstOutput.downstreamProcess['@version']).toBe('02.02.000');
+  });
+
+  it('should satisfy the TIDAS SDK connection Flow version contract', () => {
+    const result = genLifeCycleModelJsonOrdered('model-sdk-flow-version', baseModelData);
+    const validation = createTidasLifeCycleModel(result).validateEnhanced();
+    const issues = validation.success ? [] : validation.error.issues;
+    const connectionVersionIssues = issues.filter((issue) => {
+      const path = issue.path.map(String);
+      return path.includes('outputExchange') && path.includes('@version');
+    });
+
+    expect(connectionVersionIssues).toEqual([]);
+  });
+
+  it('should recover missing edge Flow versions from the matching source and target ports', () => {
+    const result = genLifeCycleModelJsonOrdered('model-port-version-fallback', {
+      ...baseModelData,
+      model: {
+        nodes: [
+          {
+            ...baseModelData.model.nodes[0],
+            ports: {
+              items: [
+                {
+                  id: 'OUTPUT:flow-1',
+                  group: 'groupOutput',
+                  data: { flowId: 'flow-1', flowVersion: '03.01.004' },
+                },
+              ],
+            },
+          },
+          {
+            ...baseModelData.model.nodes[1],
+            ports: {
+              items: [
+                {
+                  id: 'INPUT:flow-2',
+                  group: 'groupInput',
+                  data: { flowId: 'flow-2', flowVersion: '04.02.005' },
+                },
+              ],
+            },
+          },
+        ],
+        edges: [
+          {
+            id: 'edge-port-version-fallback',
+            source: { cell: 'node-a' },
+            target: { cell: 'node-b' },
+            data: {
+              connection: {
+                outputExchange: {
+                  '@flowUUID': 'flow-1',
+                  downstreamProcess: { '@flowUUID': 'flow-2' },
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const processes = result.lifeCycleModelDataSet.lifeCycleModelInformation.technology.processes
+      .processInstance as any[];
+    const outputExchange = processes[0].connections.outputExchange;
+
+    expect(outputExchange['@version']).toBe('03.01.004');
+    expect(outputExchange.downstreamProcess['@version']).toBe('04.02.005');
+  });
+
+  it('should prefer versions already persisted on the edge over port fallback values', () => {
+    const result = genLifeCycleModelJsonOrdered('model-edge-version-precedence', {
+      ...baseModelData,
+      model: {
+        nodes: baseModelData.model.nodes.map((node, index) => ({
+          ...node,
+          ports: {
+            items: [
+              {
+                id: index === 0 ? 'OUTPUT:flow-1' : 'INPUT:flow-2',
+                group: index === 0 ? 'groupOutput' : 'groupInput',
+                data: {
+                  flowId: index === 0 ? 'flow-1' : 'flow-2',
+                  flowVersion: '99.99.999',
+                },
+              },
+            ],
+          },
+        })),
+        edges: [
+          {
+            ...baseModelData.model.edges[0],
+            source: { cell: 'node-a', port: 'OUTPUT:flow-1' },
+            target: { cell: 'node-b', port: 'INPUT:flow-2' },
+          },
+        ],
+      },
+    });
+
+    const processes = result.lifeCycleModelDataSet.lifeCycleModelInformation.technology.processes
+      .processInstance as any[];
+    const outputExchange = processes[0].connections.outputExchange;
+
+    expect(outputExchange['@version']).toBe('01.01.000');
+    expect(outputExchange.downstreamProcess['@version']).toBe('02.02.000');
+  });
+
+  it('should keep process instances connection-free when the graph has no edge collection', () => {
+    const result = genLifeCycleModelJsonOrdered('model-without-edges', {
+      ...baseModelData,
+      model: {
+        nodes: baseModelData.model.nodes,
+      },
+    });
+    const processes = result.lifeCycleModelDataSet.lifeCycleModelInformation.technology.processes
+      .processInstance as any[];
+
+    expect(processes).toHaveLength(2);
+    expect(processes[0].connections).toBeUndefined();
+  });
+
+  it('should reject a connection when the source output Flow version cannot be resolved', () => {
+    expect(() =>
+      genLifeCycleModelJsonOrdered('model-missing-output-version', {
+        ...baseModelData,
+        model: {
+          ...baseModelData.model,
+          edges: [
+            {
+              id: 'edge-missing-output-version',
+              source: { cell: 'node-a', port: 'OUTPUT:flow-1' },
+              target: { cell: 'node-b', port: 'INPUT:flow-2' },
+              data: {
+                connection: {
+                  outputExchange: {
+                    '@flowUUID': 'flow-1',
+                    '@version': '   ',
+                    downstreamProcess: {
+                      '@flowUUID': 'flow-2',
+                      '@version': '02.02.000',
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }),
+    ).toThrow(/outputExchange\.@version.*flow-1/i);
+  });
+
+  it('should reject a connection when the target input Flow version cannot be resolved', () => {
+    expect(() =>
+      genLifeCycleModelJsonOrdered('model-missing-downstream-version', {
+        ...baseModelData,
+        model: {
+          ...baseModelData.model,
+          edges: [
+            {
+              id: 'edge-missing-downstream-version',
+              source: { cell: 'node-a', port: 'OUTPUT:flow-1' },
+              target: { cell: 'node-b', port: 'INPUT:flow-2' },
+              data: {
+                connection: {
+                  outputExchange: {
+                    '@flowUUID': 'flow-1',
+                    '@version': '01.01.000',
+                    downstreamProcess: { '@flowUUID': 'flow-2' },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }),
+    ).toThrow(/downstreamProcess\.@version.*flow-2/i);
   });
 
   it('should preserve empty downstreamProcess placeholders when an edge target node is missing', () => {
@@ -373,6 +556,7 @@ describe('genLifeCycleModelJsonOrdered', () => {
               connection: {
                 outputExchange: {
                   '@flowUUID': 'flow-missing',
+                  '@version': '01.00.000',
                   downstreamProcess: {},
                 },
               },
@@ -414,8 +598,10 @@ describe('genLifeCycleModelJsonOrdered', () => {
               connection: {
                 outputExchange: {
                   '@flowUUID': 'flow-1',
+                  '@version': '01.01.000',
                   downstreamProcess: {
                     '@flowUUID': 'flow-3',
+                    '@version': '03.03.000',
                   },
                 },
               },
@@ -431,9 +617,18 @@ describe('genLifeCycleModelJsonOrdered', () => {
     const groupedOutput = processes[0].connections.outputExchange;
 
     expect(groupedOutput['@flowUUID']).toBe('flow-1');
+    expect(groupedOutput['@version']).toBe('01.01.000');
     expect(groupedOutput.downstreamProcess).toEqual([
-      expect.objectContaining({ '@id': '1', '@flowUUID': 'flow-2' }),
-      expect.objectContaining({ '@id': '2', '@flowUUID': 'flow-3' }),
+      expect.objectContaining({
+        '@id': '1',
+        '@flowUUID': 'flow-2',
+        '@version': '02.02.000',
+      }),
+      expect.objectContaining({
+        '@id': '2',
+        '@flowUUID': 'flow-3',
+        '@version': '03.03.000',
+      }),
     ]);
   });
 
@@ -607,6 +802,71 @@ describe('genLifeCycleModelJsonOrdered', () => {
         '@refObjectId': 'system-sparse',
       }),
     );
+  });
+});
+
+describe('connection Flow version helpers', () => {
+  it('resolves Flow versions by exact port, Flow id, and direction-derived port id', () => {
+    const node = {
+      id: 'node-flow-versions',
+      ports: {
+        items: [
+          {
+            id: 'INPUT:flow-output',
+            group: 'groupInput',
+            data: { flowId: 'flow-output', flowVersion: '90.00.000' },
+          },
+          {
+            id: 'OUTPUT:flow-output',
+            group: 'groupOutput',
+            data: { flowVersion: '01.02.003' },
+          },
+          {
+            id: 'custom-input-port',
+            group: 'groupInput',
+            data: { flowId: 'flow-input', flowVersion: '04.05.006' },
+          },
+          {
+            id: 'bad-version-port',
+            group: 'groupOutput',
+            data: { flowId: 'flow-bad', flowVersion: 123 },
+          },
+        ],
+      },
+    } as any;
+
+    expect(
+      getLifeCycleModelPortFlowVersion(
+        node,
+        'custom-input-port',
+        'ignored-by-exact-port',
+        'groupInput',
+      ),
+    ).toBe('04.05.006');
+    expect(getLifeCycleModelPortFlowVersion(node, undefined, 'flow-output', 'groupOutput')).toBe(
+      '01.02.003',
+    );
+    expect(getLifeCycleModelPortFlowVersion(node, undefined, 'flow-input', 'groupInput')).toBe(
+      '04.05.006',
+    );
+    expect(
+      getLifeCycleModelPortFlowVersion(node, 'bad-version-port', 'flow-bad', 'groupOutput'),
+    ).toBeUndefined();
+    expect(
+      getLifeCycleModelPortFlowVersion(undefined, undefined, undefined, 'groupOutput'),
+    ).toBeUndefined();
+  });
+
+  it('describes unresolved sparse connections without substituting another version', () => {
+    const error = new MissingLifeCycleModelFlowVersionError({
+      fieldPath: 'outputExchange.@version',
+      flowUUID: 'flow-sparse',
+      role: 'outputExchange',
+    });
+
+    expect(error.message).toContain('edge "unknown"');
+    expect(error.message).toContain('node "unknown"');
+    expect(error.message).toContain('port "unknown"');
   });
 });
 


### PR DESCRIPTION
Closes #661

## Summary
- Promote canonical dev commit 8f00cb91dde60e0dff2146d4231a417716f062af, including the lifecycle-model Flow @version fix merged by #664, into main.
- Bump package.json and package-lock.json from 0.0.54 to 0.0.55 so the canonical main workflow creates v0.0.55 and executes the release pipeline.

## Key Decisions
- The promotion branch is based on the current origin/dev and adds only the v0.0.55 version metadata plus required Docpact review evidence.
- No direct main hotfix is included; after merge, back-merge main into dev so the next development cycle inherits version 0.0.55.

## Validation
- npm run push:checked -- fork codex/release-v0.0.55: passed Docpact, LCIA cache, reference data, lint, typecheck, 398 suites / 5,386 tests, and 450/450 source files at 100% statements/branches/functions/lines.
- npm run build: passed for tiangong-lca-next@0.0.55.
- Docpact enforce check against origin/main: passed with 40 changed paths and 42 matched rules.

## Risks / Rollback
- Merging to main intentionally starts the v0.0.55 release workflow, including the release gate, credential-free semantic E2E, web deployment, and Electron draft release assets.
- Rollback requires reverting the main promotion; any tag or release artifacts already created must be handled through the repository release recovery process.

## Follow-ups
- Monitor the canonical Build/release workflow and verify v0.0.55 points to the merged main commit.
- Back-merge main into dev after the release promotion merges.

## Workspace Integration
- After v0.0.55 is established on child main, update the lca-workspace tiangong-lca-next submodule pointer before marking workspace delivery complete.