### PR TITLE
test: stabilize semantic role-boundary evidence

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-29"
-lastReviewedCommit: "16dcca003930ec1720fbb96566cd445273983aa2"
-lastReviewedNote: 'Reviewed for Issues #698, #703, and #704 during the v0.0.62 back-merge: fresh production evidence supersedes the active #703 waiver and stale digest pairs without changing routing or ownership; #704 retains the runner repairs.'
+lastReviewedCommit: "103b83b8610b714c36cc90cb9e26b1fb7536928a"
+lastReviewedNote: 'Reviewed for Issue #711: deterministic standard-user semantic route evidence stays within the existing i18n/testing ownership and routing contract.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 16dcca003930ec1720fbb96566cd445273983aa2
-lastReviewedNote: 'Reviewed for Issues #698, #703, and #704 during the v0.0.62 back-merge: fresh evidence and waiver sunset preserve repo ownership, dev-to-main delivery, production-write guards, managed-push rules, and workspace integration.'
+lastReviewedCommit: aaf4be377df8dc84bc755f93ea4ffc0858936fe7
+lastReviewedNote: 'Reviewed for Issue #711: the audited standard-user semantic fixture preserves repo ownership, dev-to-main delivery, production-write guards, managed-push rules, and workspace integration.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 16dcca003930ec1720fbb96566cd445273983aa2
-lastReviewedNote: 'Reviewed for Issues #698, #703, and #704 during the v0.0.62 back-merge: bootstrap, exact-candidate proof, guarded cleanup, canonical artifact generation, main-relative Docpact, and managed push remain unchanged.'
+lastReviewedCommit: aaf4be377df8dc84bc755f93ea4ffc0858936fe7
+lastReviewedNote: 'Reviewed for Issue #711: deterministic role-boundary evidence does not change bootstrap, exact-candidate proof, guarded cleanup, canonical artifact generation, main-relative Docpact, or managed push.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -56,9 +56,9 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - .github/workflows/build.yml
   - package.json
-lastReviewedAt: 2026-07-28
-lastReviewedCommit: 61b2158f9de009278371bb40e0217160933025cb
-lastReviewedNote: 'Reviewed for Issues #698, #703, and #704 during the v0.0.62 back-merge: the fresh authenticated proof supersedes the active skip waiver while preserving exact cleanup, credential-free CI, and the existing language-delivery contract.'
+lastReviewedAt: 2026-07-29
+lastReviewedCommit: 103b83b8610b714c36cc90cb9e26b1fb7536928a
+lastReviewedNote: 'Reviewed for Issue #711: the audited standard-user role fixture makes route-boundary evidence independent of the production actor role while preserving credential-free CI and local-only production-data safeguards.'
 baselineObservedAt: 2026-07-18
 related:
   - ../../AGENTS.md

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 16dcca003930ec1720fbb96566cd445273983aa2
-lastReviewedNote: 'Reviewed for Issues #698, #703, and #704 during the v0.0.62 back-merge: fresh evidence retires the active release-candidate waiver, exact non-browser mappings remain fail closed, and main-target managed-push policy is unchanged.'
+lastReviewedCommit: 103b83b8610b714c36cc90cb9e26b1fb7536928a
+lastReviewedNote: 'Reviewed for Issue #711: deterministic role-boundary evidence remains audited read-only browser proof and does not change managed-push or protected-branch gate policy.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 16dcca003930ec1720fbb96566cd445273983aa2
-lastReviewedNote: 'Reviewed for Issues #698, #703, and #704 during the v0.0.62 back-merge: the authorized production run, exact cleanup, canonical evidence, focused proof, artifact idempotence, release preflight, and managed-push gates remain the required closure.'
+lastReviewedCommit: 103b83b8610b714c36cc90cb9e26b1fb7536928a
+lastReviewedNote: 'Reviewed for Issue #711: role-boundary semantic proof now uses an exact audited standard-user fixture; authenticated evidence, cleanup, release preflight, and managed gates remain required.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 16dcca003930ec1720fbb96566cd445273983aa2
-lastReviewedNote: 'Reviewed for Issues #698, #703, and #704 during the v0.0.62 back-merge: fresh evidence sunsets the one-time waiver and redundant pairs without expanding browser scope; #704 retains the isolated harness repairs.'
+lastReviewedCommit: 103b83b8610b714c36cc90cb9e26b1fb7536928a
+lastReviewedNote: 'Reviewed for Issue #711: the standard-user route fixture removes production-role variance without expanding browser scope or changing the improvement backlog.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 16dcca003930ec1720fbb96566cd445273983aa2
-lastReviewedNote: 'Updated for Issues #698, #703, and #704 during the replacement v0.0.62 back-merge: recorded fresh production proof, exact cleanup, waiver sunset, remaining exact harness pairs, and why the pre-#707 back-merge was superseded; #704 retains its follow-ups and the coverage queue remains empty.'
+lastReviewedCommit: 103b83b8610b714c36cc90cb9e26b1fb7536928a
+lastReviewedNote: 'Reviewed for Issue #711: deterministic route-role proof closes the production-actor variance; no new coverage or harness follow-up remains.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 16dcca003930ec1720fbb96566cd445273983aa2
-lastReviewedNote: 'Reviewed for Issues #698, #703, and #704 during the v0.0.62 back-merge: active waivers and exact mappings must represent real current mismatches and retire when fresh evidence covers them; #704 retains its repairs.'
+lastReviewedCommit: 103b83b8610b714c36cc90cb9e26b1fb7536928a
+lastReviewedNote: 'Reviewed for Issue #711: exact audited synthetic reads are the retained pattern for role-neutral route-boundary evidence; no waiver or broad fallback was added.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 16dcca003930ec1720fbb96566cd445273983aa2
-lastReviewedNote: 'Reviewed for Issues #698, #703, and #704 during the v0.0.62 back-merge: canonical regeneration and exact harness mappings resolve post-evidence drift, fresh evidence retires the active waiver, and #704 retains the resume repair.'
+lastReviewedCommit: 103b83b8610b714c36cc90cb9e26b1fb7536928a
+lastReviewedNote: 'Reviewed for Issue #711: production-actor role drift is resolved through the exact audited standard-user route fixture, not by weakening access-boundary assertions.'
 ---
 
 # Testing Troubleshooting

--- a/tests/e2e/i18n/route-inventory.spec.ts
+++ b/tests/e2e/i18n/route-inventory.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from './fixtures';
+import { expect, test, type Page, type Route } from './fixtures';
 
 import { signInViaUi } from './auth';
 import {
@@ -14,8 +14,51 @@ import {
   spaLocationToCandidateUrl,
   type SpaLocationTarget,
 } from './contracts';
-import { installVerifiedProductionReadOnlyGuard } from './production-backend-target';
-import { assertNoBlockedProductionRequests } from './production-request-guard';
+import {
+  installVerifiedProductionReadOnlyGuard,
+  readVerifiedProductionBackendTarget,
+} from './production-backend-target';
+import {
+  assertAuditedSyntheticReadRequest,
+  assertNoBlockedProductionRequests,
+} from './production-request-guard';
+
+const ROLES_API_PATTERN = '**/rest/v1/roles?*';
+const productionBackendTarget = readVerifiedProductionBackendTarget();
+
+async function fulfillStandardUserRole(route: Route): Promise<boolean> {
+  if (route.request().method() === 'OPTIONS') {
+    await route.fallback();
+    return false;
+  }
+  const requestTarget = new URL(route.request().url());
+  const userFilter = requestTarget.searchParams.get('user_id') ?? '';
+  expect(userFilter).toMatch(/^eq\.[0-9a-f-]+$/iu);
+  assertAuditedSyntheticReadRequest(route.request(), {
+    expectedOrigin: productionBackendTarget.origin,
+    expectedPublishableKey: productionBackendTarget.publishableKey,
+    method: 'GET',
+    pathname: '/rest/v1/roles',
+    searchParams: {
+      select: 'user_id,role',
+      team_id: 'eq.00000000-0000-0000-0000-000000000000',
+      user_id: userFilter,
+    },
+  });
+  await route.fulfill({
+    // Route-boundary evidence is defined for a standard authenticated user. Keep that
+    // boundary deterministic even when the supplied production actor owns elevated roles.
+    body: JSON.stringify([]),
+    contentType: 'application/json',
+    headers: {
+      'access-control-allow-origin': '*',
+      'access-control-expose-headers': 'content-range',
+      'content-range': '*/0',
+    },
+    status: 200,
+  });
+  return true;
+}
 
 function readSpaLocation(page: Page): SpaLocationTarget {
   const hash = new URL(page.url()).hash.slice(1);
@@ -61,6 +104,16 @@ test('Chromium route semantics inventory closes every stable assertion ID', asyn
 
   expect(baseURL).toBeTruthy();
   await signInViaUi(page);
+  let fulfilledStandardRoleReads = 0;
+  await page.route(ROLES_API_PATTERN, async (route) => {
+    if (new URL(page.url()).hash.split('?')[0] !== '#/data-processing') {
+      await route.fallback();
+      return;
+    }
+    if (await fulfillStandardUserRole(route)) {
+      fulfilledStandardRoleReads += 1;
+    }
+  });
   const anonymousContext = await browser.newContext({
     locale: 'en-US',
     serviceWorkers: 'block',
@@ -187,6 +240,7 @@ test('Chromium route semantics inventory closes every stable assertion ID', asyn
         }
       });
     }
+    expect(fulfilledStandardRoleReads).toBeGreaterThan(0);
   } finally {
     await anonymousContext.close();
     assertNoBlockedProductionRequests(anonymousProductionRequestGuard);

--- a/tests/unit/e2e/productionRequestGuard.test.ts
+++ b/tests/unit/e2e/productionRequestGuard.test.ts
@@ -914,6 +914,17 @@ describe('production browser request guard', () => {
     expect(auditedCalls).toHaveLength(fulfillCalls.length);
   });
 
+  it('keeps the standard-user route fixture behind the audited fulfill classifier', () => {
+    const source = readFileSync(
+      path.join(REPOSITORY_ROOT, 'tests/e2e/i18n/route-inventory.spec.ts'),
+      'utf8',
+    );
+    const fulfillCalls = source.match(/await route[.]fulfill[(]/gu) ?? [];
+    const auditedCalls = source.match(/assertAuditedSyntheticReadRequest[(]/gu) ?? [];
+    expect(fulfillCalls).toHaveLength(1);
+    expect(auditedCalls).toHaveLength(fulfillCalls.length);
+  });
+
   it('records blocked requests as method and pathname only', async () => {
     const { guard, routeHandler } = await makeInstalledGuard({});
     const abort = jest.fn(async () => undefined);


### PR DESCRIPTION
## Summary
- make route-boundary semantic evidence deterministic for the declared standard authenticated user
- synthesize an empty system-role projection only on `/data-processing`, through the existing exact audited read classifier
- preserve the separate typed Data Processing manager fixture and all production write/cleanup guards

## Finding
The protected production actor used by the canonical release runner currently has the `data_product_manager` role. The route inventory contract declares the `/data-processing` assertion as a standard-user access boundary, so reading the actor real role made that assertion depend on credential assignment. The dedicated typed Data Processing assertions already inject manager access independently.

## Validation
- canonical focused authenticated diagnostic: Chromium route inventory 1/1 passed, 49 stable assertions × 4 locales
- managed pre-push: Docpact pass; cache/reference-data pass; lint/Prettier/TypeScript pass
- Jest receipt suite: 31/31
- complete coverage: 404 suites, 5,482 tests; 456/456 tracked source files at 100/100/100/100
- production writes in the diagnostic: none

## Safety
- no credential values, auth state, or production actor identifiers are persisted
- synthetic response is permitted only after exact origin, publishable key, pathname, query, method, and read-only classifier checks
- no application/runtime behavior changes

Refs #711
Refs tiangong-lca/workspace#511