### PR TITLE
test: make production role-boundary evidence deterministic

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-07-29"
-lastReviewedCommit: "d0042d063b4cffd1363b346df69ee8ab6242da2e"
-lastReviewedNote: 'Reviewed for Issue #722: the tracked semantic-harness qualification receipt remains governed by the existing testing-and-gate contract; the required-doc and ownership sets remain correct.'
+lastReviewedAt: '2026-07-29'
+lastReviewedCommit: 'ab3003ed063f6651f37a8c8c4a136be266b563c0'
+lastReviewedNote: 'Reviewed for Issue #724: deterministic data-processing role-boundary evidence remains governed by the existing semantic-E2E and testing contracts; the required-doc and ownership sets remain correct.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: d0042d063b4cffd1363b346df69ee8ab6242da2e
-lastReviewedNote: 'Reviewed for Issue #722: the tracked qualification receipt and clean-candidate production-E2E sequence fit the existing repository ownership, delivery, and managed-push boundaries.'
+lastReviewedCommit: 336ae0226b99014b070fe9114fc17a41cf819aae
+lastReviewedNote: 'Reviewed for Issue #724: deterministic role-boundary proof and its refreshed qualification receipt remain within the existing repository ownership, delivery, and managed-push boundaries.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: d0042d063b4cffd1363b346df69ee8ab6242da2e
-lastReviewedNote: 'Reviewed for Issue #722: qualification generates one tracked receipt that must merge through dev before the clean authorized production-E2E candidate runs.'
+lastReviewedCommit: 336ae0226b99014b070fe9114fc17a41cf819aae
+lastReviewedNote: 'Reviewed for Issue #724: the exact role-boundary fix follows the existing qualify, commit-receipt, focused-production-proof, and managed-push sequence.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -57,8 +57,8 @@ checkPaths:
   - .github/workflows/build.yml
   - package.json
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 357778f9ca2f9ed3f10d79d617a027ff87a451c5
-lastReviewedNote: 'Reviewed for Issues #704, #711, and #713 after the latest dev merge: canonical locale evidence, credential-free CI, local-only production safeguards, and the language-delivery contract remain unchanged by the Process search cutover.'
+lastReviewedCommit: ab3003ed063f6651f37a8c8c4a136be266b563c0
+lastReviewedNote: 'Reviewed for Issue #724: qualification and authenticated production proof now require the same exact data-processing role fulfillment; the 49-ID, credential, write-safety, and cleanup contracts remain unchanged.'
 baselineObservedAt: 2026-07-18
 related:
   - ../../AGENTS.md

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: d0042d063b4cffd1363b346df69ee8ab6242da2e
-lastReviewedNote: 'Reviewed for Issue #722: qualification updates one tracked receipt that must land through a clean dev PR before production release proof; the managed-push and production-write policies remain fail closed.'
+lastReviewedCommit: ab3003ed063f6651f37a8c8c4a136be266b563c0
+lastReviewedNote: 'Reviewed for Issue #724: the refreshed qualification receipt and test-only fix still require one clean managed push; production-write authorization and release-evidence policies remain fail closed.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: d0042d063b4cffd1363b346df69ee8ab6242da2e
-lastReviewedNote: 'Reviewed for Issue #722: a successful semantic-harness qualification must land its generated tracked receipt through a clean dev PR before authenticated production release proof.'
+lastReviewedCommit: ab3003ed063f6651f37a8c8c4a136be266b563c0
+lastReviewedNote: 'Reviewed for Issue #724: the route-inventory fix and refreshed qualification receipt follow the existing clean-candidate, focused-production-proof, and managed-gate workflow without changing validation commands.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: d0042d063b4cffd1363b346df69ee8ab6242da2e
-lastReviewedNote: 'Reviewed for Issue #722: the existing three-browser qualification and tracked-receipt workflow remains sufficient; no expansion of the semantic matrix is required.'
+lastReviewedCommit: ab3003ed063f6651f37a8c8c4a136be266b563c0
+lastReviewedNote: 'Reviewed for Issue #724: exact role-boundary fulfillment removes the qualification false positive within the existing three-browser matrix; no strategy or matrix expansion is required.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: d0042d063b4cffd1363b346df69ee8ab6242da2e
-lastReviewedNote: 'Reviewed for Issue #722: the coverage queue remains empty; the exact Edge mirror gate and current three-browser qualification refresh the maintained full-closure baseline.'
+lastReviewedCommit: ab3003ed063f6651f37a8c8c4a136be266b563c0
+lastReviewedNote: 'Reviewed for Issue #724: the coverage queue remains empty; deterministic role-boundary fulfillment closes a release-harness false positive without adding a new testing backlog item.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: d0042d063b4cffd1363b346df69ee8ab6242da2e
-lastReviewedNote: 'Reviewed for Issue #722: qualification-receipt generation, review, and clean-candidate reuse now form an explicit release-E2E pattern; the browser scope is unchanged.'
+lastReviewedCommit: ab3003ed063f6651f37a8c8c4a136be266b563c0
+lastReviewedNote: 'Reviewed for Issue #724: hash-only role-boundary navigation now uses the existing fresh-document and exact-request-fulfillment pattern; qualification and production share one assertion path.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: d0042d063b4cffd1363b346df69ee8ab6242da2e
-lastReviewedNote: 'Reviewed for Issue #722: release recovery now explicitly distinguishes a stale qualification receipt from the expected dirty tree produced by successful qualification.'
+lastReviewedCommit: ab3003ed063f6651f37a8c8c4a136be266b563c0
+lastReviewedNote: 'Reviewed for Issue #724: a zero exact-role-fulfillment count is resolved through deterministic document reload and targeted proof, not by widening request counts or retrying production blindly.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "66f8c18975f5426652af75b3526fc85517905cab1919428509ad0ab7f3ef0fc6"
+    "runResultSha256": "72b8266014c3a76b7d4b33dd858d1fffb478229336388e9cc41b6fdecfa0bcea"
   },
-  "environmentManifestSha256": "90b1e2bc919eb3b38ca1895160fa54874e6066eb3bd5f3946519db65a5464776",
+  "environmentManifestSha256": "88192656e4d46eddcf12f4b53b423a59c0e2e66e36b619ce8535fbc37d2c05ad",
   "externalRequests": 0,
-  "generatedAt": "2026-07-29T17:35:55.977Z",
+  "generatedAt": "2026-07-29T18:38:16.753Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "58bcead4351447e72c844ccf7de2aff7f4e6fef01c4c1d0760a7e8011713fdfc",
-  "qualifiedCommit": "d0042d063b4cffd1363b346df69ee8ab6242da2e",
-  "qualifiedTree": "ae8194aa3ca4702150ace9cbefc73fdcbc79c73a",
+  "qualificationInputSha256": "b37fcaab86674353c2c7d4ad22c2712da7a8d6fca8ae783cb1d55af1767ed155",
+  "qualifiedCommit": "730aa5493125450367564d96ea3da1cc500d71dc",
+  "qualifiedTree": "3bb8c2415105ea31ec392ad6c44b02a26125ae01",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }

--- a/tests/e2e/i18n/route-inventory.spec.ts
+++ b/tests/e2e/i18n/route-inventory.spec.ts
@@ -93,7 +93,6 @@ test('Chromium route semantics inventory closes every stable assertion ID', asyn
   browser,
   browserName,
   page,
-  productionRequestGuard,
 }, testInfo) => {
   // This is intentionally one auditable matrix: 49 stable route assertions × four locales.
   // Keep the timeout local so ordinary focused E2E tests retain the stricter suite default.
@@ -108,17 +107,17 @@ test('Chromium route semantics inventory closes every stable assertion ID', asyn
   );
 
   expect(baseURL).toBeTruthy();
-  let fulfilledStandardRoleReads = 0;
+  await signInViaUi(page);
+  const standardRoleReads = { fulfilled: 0 };
   await page.route(ROLES_API_PATTERN, async (route) => {
     if (new URL(page.url()).hash.split('?')[0] !== '#/data-processing') {
       await route.fallback();
       return;
     }
     if (await fulfillStandardUserRole(route)) {
-      fulfilledStandardRoleReads += 1;
+      standardRoleReads.fulfilled += 1;
     }
   });
-  await signInViaUi(page);
   const anonymousContext = await browser.newContext({
     locale: 'en-US',
     serviceWorkers: 'block',
@@ -163,9 +162,23 @@ test('Chromium route semantics inventory closes every stable assertion ID', asyn
 
               // The product selector changes locale in the mounted document. This exercises the
               // same transition users perform and preserves the authenticated session and URL state.
+              const standardRoleReadsBeforeNavigation = standardRoleReads.fulfilled;
               await assertionPage.goto(spaLocationToCandidateUrl(baseURL!, target.navigate), {
                 waitUntil: 'domcontentloaded',
               });
+              if (
+                assertionPage === page &&
+                target.kind === 'role-boundary' &&
+                target.navigate.hashPath === '/data-processing'
+              ) {
+                // Hash-only navigation can reuse the mounted application without issuing a fresh
+                // role read. Reload so the exact standard-user route fulfillment proves this
+                // boundary in both qualification and authenticated production runs.
+                await assertionPage.reload({ waitUntil: 'domcontentloaded' });
+                await expect
+                  .poll(() => standardRoleReads.fulfilled)
+                  .toBeGreaterThan(standardRoleReadsBeforeNavigation);
+              }
               await expect.poll(() => readSpaLocation(assertionPage)).toEqual(target.expected);
               if (target.localeTransition === 'storage-reload') {
                 await setStoredAppLocale(assertionPage, locale);
@@ -247,13 +260,7 @@ test('Chromium route semantics inventory closes every stable assertion ID', asyn
         }
       });
     }
-    if (process.env.E2E_QUALIFICATION === 'true' && 'requestCounts' in productionRequestGuard) {
-      expect(
-        (productionRequestGuard.requestCounts as Record<string, number>)['GET /rest/v1/roles'],
-      ).toBeGreaterThan(0);
-    } else {
-      expect(fulfilledStandardRoleReads).toBeGreaterThan(0);
-    }
+    expect(standardRoleReads.fulfilled).toBeGreaterThan(0);
   } finally {
     await anonymousContext.close();
     if (


### PR DESCRIPTION
## Summary

- force a fresh document load before proving the authenticated `/data-processing` standard-user boundary
- require the exact audited synthetic roles fulfillment to advance before the boundary assertion
- use that same exact assertion in local qualification and authenticated production execution, removing the broad qualification-only roles count
- refresh the tracked qualification receipt and record the required Docpact reviews

## Why

The complete authenticated production semantic E2E on canonical dev reached 59 passed / 24 designed skips / 1 failed because the new role-boundary counter remained zero. Hash-only navigation could reuse the mounted application without a fresh role read, while qualification accepted an unrelated broader roles-request count. The defect was in the release harness, not `OPENAI_API_KEY`, Hybrid Search, or production application behavior.

The failed run closed its only fixture safely: `created=1`, `cleaned=1`, `leaked=0`; verified evidence was withheld.

## Validation

- ESLint, Prettier, TypeScript: passed
- semantic-harness qualification: 60 passed / 24 designed skips; 49/49 assertion IDs; 0 external requests; 0 production writes; cleanup 0/0/0
- authenticated production-backed focused Chromium route inventory: 1/1 passed; read-only; no production fixture
- Docpact: 12 changed paths / 13 matched rules; strict config and lint passed
- managed checked-push gate: LCIA/reference resources, lint/typecheck, full Jest coverage, and 456/456 source files at 100% statements/branches/functions/lines passed
- initial Git transport failed after gates; bounded `push:retry` succeeded without rerunning them

## Risk

Test-only behavior plus governed review metadata. No application, schema, Edge runtime, credential, authorization, or production-write policy changes.

Closes #724

Parent: tiangong-lca/workspace#512
