### PR TITLE
fix: send versioned LCIA identities for closure checks

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-07-23'
-lastReviewedCommit: '8d4f4a489484c56068ba54936209127568cf992b'
-lastReviewedNote: 'Reviewed for Issue #676 after the v0.0.58 production-readiness failure; routing, ownership, and required-document rules remain unchanged.'
+lastReviewedCommit: '0706ad1c9808e90c48a029c6e09af04d0b72698f'
+lastReviewedNote: 'Reviewed for Issue #680 production closure payload hotfix; routing, ownership, and required-document rules remain unchanged.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-23
-lastReviewedCommit: 8d4f4a489484c56068ba54936209127568cf992b
-lastReviewedNote: 'Reviewed for Issue #676 after the v0.0.58 production-readiness failure; repository entry, branch, release, and backmerge rules remain current.'
+lastReviewedCommit: 0706ad1c9808e90c48a029c6e09af04d0b72698f
+lastReviewedNote: 'Reviewed for Issue #680 production closure payload hotfix; repository ownership, release, validation, and backmerge rules remain current.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -26,8 +26,8 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - .nvmrc
 lastReviewedAt: 2026-07-23
-lastReviewedCommit: 8d4f4a489484c56068ba54936209127568cf992b
-lastReviewedNote: 'Reviewed for Issue #676 after the v0.0.58 production-readiness failure; development bootstrap and checked-push commands remain current.'
+lastReviewedCommit: 0706ad1c9808e90c48a029c6e09af04d0b72698f
+lastReviewedNote: 'Reviewed for Issue #680 production closure payload hotfix; development bootstrap, focused validation, and checked-push commands remain current.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-07-23
-lastReviewedCommit: 8d4f4a489484c56068ba54936209127568cf992b
-lastReviewedNote: 'Reviewed for Issue #676 after the v0.0.58 production-readiness failure; package-lock evidence now binds executable semantics instead of root release metadata.'
+lastReviewedCommit: 0706ad1c9808e90c48a029c6e09af04d0b72698f
+lastReviewedNote: 'Reviewed for Issue #680 production closure payload hotfix; gate ownership and release-version trigger rules remain current.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - playwright.config.ts
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-07-23
-lastReviewedCommit: 74b36dfcb6abc66623a058873c42a653108f2ac9
-lastReviewedNote: 'Updated for Issue #657 release integration: mapped the data-product closure preflight, unified task-summary feed, and release-E2E read boundary.'
+lastReviewedCommit: 0706ad1c9808e90c48a029c6e09af04d0b72698f
+lastReviewedNote: 'Reviewed for Issue #680 production closure payload hotfix; documented the existing exact LCIA method identity boundary.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -97,7 +97,7 @@ The task-center recovery path is:
 
 `src/components/LcaTaskCenter/index.tsx -> src/services/dataProducts/taskCenter.ts -> app_data_product_commands:list_task_feed`
 
-Next owns scope selection, command orchestration, curated closure-issue presentation, report download initiation, task-summary rendering, and deep-link navigation. Result-package generation remains unavailable until the selected closure check reports `passed`, a `valid` certificate, a `complete` scan, and matching scope/policy evidence; the backend revalidates those facts when it accepts `create_build`.
+Next owns scope selection, command orchestration, curated closure-issue presentation, report download initiation, task-summary rendering, and deep-link navigation. Requested LCIA methods cross the command boundary as exact `{ id, version }` identities derived from the reviewed static catalog; Next must not collapse them to identifier-only strings. Result-package generation remains unavailable until the selected closure check reports `passed`, a `valid` certificate, a `complete` scan, and matching scope/policy evidence; the backend revalidates those facts when it accepts `create_build`.
 
 The global task center consumes only the whitelisted `task-summary.v2` projection for `lcia.scope_closure_check` and `lcia_result.package_build`. It must not decode raw worker rows, payloads, diagnostics, artifact locators, or infer domain validity from worker status. Database, Edge, and Worker remain authoritative for task state, closure evidence, artifacts, and authorization.
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/prepush-gate-receipt.cjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-23
-lastReviewedCommit: 8d4f4a489484c56068ba54936209127568cf992b
-lastReviewedNote: 'Reviewed for Issue #676 after the v0.0.58 production-readiness failure; package-lock binding now distinguishes root release metadata from executable dependency drift.'
+lastReviewedCommit: 0706ad1c9808e90c48a029c6e09af04d0b72698f
+lastReviewedNote: 'Reviewed for Issue #680 production closure payload hotfix; existing page/service proof and release-gate requirements remain sufficient.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -23,8 +23,8 @@ checkPaths:
   - playwright.config.ts
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-07-23
-lastReviewedCommit: 74b36dfcb6abc66623a058873c42a653108f2ac9
-lastReviewedNote: 'Updated for Issue #657 release integration: documented the authenticated data-product command/task-feed boundary and its exact release-E2E read contract.'
+lastReviewedCommit: 0706ad1c9808e90c48a029c6e09af04d0b72698f
+lastReviewedNote: 'Reviewed for Issue #680 production closure payload hotfix; clarified the existing versioned LCIA method command boundary.'
 ---
 
 # Supabase Environment And Database Workflow
@@ -67,7 +67,7 @@ Rules:
 - national-carbon process-flow graph cache reads go through `src/services/nationalCarbonGraphCache/objects.ts` and its signed object bundle; the frontend no longer owns a public cache base URL override and local direct-read debugging paths should not be reintroduced without a new runtime ownership decision
 - ordered-dataset shaping in `src/services/**` stays an app-side boundary even when it mirrors backend schema names
 - persisted Calculation Bundle and release readback go through `src/services/lcaReleases/**`: private bundle reads forward the current user session, public current-release and Process projections may be anonymous, and neither path accepts a service-role credential or exposes private object locators
-- closure checks, closure reports, result-package commands, publication reads, and the unified data-product task feed go through `src/services/dataProducts/**` and authenticated `app_data_product_commands`; Next consumes curated closure and `task-summary.v2` projections rather than worker rows or private artifact locators
+- closure checks, closure reports, result-package commands, publication reads, and the unified data-product task feed go through `src/services/dataProducts/**` and authenticated `app_data_product_commands`; closure requests preserve exact LCIA method `{ id, version }` identities from the reviewed static catalog, and Next consumes curated closure and `task-summary.v2` projections rather than worker rows or private artifact locators
 - Node-loaded smoke workflows may call shared service helpers; runtime fallbacks such as locale detection still belong in `src/services/**` and do not create database schema or Edge runtime ownership
 - app-side service errors must remain distinguishable from successful empty results so localized pages can render truthful error and retry states; this presentation contract does not move schema, authorization, or Edge ownership into Next
 - the authenticated semantic localization E2E is an explicit test-only exception to the shipped `src/services/**` placement rule: direct development mode serves the worktree with `npm run start:main`, while release mode builds and serves the archived clean commit inside its isolated container; both verify the selected Supabase origin against tracked `main`, authenticate as the runtime test user, never use a service-role key, and may create/delete only the exact UUID/version `codex-e2e` process recorded in the primary plus externally mounted recovery ledger

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -25,8 +25,8 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - package.json
 lastReviewedAt: 2026-07-23
-lastReviewedCommit: 8d4f4a489484c56068ba54936209127568cf992b
-lastReviewedNote: 'Reviewed for Issue #676 after the v0.0.58 production-readiness failure; runtime dependency proof now excludes only root release-version metadata.'
+lastReviewedCommit: 0706ad1c9808e90c48a029c6e09af04d0b72698f
+lastReviewedNote: 'Reviewed for Issue #680 production closure payload hotfix; full-closure maintenance strategy remains current.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -26,8 +26,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/test-coverage-report.js
 lastReviewedAt: 2026-07-23
-lastReviewedCommit: 8d4f4a489484c56068ba54936209127568cf992b
-lastReviewedNote: 'Reviewed for Issue #676 after the v0.0.58 production-readiness failure; semantic lock binding now excludes only root release-version metadata.'
+lastReviewedCommit: 0706ad1c9808e90c48a029c6e09af04d0b72698f
+lastReviewedNote: 'Reviewed for Issue #680 production closure payload hotfix; no new ordered coverage queue is required.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -26,8 +26,8 @@ checkPaths:
   - playwright.config.ts
   - package.json
 lastReviewedAt: 2026-07-23
-lastReviewedCommit: 8d4f4a489484c56068ba54936209127568cf992b
-lastReviewedNote: 'Reviewed for Issue #676 after the v0.0.58 production-readiness failure; release proof now tests version-only lock metadata separately from dependency drift.'
+lastReviewedCommit: 0706ad1c9808e90c48a029c6e09af04d0b72698f
+lastReviewedNote: 'Reviewed for Issue #680 production closure payload hotfix; added exact strict-command payload proof guidance.'
 ---
 
 # Testing Patterns Reference
@@ -82,6 +82,7 @@ Special cases:
 - repo integration matrix pattern: use when one service path branches by source, type, or permission
 - permission and URL-state pattern: use when behavior depends on auth, query params, or navigation state
 - data workflow fixture pattern: keep each `tests/data-workflows/fixtures/result/**` expected-result file aligned with its same-scope `fixtures/data/**` payload, workflow lib default path, and unit proof; the fixture relationship map lives in `tests/data-workflows/fixtures/result/README.md`
+- strict command-contract pattern: type the complete client payload, assert its exact serialized shape at the service boundary, and preserve versioned dataset identities as `{ id, version }` rather than weakening tests to identifier-only fixtures
 - escalate to E2E only when browser-only behavior cannot be proved in Jest
 
 ## Component Pattern

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -25,8 +25,8 @@ checkPaths:
   - tests/e2e/i18n/**
   - package.json
 lastReviewedAt: 2026-07-23
-lastReviewedCommit: 8d4f4a489484c56068ba54936209127568cf992b
-lastReviewedNote: 'Reviewed for Issue #676 after the v0.0.58 production-readiness failure; added the version-only package-lock recovery distinction.'
+lastReviewedCommit: 0706ad1c9808e90c48a029c6e09af04d0b72698f
+lastReviewedNote: 'Reviewed for Issue #680 production closure payload hotfix; existing contract-test and release troubleshooting guidance remains current.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "b01253880e05a35766afff22a678f5e820631e970a8c55e2f230cdae4d941bd0",
-    "auditedInputDigest": "925c13d12607859bd96e18491e7bfe7fb6521be7209f0b2b59261ebb402ee79f"
+    "sourceManifestDigest": "f22b2b913ca54c678dd3eddad836c986c4813c7f57a578dd004244cf70127460",
+    "auditedInputDigest": "bdab8d5ce5f62c4c19271970ba58111f469a1bb3445bd55c834c36fc6a76678f"
   },
   "inventory": {
-    "sourceMessageCount": 3061,
-    "localeMessageCount": 3061,
+    "sourceMessageCount": 3062,
+    "localeMessageCount": 3062,
     "leafModuleCount": 30,
     "dynamicFamilyCount": 17,
     "dynamicCallsiteCount": 39,
@@ -44,15 +44,15 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3061,
-    "completeCount": 3061,
+    "messageCount": 3062,
+    "completeCount": 3062,
     "blockedCount": 0,
-    "dossierDigest": "590270380ad926f82117613edba9eee9da03afe70a11fff3715a7341b97f9389",
-    "catalogDigest": "9dcc2c4f29958048c36721627ee6da0b3788c0987ec94bb4ae3426501260d022",
+    "dossierDigest": "f809e2c9c935cd6d38b610c304d4ecc8a461c75f8e4472e376c0973622cb6c03",
+    "catalogDigest": "5783af6b6df22f3e6681c9c54d3b383335a6b8b547205b550fac6f8d44869fad",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
     "roleCounts": {
-      "error-or-validation": 353,
+      "error-or-validation": 354,
       "explanatory-copy": 110,
       "field-guidance": 49,
       "label-or-body-copy": 1234,
@@ -65,15 +65,15 @@
     },
     "stateCounts": {
       "destructive-or-rejecting-action": 43,
-      "failure-or-invalid-input": 353,
+      "failure-or-invalid-input": 354,
       "interactive-ready": 513,
       "retained-not-currently-reachable": 354,
       "successful-completion": 179,
       "visible": 1619
     },
-    "riskCounts": { "high": 1352, "low": 1490, "medium": 219 },
-    "highRiskMessageCount": 1352,
-    "highRiskMessageDigest": "296a58c6f60307c87c5f5dd4f686d97294d286a59ab9d74c9c1ee46cf65e5b7e"
+    "riskCounts": { "high": 1353, "low": 1490, "medium": 219 },
+    "highRiskMessageCount": 1353,
+    "highRiskMessageDigest": "1d6147be32146321d00a1cba9d2d30125004e3b8b2284f798deae98df0664c32"
   },
   "typedContentDossiers": {
     "sourcePath": "src/components/ImportTidasPackage/reportContent.ts",
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4045,
+    "literalReferenceCount": 4046,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale de-DE --message <MESSAGE_ID>"
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "d137eec2902a65581bce1bd1828bcc97987ad77c292ab32d96af980ffa583bd6",
+      "sourceEvidenceDigest": "c5058a61eb75505dc263495c65b9d914fbc756bc9fff1509e26eabfa8a5cbf42",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "b805d63ef90d2ccf7497f655cb970b1244433bf27fa059d2f8389ea9aa0756f6",
+          "sourceDigest": "7074ee5542799f412e61039c48aff377ff861de86e00fc36730e052b6fbada28",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "84b4a893228a3a3b806a7cdd969cef9d136f8ec9082f48a491d91c326bb86c02",
+          "sourceDigest": "091a3615a8eb36fb212e2154184bb94836847f8d0cf2f9d5915d37214d6c3304",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "773b0c752896d035c1820fb988670070f78f6681b6897d0efb6e04504061c67a",
+          "sourceDigest": "d7f434a73f8cb51655c9783fc8e27ec344af18bbb12f70d7745a863ea6712c6e",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -367,7 +367,7 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "6de6b4ab248e493ac6243e0351874e8c6d24633be643f058fed49150642350a7",
+          "sourceDigest": "cd7dd78b91f984eb4d87746c077757d263436d0752388e7146dc228930f75312",
           "focusedTestDigest": "342a74fe96651abf404aa2c6f2212d0c85b6057c35fa5f74d0b91ae0687fcf39",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
@@ -1042,12 +1042,12 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "0a1218aee44a50fd7335eafe141b690c5b15ccc21c06b41b853fa336424cfaf6",
-          "focusedTestDigest": "0105ef30441b5b81b92907d9d5485939156f01fb3874c82af74808208bc0fb99",
+          "sourceDigest": "2688a8c8e1ba9111d60549fa3190091f3a497193b1362785febe678f3338ce30",
+          "focusedTestDigest": "68898c74bd4a7b6b15849fa9a343ce2f3396075bb2529bf8c9188bf2a7eb3696",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
-          "derivedMessageCount": 114,
-          "derivedMessageDigest": "10318a3192185039f6283d62c21554da3a7cbbcd6c3c7937f8649daa7cccfbef",
+          "derivedMessageCount": 115,
+          "derivedMessageDigest": "22c5f996bcbfd7a98b8a9b99febac861c4240779d1b4aceea27b62ed99726a40",
           "stateSignals": ["empty", "error", "loading", "success", "unavailable"],
           "queryParameters": ["tid"],
           "navigationTargets": [
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "e19142154f9cb2620f1db298989a091b8496aec91c253d2bd0bd4f430dc78125",
+      "rowEvidenceDigest": "894d7649f7a9038912b4edd75b22f3f8cdb1916a85161ea1dcddd87146d8ac5a",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "bfc177dca6f5a3f3513dc7ebe0fda8294186438c86fdadab64c5f902dba4b58b"
+  "contextDigest": "591fb6559519b94d66b42d7b28644e97ba5af4e7d91a0bff72f166ef288ca026"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "b01253880e05a35766afff22a678f5e820631e970a8c55e2f230cdae4d941bd0"
+    "sourceManifestDigest": "f22b2b913ca54c678dd3eddad836c986c4813c7f57a578dd004244cf70127460"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "bfc177dca6f5a3f3513dc7ebe0fda8294186438c86fdadab64c5f902dba4b58b",
-    "qualityDigest": "55015ac91555aca6fd9a087c8d665f4791b78f53c1001cc8e146c291b01915c5",
+    "contextDigest": "591fb6559519b94d66b42d7b28644e97ba5af4e7d91a0bff72f166ef288ca026",
+    "qualityDigest": "f2c42c3fa701d26e12fa2fb0adedcde84dc8b34d922f8eefffe5d6a626a19d4c",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
     "routeViewCoverageDigest": "7572961eab49af0ec4c0d173379beb9a54ba9bc87612b5ad6a7fb13fdd69d455",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "b9e7b0ca4d1a4cf3f0738c9ffc62ac982236c92d59cd11b8fddd44e1e427af10"
+  "activationDigest": "f49f16ff5f28c3964e514061e2b3f3c274e984ea6fdaf0084740a0b8c050d428"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,12 +3,12 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "b01253880e05a35766afff22a678f5e820631e970a8c55e2f230cdae4d941bd0",
-    "contextDigest": "bfc177dca6f5a3f3513dc7ebe0fda8294186438c86fdadab64c5f902dba4b58b"
+    "sourceManifestDigest": "f22b2b913ca54c678dd3eddad836c986c4813c7f57a578dd004244cf70127460",
+    "contextDigest": "591fb6559519b94d66b42d7b28644e97ba5af4e7d91a0bff72f166ef288ca026"
   },
   "catalog": {
-    "messageCount": 3061,
-    "catalogDigest": "9dcc2c4f29958048c36721627ee6da0b3788c0987ec94bb4ae3426501260d022",
+    "messageCount": 3062,
+    "catalogDigest": "5783af6b6df22f3e6681c9c54d3b383335a6b8b547205b550fac6f8d44869fad",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
@@ -21,7 +21,7 @@
     "acceptedDeclaredSourceEqualityDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
     "forbiddenGlossaryMatchCount": 0,
     "forbiddenGlossaryMatchDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
-    "suspiciousSourceEqualityRatio": 0.011434171839268212,
+    "suspiciousSourceEqualityRatio": 0.011430437622468974,
     "maxSuspiciousSourceEqualityRatio": 0.02
   },
   "automatedChecks": {
@@ -41,16 +41,16 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "949941cd614bea01de704b969b9d5daf5059f1a8843763e94e52fc06a1dbce11",
-    "validationDigest": "1a88981d76535e21d539e033847de59ba9ea22c399434097945301fb2e68dbe0",
+    "digest": "e595d6fe14e4c6a0be761de1f20299e6e2f7974772bc3454fc51df67ca0f0b2d",
+    "validationDigest": "7c00e8b0a12c6409910ea8892348ca395a76c696a3e32ca42b80e2930bc33a63",
     "laneCount": 1,
-    "validatedMessageCount": 3061,
+    "validatedMessageCount": 3062,
     "validatedModuleCount": 31,
-    "highRiskMessageCount": 1352,
-    "highRiskMessageDigest": "296a58c6f60307c87c5f5dd4f686d97294d286a59ab9d74c9c1ee46cf65e5b7e",
+    "highRiskMessageCount": 1353,
+    "highRiskMessageDigest": "1d6147be32146321d00a1cba9d2d30125004e3b8b2284f798deae98df0664c32",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635",
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "55015ac91555aca6fd9a087c8d665f4791b78f53c1001cc8e146c291b01915c5"
+  "qualityDigest": "f2c42c3fa701d26e12fa2fb0adedcde84dc8b34d922f8eefffe5d6a626a19d4c"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "925c13d12607859bd96e18491e7bfe7fb6521be7209f0b2b59261ebb402ee79f",
-    "validatedMessageCount": 3061,
+    "auditedInputDigest": "bdab8d5ce5f62c4c19271970ba58111f469a1bb3445bd55c834c36fc6a76678f",
+    "validatedMessageCount": 3062,
     "validatedModules": [
       "$entry",
       "component",
@@ -38,12 +38,12 @@
       "settings",
       "validator"
     ],
-    "highRiskMessageCount": 1352,
-    "highRiskMessageDigest": "296a58c6f60307c87c5f5dd4f686d97294d286a59ab9d74c9c1ee46cf65e5b7e",
-    "catalogDigest": "9dcc2c4f29958048c36721627ee6da0b3788c0987ec94bb4ae3426501260d022",
-    "dossierDigest": "590270380ad926f82117613edba9eee9da03afe70a11fff3715a7341b97f9389",
+    "highRiskMessageCount": 1353,
+    "highRiskMessageDigest": "1d6147be32146321d00a1cba9d2d30125004e3b8b2284f798deae98df0664c32",
+    "catalogDigest": "5783af6b6df22f3e6681c9c54d3b383335a6b8b547205b550fac6f8d44869fad",
+    "dossierDigest": "f809e2c9c935cd6d38b610c304d4ecc8a461c75f8e4472e376c0973622cb6c03",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "e19142154f9cb2620f1db298989a091b8496aec91c253d2bd0bd4f430dc78125",
+    "routeEvidenceDigest": "894d7649f7a9038912b4edd75b22f3f8cdb1916a85161ea1dcddd87146d8ac5a",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -92,11 +92,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3061,
-        "messageDigest": "d1e9755caac11fd5d5c5059aa96b7ada7de3435e596a82dfab52f046f14fcbf7",
-        "highRiskMessageCount": 1352,
-        "highRiskMessageDigest": "296a58c6f60307c87c5f5dd4f686d97294d286a59ab9d74c9c1ee46cf65e5b7e",
-        "dossierDigest": "590270380ad926f82117613edba9eee9da03afe70a11fff3715a7341b97f9389",
+        "messageCount": 3062,
+        "messageDigest": "13c60bc9e033e469bfdc4ab8701bc1770ec9541f1da03aa64d2ebe3e61c8dfcf",
+        "highRiskMessageCount": 1353,
+        "highRiskMessageDigest": "1d6147be32146321d00a1cba9d2d30125004e3b8b2284f798deae98df0664c32",
+        "dossierDigest": "f809e2c9c935cd6d38b610c304d4ecc8a461c75f8e4472e376c0973622cb6c03",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "1a88981d76535e21d539e033847de59ba9ea22c399434097945301fb2e68dbe0"
+  "validationDigest": "7c00e8b0a12c6409910ea8892348ca395a76c696a3e32ca42b80e2930bc33a63"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "b01253880e05a35766afff22a678f5e820631e970a8c55e2f230cdae4d941bd0",
-    "auditedInputDigest": "925c13d12607859bd96e18491e7bfe7fb6521be7209f0b2b59261ebb402ee79f"
+    "sourceManifestDigest": "f22b2b913ca54c678dd3eddad836c986c4813c7f57a578dd004244cf70127460",
+    "auditedInputDigest": "bdab8d5ce5f62c4c19271970ba58111f469a1bb3445bd55c834c36fc6a76678f"
   },
   "inventory": {
-    "sourceMessageCount": 3061,
-    "localeMessageCount": 3061,
+    "sourceMessageCount": 3062,
+    "localeMessageCount": 3062,
     "leafModuleCount": 30,
     "dynamicFamilyCount": 17,
     "dynamicCallsiteCount": 39,
@@ -44,15 +44,15 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3061,
-    "completeCount": 3061,
+    "messageCount": 3062,
+    "completeCount": 3062,
     "blockedCount": 0,
-    "dossierDigest": "ac2d7b0afc076cb20f33c32a181dfb7092f147d656cd1cd9fd65e0e3c3947476",
-    "catalogDigest": "4c09464d67b9012bef8d17149ae75fe0c7d0fa95e84df21f0f95b56b6b9d3af8",
+    "dossierDigest": "e66c836b3c37cd8868ad609bd0e58f20e93082c7b45d15b7992c3470dcfb7782",
+    "catalogDigest": "66a9bc94cf8aa5a39a7102b87070d5924a333abe8503e697615aed3625151254",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
     "roleCounts": {
-      "error-or-validation": 353,
+      "error-or-validation": 354,
       "explanatory-copy": 110,
       "field-guidance": 49,
       "label-or-body-copy": 1234,
@@ -65,15 +65,15 @@
     },
     "stateCounts": {
       "destructive-or-rejecting-action": 43,
-      "failure-or-invalid-input": 353,
+      "failure-or-invalid-input": 354,
       "interactive-ready": 513,
       "retained-not-currently-reachable": 354,
       "successful-completion": 179,
       "visible": 1619
     },
-    "riskCounts": { "high": 1352, "low": 1509, "medium": 200 },
-    "highRiskMessageCount": 1352,
-    "highRiskMessageDigest": "296a58c6f60307c87c5f5dd4f686d97294d286a59ab9d74c9c1ee46cf65e5b7e"
+    "riskCounts": { "high": 1353, "low": 1509, "medium": 200 },
+    "highRiskMessageCount": 1353,
+    "highRiskMessageDigest": "1d6147be32146321d00a1cba9d2d30125004e3b8b2284f798deae98df0664c32"
   },
   "typedContentDossiers": {
     "sourcePath": "src/components/ImportTidasPackage/reportContent.ts",
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4045,
+    "literalReferenceCount": 4046,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale en-US --message <MESSAGE_ID>"
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "d137eec2902a65581bce1bd1828bcc97987ad77c292ab32d96af980ffa583bd6",
+      "sourceEvidenceDigest": "c5058a61eb75505dc263495c65b9d914fbc756bc9fff1509e26eabfa8a5cbf42",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "b805d63ef90d2ccf7497f655cb970b1244433bf27fa059d2f8389ea9aa0756f6",
+          "sourceDigest": "7074ee5542799f412e61039c48aff377ff861de86e00fc36730e052b6fbada28",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "84b4a893228a3a3b806a7cdd969cef9d136f8ec9082f48a491d91c326bb86c02",
+          "sourceDigest": "091a3615a8eb36fb212e2154184bb94836847f8d0cf2f9d5915d37214d6c3304",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "773b0c752896d035c1820fb988670070f78f6681b6897d0efb6e04504061c67a",
+          "sourceDigest": "d7f434a73f8cb51655c9783fc8e27ec344af18bbb12f70d7745a863ea6712c6e",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -367,7 +367,7 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "6de6b4ab248e493ac6243e0351874e8c6d24633be643f058fed49150642350a7",
+          "sourceDigest": "cd7dd78b91f984eb4d87746c077757d263436d0752388e7146dc228930f75312",
           "focusedTestDigest": "342a74fe96651abf404aa2c6f2212d0c85b6057c35fa5f74d0b91ae0687fcf39",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
@@ -1042,12 +1042,12 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "0a1218aee44a50fd7335eafe141b690c5b15ccc21c06b41b853fa336424cfaf6",
-          "focusedTestDigest": "0105ef30441b5b81b92907d9d5485939156f01fb3874c82af74808208bc0fb99",
+          "sourceDigest": "2688a8c8e1ba9111d60549fa3190091f3a497193b1362785febe678f3338ce30",
+          "focusedTestDigest": "68898c74bd4a7b6b15849fa9a343ce2f3396075bb2529bf8c9188bf2a7eb3696",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
-          "derivedMessageCount": 114,
-          "derivedMessageDigest": "10318a3192185039f6283d62c21554da3a7cbbcd6c3c7937f8649daa7cccfbef",
+          "derivedMessageCount": 115,
+          "derivedMessageDigest": "22c5f996bcbfd7a98b8a9b99febac861c4240779d1b4aceea27b62ed99726a40",
           "stateSignals": ["empty", "error", "loading", "success", "unavailable"],
           "queryParameters": ["tid"],
           "navigationTargets": [
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "e19142154f9cb2620f1db298989a091b8496aec91c253d2bd0bd4f430dc78125",
+      "rowEvidenceDigest": "894d7649f7a9038912b4edd75b22f3f8cdb1916a85161ea1dcddd87146d8ac5a",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "a2bfa23dbd08e86b6b9b3fc0504321ed8ef00e87a596244dc8389e05323c15ca"
+  "contextDigest": "44687a4076872dff371d5c6169f3df4cac144f89f290b6ca02facd956877f5c4"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "b01253880e05a35766afff22a678f5e820631e970a8c55e2f230cdae4d941bd0"
+    "sourceManifestDigest": "f22b2b913ca54c678dd3eddad836c986c4813c7f57a578dd004244cf70127460"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "a2bfa23dbd08e86b6b9b3fc0504321ed8ef00e87a596244dc8389e05323c15ca",
-    "qualityDigest": "3c586614005ad8d025e53b3f1c32bb7314257ca4aa24bc23bcbc022dbd2fd552",
+    "contextDigest": "44687a4076872dff371d5c6169f3df4cac144f89f290b6ca02facd956877f5c4",
+    "qualityDigest": "e1a93609b4b9102f8d98a945d120a6ebef295ae53c4f12b247fe130f12a37ab5",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
     "routeViewCoverageDigest": "7572961eab49af0ec4c0d173379beb9a54ba9bc87612b5ad6a7fb13fdd69d455",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "834265974a92ba887bbc7585baf471d4d66083c947a0e958465ddd5ea54d824a"
+  "activationDigest": "175ce4a34c09de70e061d060c656a8347d0c6b45478bb2301fea0d32be3b949e"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,25 +3,25 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "b01253880e05a35766afff22a678f5e820631e970a8c55e2f230cdae4d941bd0",
-    "contextDigest": "a2bfa23dbd08e86b6b9b3fc0504321ed8ef00e87a596244dc8389e05323c15ca"
+    "sourceManifestDigest": "f22b2b913ca54c678dd3eddad836c986c4813c7f57a578dd004244cf70127460",
+    "contextDigest": "44687a4076872dff371d5c6169f3df4cac144f89f290b6ca02facd956877f5c4"
   },
   "catalog": {
-    "messageCount": 3061,
-    "catalogDigest": "4c09464d67b9012bef8d17149ae75fe0c7d0fa95e84df21f0f95b56b6b9d3af8",
+    "messageCount": 3062,
+    "catalogDigest": "66a9bc94cf8aa5a39a7102b87070d5924a333abe8503e697615aed3625151254",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
     "cjkLeakCount": 0,
-    "suspiciousSourceEqualityCount": 2983,
-    "suspiciousSourceEqualityDigest": "bbd0022863b1cd6f8c5470b68e391f253afd8234cdbfc73cb0c5c1fca49ae645",
+    "suspiciousSourceEqualityCount": 2984,
+    "suspiciousSourceEqualityDigest": "c3dc44e4ccab3a370c72d2617cf9231e32ed6390224429f85bf649deccc329f4",
     "acceptedTechnicalSourceEqualityCount": 77,
     "acceptedTechnicalSourceEqualityDigest": "b63cc0f26872a7af07a5fc178f16ad44d1c2a5aff02197660f7fb1a649c3eabc",
     "acceptedDeclaredSourceEqualityCount": 0,
     "acceptedDeclaredSourceEqualityDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
     "forbiddenGlossaryMatchCount": 0,
     "forbiddenGlossaryMatchDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
-    "suspiciousSourceEqualityRatio": 0.9745181313296308,
+    "suspiciousSourceEqualityRatio": 0.9745264532984977,
     "maxSuspiciousSourceEqualityRatio": 1
   },
   "automatedChecks": {
@@ -41,16 +41,16 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "1885162c2abb73b1e6ce2e113eec37c3bb9b32fbda7163e97a51964c979a84e4",
-    "validationDigest": "d428daa55243783bcb2f53913dafc91bfb6476c0bf66b42a9045fcb22379863d",
+    "digest": "98f7d08ece516471f5768048b48c3cd2dbe2e89cbf96fff8fad74954248c9e03",
+    "validationDigest": "6fc14524c3afcaa6a47cf908656f4c0d2cf1e6d07e18ea62de7076b33894c797",
     "laneCount": 1,
-    "validatedMessageCount": 3061,
+    "validatedMessageCount": 3062,
     "validatedModuleCount": 31,
-    "highRiskMessageCount": 1352,
-    "highRiskMessageDigest": "296a58c6f60307c87c5f5dd4f686d97294d286a59ab9d74c9c1ee46cf65e5b7e",
+    "highRiskMessageCount": 1353,
+    "highRiskMessageDigest": "1d6147be32146321d00a1cba9d2d30125004e3b8b2284f798deae98df0664c32",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635",
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "3c586614005ad8d025e53b3f1c32bb7314257ca4aa24bc23bcbc022dbd2fd552"
+  "qualityDigest": "e1a93609b4b9102f8d98a945d120a6ebef295ae53c4f12b247fe130f12a37ab5"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "925c13d12607859bd96e18491e7bfe7fb6521be7209f0b2b59261ebb402ee79f",
-    "validatedMessageCount": 3061,
+    "auditedInputDigest": "bdab8d5ce5f62c4c19271970ba58111f469a1bb3445bd55c834c36fc6a76678f",
+    "validatedMessageCount": 3062,
     "validatedModules": [
       "$entry",
       "component",
@@ -38,12 +38,12 @@
       "settings",
       "validator"
     ],
-    "highRiskMessageCount": 1352,
-    "highRiskMessageDigest": "296a58c6f60307c87c5f5dd4f686d97294d286a59ab9d74c9c1ee46cf65e5b7e",
-    "catalogDigest": "4c09464d67b9012bef8d17149ae75fe0c7d0fa95e84df21f0f95b56b6b9d3af8",
-    "dossierDigest": "ac2d7b0afc076cb20f33c32a181dfb7092f147d656cd1cd9fd65e0e3c3947476",
+    "highRiskMessageCount": 1353,
+    "highRiskMessageDigest": "1d6147be32146321d00a1cba9d2d30125004e3b8b2284f798deae98df0664c32",
+    "catalogDigest": "66a9bc94cf8aa5a39a7102b87070d5924a333abe8503e697615aed3625151254",
+    "dossierDigest": "e66c836b3c37cd8868ad609bd0e58f20e93082c7b45d15b7992c3470dcfb7782",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "e19142154f9cb2620f1db298989a091b8496aec91c253d2bd0bd4f430dc78125",
+    "routeEvidenceDigest": "894d7649f7a9038912b4edd75b22f3f8cdb1916a85161ea1dcddd87146d8ac5a",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -92,11 +92,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3061,
-        "messageDigest": "d1e9755caac11fd5d5c5059aa96b7ada7de3435e596a82dfab52f046f14fcbf7",
-        "highRiskMessageCount": 1352,
-        "highRiskMessageDigest": "296a58c6f60307c87c5f5dd4f686d97294d286a59ab9d74c9c1ee46cf65e5b7e",
-        "dossierDigest": "ac2d7b0afc076cb20f33c32a181dfb7092f147d656cd1cd9fd65e0e3c3947476",
+        "messageCount": 3062,
+        "messageDigest": "13c60bc9e033e469bfdc4ab8701bc1770ec9541f1da03aa64d2ebe3e61c8dfcf",
+        "highRiskMessageCount": 1353,
+        "highRiskMessageDigest": "1d6147be32146321d00a1cba9d2d30125004e3b8b2284f798deae98df0664c32",
+        "dossierDigest": "e66c836b3c37cd8868ad609bd0e58f20e93082c7b45d15b7992c3470dcfb7782",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "d428daa55243783bcb2f53913dafc91bfb6476c0bf66b42a9045fcb22379863d"
+  "validationDigest": "6fc14524c3afcaa6a47cf908656f4c0d2cf1e6d07e18ea62de7076b33894c797"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "b01253880e05a35766afff22a678f5e820631e970a8c55e2f230cdae4d941bd0",
-    "auditedInputDigest": "925c13d12607859bd96e18491e7bfe7fb6521be7209f0b2b59261ebb402ee79f"
+    "sourceManifestDigest": "f22b2b913ca54c678dd3eddad836c986c4813c7f57a578dd004244cf70127460",
+    "auditedInputDigest": "bdab8d5ce5f62c4c19271970ba58111f469a1bb3445bd55c834c36fc6a76678f"
   },
   "inventory": {
-    "sourceMessageCount": 3061,
-    "localeMessageCount": 3061,
+    "sourceMessageCount": 3062,
+    "localeMessageCount": 3062,
     "leafModuleCount": 30,
     "dynamicFamilyCount": 17,
     "dynamicCallsiteCount": 39,
@@ -44,15 +44,15 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3061,
-    "completeCount": 3061,
+    "messageCount": 3062,
+    "completeCount": 3062,
     "blockedCount": 0,
-    "dossierDigest": "62e4f639e2720b4306ac0a71fbd066bde396d2d6188ef8964042d07a5bd5b29a",
-    "catalogDigest": "1bba910bf37f4fd1b6e4d4a07b8dbed5fff4761d4580c27e3cca1c857152d485",
+    "dossierDigest": "3315279d14d128e25cbd77e699e9e412febbaaab172602d5280422853613d215",
+    "catalogDigest": "a1aa6ac5e56cf9aea1aa93bd3491fd3043b5e410853bb6d733eb8d6aafa1e65c",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
     "roleCounts": {
-      "error-or-validation": 353,
+      "error-or-validation": 354,
       "explanatory-copy": 110,
       "field-guidance": 49,
       "label-or-body-copy": 1234,
@@ -65,15 +65,15 @@
     },
     "stateCounts": {
       "destructive-or-rejecting-action": 43,
-      "failure-or-invalid-input": 353,
+      "failure-or-invalid-input": 354,
       "interactive-ready": 513,
       "retained-not-currently-reachable": 354,
       "successful-completion": 179,
       "visible": 1619
     },
-    "riskCounts": { "high": 1352, "low": 1489, "medium": 220 },
-    "highRiskMessageCount": 1352,
-    "highRiskMessageDigest": "296a58c6f60307c87c5f5dd4f686d97294d286a59ab9d74c9c1ee46cf65e5b7e"
+    "riskCounts": { "high": 1353, "low": 1489, "medium": 220 },
+    "highRiskMessageCount": 1353,
+    "highRiskMessageDigest": "1d6147be32146321d00a1cba9d2d30125004e3b8b2284f798deae98df0664c32"
   },
   "typedContentDossiers": {
     "sourcePath": "src/components/ImportTidasPackage/reportContent.ts",
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4045,
+    "literalReferenceCount": 4046,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale fr-FR --message <MESSAGE_ID>"
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "d137eec2902a65581bce1bd1828bcc97987ad77c292ab32d96af980ffa583bd6",
+      "sourceEvidenceDigest": "c5058a61eb75505dc263495c65b9d914fbc756bc9fff1509e26eabfa8a5cbf42",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "b805d63ef90d2ccf7497f655cb970b1244433bf27fa059d2f8389ea9aa0756f6",
+          "sourceDigest": "7074ee5542799f412e61039c48aff377ff861de86e00fc36730e052b6fbada28",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "84b4a893228a3a3b806a7cdd969cef9d136f8ec9082f48a491d91c326bb86c02",
+          "sourceDigest": "091a3615a8eb36fb212e2154184bb94836847f8d0cf2f9d5915d37214d6c3304",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "773b0c752896d035c1820fb988670070f78f6681b6897d0efb6e04504061c67a",
+          "sourceDigest": "d7f434a73f8cb51655c9783fc8e27ec344af18bbb12f70d7745a863ea6712c6e",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -367,7 +367,7 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "6de6b4ab248e493ac6243e0351874e8c6d24633be643f058fed49150642350a7",
+          "sourceDigest": "cd7dd78b91f984eb4d87746c077757d263436d0752388e7146dc228930f75312",
           "focusedTestDigest": "342a74fe96651abf404aa2c6f2212d0c85b6057c35fa5f74d0b91ae0687fcf39",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
@@ -1042,12 +1042,12 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "0a1218aee44a50fd7335eafe141b690c5b15ccc21c06b41b853fa336424cfaf6",
-          "focusedTestDigest": "0105ef30441b5b81b92907d9d5485939156f01fb3874c82af74808208bc0fb99",
+          "sourceDigest": "2688a8c8e1ba9111d60549fa3190091f3a497193b1362785febe678f3338ce30",
+          "focusedTestDigest": "68898c74bd4a7b6b15849fa9a343ce2f3396075bb2529bf8c9188bf2a7eb3696",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
-          "derivedMessageCount": 114,
-          "derivedMessageDigest": "10318a3192185039f6283d62c21554da3a7cbbcd6c3c7937f8649daa7cccfbef",
+          "derivedMessageCount": 115,
+          "derivedMessageDigest": "22c5f996bcbfd7a98b8a9b99febac861c4240779d1b4aceea27b62ed99726a40",
           "stateSignals": ["empty", "error", "loading", "success", "unavailable"],
           "queryParameters": ["tid"],
           "navigationTargets": [
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "e19142154f9cb2620f1db298989a091b8496aec91c253d2bd0bd4f430dc78125",
+      "rowEvidenceDigest": "894d7649f7a9038912b4edd75b22f3f8cdb1916a85161ea1dcddd87146d8ac5a",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "f2b200e7a7054d3d377ab54a136226b627f0485e4f26f7f6cf3986a5cb469929"
+  "contextDigest": "a6c476946c4a069a9e602f8d1a08ecc8e4fafc2ac01dfdc134e7acf6d0e8f8b8"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "b01253880e05a35766afff22a678f5e820631e970a8c55e2f230cdae4d941bd0"
+    "sourceManifestDigest": "f22b2b913ca54c678dd3eddad836c986c4813c7f57a578dd004244cf70127460"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "f2b200e7a7054d3d377ab54a136226b627f0485e4f26f7f6cf3986a5cb469929",
-    "qualityDigest": "e5780a11cfb6582a543bdca6ac9063bb505dfb588633de58c544b2caab3948bb",
+    "contextDigest": "a6c476946c4a069a9e602f8d1a08ecc8e4fafc2ac01dfdc134e7acf6d0e8f8b8",
+    "qualityDigest": "58cb0005e39973f36980c965bea6fcb3cd4f9d43b34f569d93905fbbcacb497e",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
     "routeViewCoverageDigest": "7572961eab49af0ec4c0d173379beb9a54ba9bc87612b5ad6a7fb13fdd69d455",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "542783f6f6b557e90b8d4a409dabb2f58030d47342817cc877bf45e8243f7897"
+  "activationDigest": "e3fde0e7afdbdd6f6f0ae43822f18d20f76a6a64df90280dda3ccc50a21273ce"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,12 +3,12 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "b01253880e05a35766afff22a678f5e820631e970a8c55e2f230cdae4d941bd0",
-    "contextDigest": "f2b200e7a7054d3d377ab54a136226b627f0485e4f26f7f6cf3986a5cb469929"
+    "sourceManifestDigest": "f22b2b913ca54c678dd3eddad836c986c4813c7f57a578dd004244cf70127460",
+    "contextDigest": "a6c476946c4a069a9e602f8d1a08ecc8e4fafc2ac01dfdc134e7acf6d0e8f8b8"
   },
   "catalog": {
-    "messageCount": 3061,
-    "catalogDigest": "1bba910bf37f4fd1b6e4d4a07b8dbed5fff4761d4580c27e3cca1c857152d485",
+    "messageCount": 3062,
+    "catalogDigest": "a1aa6ac5e56cf9aea1aa93bd3491fd3043b5e410853bb6d733eb8d6aafa1e65c",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
@@ -41,16 +41,16 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "5c7f60ebc052ed94fc1ab63804ad8a198f7ef211d4962553ab55b38150884eb4",
-    "validationDigest": "05a74f6f332a90087a6cf83706841dd5fbf1222b29ef52cb24ab37fb1535fc9b",
+    "digest": "ce00104d2125b762c1c217a892ae29044f1bfa5a5ec761d6b42356df7b78f534",
+    "validationDigest": "cc9d876f9d27f10f656bf59b0e77a511e19a9b0305ccb79aacfa93aa4c6df631",
     "laneCount": 1,
-    "validatedMessageCount": 3061,
+    "validatedMessageCount": 3062,
     "validatedModuleCount": 31,
-    "highRiskMessageCount": 1352,
-    "highRiskMessageDigest": "296a58c6f60307c87c5f5dd4f686d97294d286a59ab9d74c9c1ee46cf65e5b7e",
+    "highRiskMessageCount": 1353,
+    "highRiskMessageDigest": "1d6147be32146321d00a1cba9d2d30125004e3b8b2284f798deae98df0664c32",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635",
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "e5780a11cfb6582a543bdca6ac9063bb505dfb588633de58c544b2caab3948bb"
+  "qualityDigest": "58cb0005e39973f36980c965bea6fcb3cd4f9d43b34f569d93905fbbcacb497e"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "925c13d12607859bd96e18491e7bfe7fb6521be7209f0b2b59261ebb402ee79f",
-    "validatedMessageCount": 3061,
+    "auditedInputDigest": "bdab8d5ce5f62c4c19271970ba58111f469a1bb3445bd55c834c36fc6a76678f",
+    "validatedMessageCount": 3062,
     "validatedModules": [
       "$entry",
       "component",
@@ -38,12 +38,12 @@
       "settings",
       "validator"
     ],
-    "highRiskMessageCount": 1352,
-    "highRiskMessageDigest": "296a58c6f60307c87c5f5dd4f686d97294d286a59ab9d74c9c1ee46cf65e5b7e",
-    "catalogDigest": "1bba910bf37f4fd1b6e4d4a07b8dbed5fff4761d4580c27e3cca1c857152d485",
-    "dossierDigest": "62e4f639e2720b4306ac0a71fbd066bde396d2d6188ef8964042d07a5bd5b29a",
+    "highRiskMessageCount": 1353,
+    "highRiskMessageDigest": "1d6147be32146321d00a1cba9d2d30125004e3b8b2284f798deae98df0664c32",
+    "catalogDigest": "a1aa6ac5e56cf9aea1aa93bd3491fd3043b5e410853bb6d733eb8d6aafa1e65c",
+    "dossierDigest": "3315279d14d128e25cbd77e699e9e412febbaaab172602d5280422853613d215",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "e19142154f9cb2620f1db298989a091b8496aec91c253d2bd0bd4f430dc78125",
+    "routeEvidenceDigest": "894d7649f7a9038912b4edd75b22f3f8cdb1916a85161ea1dcddd87146d8ac5a",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -92,11 +92,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3061,
-        "messageDigest": "d1e9755caac11fd5d5c5059aa96b7ada7de3435e596a82dfab52f046f14fcbf7",
-        "highRiskMessageCount": 1352,
-        "highRiskMessageDigest": "296a58c6f60307c87c5f5dd4f686d97294d286a59ab9d74c9c1ee46cf65e5b7e",
-        "dossierDigest": "62e4f639e2720b4306ac0a71fbd066bde396d2d6188ef8964042d07a5bd5b29a",
+        "messageCount": 3062,
+        "messageDigest": "13c60bc9e033e469bfdc4ab8701bc1770ec9541f1da03aa64d2ebe3e61c8dfcf",
+        "highRiskMessageCount": 1353,
+        "highRiskMessageDigest": "1d6147be32146321d00a1cba9d2d30125004e3b8b2284f798deae98df0664c32",
+        "dossierDigest": "3315279d14d128e25cbd77e699e9e412febbaaab172602d5280422853613d215",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "05a74f6f332a90087a6cf83706841dd5fbf1222b29ef52cb24ab37fb1535fc9b"
+  "validationDigest": "cc9d876f9d27f10f656bf59b0e77a511e19a9b0305ccb79aacfa93aa4c6df631"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "b01253880e05a35766afff22a678f5e820631e970a8c55e2f230cdae4d941bd0",
-    "auditedInputDigest": "925c13d12607859bd96e18491e7bfe7fb6521be7209f0b2b59261ebb402ee79f"
+    "sourceManifestDigest": "f22b2b913ca54c678dd3eddad836c986c4813c7f57a578dd004244cf70127460",
+    "auditedInputDigest": "bdab8d5ce5f62c4c19271970ba58111f469a1bb3445bd55c834c36fc6a76678f"
   },
   "inventory": {
-    "sourceMessageCount": 3061,
-    "localeMessageCount": 3061,
+    "sourceMessageCount": 3062,
+    "localeMessageCount": 3062,
     "leafModuleCount": 30,
     "dynamicFamilyCount": 17,
     "dynamicCallsiteCount": 39,
@@ -44,15 +44,15 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3061,
-    "completeCount": 3061,
+    "messageCount": 3062,
+    "completeCount": 3062,
     "blockedCount": 0,
-    "dossierDigest": "591ae024de2e08c9903b27c4bd4cb625b25191d7366a971282c8102db50dbbea",
-    "catalogDigest": "0282b25b708930bad56550749f2c38c762923dcfe3b1b3f025369d45f5f822f0",
+    "dossierDigest": "08f637ba7be17088353148dfc3378ac9ccdd1daee0e3817c4327d9241e75cb34",
+    "catalogDigest": "92ec459c8378d146358d91766e7d3e61a56226763c6d1ab2f2b1b43f3c6c880f",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
     "roleCounts": {
-      "error-or-validation": 353,
+      "error-or-validation": 354,
       "explanatory-copy": 110,
       "field-guidance": 49,
       "label-or-body-copy": 1234,
@@ -65,15 +65,15 @@
     },
     "stateCounts": {
       "destructive-or-rejecting-action": 43,
-      "failure-or-invalid-input": 353,
+      "failure-or-invalid-input": 354,
       "interactive-ready": 513,
       "retained-not-currently-reachable": 354,
       "successful-completion": 179,
       "visible": 1619
     },
-    "riskCounts": { "high": 1352, "low": 1541, "medium": 168 },
-    "highRiskMessageCount": 1352,
-    "highRiskMessageDigest": "296a58c6f60307c87c5f5dd4f686d97294d286a59ab9d74c9c1ee46cf65e5b7e"
+    "riskCounts": { "high": 1353, "low": 1541, "medium": 168 },
+    "highRiskMessageCount": 1353,
+    "highRiskMessageDigest": "1d6147be32146321d00a1cba9d2d30125004e3b8b2284f798deae98df0664c32"
   },
   "typedContentDossiers": {
     "sourcePath": "src/components/ImportTidasPackage/reportContent.ts",
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4045,
+    "literalReferenceCount": 4046,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale zh-CN --message <MESSAGE_ID>"
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "d137eec2902a65581bce1bd1828bcc97987ad77c292ab32d96af980ffa583bd6",
+      "sourceEvidenceDigest": "c5058a61eb75505dc263495c65b9d914fbc756bc9fff1509e26eabfa8a5cbf42",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "b805d63ef90d2ccf7497f655cb970b1244433bf27fa059d2f8389ea9aa0756f6",
+          "sourceDigest": "7074ee5542799f412e61039c48aff377ff861de86e00fc36730e052b6fbada28",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "84b4a893228a3a3b806a7cdd969cef9d136f8ec9082f48a491d91c326bb86c02",
+          "sourceDigest": "091a3615a8eb36fb212e2154184bb94836847f8d0cf2f9d5915d37214d6c3304",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "773b0c752896d035c1820fb988670070f78f6681b6897d0efb6e04504061c67a",
+          "sourceDigest": "d7f434a73f8cb51655c9783fc8e27ec344af18bbb12f70d7745a863ea6712c6e",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -367,7 +367,7 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "6de6b4ab248e493ac6243e0351874e8c6d24633be643f058fed49150642350a7",
+          "sourceDigest": "cd7dd78b91f984eb4d87746c077757d263436d0752388e7146dc228930f75312",
           "focusedTestDigest": "342a74fe96651abf404aa2c6f2212d0c85b6057c35fa5f74d0b91ae0687fcf39",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
@@ -1042,12 +1042,12 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "0a1218aee44a50fd7335eafe141b690c5b15ccc21c06b41b853fa336424cfaf6",
-          "focusedTestDigest": "0105ef30441b5b81b92907d9d5485939156f01fb3874c82af74808208bc0fb99",
+          "sourceDigest": "2688a8c8e1ba9111d60549fa3190091f3a497193b1362785febe678f3338ce30",
+          "focusedTestDigest": "68898c74bd4a7b6b15849fa9a343ce2f3396075bb2529bf8c9188bf2a7eb3696",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
-          "derivedMessageCount": 114,
-          "derivedMessageDigest": "10318a3192185039f6283d62c21554da3a7cbbcd6c3c7937f8649daa7cccfbef",
+          "derivedMessageCount": 115,
+          "derivedMessageDigest": "22c5f996bcbfd7a98b8a9b99febac861c4240779d1b4aceea27b62ed99726a40",
           "stateSignals": ["empty", "error", "loading", "success", "unavailable"],
           "queryParameters": ["tid"],
           "navigationTargets": [
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "e19142154f9cb2620f1db298989a091b8496aec91c253d2bd0bd4f430dc78125",
+      "rowEvidenceDigest": "894d7649f7a9038912b4edd75b22f3f8cdb1916a85161ea1dcddd87146d8ac5a",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "004c6cc13ccc3c3e79c34652fcb7cbd1bd18dcf6baffe2bcb05e4d7207e8e988"
+  "contextDigest": "d4f1d38775d9164e28dbf494156ea8f31b3fcf8f3d1cded288ee1cafe22fa1e5"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "b01253880e05a35766afff22a678f5e820631e970a8c55e2f230cdae4d941bd0"
+    "sourceManifestDigest": "f22b2b913ca54c678dd3eddad836c986c4813c7f57a578dd004244cf70127460"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "004c6cc13ccc3c3e79c34652fcb7cbd1bd18dcf6baffe2bcb05e4d7207e8e988",
-    "qualityDigest": "878377a5cbcabe66c5b3b64811b5ce09b4e9f3a31481cd6a559ef2c9be088a30",
+    "contextDigest": "d4f1d38775d9164e28dbf494156ea8f31b3fcf8f3d1cded288ee1cafe22fa1e5",
+    "qualityDigest": "7e0bbb02d80b5a81723c2079f7ee9ff6b7f75c12748fb696e9d163dac79e45a0",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
     "routeViewCoverageDigest": "7572961eab49af0ec4c0d173379beb9a54ba9bc87612b5ad6a7fb13fdd69d455",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "ab574c55cbddd33dea5e49fb8a73a11b51c5cf1655e7860d7b315dee3798b3ec"
+  "activationDigest": "1abe278b165cc7f82974c3dc877852927c0d5dbbd303dfe439ecb27a26732028"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,12 +3,12 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "b01253880e05a35766afff22a678f5e820631e970a8c55e2f230cdae4d941bd0",
-    "contextDigest": "004c6cc13ccc3c3e79c34652fcb7cbd1bd18dcf6baffe2bcb05e4d7207e8e988"
+    "sourceManifestDigest": "f22b2b913ca54c678dd3eddad836c986c4813c7f57a578dd004244cf70127460",
+    "contextDigest": "d4f1d38775d9164e28dbf494156ea8f31b3fcf8f3d1cded288ee1cafe22fa1e5"
   },
   "catalog": {
-    "messageCount": 3061,
-    "catalogDigest": "0282b25b708930bad56550749f2c38c762923dcfe3b1b3f025369d45f5f822f0",
+    "messageCount": 3062,
+    "catalogDigest": "92ec459c8378d146358d91766e7d3e61a56226763c6d1ab2f2b1b43f3c6c880f",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
@@ -41,16 +41,16 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "322ed086cd3cbd2b6e50ba0800cf1aeb600cdc933de0a46a9afc6850ff683677",
-    "validationDigest": "6ddd5501ca172cefeb86e20bc88a05ed986066f4690405c02871b1d05e79dc3a",
+    "digest": "e733c5b602e4f6761322b644dbe1cbfce276a75170bb7af18b8d50fa99f76bf8",
+    "validationDigest": "c3ab4c664121c52823b33dcc734050afbf93341122a22114f4098f14317c0f4b",
     "laneCount": 1,
-    "validatedMessageCount": 3061,
+    "validatedMessageCount": 3062,
     "validatedModuleCount": 31,
-    "highRiskMessageCount": 1352,
-    "highRiskMessageDigest": "296a58c6f60307c87c5f5dd4f686d97294d286a59ab9d74c9c1ee46cf65e5b7e",
+    "highRiskMessageCount": 1353,
+    "highRiskMessageDigest": "1d6147be32146321d00a1cba9d2d30125004e3b8b2284f798deae98df0664c32",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635",
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "878377a5cbcabe66c5b3b64811b5ce09b4e9f3a31481cd6a559ef2c9be088a30"
+  "qualityDigest": "7e0bbb02d80b5a81723c2079f7ee9ff6b7f75c12748fb696e9d163dac79e45a0"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "925c13d12607859bd96e18491e7bfe7fb6521be7209f0b2b59261ebb402ee79f",
-    "validatedMessageCount": 3061,
+    "auditedInputDigest": "bdab8d5ce5f62c4c19271970ba58111f469a1bb3445bd55c834c36fc6a76678f",
+    "validatedMessageCount": 3062,
     "validatedModules": [
       "$entry",
       "component",
@@ -38,12 +38,12 @@
       "settings",
       "validator"
     ],
-    "highRiskMessageCount": 1352,
-    "highRiskMessageDigest": "296a58c6f60307c87c5f5dd4f686d97294d286a59ab9d74c9c1ee46cf65e5b7e",
-    "catalogDigest": "0282b25b708930bad56550749f2c38c762923dcfe3b1b3f025369d45f5f822f0",
-    "dossierDigest": "591ae024de2e08c9903b27c4bd4cb625b25191d7366a971282c8102db50dbbea",
+    "highRiskMessageCount": 1353,
+    "highRiskMessageDigest": "1d6147be32146321d00a1cba9d2d30125004e3b8b2284f798deae98df0664c32",
+    "catalogDigest": "92ec459c8378d146358d91766e7d3e61a56226763c6d1ab2f2b1b43f3c6c880f",
+    "dossierDigest": "08f637ba7be17088353148dfc3378ac9ccdd1daee0e3817c4327d9241e75cb34",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "e19142154f9cb2620f1db298989a091b8496aec91c253d2bd0bd4f430dc78125",
+    "routeEvidenceDigest": "894d7649f7a9038912b4edd75b22f3f8cdb1916a85161ea1dcddd87146d8ac5a",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -92,11 +92,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3061,
-        "messageDigest": "d1e9755caac11fd5d5c5059aa96b7ada7de3435e596a82dfab52f046f14fcbf7",
-        "highRiskMessageCount": 1352,
-        "highRiskMessageDigest": "296a58c6f60307c87c5f5dd4f686d97294d286a59ab9d74c9c1ee46cf65e5b7e",
-        "dossierDigest": "591ae024de2e08c9903b27c4bd4cb625b25191d7366a971282c8102db50dbbea",
+        "messageCount": 3062,
+        "messageDigest": "13c60bc9e033e469bfdc4ab8701bc1770ec9541f1da03aa64d2ebe3e61c8dfcf",
+        "highRiskMessageCount": 1353,
+        "highRiskMessageDigest": "1d6147be32146321d00a1cba9d2d30125004e3b8b2284f798deae98df0664c32",
+        "dossierDigest": "08f637ba7be17088353148dfc3378ac9ccdd1daee0e3817c4327d9241e75cb34",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "6ddd5501ca172cefeb86e20bc88a05ed986066f4690405c02871b1d05e79dc3a"
+  "validationDigest": "c3ab4c664121c52823b33dcc734050afbf93341122a22114f4098f14317c0f4b"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.59",
+      "version": "0.0.60",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",

--- a/src/locales/de-DE/pages.ts
+++ b/src/locales/de-DE/pages.ts
@@ -258,6 +258,7 @@ export default {
   'pages.dataProcessing.validation.packageNameRequired': 'Der Name des Ergebnisdatensatzes ist erforderlich.',
   'pages.dataProcessing.validation.packageIdRequired': 'Ein Ergebnisdatensatz ist erforderlich.',
   'pages.dataProcessing.validation.defaultImpactCategoryRequired': 'Eine Standard-Wirkungskategorie ist erforderlich.',
+  'pages.dataProcessing.validation.defaultImpactCategoryInvalid': 'Die ausgewählte Wirkungskategorie ist nicht verfügbar oder hat keine gültige Version.',
   'pages.dataProcessing.validation.publicationIdRequired': 'Eine Veröffentlichungs-ID ist erforderlich.',
   'pages.dataProcessing.jobs.title': 'Aufgaben zur Ergebnisgenerierung',
   'pages.dataProcessing.taskCenter.kind': 'Datenprodukt',

--- a/src/locales/en-US/pages.ts
+++ b/src/locales/en-US/pages.ts
@@ -258,6 +258,7 @@ export default {
   'pages.dataProcessing.validation.packageNameRequired': 'Result set name is required',
   'pages.dataProcessing.validation.packageIdRequired': 'Result set is required',
   'pages.dataProcessing.validation.defaultImpactCategoryRequired': 'Default impact category is required',
+  'pages.dataProcessing.validation.defaultImpactCategoryInvalid': 'The selected impact category is unavailable or has no valid version.',
   'pages.dataProcessing.validation.publicationIdRequired': 'Publication id is required',
   'pages.dataProcessing.jobs.title': 'Result generation tasks',
   'pages.dataProcessing.taskCenter.kind': 'Data Product',

--- a/src/locales/fr-FR/pages.ts
+++ b/src/locales/fr-FR/pages.ts
@@ -258,6 +258,7 @@ export default {
   'pages.dataProcessing.validation.packageNameRequired': 'Le nom du jeu de résultats est obligatoire',
   'pages.dataProcessing.validation.packageIdRequired': 'Le jeu de résultats est obligatoire',
   'pages.dataProcessing.validation.defaultImpactCategoryRequired': 'La catégorie d’impact par défaut est obligatoire',
+  'pages.dataProcessing.validation.defaultImpactCategoryInvalid': 'La catégorie d’impact sélectionnée est indisponible ou ne possède pas de version valide',
   'pages.dataProcessing.validation.publicationIdRequired': 'L’ID de publication est obligatoire',
   'pages.dataProcessing.jobs.title': 'Tâches de génération des résultats',
   'pages.dataProcessing.taskCenter.kind': 'Produit de données',

--- a/src/locales/zh-CN/pages.ts
+++ b/src/locales/zh-CN/pages.ts
@@ -258,6 +258,7 @@ export default {
   'pages.dataProcessing.validation.packageNameRequired': '请输入结果集名称',
   'pages.dataProcessing.validation.packageIdRequired': '请选择结果集',
   'pages.dataProcessing.validation.defaultImpactCategoryRequired': '请选择默认影响类别',
+  'pages.dataProcessing.validation.defaultImpactCategoryInvalid': '所选影响类别不可用或缺少有效版本',
   'pages.dataProcessing.validation.publicationIdRequired': '请输入发布 ID',
   'pages.dataProcessing.jobs.title': '结果生成任务',
   'pages.dataProcessing.taskCenter.kind': '数据产品',

--- a/src/pages/DataProcessing/index.tsx
+++ b/src/pages/DataProcessing/index.tsx
@@ -12,6 +12,7 @@ import {
   unpublishLciaResultPublication,
   type ClosureCheckIssueV1,
   type ClosureCheckSummaryV1,
+  type ClosureScopeIdentityV1,
   type LciaResultPublication,
 } from '@/services/dataProducts';
 import {
@@ -97,6 +98,7 @@ type LciaMethodListPayload = {
 type ImpactCategoryOption = {
   label: string;
   value: string;
+  version: string;
 };
 
 type LciaResultPackageOption = {
@@ -124,10 +126,27 @@ function newIdempotencyToken(): string {
   return `closure-check-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
-function scopeSelectionKey(values: Record<string, unknown>): string {
+export function selectedImpactCategoryIdentity(
+  value: unknown,
+  options: ImpactCategoryOption[],
+): ClosureScopeIdentityV1 | null {
+  if (typeof value !== 'string') return null;
+  const option = options.find((candidate) => candidate.value === value);
+  return option ? { id: option.value, version: option.version } : null;
+}
+
+export function scopeSelectionKey(
+  values: Record<string, unknown>,
+  options: ImpactCategoryOption[] = [],
+): string {
+  const selectedIdentity = selectedImpactCategoryIdentity(values.defaultImpactCategory, options);
   return JSON.stringify({
     coverageMode: values.coverageMode ?? 'global_eligible',
-    defaultImpactCategory: values.defaultImpactCategory ?? null,
+    defaultImpactCategory:
+      selectedIdentity ??
+      (typeof values.defaultImpactCategory === 'string'
+        ? { id: values.defaultImpactCategory, version: null }
+        : null),
   });
 }
 
@@ -530,20 +549,38 @@ export function buildImpactCategoryOptions(
   payload: LciaMethodListPayload,
   locale: string,
 ): ImpactCategoryOption[] {
-  return (payload.files ?? [])
-    .filter((file) => file.id)
-    .map((file) => {
-      const name = resolveLocalizedText(file.description, locale) || (file.id as string);
-      const unit = resolveLocalizedText(
-        file.referenceQuantity?.['common:shortDescription'],
-        locale,
-      );
-      const suffix = [file.version, unit].filter(Boolean).join(' / ');
-      return {
-        value: file.id as string,
-        label: suffix ? `${name} (${suffix})` : name,
-      };
-    });
+  return (payload.files ?? []).flatMap((file) => {
+    const id = typeof file.id === 'string' ? file.id.trim() : '';
+    const version = typeof file.version === 'string' ? file.version.trim() : '';
+    if (!id || !/^\d{2}\.\d{2}\.\d{3}$/.test(version)) return [];
+
+    const name = resolveLocalizedText(file.description, locale) || id;
+    const unit = resolveLocalizedText(file.referenceQuantity?.['common:shortDescription'], locale);
+    const suffix = [version, unit].filter(Boolean).join(' / ');
+    return [
+      {
+        value: id,
+        version,
+        label: `${name} (${suffix})`,
+      },
+    ];
+  });
+}
+
+export function parseImpactCategoryOptionLabel(label?: string) {
+  if (!label) {
+    return {};
+  }
+  const match = label.match(/^(.*?)\s*\((.*?)\)\s*$/);
+  if (!match) {
+    return { name: label };
+  }
+  const parts = match[2].split('/').map((part) => part.trim());
+  return {
+    name: match[1].trim(),
+    version: parts[0],
+    unit: parts.slice(1).join(' / '),
+  };
 }
 
 const DataProcessing = () => {
@@ -697,12 +734,21 @@ const DataProcessing = () => {
     void getClosureCheck(deepLink.closureCheckId).then((result) => {
       if (!result.error && result.data) {
         setClosureCheck(result.data);
-        const selectionKey = scopeSelectionKey(buildForm.getFieldsValue?.() ?? {});
+        const selectionKey = scopeSelectionKey(
+          buildForm.getFieldsValue?.() ?? {},
+          impactCategoryOptions,
+        );
         setClosureSelectionKey(selectionKey);
         setCurrentSelectionKey(selectionKey);
       }
     });
-  }, [buildForm, deepLink.closureCheckId, isAuthorized]);
+  }, [buildForm, deepLink.closureCheckId, impactCategoryOptions, isAuthorized]);
+
+  useEffect(() => {
+    setCurrentSelectionKey(
+      scopeSelectionKey(buildForm.getFieldsValue?.() ?? {}, impactCategoryOptions),
+    );
+  }, [buildForm, impactCategoryOptions]);
 
   const loadClosureIssues = useCallback(
     async (afterIssueId?: string) => {
@@ -978,7 +1024,7 @@ const DataProcessing = () => {
 
   const handleCreateBuild = async () => {
     const values = await buildForm.validateFields();
-    const selectionKey = scopeSelectionKey(values);
+    const selectionKey = scopeSelectionKey(values, impactCategoryOptions);
     const closureIsUsable =
       closureCheck?.runStatus === 'passed' &&
       closureCheck.certificateValidity === 'valid' &&
@@ -1019,12 +1065,26 @@ const DataProcessing = () => {
 
   const handleCreateClosureCheck = async () => {
     const values = await buildForm.validateFields(['coverageMode', 'defaultImpactCategory']);
-    const selectionKey = scopeSelectionKey(values);
+    const selectedLciaMethod = selectedImpactCategoryIdentity(
+      values.defaultImpactCategory,
+      impactCategoryOptions,
+    );
+    if (!selectedLciaMethod) {
+      setCommandStatus({
+        kind: 'error',
+        message: t(
+          'pages.dataProcessing.validation.defaultImpactCategoryInvalid',
+          'The selected impact category is unavailable or has no valid version.',
+        ),
+      });
+      return;
+    }
+    const selectionKey = scopeSelectionKey(values, impactCategoryOptions);
     const result = await runCommand('createClosureCheck', () =>
       createClosureCheck({
         requestedScope: {
           coverageMode: values.coverageMode || 'global_eligible',
-          lciaMethods: values.defaultImpactCategory ? [values.defaultImpactCategory] : [],
+          lciaMethods: [selectedLciaMethod],
         },
         requestIdempotencyToken: newIdempotencyToken(),
       }),
@@ -1309,7 +1369,7 @@ const DataProcessing = () => {
             coverageMode: 'global_eligible',
           }}
           onValuesChange={(_changedValues, allValues) => {
-            setCurrentSelectionKey(scopeSelectionKey(allValues));
+            setCurrentSelectionKey(scopeSelectionKey(allValues, impactCategoryOptions));
           }}
         >
           <Form.Item
@@ -1504,22 +1564,6 @@ const DataProcessing = () => {
   const impactCategoryLabelById = new Map(
     impactCategoryOptions.map((option) => [option.value, option.label]),
   );
-  const parseLocalImpactLabel = (impactCategoryId?: string) => {
-    const label = impactCategoryId ? impactCategoryLabelById.get(impactCategoryId) : undefined;
-    if (!label) {
-      return {};
-    }
-    const match = label.match(/^(.*?)\s*\((.*?)\)\s*$/);
-    if (!match) {
-      return { name: label };
-    }
-    const parts = match[2].split('/').map((part) => part.trim());
-    return {
-      name: match[1].trim(),
-      version: parts[0],
-      unit: parts.slice(1).join(' / '),
-    };
-  };
   const previewImpactOptionRecords = recordArray(previewData?.impactOptions);
   const fallbackPreviewImpactCategoryId = firstString(
     previewDetailPage.impactCategoryId,
@@ -1570,7 +1614,11 @@ const DataProcessing = () => {
     previewDetailPage.impactKey,
     previewImpactCategoryId,
   );
-  const selectedPreviewImpactLocal = parseLocalImpactLabel(selectedPreviewImpactCategoryId);
+  const selectedPreviewImpactLocal = parseImpactCategoryOptionLabel(
+    selectedPreviewImpactCategoryId
+      ? impactCategoryLabelById.get(selectedPreviewImpactCategoryId)
+      : undefined,
+  );
   const previewValueUnit =
     firstDisplayString(previewDetailPage.unit) ?? selectedPreviewImpactLocal.unit;
   const previewValueTitle = previewValueUnit

--- a/src/services/dataProducts/closure.ts
+++ b/src/services/dataProducts/closure.ts
@@ -57,11 +57,16 @@ export type ClosureCheckSummaryV1 = {
   finishedAt?: string;
 };
 
+export type ClosureScopeIdentityV1 = {
+  id: string;
+  version: string;
+};
+
 export type ClosureCheckRequestV1 = {
   requestedScope: {
     coverageMode: 'global_eligible' | 'subset';
-    processes?: Array<{ id: string; version: string }>;
-    lciaMethods: unknown[];
+    processes?: ClosureScopeIdentityV1[];
+    lciaMethods: ClosureScopeIdentityV1[];
     certificateFreshnessPolicy?: string;
     linkPolicy?: {
       linkSemanticsVersion: string;

--- a/tests/unit/pages/DataProcessing/index.test.tsx
+++ b/tests/unit/pages/DataProcessing/index.test.tsx
@@ -8,7 +8,10 @@ import DataProcessing, {
   packageCountLabel,
   packageOptionsFromTaskSummaries,
   parseDataProcessingDeepLink,
+  parseImpactCategoryOptionLabel,
   resolveLocalizedText,
+  scopeSelectionKey,
+  selectedImpactCategoryIdentity,
   stateCodeCountsFromProcesses,
   stateCodeCountsFromScope,
   stateCodeFromProcess,
@@ -375,7 +378,7 @@ describe('DataProcessing page', () => {
         {
           files: [
             { description: 'Missing id' },
-            { id: 'fallback-name' },
+            { id: 'fallback-name', version: '01.00.000' },
             {
               id: 'string-name',
               description: 'String name',
@@ -389,9 +392,27 @@ describe('DataProcessing page', () => {
         'en-US',
       ),
     ).toEqual([
-      { value: 'fallback-name', label: 'fallback-name' },
-      { value: 'string-name', label: 'String name (01.00.000 / kg eq)' },
+      {
+        value: 'fallback-name',
+        version: '01.00.000',
+        label: 'fallback-name (01.00.000)',
+      },
+      {
+        value: 'string-name',
+        version: '01.00.000',
+        label: 'String name (01.00.000 / kg eq)',
+      },
     ]);
+    expect(parseImpactCategoryOptionLabel('Legacy label without metadata')).toEqual({
+      name: 'Legacy label without metadata',
+    });
+    expect(selectedImpactCategoryIdentity('missing-method', [])).toBeNull();
+    expect(scopeSelectionKey({ defaultImpactCategory: 'missing-method' }, [])).toBe(
+      JSON.stringify({
+        coverageMode: 'global_eligible',
+        defaultImpactCategory: { id: 'missing-method', version: null },
+      }),
+    );
   });
 
   it('covers data-processing display helper fallbacks', () => {
@@ -569,7 +590,7 @@ describe('DataProcessing page', () => {
       expect(mockCreateClosureCheck).toHaveBeenCalledWith({
         requestedScope: {
           coverageMode: 'global_eligible',
-          lciaMethods: ['climate-change'],
+          lciaMethods: [{ id: 'climate-change', version: '01.00.000' }],
         },
         requestIdempotencyToken: expect.any(String),
       }),
@@ -1017,6 +1038,24 @@ describe('DataProcessing page', () => {
       'title',
       expect.stringContaining('The selected data scope is not calculable.'),
     );
+  });
+
+  it('does not submit a closure check without a versioned LCIA method selection', async () => {
+    mockLocation = { pathname: '/data-processing', search: '' };
+    render(<DataProcessing />);
+
+    expect(await screen.findByTestId('page-title')).toHaveTextContent('Data Processing');
+    fireEvent.change(screen.getByLabelText('Result set name'), {
+      target: { value: 'Missing LCIA method' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Check data completeness' }));
+
+    expect(
+      await screen.findByText(
+        'The selected impact category is unavailable or has no valid version.',
+      ),
+    ).toBeInTheDocument();
+    expect(mockCreateClosureCheck).not.toHaveBeenCalled();
   });
 
   it('renders preview input scope and artifact verification details', async () => {
@@ -1526,7 +1565,7 @@ describe('DataProcessing page', () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        files: [{ id: 'plain-impact', description: 'Plain impact' }],
+        files: [{ id: 'plain-impact', version: '01.00.000', description: 'Plain impact' }],
       }),
     });
     mockPreviewLciaResultPackage.mockResolvedValueOnce({
@@ -1561,7 +1600,7 @@ describe('DataProcessing page', () => {
     render(<DataProcessing />);
 
     expect(await screen.findByTestId('page-title')).toHaveTextContent('Data Processing');
-    await screen.findByText('Plain impact');
+    await screen.findByText('Plain impact (01.00.000)');
     fireEvent.click(screen.getByTestId('tab-preview'));
     fireEvent.change(screen.getByLabelText('Select result set'), {
       target: { value: 'package-1' },
@@ -2010,6 +2049,9 @@ describe('DataProcessing page', () => {
       fireEvent.change(screen.getByLabelText('Result set name'), {
         target: { value: 'Closure summary check' },
       });
+      fireEvent.change(screen.getByLabelText('Default impact category'), {
+        target: { value: 'climate-change' },
+      });
       fireEvent.click(screen.getByRole('button', { name: 'Check data completeness' }));
 
       expect(await screen.findByText(expectedMessage)).toBeInTheDocument();
@@ -2034,6 +2076,9 @@ describe('DataProcessing page', () => {
       fireEvent.change(screen.getByLabelText('Coverage mode'), {
         target: { value: '' },
       });
+      fireEvent.change(screen.getByLabelText('Default impact category'), {
+        target: { value: 'climate-change' },
+      });
       fireEvent.click(screen.getByRole('button', { name: 'Check data completeness' }));
 
       await waitFor(() =>
@@ -2054,7 +2099,7 @@ describe('DataProcessing page', () => {
       );
 
       fireEvent.change(screen.getByLabelText('Default impact category'), {
-        target: { value: 'climate-change' },
+        target: { value: 'acidification' },
       });
       expect(
         await screen.findByText(

--- a/tests/unit/services/dataProducts/taskCenter.test.ts
+++ b/tests/unit/services/dataProducts/taskCenter.test.ts
@@ -126,11 +126,22 @@ describe('Data Product TaskSummaryV2 safe projection', () => {
       });
 
     const created = await createClosureCheck({
-      requestedScope: { coverageMode: 'global_eligible', lciaMethods: [] },
+      requestedScope: {
+        coverageMode: 'global_eligible',
+        lciaMethods: [{ id: '11111111-1111-4111-8111-111111111111', version: '01.00.000' }],
+      },
       requestIdempotencyToken: 'request-1',
     });
     const summary = await getClosureCheck('closure-1');
 
+    expect(invokeDataProductCommand).toHaveBeenNthCalledWith(1, {
+      action: 'create_closure_check',
+      requestedScope: {
+        coverageMode: 'global_eligible',
+        lciaMethods: [{ id: '11111111-1111-4111-8111-111111111111', version: '01.00.000' }],
+      },
+      requestIdempotencyToken: 'request-1',
+    });
     expect(created.data).toEqual({
       closureCheckId: 'closure-1',
       requestedScopeHash: 'scope-hash',
@@ -708,7 +719,10 @@ describe('Data Product TaskSummaryV2 safe projection', () => {
     });
     await expect(
       createClosureCheck({
-        requestedScope: { coverageMode: 'global_eligible', lciaMethods: [] },
+        requestedScope: {
+          coverageMode: 'global_eligible',
+          lciaMethods: [{ id: '11111111-1111-4111-8111-111111111111', version: '01.00.000' }],
+        },
         requestIdempotencyToken: 'invalid-result',
       }),
     ).resolves.toMatchObject({


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#680

## Summary
- Send the selected LCIA method as an exact {id, version} identity when starting data-completeness checks.
- Reject stale or unversioned impact-category selections in the client before the command reaches the Edge Function.

## Key Decisions
- Keep the Edge Function fail-closed contract unchanged; repair the production Next payload at its source.
- Bind closure certificates to the exact selected method identity so a version change invalidates prior preflight state.

## Validation
- Authoritative pre-push gate: 401/401 suites and 5422/5422 tests passed; 454/454 tracked source files reached 100% statements, branches, functions, and lines.
- Focused DataProcessing/data-product tests: 50/50 passed; i18n regression suites: 27/27 passed; lint, TypeScript, reference-data, Docpact, and four-locale audits passed.

## Risks / Rollback
- Low and fail-closed: the change narrows closure-check requests to versioned LCIA identities; rollback is reverting this PR and package version 0.0.60.

## Follow-ups
- After merge, deploy the main release and verify the production data-completeness command no longer returns Invalid data product command payload.
- Backmerge main to dev after the hotfix release.

## Workspace Integration
- After the child main release is verified, update the lca-workspace Next submodule pointer through the normal integration flow.