### PR TITLE
fix(i18n): stabilize WebKit locale switching for v0.0.57

### DIFF
--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
+    "digest": "c3179125cf59cc3a268b82b23e19f29de57fbe5ad6e83b3f826f60b8d8a92521",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "3c5d622a5857278fc3f5cf921eaccd7b08929a1d75a249772d375f6baf572a04",
+          "sha256": "c9a4ec8dc6333300613834c12d227ebafa97a6b5da1ab7abac6dac8115e0e69a",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
+    "docs/plans/i18n/route-view-coverage.json": "c3179125cf59cc3a268b82b23e19f29de57fbe5ad6e83b3f826f60b8d8a92521",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-de-DE/glossary.json": "a5fd4e759af2713fbec83f2b95171c7b32206d7218da0401d28d2eecefccce3a",
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "fbc154b2e313525224969997afa54ef9de71ff02eeeecbef69203c7831621a8c"
+  "contextDigest": "c0dafd9238b8aed62a1e3e9fa093a6792ce4e5833f5a96a54d49b6db18d8c3ec"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "fbc154b2e313525224969997afa54ef9de71ff02eeeecbef69203c7831621a8c",
-    "qualityDigest": "9028e87f86bd3d453a80a0da6326fe5b19c765af301326d64f2f991c74889715",
+    "contextDigest": "c0dafd9238b8aed62a1e3e9fa093a6792ce4e5833f5a96a54d49b6db18d8c3ec",
+    "qualityDigest": "f4cf1275833679bc0a7cea09fb96b21f21d782b226c523e2b28e4698992288a8",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
+    "routeViewCoverageDigest": "c3179125cf59cc3a268b82b23e19f29de57fbe5ad6e83b3f826f60b8d8a92521",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "b1adb8186d00490b2212382f91acfde77f0e9a0b3f8fcf95be2ea20cde632bfb"
+  "activationDigest": "a99c490b57fb3138b6d1c532488768279d9bedcf5b6d3e8e9aa80510e33e5c52"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed",
-    "contextDigest": "fbc154b2e313525224969997afa54ef9de71ff02eeeecbef69203c7831621a8c"
+    "contextDigest": "c0dafd9238b8aed62a1e3e9fa093a6792ce4e5833f5a96a54d49b6db18d8c3ec"
   },
   "catalog": {
     "messageCount": 3032,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "9028e87f86bd3d453a80a0da6326fe5b19c765af301326d64f2f991c74889715"
+  "qualityDigest": "f4cf1275833679bc0a7cea09fb96b21f21d782b226c523e2b28e4698992288a8"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
+    "digest": "c3179125cf59cc3a268b82b23e19f29de57fbe5ad6e83b3f826f60b8d8a92521",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "3c5d622a5857278fc3f5cf921eaccd7b08929a1d75a249772d375f6baf572a04",
+          "sha256": "c9a4ec8dc6333300613834c12d227ebafa97a6b5da1ab7abac6dac8115e0e69a",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
+    "docs/plans/i18n/route-view-coverage.json": "c3179125cf59cc3a268b82b23e19f29de57fbe5ad6e83b3f826f60b8d8a92521",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-en-US/glossary.json": "4b8443ea3f91f15383683e9ece6221e40e24ceb75442ea830964b06c12559970",
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "f845d421ea3e6c33d0c51786e75ab6bdb954e30dabba092c4cb017b200aa05b7"
+  "contextDigest": "d71921ed0337456aa501e643efcc604dddcc7c5410560d47a77d42536251f244"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "f845d421ea3e6c33d0c51786e75ab6bdb954e30dabba092c4cb017b200aa05b7",
-    "qualityDigest": "490471908c757129d2155beb8044fcd00ae2a3b2e391db1d2cac6fa5af11ada7",
+    "contextDigest": "d71921ed0337456aa501e643efcc604dddcc7c5410560d47a77d42536251f244",
+    "qualityDigest": "a4051b8a77bd3da943d1570ea13abe9aa0404366a5379f6b0c16179370670e00",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
+    "routeViewCoverageDigest": "c3179125cf59cc3a268b82b23e19f29de57fbe5ad6e83b3f826f60b8d8a92521",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "8cbbe635bad7dac834f3c71210bc328389a31d9be15d53611d6210cedcdc67ee"
+  "activationDigest": "8b960cacf9b2ac9fa3e773bfcaf7eb51fe8278bb3be79f04496875ec38d7b091"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed",
-    "contextDigest": "f845d421ea3e6c33d0c51786e75ab6bdb954e30dabba092c4cb017b200aa05b7"
+    "contextDigest": "d71921ed0337456aa501e643efcc604dddcc7c5410560d47a77d42536251f244"
   },
   "catalog": {
     "messageCount": 3032,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "490471908c757129d2155beb8044fcd00ae2a3b2e391db1d2cac6fa5af11ada7"
+  "qualityDigest": "a4051b8a77bd3da943d1570ea13abe9aa0404366a5379f6b0c16179370670e00"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
+    "digest": "c3179125cf59cc3a268b82b23e19f29de57fbe5ad6e83b3f826f60b8d8a92521",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "3c5d622a5857278fc3f5cf921eaccd7b08929a1d75a249772d375f6baf572a04",
+          "sha256": "c9a4ec8dc6333300613834c12d227ebafa97a6b5da1ab7abac6dac8115e0e69a",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
+    "docs/plans/i18n/route-view-coverage.json": "c3179125cf59cc3a268b82b23e19f29de57fbe5ad6e83b3f826f60b8d8a92521",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-fr-FR/glossary.json": "057cb494f02d980106469f6a16befc102d26db5ac362b9777cd5f97c7729c91b",
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "4217c460cb1eaf823c5746615f6948fa25e69d4bdf9810f1b65805018f81bf3c"
+  "contextDigest": "94d84d504b5371b8d3b6fc29eaba4e73e1ec54e1c7d4be17bbadc74eaf4d3385"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4217c460cb1eaf823c5746615f6948fa25e69d4bdf9810f1b65805018f81bf3c",
-    "qualityDigest": "1fb71646f75e53a3015a944c316007a643aa2ee4de855f8932eb882e6c513e5a",
+    "contextDigest": "94d84d504b5371b8d3b6fc29eaba4e73e1ec54e1c7d4be17bbadc74eaf4d3385",
+    "qualityDigest": "e03f128421aa82eb7c91b68292fbda0171014178b78368f333aa36d125504dd7",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
+    "routeViewCoverageDigest": "c3179125cf59cc3a268b82b23e19f29de57fbe5ad6e83b3f826f60b8d8a92521",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "7723cd9fa6cbcc61a080b22cb50d23f4ba2fd9fbc8407b14ad41eb48ddc7aa11"
+  "activationDigest": "8bc377eb29e4f63ac24f1a6d3ddbccab4a72ba55d234cfc4b7ab8ea372869021"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed",
-    "contextDigest": "4217c460cb1eaf823c5746615f6948fa25e69d4bdf9810f1b65805018f81bf3c"
+    "contextDigest": "94d84d504b5371b8d3b6fc29eaba4e73e1ec54e1c7d4be17bbadc74eaf4d3385"
   },
   "catalog": {
     "messageCount": 3032,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "1fb71646f75e53a3015a944c316007a643aa2ee4de855f8932eb882e6c513e5a"
+  "qualityDigest": "e03f128421aa82eb7c91b68292fbda0171014178b78368f333aa36d125504dd7"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
+    "digest": "c3179125cf59cc3a268b82b23e19f29de57fbe5ad6e83b3f826f60b8d8a92521",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "3c5d622a5857278fc3f5cf921eaccd7b08929a1d75a249772d375f6baf572a04",
+          "sha256": "c9a4ec8dc6333300613834c12d227ebafa97a6b5da1ab7abac6dac8115e0e69a",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
+    "docs/plans/i18n/route-view-coverage.json": "c3179125cf59cc3a268b82b23e19f29de57fbe5ad6e83b3f826f60b8d8a92521",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-zh-CN/glossary.json": "c891add0ee4bd6d24c0213d0c839474e145d85867426df796763b8e038053d9b",
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "c0c61d95b12f74c24e48a39fc5f5f7550626a58c6d49ab4da2ad2b53d5e4368f"
+  "contextDigest": "10168cee4b492ced4c573764b1b8d786101c1e133a5360c6ac14fd5f63b756fa"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "c0c61d95b12f74c24e48a39fc5f5f7550626a58c6d49ab4da2ad2b53d5e4368f",
-    "qualityDigest": "751846100b8269b0aa8e4b354ed0b0444285ee6c30fa13d9b2c5d3ab0b8b9468",
+    "contextDigest": "10168cee4b492ced4c573764b1b8d786101c1e133a5360c6ac14fd5f63b756fa",
+    "qualityDigest": "7efa5d0361ef42a6e5f1bb4506a19351ac04513853628259b1bbc3ec096585dd",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "b808d3bc904f852b471870c5631f527be7cdd642e256d0b629d2f8b0a634b70a",
+    "routeViewCoverageDigest": "c3179125cf59cc3a268b82b23e19f29de57fbe5ad6e83b3f826f60b8d8a92521",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "2fbdace08aad3a33781e0d54fc38e4e8014221a72f51bad5f231105dd7bc5ebc"
+  "activationDigest": "01257ebedc4e11adde9f185e781b94d3171f0ad549c0f952ef92ef059b30fb7b"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "c098fe56a73b0c0d9925198e395c3e4decc570e7fbcb69fc5d00d5e7d26b73ed",
-    "contextDigest": "c0c61d95b12f74c24e48a39fc5f5f7550626a58c6d49ab4da2ad2b53d5e4368f"
+    "contextDigest": "10168cee4b492ced4c573764b1b8d786101c1e133a5360c6ac14fd5f63b756fa"
   },
   "catalog": {
     "messageCount": 3032,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "751846100b8269b0aa8e4b354ed0b0444285ee6c30fa13d9b2c5d3ab0b8b9468"
+  "qualityDigest": "7efa5d0361ef42a6e5f1bb4506a19351ac04513853628259b1bbc3ec096585dd"
 }

--- a/docs/plans/i18n/route-view-coverage.json
+++ b/docs/plans/i18n/route-view-coverage.json
@@ -353,7 +353,7 @@
       "executedEvidence": [
         {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "3c5d622a5857278fc3f5cf921eaccd7b08929a1d75a249772d375f6baf572a04"
+          "sha256": "c9a4ec8dc6333300613834c12d227ebafa97a6b5da1ab7abac6dac8115e0e69a"
         }
       ]
     }

--- a/docs/plans/i18n/semantic-e2e-evidence.json
+++ b/docs/plans/i18n/semantic-e2e-evidence.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": "tiangong.i18n-semantic-e2e-evidence.v1",
   "status": "verified",
-  "generatedAt": "2026-07-22T08:58:00.948Z",
-  "runId": "local-6b1ee179-ecbd-464a-8fa9-0dc2bd1d4ca2",
+  "generatedAt": "2026-07-22T12:28:45.710Z",
+  "runId": "local-5c2923f7-5266-4dd0-99f4-1f4f8f881eb5",
   "candidate": {
     "configTreeDigest": "a5f819459fba99fbf639dbbfd9c6b863672bb2356203113c736ba508b2c8a176",
-    "observedHeadCommit": "6c394521e7f950a7034603fcc68fe396228462a8",
-    "packageManifestDigest": "6a0e84db397073141ca2faef8674446aa03bd07b4fb287937f443250d9be5225",
+    "observedHeadCommit": "39ecc582c675bb6adf38f972af05c3522baaa8bc",
+    "packageManifestDigest": "aaad56dba2758ccd5baed28f95ae7dc43d5bf86c28650c2cd72b7bb9a9e42355",
     "sourceTreeDigest": "5aa2311b857a493eab9755059853e7b3ac3689ac6af88ed795a1447709dac33e",
-    "unitTestTreeDigest": "c6f3c684dada88c46c2db25505b682a4674ce50963e0b09128f4dcf2aee77959"
+    "unitTestTreeDigest": "ead4be6949e7a93b83834c5e1ffe03910b1a1a780e763f281659d5dd5774aba6"
   },
   "target": {
     "frontend": "candidate-local",
@@ -34,7 +34,7 @@
   "digests": {
     "packageLock": {
       "path": "package-lock.json",
-      "sha256": "f6982084b05eb7a416508d645f17b7c95dfdef9c9da2c8aa5c4155b5978f2c6f"
+      "sha256": "ccfbdb073e16e9f0ada3144b272fabb847ed653ef8ffbc16c03c9d29aa3b48e1"
     },
     "runtimeAssets": [
       {
@@ -229,7 +229,7 @@
       },
       {
         "path": "tests/e2e/i18n/query-responsive.spec.ts",
-        "sha256": "b5d8d0e504de3233c729df92741abb72c6f2d4e3aaca2c52ee14256cccc9f92c"
+        "sha256": "600a08cbea83d1461662f9f3237976dbda7b2382e2a549fbfeb8eaaa54bedc17"
       },
       {
         "path": "tests/e2e/i18n/reference-fixture.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.56",
+      "version": "0.0.57",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",

--- a/tests/e2e/i18n/query-responsive.spec.ts
+++ b/tests/e2e/i18n/query-responsive.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from './fixtures';
 
 import { LOCALE_REGISTRY } from '../../../src/services/general/localeRegistry';
-import { annotateEvidence, findRouteAssertion, readStoredAppLocale } from './contracts';
+import { annotateEvidence, findRouteAssertion, selectAppLocaleThroughUi } from './contracts';
 import { waitForRenderedLoginControl } from './login-route-readiness';
 
 const loginAssertion = findRouteAssertion('/user/login');
@@ -13,13 +13,7 @@ test('locale switching preserves hash query at a narrow viewport', async ({ page
   await waitForRenderedLoginControl(page);
 
   for (const localeDefinition of LOCALE_REGISTRY) {
-    const languageControl = await waitForRenderedLoginControl(page);
-    await languageControl.click();
-    await page
-      .locator('.ant-dropdown-menu-item')
-      .filter({ hasText: localeDefinition.nativeLabel })
-      .click();
-    await expect.poll(() => readStoredAppLocale(page)).toBe(localeDefinition.canonicalLocale);
+    await selectAppLocaleThroughUi(page, localeDefinition.canonicalLocale);
     expect(new URL(page.url()).hash).toContain('codex-e2e=query-preserved');
     await waitForRenderedLoginControl(page);
   }

--- a/tests/unit/e2e/responsiveSurfaceMatrixContract.test.ts
+++ b/tests/unit/e2e/responsiveSurfaceMatrixContract.test.ts
@@ -147,6 +147,18 @@ describe('responsive surface evidence contract', () => {
     );
   });
 
+  it('uses the settled locale-menu contract for the narrow query-preservation scenario', () => {
+    const source = readFileSync(
+      path.resolve(process.cwd(), 'tests/e2e/i18n/query-responsive.spec.ts'),
+      'utf8',
+    );
+    expect(source).toContain(
+      'await selectAppLocaleThroughUi(page, localeDefinition.canonicalLocale);',
+    );
+    expect(source).not.toContain("locator('.ant-dropdown-menu-item')");
+    expect(source).not.toContain('readStoredAppLocale');
+  });
+
   it('scopes persisted authoring rows to an exact Ant Card class token', () => {
     const source = readFileSync(
       path.resolve(process.cwd(), 'tests/e2e/i18n/process-persisted-authoring.spec.ts'),


### PR DESCRIPTION
## Summary

- Stabilize narrow-viewport locale selection in WebKit by using the settled locale-menu interaction helper before asserting persisted locale state.
- Add a static E2E contract that prevents the responsive query-preservation scenario from returning to the racy direct-click pattern.
- Prepare v0.0.57 and bind production-verified semantic E2E evidence to the current package lock and candidate code.

## Root cause

The responsive query-preservation test clicked the WebKit locale menu item directly. On a narrow viewport, the menu open and selection lifecycle could race, leaving `en-US` in storage when the test expected `de-DE`. The shared interaction helper waits for the loader and menu state to settle before selecting the locale.

## Validation

- Controlled production-backend release E2E on candidate `39ecc582`: 48 passed, 24 browser-specific tests skipped by design; exact production fixture result `created=1`, `cleaned=1`, `leaked=0`.
- `npm run i18n:locale:all:production:check`
- `npm run push:checked -- fork codex/fix-issue-666-webkit-locale-menu`
  - 398/398 test suites passed
  - 5387/5387 tests passed
  - 450/450 tracked source files at 100% statements, branches, functions, and lines

## Delivery notes

- No database migration or persistent production test data remains.
- After this release PR merges to `main`, backmerge `main` into `dev` before new daily work diverges.
- Update the root workspace submodule pointer only after the release commit is on child `main`.
- Rollback is a revert of the three commits in this PR.

Closes #666
