### PR TITLE
fix: close release-range Docpact review for v0.0.58

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-07-22"
-lastReviewedCommit: "6c2f93fa6fda6ff220c9c5975241bc5739e0b89d"
-lastReviewedNote: 'Reviewed for Issue #666; the release recovery changes the package version and tracked i18n evidence/artifacts only, with no routing or ownership change required.'
+lastReviewedAt: "2026-07-23"
+lastReviewedCommit: "578438724501bcfd561c496d09240766b5f9b2c8"
+lastReviewedNote: 'Reviewed for Issue #674 across the complete v0.0.57 main release range; routing, ownership, and required-document rules remain unchanged.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,9 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-07-22
-lastReviewedCommit: ff86b9f7349fd70f8da4852904d48e8948bd2e71
-lastReviewedNote: 'Reviewed for Issue #666: the v0.0.56 release recovery follows the existing production E2E and checked-push contract; no repository entry rule changes are required.'
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 578438724501bcfd561c496d09240766b5f9b2c8
+lastReviewedNote: 'Reviewed for Issue #674 across the complete v0.0.57 main release range; repository entry, branch, release, and backmerge rules remain current.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -25,9 +25,9 @@ checkPaths:
   - tests/e2e/i18n/**
   - .github/workflows/i18n-semantic-e2e.yml
   - .nvmrc
-lastReviewedAt: 2026-07-22
-lastReviewedCommit: ff86b9f7349fd70f8da4852904d48e8948bd2e71
-lastReviewedNote: 'Reviewed for Issue #666: the existing development bootstrap already covers production evidence refresh, validation, and checked push; no command changes are required.'
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 578438724501bcfd561c496d09240766b5f9b2c8
+lastReviewedNote: 'Reviewed for Issue #674 across the complete v0.0.57 main release range; development bootstrap and checked-push commands remain current.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -55,9 +55,9 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - .github/workflows/build.yml
   - package.json
-lastReviewedAt: 2026-07-22
-lastReviewedCommit: 6c2f93fa6fda6ff220c9c5975241bc5739e0b89d
-lastReviewedNote: 'Reviewed for Issue #666: verified semantic E2E evidence is bound to the v0.0.56 package lock and records one controlled production-data create/cleanup cycle; locale delivery semantics remain unchanged.'
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 578438724501bcfd561c496d09240766b5f9b2c8
+lastReviewedNote: 'Reviewed for Issue #674 across the complete v0.0.57 main release range; locale delivery, release recovery, and immutable-tag semantics remain current.'
 baselineObservedAt: 2026-07-18
 related:
   - ../../AGENTS.md

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -28,9 +28,9 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-07-22
-lastReviewedCommit: 6c2f93fa6fda6ff220c9c5975241bc5739e0b89d
-lastReviewedNote: 'Reviewed for Issue #666: the existing gate policy already requires final package-lock-bound semantic E2E evidence; no policy change is required.'
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 578438724501bcfd561c496d09240766b5f9b2c8
+lastReviewedNote: 'Reviewed for Issue #674 across the complete v0.0.57 main release range; clarified that release-range Docpact proof is distinct from a feature-branch gate.'
 ---
 
 # Pre-Push Gate Policy
@@ -80,6 +80,7 @@ It does not own:
 | same-push transport retry | permit the repo-owned retry helper only when a managed original push failed after its hook completed and the ignored bounded receipt proves the exact clean HEAD, branch, ref update, remote, toolchain, dependency tree, gate inputs, and Docpact base are unchanged |
 | ordinary GitHub branch pushes | do not run broad duplicate remote test jobs or the Playwright browser matrix |
 | PRs into `dev` or `main` | rely on local test-gate evidence, focused proof, and docpact PR governance; run browser semantic E2E manually only when risk warrants it |
+| `dev -> main` promotion candidate | run Docpact against the current `main` release base and the intended candidate head; a feature-branch or `dev`-relative pass does not close review evidence for the complete release range |
 | semantic E2E `workflow_dispatch` | remains credential-free/read-only and runs the same contract/public browser boundary; it never receives production credentials or authorizes production writes |
 | local authenticated semantic E2E | run `e2e:release` only in an explicitly authorized operator session with a protected runtime-only credential file, archived clean candidate, verified local-bundle/production-backend targeting, explicit authenticated/write/evidence options, and exact cleanup |
 | canonical post-merge `main` pushes | read `package.json.version`, create the matching `v*` tag when missing, run release-gate tests and reusable exact-SHA credential-free semantic E2E, pre-create exactly one tag-scoped draft, then run web deploy and the Electron matrix; the workflow succeeds only after one draft contains the exact 12 expected non-empty assets |
@@ -115,6 +116,7 @@ It does not own:
 - a successful helper transport deletes the receipt; a retry transport failure may retain it only while the remote remains at the bound pre-push SHA and the one-hour TTL is valid, and a pre-transport verification outage performs no push and leaves the bounded receipt available until verification recovers or the TTL expires; expiry, malformed state, controlled-input drift, or any other verified remote state fails closed and invalidates it
 - never invoke `git push --no-verify` or `HUSKY=0` manually; a missing or invalidated receipt requires a new managed push and hook-owned gate run
 - run the lightweight docpact gate before the full local test gate so governed-doc review failures surface early
+- before a `dev -> main` promotion, run `DOCPACT_BASE_REF=origin/main npm run docpact:gate` from the intended candidate head; the post-merge Release Gate repeats this proof against the merge commit's first parent
 - protect the actual local and release gates
 - keep one logical full-suite execution inside each production release workflow; `prepush:gate` runs the receipt suite once in an isolated no-coverage Jest process and every remaining suite once through a coverage-enabled coordinator with only one worker active at a time and a `64MB` idle-memory recycle boundary, so do not precede it with a second standalone `test:ci` or coverage run
 - avoid spending GitHub Actions minutes on ordinary push-triggered test jobs

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -26,9 +26,9 @@ checkPaths:
   - .husky/pre-push
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
-lastReviewedAt: 2026-07-22
-lastReviewedCommit: 6c2f93fa6fda6ff220c9c5975241bc5739e0b89d
-lastReviewedNote: 'Reviewed for Issue #666: the documented release validation commands cover the refreshed production-ready evidence and final package lock; no command change is required.'
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 578438724501bcfd561c496d09240766b5f9b2c8
+lastReviewedNote: 'Reviewed for Issue #674 across the complete v0.0.57 main release range; added the missing promotion-range Docpact proof.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -101,6 +101,8 @@ Authenticated setup may create only UUID-scoped `codex-e2e` process data. It wri
 The shared Header wraps Umi `SelectLang` with `reload={false}`. Browser proof must show that locale switching preserves the current URL and document identity, refreshes locale-bound reference labels in the mounted page, and prevents a delayed response for the old locale from overwriting the current locale.
 
 The local `pre-push` hook always runs `npm run docpact:gate` first, then runs the full `npm run prepush:gate` local test gate on every branch. The docpact gate defaults to `origin/dev` and can be redirected with `DOCPACT_BASE_REF=<ref>` for promote or hotfix branches. For a normal delivery, commit the final controlled tracked change and let that hook own the one authoritative full-gate run; do not manually run the same full gate immediately before pushing. Manual full-gate execution is for a no-push evidence handoff.
+
+A passing feature-branch or `dev`-relative Docpact gate proves only that configured comparison range. Before a `dev -> main` promotion, check out the intended candidate head and run `DOCPACT_BASE_REF=origin/main npm run docpact:gate`; this closes the complete release range that the post-merge Release Gate checks from the merge commit's first parent. If that range reports `missing-review`, genuinely review and update every required governed document before promotion; do not hide active findings with a baseline, waiver, or narrower comparison base.
 
 The hook uses an already-active Node.js 24 from `PATH`, including GitHub `setup-node`, before consulting NVM. It sources NVM and runs `nvm use 24` only when the active Node is missing or has another major version, then fails closed with an explicit version error if Node 24 is still unavailable.
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -24,9 +24,9 @@ checkPaths:
   - docker/e2e/**
   - .github/workflows/i18n-semantic-e2e.yml
   - package.json
-lastReviewedAt: 2026-07-22
-lastReviewedCommit: 6c2f93fa6fda6ff220c9c5975241bc5739e0b89d
-lastReviewedNote: 'Reviewed for Issue #666: the release recovery refreshes evidence under the existing authenticated E2E strategy; no strategy change is required.'
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 578438724501bcfd561c496d09240766b5f9b2c8
+lastReviewedNote: 'Reviewed for Issue #674 across the complete v0.0.57 main release range; the maintained testing strategy remains unchanged.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -25,9 +25,9 @@ checkPaths:
   - tests/**
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
-lastReviewedAt: 2026-07-22
-lastReviewedCommit: 6c2f93fa6fda6ff220c9c5975241bc5739e0b89d
-lastReviewedNote: 'Reviewed for Issue #666: the tracked semantic E2E evidence is refreshed and production cleanup is verified; no new testing TODO is required.'
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 578438724501bcfd561c496d09240766b5f9b2c8
+lastReviewedNote: 'Reviewed for Issue #674 across the complete v0.0.57 main release range; no coverage queue or testing-state change is required.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -25,9 +25,9 @@ checkPaths:
   - docker/e2e/**
   - playwright.config.ts
   - package.json
-lastReviewedAt: 2026-07-22
-lastReviewedCommit: 6c2f93fa6fda6ff220c9c5975241bc5739e0b89d
-lastReviewedNote: 'Reviewed for Issue #666: the controlled production E2E followed the existing create/cleanup evidence pattern; no pattern change is required.'
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 578438724501bcfd561c496d09240766b5f9b2c8
+lastReviewedNote: 'Reviewed for Issue #674 across the complete v0.0.57 main release range; test-selection and release-proof patterns remain current.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -24,9 +24,9 @@ checkPaths:
   - docker/e2e/**
   - tests/e2e/i18n/**
   - package.json
-lastReviewedAt: 2026-07-22
-lastReviewedCommit: 6c2f93fa6fda6ff220c9c5975241bc5739e0b89d
-lastReviewedNote: 'Reviewed for Issue #666: stale package-lock binding is resolved by regenerating verified evidence on the final candidate; no troubleshooting change is required.'
+lastReviewedAt: 2026-07-23
+lastReviewedCommit: 578438724501bcfd561c496d09240766b5f9b2c8
+lastReviewedNote: 'Reviewed for Issue #674 across the complete v0.0.57 main release range; added the release-only missing-review recovery path.'
 ---
 
 # Testing Troubleshooting
@@ -73,6 +73,7 @@ Canonical baseline and proof ownership stays with `DEV.md` and `docs/agents/repo
 | one gate fails only while another Umi-generating command is running locally | concurrent focused tests, coverage, or full gate regenerated shared `.umi-test` | stop or await every heavy command, then rerun only the narrow failed command serially; do not chain broad test, coverage, and full-gate reruns |
 | Jest exits non-zero without a failure or final summary and macOS writes a Node `.ips` report with `ClearStaleLeftTrimmedPointerVisitor` | native Node/V8 GC crash in the long-lived in-band coverage process, not a Jest assertion failure | confirm the crash signature once; keep `prepushGateReceipt.test.ts` in its repo-owned no-coverage process and run the remaining coverage suites through one worker at a time with the `64MB` idle-memory recycle boundary; do not rerun the unchanged monolithic gate |
 | local `docpact:gate` or manual `ai-doc-lint` fails with `missing-review` after runtime, service, or test changes | required governed docs were not reviewed in the same PR | rerun `npm run docpact:gate`, inspect the required docs from `.docpact/config.yaml`, and touch the owning docs with a real review/update |
+| feature/dev Docpact passed but the post-merge Release Gate reports `missing-review` | the earlier gate used a narrower feature or `dev` base, while the release gate checks the complete `main` promotion range | reproduce from the intended candidate with `DOCPACT_BASE_REF=origin/main npm run docpact:gate`, genuinely review every required document, publish a new patch version if an immutable release tag already exists, and backmerge the `main` hotfix to `dev` |
 | `i18n:audit` reports missing, duplicate, or computed message IDs | locale topology drift, one key has multiple owners, or a runtime family is not enumerated | inspect the reported key and callsites, update the canonical manifest/decision record, then rerun the audit before translating or adding an allowlist |
 | language-platform or hardcoding audit reports a new locale/language finding | a registry/Manifest join is incomplete, an alias/adapter conflicts, or business code owns a language literal outside the typed boundary | update the owning registry/Manifest and derive the consumer; use only an exact, issue-owned adapter exception when the literal is an unavoidable external boundary |
 | activation reports `platformContractValid` but `productionActivationReady` is false | the platform structure is valid but a required reference resource is missing, development-only, or not yet official/project-reviewed | inspect `referenceResourceBlockers` and complete the owner Issue; do not relabel an English development base as localized data |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.57",
+      "version": "0.0.58",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
## Summary

- genuinely review and refresh all ten documents required by the full `main` release range
- document that `dev -> main` promotion proof must compare the intended candidate against current `main`
- publish a runtime-equivalent `0.0.58` patch because the failed `v0.0.57` tag is immutable

## Why a new patch version

`v0.0.57` points to `578438724501bcfd561c496d09240766b5f9b2c8`. Recovery dispatch checks out that exact commit, so it cannot consume review evidence added later on `main`. Moving or reusing the tag is forbidden; `0.0.58` is the minimal safe recovery.

## Validation

- `scripts/docpact validate-config --root . --strict`
- `scripts/docpact lint --root . --worktree --mode enforce`
- `npm run docpact:gate -- --base 578438724501bcfd561c496d09240766b5f9b2c8 --head e828d81bb0c7db21faa012f4eaefba5f29b37dc2`
- protected `npm run push:checked -- ...` gate:
  - Docpact: pass
  - LCIA cache: pass
  - reference data: pass
  - ESLint / Prettier / TypeScript: pass
  - Jest: 400 suites, 5,416 tests, all pass
  - coverage: 454/454 tracked source files at 100% statements, branches, functions, and lines
- initial Git transport failed after successful gates; argument-free `npm run push:retry` consumed the bound receipt and pushed the exact commit without rerunning tests

## Release / integration

- merge to `main` triggers canonical creation and release of `v0.0.58`
- after release succeeds, back-merge the resulting `main` hotfix to `dev`
- root workspace must then pin the exact eligible Next `main` commit

Closes #674
