### PR TITLE
release: 修复语义 E2E 证据绑定并发布 v0.0.56

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-22"
-lastReviewedCommit: "b7f2b671323ced00de79b5424cd3d3747b5b0d7f"
-lastReviewedNote: 'Reviewed for Issue #660; the host/controller CI boundary remains covered by the existing bootstrap and testing/quality contracts, with no routing-rule change required.'
+lastReviewedCommit: "6c2f93fa6fda6ff220c9c5975241bc5739e0b89d"
+lastReviewedNote: 'Reviewed for Issue #666; the release recovery changes the package version and tracked i18n evidence/artifacts only, with no routing or ownership change required.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: b7f2b671323ced00de79b5424cd3d3747b5b0d7f
-lastReviewedNote: 'Updated for Issue #660: production-data release E2E now rejects host CI before clearing image-inherited CI markers for a local operator run.'
+lastReviewedCommit: ff86b9f7349fd70f8da4852904d48e8948bd2e71
+lastReviewedNote: 'Reviewed for Issue #666: the v0.0.56 release recovery follows the existing production E2E and checked-push contract; no repository entry rule changes are required.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -26,8 +26,8 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - .nvmrc
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: b7f2b671323ced00de79b5424cd3d3747b5b0d7f
-lastReviewedNote: 'Updated for Issue #660: documented the host-CI refusal and local container CI-marker override for production-data E2E.'
+lastReviewedCommit: ff86b9f7349fd70f8da4852904d48e8948bd2e71
+lastReviewedNote: 'Reviewed for Issue #666: the existing development bootstrap already covers production evidence refresh, validation, and checked push; no command changes are required.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -56,8 +56,8 @@ checkPaths:
   - .github/workflows/build.yml
   - package.json
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: 8d7d9ee4
-lastReviewedNote: 'Reviewed for Issue #654: isolated release E2E execution changes candidate packaging and diagnostics only; locale, route, assertion, production-data, and credential-free CI semantics remain unchanged.'
+lastReviewedCommit: 6c2f93fa6fda6ff220c9c5975241bc5739e0b89d
+lastReviewedNote: 'Reviewed for Issue #666: verified semantic E2E evidence is bound to the v0.0.56 package lock and records one controlled production-data create/cleanup cycle; locale delivery semantics remain unchanged.'
 baselineObservedAt: 2026-07-18
 related:
   - ../../AGENTS.md

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: b7f2b671323ced00de79b5424cd3d3747b5b0d7f
-lastReviewedNote: 'Updated for Issue #660: local production-data E2E now rejects host CI before overriding image-inherited CI markers.'
+lastReviewedCommit: 6c2f93fa6fda6ff220c9c5975241bc5739e0b89d
+lastReviewedNote: 'Reviewed for Issue #666: the existing gate policy already requires final package-lock-bound semantic E2E evidence; no policy change is required.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: b7f2b671323ced00de79b5424cd3d3747b5b0d7f
-lastReviewedNote: 'Updated for Issue #660: added proof requirements for the host-CI refusal and local container CI-marker boundary.'
+lastReviewedCommit: 6c2f93fa6fda6ff220c9c5975241bc5739e0b89d
+lastReviewedNote: 'Reviewed for Issue #666: the documented release validation commands cover the refreshed production-ready evidence and final package lock; no command change is required.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -25,8 +25,8 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - package.json
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: b7f2b671323ced00de79b5424cd3d3747b5b0d7f
-lastReviewedNote: 'Updated for Issue #660: the local-operator strategy now distinguishes host CI refusal from image-inherited container markers.'
+lastReviewedCommit: 6c2f93fa6fda6ff220c9c5975241bc5739e0b89d
+lastReviewedNote: 'Reviewed for Issue #666: the release recovery refreshes evidence under the existing authenticated E2E strategy; no strategy change is required.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: b7f2b671323ced00de79b5424cd3d3747b5b0d7f
-lastReviewedNote: 'Updated for Issue #660: recorded the corrected host-CI/local-container boundary for authenticated release E2E.'
+lastReviewedCommit: 6c2f93fa6fda6ff220c9c5975241bc5739e0b89d
+lastReviewedNote: 'Reviewed for Issue #666: the tracked semantic E2E evidence is refreshed and production cleanup is verified; no new testing TODO is required.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -26,8 +26,8 @@ checkPaths:
   - playwright.config.ts
   - package.json
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: b7f2b671323ced00de79b5424cd3d3747b5b0d7f
-lastReviewedNote: 'Updated for Issue #660: documented the two-sided host-CI and local container-marker production-write boundary.'
+lastReviewedCommit: 6c2f93fa6fda6ff220c9c5975241bc5739e0b89d
+lastReviewedNote: 'Reviewed for Issue #666: the controlled production E2E followed the existing create/cleanup evidence pattern; no pattern change is required.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -25,8 +25,8 @@ checkPaths:
   - tests/e2e/i18n/**
   - package.json
 lastReviewedAt: 2026-07-22
-lastReviewedCommit: b7f2b671323ced00de79b5424cd3d3747b5b0d7f
-lastReviewedNote: 'Updated for Issue #660: added diagnosis for host-CI refusal versus inherited container CI markers.'
+lastReviewedCommit: 6c2f93fa6fda6ff220c9c5975241bc5739e0b89d
+lastReviewedNote: 'Reviewed for Issue #666: stale package-lock binding is resolved by regenerating verified evidence on the final candidate; no troubleshooting change is required.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
+    "digest": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "048201d12bb912ee2421dcdf3a104bcee571239c62e4e6a20b3594c6d7cec075",
+          "sha256": "3c5d622a5857278fc3f5cf921eaccd7b08929a1d75a249772d375f6baf572a04",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
+    "docs/plans/i18n/route-view-coverage.json": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-de-DE/glossary.json": "a5fd4e759af2713fbec83f2b95171c7b32206d7218da0401d28d2eecefccce3a",
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "a469726ac0d7ed0095e2dab5189ce3fb72118abc2e117f10278989972d0f2fcf"
+  "contextDigest": "fbc154b2e313525224969997afa54ef9de71ff02eeeecbef69203c7831621a8c"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "a469726ac0d7ed0095e2dab5189ce3fb72118abc2e117f10278989972d0f2fcf",
-    "qualityDigest": "d716a096b77bbf2734b353ee01c12520be9f3da1e564660f1333056b0a8ef8bf",
+    "contextDigest": "fbc154b2e313525224969997afa54ef9de71ff02eeeecbef69203c7831621a8c",
+    "qualityDigest": "9028e87f86bd3d453a80a0da6326fe5b19c765af301326d64f2f991c74889715",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
+    "routeViewCoverageDigest": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "66e258ac7ce73d99649a44f4e6564b9cdbb4e7867e6c7d886a640df7dd13d07c"
+  "activationDigest": "b1adb8186d00490b2212382f91acfde77f0e9a0b3f8fcf95be2ea20cde632bfb"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed",
-    "contextDigest": "a469726ac0d7ed0095e2dab5189ce3fb72118abc2e117f10278989972d0f2fcf"
+    "contextDigest": "fbc154b2e313525224969997afa54ef9de71ff02eeeecbef69203c7831621a8c"
   },
   "catalog": {
     "messageCount": 3032,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "d716a096b77bbf2734b353ee01c12520be9f3da1e564660f1333056b0a8ef8bf"
+  "qualityDigest": "9028e87f86bd3d453a80a0da6326fe5b19c765af301326d64f2f991c74889715"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
+    "digest": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "048201d12bb912ee2421dcdf3a104bcee571239c62e4e6a20b3594c6d7cec075",
+          "sha256": "3c5d622a5857278fc3f5cf921eaccd7b08929a1d75a249772d375f6baf572a04",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
+    "docs/plans/i18n/route-view-coverage.json": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-en-US/glossary.json": "4b8443ea3f91f15383683e9ece6221e40e24ceb75442ea830964b06c12559970",
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "4e18877c7c2094b5d8da2ec09161f1d22c77e0f2d7c5fe117e5ec26d7c488c20"
+  "contextDigest": "f845d421ea3e6c33d0c51786e75ab6bdb954e30dabba092c4cb017b200aa05b7"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4e18877c7c2094b5d8da2ec09161f1d22c77e0f2d7c5fe117e5ec26d7c488c20",
-    "qualityDigest": "66ee956e052eb525a95fcb39131633c4872633ecd771e173fa135b11a392a14e",
+    "contextDigest": "f845d421ea3e6c33d0c51786e75ab6bdb954e30dabba092c4cb017b200aa05b7",
+    "qualityDigest": "490471908c757129d2155beb8044fcd00ae2a3b2e391db1d2cac6fa5af11ada7",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
+    "routeViewCoverageDigest": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "0fb47adf5275fb8dd8577bc7bd6ee94d9d33df607ceea8f363186d488b39a141"
+  "activationDigest": "8cbbe635bad7dac834f3c71210bc328389a31d9be15d53611d6210cedcdc67ee"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed",
-    "contextDigest": "4e18877c7c2094b5d8da2ec09161f1d22c77e0f2d7c5fe117e5ec26d7c488c20"
+    "contextDigest": "f845d421ea3e6c33d0c51786e75ab6bdb954e30dabba092c4cb017b200aa05b7"
   },
   "catalog": {
     "messageCount": 3032,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "66ee956e052eb525a95fcb39131633c4872633ecd771e173fa135b11a392a14e"
+  "qualityDigest": "490471908c757129d2155beb8044fcd00ae2a3b2e391db1d2cac6fa5af11ada7"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
+    "digest": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "048201d12bb912ee2421dcdf3a104bcee571239c62e4e6a20b3594c6d7cec075",
+          "sha256": "3c5d622a5857278fc3f5cf921eaccd7b08929a1d75a249772d375f6baf572a04",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
+    "docs/plans/i18n/route-view-coverage.json": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-fr-FR/glossary.json": "057cb494f02d980106469f6a16befc102d26db5ac362b9777cd5f97c7729c91b",
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "4bc996bb340fa885f8c9502b3510906f94a21eb04c560830c2cf9d3420eca280"
+  "contextDigest": "4217c460cb1eaf823c5746615f6948fa25e69d4bdf9810f1b65805018f81bf3c"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4bc996bb340fa885f8c9502b3510906f94a21eb04c560830c2cf9d3420eca280",
-    "qualityDigest": "0bc0a74cff6d7e7aecef5e9a8d0e812d13047e9fa2df525c3fcf6ee41040d838",
+    "contextDigest": "4217c460cb1eaf823c5746615f6948fa25e69d4bdf9810f1b65805018f81bf3c",
+    "qualityDigest": "1fb71646f75e53a3015a944c316007a643aa2ee4de855f8932eb882e6c513e5a",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
+    "routeViewCoverageDigest": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "4eac43ec91e3e92ee11e86e58303f7561ddccf3d4def38a050ef1062bfb8683c"
+  "activationDigest": "7723cd9fa6cbcc61a080b22cb50d23f4ba2fd9fbc8407b14ad41eb48ddc7aa11"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed",
-    "contextDigest": "4bc996bb340fa885f8c9502b3510906f94a21eb04c560830c2cf9d3420eca280"
+    "contextDigest": "4217c460cb1eaf823c5746615f6948fa25e69d4bdf9810f1b65805018f81bf3c"
   },
   "catalog": {
     "messageCount": 3032,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "0bc0a74cff6d7e7aecef5e9a8d0e812d13047e9fa2df525c3fcf6ee41040d838"
+  "qualityDigest": "1fb71646f75e53a3015a944c316007a643aa2ee4de855f8932eb882e6c513e5a"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
+    "digest": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "048201d12bb912ee2421dcdf3a104bcee571239c62e4e6a20b3594c6d7cec075",
+          "sha256": "3c5d622a5857278fc3f5cf921eaccd7b08929a1d75a249772d375f6baf572a04",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
+    "docs/plans/i18n/route-view-coverage.json": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-zh-CN/glossary.json": "c891add0ee4bd6d24c0213d0c839474e145d85867426df796763b8e038053d9b",
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "4d4b2052788a6d32f5815d60eb3e0c7628f32b82c7c32a326f174ec95f31c10a"
+  "contextDigest": "c0c61d95b12f74c24e48a39fc5f5f7550626a58c6d49ab4da2ad2b53d5e4368f"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4d4b2052788a6d32f5815d60eb3e0c7628f32b82c7c32a326f174ec95f31c10a",
-    "qualityDigest": "e97e496d5287a8eef9732063c9e45258ea4cfc9a1a9d8d9db3f9e7f532eb6027",
+    "contextDigest": "c0c61d95b12f74c24e48a39fc5f5f7550626a58c6d49ab4da2ad2b53d5e4368f",
+    "qualityDigest": "751846100b8269b0aa8e4b354ed0b0444285ee6c30fa13d9b2c5d3ab0b8b9468",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "abc1d308bd666ba591d1a3cb230c423ee39544bacdb6d7344c7866cc54e0d254",
+    "routeViewCoverageDigest": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "3a95fd6210f1306fff263fe67165e2d6f5d45b021faaa94cfce59f8b906c3b07"
+  "activationDigest": "2fbdace08aad3a33781e0d54fc38e4e8014221a72f51bad5f231105dd7bc5ebc"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed",
-    "contextDigest": "4d4b2052788a6d32f5815d60eb3e0c7628f32b82c7c32a326f174ec95f31c10a"
+    "contextDigest": "c0c61d95b12f74c24e48a39fc5f5f7550626a58c6d49ab4da2ad2b53d5e4368f"
   },
   "catalog": {
     "messageCount": 3032,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "e97e496d5287a8eef9732063c9e45258ea4cfc9a1a9d8d9db3f9e7f532eb6027"
+  "qualityDigest": "751846100b8269b0aa8e4b354ed0b0444285ee6c30fa13d9b2c5d3ab0b8b9468"
 }

--- a/docs/plans/i18n/route-view-coverage.json
+++ b/docs/plans/i18n/route-view-coverage.json
@@ -353,7 +353,7 @@
       "executedEvidence": [
         {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "048201d12bb912ee2421dcdf3a104bcee571239c62e4e6a20b3594c6d7cec075"
+          "sha256": "3c5d622a5857278fc3f5cf921eaccd7b08929a1d75a249772d375f6baf572a04"
         }
       ]
     }

--- a/docs/plans/i18n/semantic-e2e-evidence.json
+++ b/docs/plans/i18n/semantic-e2e-evidence.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": "tiangong.i18n-semantic-e2e-evidence.v1",
   "status": "verified",
-  "generatedAt": "2026-07-21T13:16:30.855Z",
-  "runId": "local-16685da0-f047-467b-826e-4a14a4722909",
+  "generatedAt": "2026-07-22T08:58:00.948Z",
+  "runId": "local-6b1ee179-ecbd-464a-8fa9-0dc2bd1d4ca2",
   "candidate": {
     "configTreeDigest": "a5f819459fba99fbf639dbbfd9c6b863672bb2356203113c736ba508b2c8a176",
-    "observedHeadCommit": "804a44c0816076fd5166a6f36764483c7f37aaa8",
-    "packageManifestDigest": "4de95641ba4877d61901bf9f67cfe1f83cd788721b39b74972d302ba2e4a2486",
-    "sourceTreeDigest": "8939ba3cc13c25997f75bb616fbb16e62e57852ae57ab80e8a95e6672051b58b",
-    "unitTestTreeDigest": "0f9266215df76d748c0dacd4bc3151e4d32c250ad03232fcaa83211ab0737c83"
+    "observedHeadCommit": "6c394521e7f950a7034603fcc68fe396228462a8",
+    "packageManifestDigest": "6a0e84db397073141ca2faef8674446aa03bd07b4fb287937f443250d9be5225",
+    "sourceTreeDigest": "5aa2311b857a493eab9755059853e7b3ac3689ac6af88ed795a1447709dac33e",
+    "unitTestTreeDigest": "c6f3c684dada88c46c2db25505b682a4674ce50963e0b09128f4dcf2aee77959"
   },
   "target": {
     "frontend": "candidate-local",
@@ -19,7 +19,7 @@
       "backendTrackedOriginSha256": "bf39ee1b65b9f4b508e97aeb69b704b9fc172f20b7d74e7f24ccfbc515161495",
       "backendTrackedPublishableKeySha256": "f48ee2a57a2e550f6a43fee565727d28865ec821b3cf8e5e08854bd7cc33ba9e",
       "candidateEnvironmentSha256": "e8e821970e6b99bc30b13f7b142b6db5afce7480238f7b178dd67d32fadb4174",
-      "frontendOriginSha256": "aea53e7b670632001d67f90ba2fc0bc6c1ad315c8b88bf5019e01594bfa84966",
+      "frontendOriginSha256": "63767aa5615dabadd32b93fdf0db0c7190c850062ba568114ea4f28b6cdc9e71",
       "freshPlaywrightServer": true,
       "observer": "chromium-auth-request",
       "trackedMainEnvironmentSha256": "e8e821970e6b99bc30b13f7b142b6db5afce7480238f7b178dd67d32fadb4174"
@@ -34,7 +34,7 @@
   "digests": {
     "packageLock": {
       "path": "package-lock.json",
-      "sha256": "05311df9e31427d52d6bf45e2445850315e23a22ad0489f9a07c6af6ce9f5f43"
+      "sha256": "f6982084b05eb7a416508d645f17b7c95dfdef9c9da2c8aa5c4155b5978f2c6f"
     },
     "runtimeAssets": [
       {
@@ -137,7 +137,7 @@
       },
       {
         "path": "playwright.config.ts",
-        "sha256": "131ac48a2a5cac438d0cca681da4ceee014dead9ca641a31c97ed46fc738c9a3"
+        "sha256": "2a9a8e25a097ed7878bf18009177accb318d50b27996a99762fd8a992a6a0ae0"
       },
       {
         "path": "scripts/i18n/locale-delivery.mjs",
@@ -157,11 +157,11 @@
       },
       {
         "path": "tests/e2e/i18n/auth.ts",
-        "sha256": "65b5528396835894644c9b80992edf1b62ccd00eca9a8ef7a236ec06f4b33349"
+        "sha256": "e2a34b56f3f3941b538e865dd585e9ae15e20da862083c0e8dc43e57266ac09d"
       },
       {
         "path": "tests/e2e/i18n/candidate-readiness.ts",
-        "sha256": "3c3caa4860092ef012301c6a2a099b32f17c071c8e9f1606521a6545ebc1b5f5"
+        "sha256": "8f05be640ee568be1fd2a34031c35b392f19cad3691562eaaef7bf7d2b0882c2"
       },
       {
         "path": "tests/e2e/i18n/carbon-footprint-guide.spec.ts",
@@ -173,11 +173,11 @@
       },
       {
         "path": "tests/e2e/i18n/contracts.ts",
-        "sha256": "d6d43ed4e2147b7a3cc7f203f6cb313b8bcb856bb8432969d67b781487bafaee"
+        "sha256": "345b44b33f285323b98ebaab5f3353a7da9e598c3d939d0d54209f47c24b6793"
       },
       {
         "path": "tests/e2e/i18n/evidence-reporter.ts",
-        "sha256": "aa6e2a29633056275a3ae4d384f39f5ee09616a8534311a5f11f09a860c0a598"
+        "sha256": "cb4f29bb95afb916d62b4c81e6f35855eb880ce1da8691d9b90b78c48611d833"
       },
       {
         "path": "tests/e2e/i18n/fixtures.ts",
@@ -213,11 +213,11 @@
       },
       {
         "path": "tests/e2e/i18n/production-backend-target.ts",
-        "sha256": "e166530894ab5199a110b7ae2c7f64be0e50005ada1545a39f7a8d0bd08f5823"
+        "sha256": "d2f4d82be10fef63920e2bcafa3db5f8544d364b6e4910b4a3486a373a4396fe"
       },
       {
         "path": "tests/e2e/i18n/production-data-ledger.ts",
-        "sha256": "7aab896b3f947c85173f4617bc9829bce1d496a366017dd38748e2ad327eb694"
+        "sha256": "dc85d963d17a03ccf5c2bdad8bcf119744963325dce9f5a09d83eb8efe29f7f6"
       },
       {
         "path": "tests/e2e/i18n/production-data-safety.ts",
@@ -321,7 +321,7 @@
       },
       {
         "path": "tests/unit/e2e/evidenceReporter.test.ts",
-        "sha256": "aa603958dc81f7092408721cb8fd6dbd5870ca006280ac6d36a8bdae1e8cd0ab"
+        "sha256": "a61467e8e17859518aedbc35fd9123d841e1db96535c78155db9bbec3216adc7"
       },
       {
         "path": "tests/unit/e2e/productionDataLedger.test.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.55",
+      "version": "0.0.56",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
## 摘要

修复 v0.0.55 发布门禁中语义 E2E 证据未绑定最终 `package-lock.json` 的问题，并准备 v0.0.56 发布候选。

- 将 `package.json` / `package-lock.json` 版本提升到 0.0.56
- 在精确候选提交上运行一次受控、已认证的生产后端 E2E
- 更新受校验的语义 E2E 证据、浏览器证明 SHA 和四个 locale 的派生清单
- 完成 Docpact 要求的发布恢复文档复核记录

## 关键结果

- 语义证据已绑定当前 package lock：`f6982084b05eb7a416508d645f17b7c95dfdef9c9da2c8aa5c4155b5978f2c6f`
- 受控生产数据：创建 1 条、清理 1 条、泄漏 0 条
- 不包含账号、密码、token、截图、trace 或视频等私密材料

## 验证

- 受控 authenticated release E2E：48 passed / 24 designed skips / 0 failed；Chromium、Firefox、WebKit
- `npm run i18n:locale:all:production:check`：4 个 active locale 全部通过
- 相关单测：3 suites / 42 tests 全部通过
- `npm run lint`：通过
- `npm run build`：通过
- `npm run docpact:gate -- --base origin/main --head HEAD`：通过
- checked-push：398 suites / 5,386 tests 全部通过；450/450 源码文件四项覆盖率 100%

## 风险与后续

本 PR 不修改运行时代码，只更新发布版本、验证证据、派生清单和审查元数据。合并到 `main` 后应验证 v0.0.56 release workflow；发布成功后再按分支策略回合并 `main -> dev`，并完成根 workspace 子模块指针集成。

Closes #666
