### PR TITLE
test(e2e): record verified production evidence

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-07-29'
-lastReviewedCommit: 'd6e1c29e8e7b5e2434391d1f6c96b029abd10765'
-lastReviewedNote: 'Reviewed for Issue #724: the refreshed qualification receipt for the production-evidence commit remains governed by the existing testing contract; required-doc and ownership sets remain correct.'
+lastReviewedCommit: 'af58e108e6bd350fca71f070c245f2ee0a26b527'
+lastReviewedNote: 'Reviewed for Issue #724: obsolete semantic-evidence digest compatibility entries are removed after exact production evidence supersedes them; required-doc and ownership sets remain correct.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-07-29'
-lastReviewedCommit: 'ab3003ed063f6651f37a8c8c4a136be266b563c0'
-lastReviewedNote: 'Reviewed for Issue #724: deterministic data-processing role-boundary evidence remains governed by the existing semantic-E2E and testing contracts; the required-doc and ownership sets remain correct.'
+lastReviewedCommit: '82ed0855eed7c855c5298f6568c707b3e3b4eced'
+lastReviewedNote: 'Reviewed for Issue #724: verified production evidence and regenerated locale artifacts remain governed by the existing semantic-E2E and testing contracts; the required-doc and ownership sets remain correct.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-07-29'
-lastReviewedCommit: '82ed0855eed7c855c5298f6568c707b3e3b4eced'
-lastReviewedNote: 'Reviewed for Issue #724: verified production evidence and regenerated locale artifacts remain governed by the existing semantic-E2E and testing contracts; the required-doc and ownership sets remain correct.'
+lastReviewedCommit: 'd6e1c29e8e7b5e2434391d1f6c96b029abd10765'
+lastReviewedNote: 'Reviewed for Issue #724: the refreshed qualification receipt for the production-evidence commit remains governed by the existing testing contract; required-doc and ownership sets remain correct.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: d6e1c29e8e7b5e2434391d1f6c96b029abd10765
-lastReviewedNote: 'Reviewed for Issue #724: the refreshed qualification receipt remains within the existing repository ownership, release-evidence, and managed-push boundaries.'
+lastReviewedCommit: af58e108e6bd350fca71f070c245f2ee0a26b527
+lastReviewedNote: 'Reviewed for Issue #724: retiring superseded semantic-evidence compatibility entries remains within the existing repository ownership, release-evidence, and managed-push boundaries.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 336ae0226b99014b070fe9114fc17a41cf819aae
-lastReviewedNote: 'Reviewed for Issue #724: deterministic role-boundary proof and its refreshed qualification receipt remain within the existing repository ownership, delivery, and managed-push boundaries.'
+lastReviewedCommit: 82ed0855eed7c855c5298f6568c707b3e3b4eced
+lastReviewedNote: 'Reviewed for Issue #724: verified production evidence delivery remains within the existing repository ownership, release, and managed-push boundaries.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 82ed0855eed7c855c5298f6568c707b3e3b4eced
-lastReviewedNote: 'Reviewed for Issue #724: verified production evidence delivery remains within the existing repository ownership, release, and managed-push boundaries.'
+lastReviewedCommit: d6e1c29e8e7b5e2434391d1f6c96b029abd10765
+lastReviewedNote: 'Reviewed for Issue #724: the refreshed qualification receipt remains within the existing repository ownership, release-evidence, and managed-push boundaries.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 82ed0855eed7c855c5298f6568c707b3e3b4eced
-lastReviewedNote: 'Reviewed for Issue #724: verified production evidence follows the existing qualify, authenticated release run, derived-artifact refresh, and managed-push sequence.'
+lastReviewedCommit: d6e1c29e8e7b5e2434391d1f6c96b029abd10765
+lastReviewedNote: 'Reviewed for Issue #724: the refreshed qualification receipt follows the existing clean-candidate, three-browser qualify, and managed-push sequence.'
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 336ae0226b99014b070fe9114fc17a41cf819aae
-lastReviewedNote: 'Reviewed for Issue #724: the exact role-boundary fix follows the existing qualify, commit-receipt, focused-production-proof, and managed-push sequence.'
+lastReviewedCommit: 82ed0855eed7c855c5298f6568c707b3e3b4eced
+lastReviewedNote: 'Reviewed for Issue #724: verified production evidence follows the existing qualify, authenticated release run, derived-artifact refresh, and managed-push sequence.'
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: d6e1c29e8e7b5e2434391d1f6c96b029abd10765
-lastReviewedNote: 'Reviewed for Issue #724: the refreshed qualification receipt follows the existing clean-candidate, three-browser qualify, and managed-push sequence.'
+lastReviewedCommit: af58e108e6bd350fca71f070c245f2ee0a26b527
+lastReviewedNote: 'Reviewed for Issue #724: retiring superseded digest compatibility entries follows the existing canonical-evidence, focused-contract-test, and managed-push sequence.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -57,8 +57,8 @@ checkPaths:
   - .github/workflows/build.yml
   - package.json
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: ab3003ed063f6651f37a8c8c4a136be266b563c0
-lastReviewedNote: 'Reviewed for Issue #724: qualification and authenticated production proof now require the same exact data-processing role fulfillment; the 49-ID, credential, write-safety, and cleanup contracts remain unchanged.'
+lastReviewedCommit: 82ed0855eed7c855c5298f6568c707b3e3b4eced
+lastReviewedNote: 'Reviewed for Issue #724: the verified 60-pass production run preserves the 49-ID, credential, write-safety, cleanup, and explicit-promotion-confirmation contracts.'
 baselineObservedAt: 2026-07-18
 related:
   - ../../AGENTS.md

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: ab3003ed063f6651f37a8c8c4a136be266b563c0
-lastReviewedNote: 'Reviewed for Issue #724: the refreshed qualification receipt and test-only fix still require one clean managed push; production-write authorization and release-evidence policies remain fail closed.'
+lastReviewedCommit: 82ed0855eed7c855c5298f6568c707b3e3b4eced
+lastReviewedNote: 'Reviewed for Issue #724: production-evidence delivery still requires one clean managed push; production-write authorization and release-evidence policies remain fail closed.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 82ed0855eed7c855c5298f6568c707b3e3b4eced
-lastReviewedNote: 'Reviewed for Issue #724: production-evidence delivery still requires one clean managed push; production-write authorization and release-evidence policies remain fail closed.'
+lastReviewedCommit: d6e1c29e8e7b5e2434391d1f6c96b029abd10765
+lastReviewedNote: 'Reviewed for Issue #724: the refreshed qualification receipt still requires one clean managed push; production-write authorization and release-evidence policies remain fail closed.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: d6e1c29e8e7b5e2434391d1f6c96b029abd10765
-lastReviewedNote: 'Reviewed for Issue #724: the refreshed qualification receipt still requires one clean managed push; production-write authorization and release-evidence policies remain fail closed.'
+lastReviewedCommit: af58e108e6bd350fca71f070c245f2ee0a26b527
+lastReviewedNote: 'Reviewed for Issue #724: removing superseded compatibility entries still requires a new clean managed push; production-write authorization and release-evidence policies remain fail closed.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: ab3003ed063f6651f37a8c8c4a136be266b563c0
-lastReviewedNote: 'Reviewed for Issue #724: the route-inventory fix and refreshed qualification receipt follow the existing clean-candidate, focused-production-proof, and managed-gate workflow without changing validation commands.'
+lastReviewedCommit: 82ed0855eed7c855c5298f6568c707b3e3b4eced
+lastReviewedNote: 'Reviewed for Issue #724: canonical production evidence, its source hash, regenerated locale artifacts, and focused production checks follow the existing validation workflow without changing commands.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: d6e1c29e8e7b5e2434391d1f6c96b029abd10765
-lastReviewedNote: 'Reviewed for Issue #724: the refreshed 60-pass, 24-skip qualification receipt follows the existing clean-candidate validation workflow without changing commands.'
+lastReviewedCommit: af58e108e6bd350fca71f070c245f2ee0a26b527
+lastReviewedNote: 'Reviewed for Issue #724: obsolete digest compatibility entries are removed only after exact evidence hashes match and focused contract tests pass; validation commands remain unchanged.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 82ed0855eed7c855c5298f6568c707b3e3b4eced
-lastReviewedNote: 'Reviewed for Issue #724: canonical production evidence, its source hash, regenerated locale artifacts, and focused production checks follow the existing validation workflow without changing commands.'
+lastReviewedCommit: d6e1c29e8e7b5e2434391d1f6c96b029abd10765
+lastReviewedNote: 'Reviewed for Issue #724: the refreshed 60-pass, 24-skip qualification receipt follows the existing clean-candidate validation workflow without changing commands.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: ab3003ed063f6651f37a8c8c4a136be266b563c0
-lastReviewedNote: 'Reviewed for Issue #724: exact role-boundary fulfillment removes the qualification false positive within the existing three-browser matrix; no strategy or matrix expansion is required.'
+lastReviewedCommit: 82ed0855eed7c855c5298f6568c707b3e3b4eced
+lastReviewedNote: 'Reviewed for Issue #724: verified three-browser production evidence completes the existing matrix objective; no strategy or matrix expansion is required.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: d6e1c29e8e7b5e2434391d1f6c96b029abd10765
-lastReviewedNote: 'Reviewed for Issue #724: the refreshed three-browser qualification receipt confirms the existing matrix objective; no strategy or matrix expansion is required.'
+lastReviewedCommit: af58e108e6bd350fca71f070c245f2ee0a26b527
+lastReviewedNote: 'Reviewed for Issue #724: exact production evidence eliminates two temporary digest compatibility entries; no strategy or matrix expansion is required.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 82ed0855eed7c855c5298f6568c707b3e3b4eced
-lastReviewedNote: 'Reviewed for Issue #724: verified three-browser production evidence completes the existing matrix objective; no strategy or matrix expansion is required.'
+lastReviewedCommit: d6e1c29e8e7b5e2434391d1f6c96b029abd10765
+lastReviewedNote: 'Reviewed for Issue #724: the refreshed three-browser qualification receipt confirms the existing matrix objective; no strategy or matrix expansion is required.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: ab3003ed063f6651f37a8c8c4a136be266b563c0
-lastReviewedNote: 'Reviewed for Issue #724: the coverage queue remains empty; deterministic role-boundary fulfillment closes a release-harness false positive without adding a new testing backlog item.'
+lastReviewedCommit: 82ed0855eed7c855c5298f6568c707b3e3b4eced
+lastReviewedNote: 'Reviewed for Issue #724: the coverage queue remains empty after verified production evidence; no new testing backlog item is required.'
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 82ed0855eed7c855c5298f6568c707b3e3b4eced
-lastReviewedNote: 'Reviewed for Issue #724: the coverage queue remains empty after verified production evidence; no new testing backlog item is required.'
+lastReviewedCommit: d6e1c29e8e7b5e2434391d1f6c96b029abd10765
+lastReviewedNote: 'Reviewed for Issue #724: the coverage queue remains empty after the refreshed qualification receipt; no new testing backlog item is required.'
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: d6e1c29e8e7b5e2434391d1f6c96b029abd10765
-lastReviewedNote: 'Reviewed for Issue #724: the coverage queue remains empty after the refreshed qualification receipt; no new testing backlog item is required.'
+lastReviewedCommit: af58e108e6bd350fca71f070c245f2ee0a26b527
+lastReviewedNote: 'Reviewed for Issue #724: the coverage queue remains empty after removing superseded digest compatibility entries; no new testing backlog item is required.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 82ed0855eed7c855c5298f6568c707b3e3b4eced
-lastReviewedNote: 'Reviewed for Issue #724: canonical evidence copy, source-hash update, and deterministic artifact regeneration follow the existing production-proof pattern.'
+lastReviewedCommit: d6e1c29e8e7b5e2434391d1f6c96b029abd10765
+lastReviewedNote: 'Reviewed for Issue #724: refreshing the qualification receipt after a governed input-hash change follows the existing clean-candidate proof pattern.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: d6e1c29e8e7b5e2434391d1f6c96b029abd10765
-lastReviewedNote: 'Reviewed for Issue #724: refreshing the qualification receipt after a governed input-hash change follows the existing clean-candidate proof pattern.'
+lastReviewedCommit: af58e108e6bd350fca71f070c245f2ee0a26b527
+lastReviewedNote: 'Reviewed for Issue #724: compatibility entries sunset when verified evidence directly matches the current input hash, following the existing exact-digest proof pattern.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: ab3003ed063f6651f37a8c8c4a136be266b563c0
-lastReviewedNote: 'Reviewed for Issue #724: hash-only role-boundary navigation now uses the existing fresh-document and exact-request-fulfillment pattern; qualification and production share one assertion path.'
+lastReviewedCommit: 82ed0855eed7c855c5298f6568c707b3e3b4eced
+lastReviewedNote: 'Reviewed for Issue #724: canonical evidence copy, source-hash update, and deterministic artifact regeneration follow the existing production-proof pattern.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: d6e1c29e8e7b5e2434391d1f6c96b029abd10765
-lastReviewedNote: 'Reviewed for Issue #724: a stale qualification input hash correctly fails closed and is resolved by rerunning the three-browser qualifier on the committed candidate.'
+lastReviewedCommit: af58e108e6bd350fca71f070c245f2ee0a26b527
+lastReviewedNote: 'Reviewed for Issue #724: a compatibility entry whose evidence hash already equals the current file correctly fails closed and is resolved by retiring the obsolete entry.'
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: ab3003ed063f6651f37a8c8c4a136be266b563c0
-lastReviewedNote: 'Reviewed for Issue #724: a zero exact-role-fulfillment count is resolved through deterministic document reload and targeted proof, not by widening request counts or retrying production blindly.'
+lastReviewedCommit: 82ed0855eed7c855c5298f6568c707b3e3b4eced
+lastReviewedNote: 'Reviewed for Issue #724: a stale evidence descriptor correctly fails closed and is resolved by updating the verified source hash before regenerating derived artifacts.'
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-29
-lastReviewedCommit: 82ed0855eed7c855c5298f6568c707b3e3b4eced
-lastReviewedNote: 'Reviewed for Issue #724: a stale evidence descriptor correctly fails closed and is resolved by updating the verified source hash before regenerating derived artifacts.'
+lastReviewedCommit: d6e1c29e8e7b5e2434391d1f6c96b029abd10765
+lastReviewedNote: 'Reviewed for Issue #724: a stale qualification input hash correctly fails closed and is resolved by rerunning the three-browser qualifier on the committed candidate.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "2c31f1257f0b9abc867eff37314f5abcdbd26c7785aba6db50598cfff547c7f0",
+    "digest": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "ef754d2ebe7001d8212765a07c30d2dc3c8b1a2380b7c3a81db2d0e9cb6ab839",
+          "sha256": "b1f06a7a21386777a7054605fbcbcdfb89b062741b816cdd1b39b9e71898b1fb",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "2c31f1257f0b9abc867eff37314f5abcdbd26c7785aba6db50598cfff547c7f0",
+    "docs/plans/i18n/route-view-coverage.json": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-de-DE/glossary.json": "a5fd4e759af2713fbec83f2b95171c7b32206d7218da0401d28d2eecefccce3a",
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "a7c8924d94787a997d63df184db87d40e8fa336b4864379be00cea02be568497"
+  "contextDigest": "d9a0eb321f19e3ebb6f2698af7eee4a09a9d15672c284d53c4a1cac93c02ae82"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "a7c8924d94787a997d63df184db87d40e8fa336b4864379be00cea02be568497",
-    "qualityDigest": "4719ed97d57cd40c58cecd172ab25bb6568f11b83ab8ed7619ded5c3f5bc2d9c",
+    "contextDigest": "d9a0eb321f19e3ebb6f2698af7eee4a09a9d15672c284d53c4a1cac93c02ae82",
+    "qualityDigest": "4cc8b6a6abdac782e9e1ca02eec185e031f59c0b7145ed24567496bfdce9c1d5",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "2c31f1257f0b9abc867eff37314f5abcdbd26c7785aba6db50598cfff547c7f0",
+    "routeViewCoverageDigest": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "48a82db47b056f9aa29b14e5d25bf1e13bce60872b0cb0c99bb12707e2fd05ee"
+  "activationDigest": "22556c8fa0bbe771cf03e2f4c73c0c4441b00084a3dafeea739b73c19befbde6"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "417a8237335eab473a84bbb9e80a690763e7f77e8e38ab86716202eb55ac8d7d",
-    "contextDigest": "a7c8924d94787a997d63df184db87d40e8fa336b4864379be00cea02be568497"
+    "contextDigest": "d9a0eb321f19e3ebb6f2698af7eee4a09a9d15672c284d53c4a1cac93c02ae82"
   },
   "catalog": {
     "messageCount": 3079,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "4719ed97d57cd40c58cecd172ab25bb6568f11b83ab8ed7619ded5c3f5bc2d9c"
+  "qualityDigest": "4cc8b6a6abdac782e9e1ca02eec185e031f59c0b7145ed24567496bfdce9c1d5"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "2c31f1257f0b9abc867eff37314f5abcdbd26c7785aba6db50598cfff547c7f0",
+    "digest": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "ef754d2ebe7001d8212765a07c30d2dc3c8b1a2380b7c3a81db2d0e9cb6ab839",
+          "sha256": "b1f06a7a21386777a7054605fbcbcdfb89b062741b816cdd1b39b9e71898b1fb",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "2c31f1257f0b9abc867eff37314f5abcdbd26c7785aba6db50598cfff547c7f0",
+    "docs/plans/i18n/route-view-coverage.json": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-en-US/glossary.json": "4b8443ea3f91f15383683e9ece6221e40e24ceb75442ea830964b06c12559970",
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "5f884bc5f912308a94c29e4393edeb344a6e75d2f0b72e5ede74a8134cfe4c2f"
+  "contextDigest": "72dda494bbcff1bf360442174d1225b74250939db28d98db1d7c5a775e980bce"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "5f884bc5f912308a94c29e4393edeb344a6e75d2f0b72e5ede74a8134cfe4c2f",
-    "qualityDigest": "006c5e6a48f52eb56b84e2cf5738ef7c8fa188707271be80cc94aefdf861b05b",
+    "contextDigest": "72dda494bbcff1bf360442174d1225b74250939db28d98db1d7c5a775e980bce",
+    "qualityDigest": "b1a78161f0ad30af8e06b272b515ee15caf27bd7dcbd412347b69c4f16e6c815",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "2c31f1257f0b9abc867eff37314f5abcdbd26c7785aba6db50598cfff547c7f0",
+    "routeViewCoverageDigest": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "a733771f49812c91102ccbab686f9105ccc9cf19e18c70d6183f712c4a46e3aa"
+  "activationDigest": "a7b25bb55ffaad54d449000974af91f126ad4cee7a3d26d379e67434f366c10a"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "417a8237335eab473a84bbb9e80a690763e7f77e8e38ab86716202eb55ac8d7d",
-    "contextDigest": "5f884bc5f912308a94c29e4393edeb344a6e75d2f0b72e5ede74a8134cfe4c2f"
+    "contextDigest": "72dda494bbcff1bf360442174d1225b74250939db28d98db1d7c5a775e980bce"
   },
   "catalog": {
     "messageCount": 3079,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "006c5e6a48f52eb56b84e2cf5738ef7c8fa188707271be80cc94aefdf861b05b"
+  "qualityDigest": "b1a78161f0ad30af8e06b272b515ee15caf27bd7dcbd412347b69c4f16e6c815"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "2c31f1257f0b9abc867eff37314f5abcdbd26c7785aba6db50598cfff547c7f0",
+    "digest": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "ef754d2ebe7001d8212765a07c30d2dc3c8b1a2380b7c3a81db2d0e9cb6ab839",
+          "sha256": "b1f06a7a21386777a7054605fbcbcdfb89b062741b816cdd1b39b9e71898b1fb",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "2c31f1257f0b9abc867eff37314f5abcdbd26c7785aba6db50598cfff547c7f0",
+    "docs/plans/i18n/route-view-coverage.json": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-fr-FR/glossary.json": "057cb494f02d980106469f6a16befc102d26db5ac362b9777cd5f97c7729c91b",
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "30a69d53c39236a60484fdfbf40dcb8017729721233a35b09f1b9b9e1a7b2725"
+  "contextDigest": "dfeb7a300d075cc1cbd38596b854f7c7b09a05093a0895f5ded10640b61a612e"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "30a69d53c39236a60484fdfbf40dcb8017729721233a35b09f1b9b9e1a7b2725",
-    "qualityDigest": "84063195ca75e70fc8226187a8b374c3fee9140ab7a1047c1220376f56fa89f0",
+    "contextDigest": "dfeb7a300d075cc1cbd38596b854f7c7b09a05093a0895f5ded10640b61a612e",
+    "qualityDigest": "f98ac09331b5b69e7087eae2df09bac0a6eaf14115af0bf67899e28d97e4989d",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "2c31f1257f0b9abc867eff37314f5abcdbd26c7785aba6db50598cfff547c7f0",
+    "routeViewCoverageDigest": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "fe56833d75c78d0d243ce07a18161c8a12f74808de14696bf4bbcb0fe34fc261"
+  "activationDigest": "dd4feb88c0e33fe574e4c062be38db36a65f9e48298f8dab379fc31261ebd2ee"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "417a8237335eab473a84bbb9e80a690763e7f77e8e38ab86716202eb55ac8d7d",
-    "contextDigest": "30a69d53c39236a60484fdfbf40dcb8017729721233a35b09f1b9b9e1a7b2725"
+    "contextDigest": "dfeb7a300d075cc1cbd38596b854f7c7b09a05093a0895f5ded10640b61a612e"
   },
   "catalog": {
     "messageCount": 3079,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "84063195ca75e70fc8226187a8b374c3fee9140ab7a1047c1220376f56fa89f0"
+  "qualityDigest": "f98ac09331b5b69e7087eae2df09bac0a6eaf14115af0bf67899e28d97e4989d"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "2c31f1257f0b9abc867eff37314f5abcdbd26c7785aba6db50598cfff547c7f0",
+    "digest": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "ef754d2ebe7001d8212765a07c30d2dc3c8b1a2380b7c3a81db2d0e9cb6ab839",
+          "sha256": "b1f06a7a21386777a7054605fbcbcdfb89b062741b816cdd1b39b9e71898b1fb",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "2c31f1257f0b9abc867eff37314f5abcdbd26c7785aba6db50598cfff547c7f0",
+    "docs/plans/i18n/route-view-coverage.json": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-zh-CN/glossary.json": "c891add0ee4bd6d24c0213d0c839474e145d85867426df796763b8e038053d9b",
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "1391453ce2b1830778cdbf8f940169beea8253f0984148fb46d5e77090865e78"
+  "contextDigest": "93e89e5e9114c8bc8c20256b6e5b3ee75f1dbdccaa5d6b9bba670278ba00a0f7"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "1391453ce2b1830778cdbf8f940169beea8253f0984148fb46d5e77090865e78",
-    "qualityDigest": "58d7939d2664da047d8684c1a80112ebbb90830a74f58584893d9079fe9a52e4",
+    "contextDigest": "93e89e5e9114c8bc8c20256b6e5b3ee75f1dbdccaa5d6b9bba670278ba00a0f7",
+    "qualityDigest": "d1df859533e630901476f2ba172b22a13ed86a691073ce3a464b93cb76fae1f7",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "2c31f1257f0b9abc867eff37314f5abcdbd26c7785aba6db50598cfff547c7f0",
+    "routeViewCoverageDigest": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "12b02d85b457bb17c3b718dd2ab5f38323a95031f18f0ca00adeee91a934c567"
+  "activationDigest": "fe3f5c1761fcab7d9592e43bf5f3673815768ea0c6b81c76cc8740800e2a67ec"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "417a8237335eab473a84bbb9e80a690763e7f77e8e38ab86716202eb55ac8d7d",
-    "contextDigest": "1391453ce2b1830778cdbf8f940169beea8253f0984148fb46d5e77090865e78"
+    "contextDigest": "93e89e5e9114c8bc8c20256b6e5b3ee75f1dbdccaa5d6b9bba670278ba00a0f7"
   },
   "catalog": {
     "messageCount": 3079,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "58d7939d2664da047d8684c1a80112ebbb90830a74f58584893d9079fe9a52e4"
+  "qualityDigest": "d1df859533e630901476f2ba172b22a13ed86a691073ce3a464b93cb76fae1f7"
 }

--- a/docs/plans/i18n/route-view-coverage.json
+++ b/docs/plans/i18n/route-view-coverage.json
@@ -353,7 +353,7 @@
       "executedEvidence": [
         {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "ef754d2ebe7001d8212765a07c30d2dc3c8b1a2380b7c3a81db2d0e9cb6ab839"
+          "sha256": "b1f06a7a21386777a7054605fbcbcdfb89b062741b816cdd1b39b9e71898b1fb"
         }
       ]
     }

--- a/docs/plans/i18n/semantic-e2e-digest-compatibility.json
+++ b/docs/plans/i18n/semantic-e2e-digest-compatibility.json
@@ -1,38 +1,5 @@
 {
   "schemaVersion": "tiangong.i18n-semantic-e2e-digest-compatibility.v1",
-  "entries": [
-    {
-      "path": "scripts/i18n/locale-delivery.mjs",
-      "evidenceObservedHeadCommit": "816c80b36debf5e75b2d5609c5241a05b04bde89",
-      "evidenceSha256": "d9023ec244cc79d2744526d7111e25b1dd506731e9c260ab997ff4c38c421ee5",
-      "compatibleSha256": "144a85e31f94bef9a559277450e8fb96a22495ceb317b109d28f7797f278925c",
-      "scope": "non-browser-semantic-release-harness-only",
-      "ownerIssue": "#703",
-      "reviewedAt": "2026-07-28",
-      "sunset": "next-verified-evidence-for-compatible-sha",
-      "proofCommands": [
-        "npm run i18n:evidence:canonical:check",
-        "npm run i18n:locale:artifacts:idempotence",
-        "npm run test:ci -- tests/unit/i18n/localeDeliveryContracts.test.ts tests/unit/e2e/evidenceReporter.test.ts --runInBand --no-coverage",
-        "npm run release:preflight"
-      ]
-    },
-    {
-      "path": "tests/unit/i18n/localeDeliveryContracts.test.ts",
-      "evidenceObservedHeadCommit": "816c80b36debf5e75b2d5609c5241a05b04bde89",
-      "evidenceSha256": "a5581fbbe9a23cf98a20086f2f4c318d3ab053d53a39bac12bd81ea3904a6fb5",
-      "compatibleSha256": "7bbc1317683c8a2418134a59c0de7735973fe74b42ecf76a0ea6b0a79c0b180e",
-      "scope": "non-browser-semantic-release-harness-only",
-      "ownerIssue": "#698",
-      "reviewedAt": "2026-07-28",
-      "sunset": "next-verified-evidence-for-compatible-sha",
-      "proofCommands": [
-        "npm run i18n:evidence:canonical:check",
-        "npm run i18n:locale:artifacts:idempotence",
-        "npm run test:ci -- tests/unit/i18n/localeDeliveryContracts.test.ts tests/unit/e2e/evidenceReporter.test.ts --runInBand --no-coverage",
-        "npm run release:preflight"
-      ]
-    }
-  ],
+  "entries": [],
   "releaseCandidateWaivers": []
 }

--- a/docs/plans/i18n/semantic-e2e-evidence.json
+++ b/docs/plans/i18n/semantic-e2e-evidence.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": "tiangong.i18n-semantic-e2e-evidence.v1",
   "status": "verified",
-  "generatedAt": "2026-07-28T07:01:18.873Z",
-  "runId": "local-b812406d-f801-49d6-bdb6-b5a9209373e4",
+  "generatedAt": "2026-07-29T19:13:51.968Z",
+  "runId": "local-81f1343b-0a88-4f61-a7ad-7649568ff953",
   "candidate": {
     "configTreeDigest": "c79878bbed6dfb7becc3cedae0fdd08e0926b674293a6f9656469ac8682cc804",
-    "observedHeadCommit": "816c80b36debf5e75b2d5609c5241a05b04bde89",
-    "packageManifestDigest": "8f6968830a53792605e21f2a46dbc99bdfbe7061f68700144c54f5a08d0ea7eb",
-    "sourceTreeDigest": "bfcc128d51da75293976ffe30daf61c833d12e8412cb72635a0107618cc276f2",
-    "unitTestTreeDigest": "879bd286abeacd161ad6149bfe606b420ab25a91242c4f770009ee75348d220b"
+    "observedHeadCommit": "82ed0855eed7c855c5298f6568c707b3e3b4eced",
+    "packageManifestDigest": "57389d83ac34ff293f1312ba4dcfdc76b5a1ac32fa71ef5449bca6e7a358dbdf",
+    "sourceTreeDigest": "f0ebaaf11f0cf19c979f2c118189d4779f65600289152ee68d7e9d653727a1d6",
+    "unitTestTreeDigest": "f5e5024efa50109a81c9daca0b1d4cb3fbb5371dc9ce0cdcdddcf359307476e6"
   },
   "target": {
     "frontend": "candidate-local",
@@ -34,7 +34,7 @@
   "digests": {
     "packageLock": {
       "path": "package-lock.json",
-      "sha256": "34c5a57f539d4ccb0f8593a7e2de7ed2cb1b6ff52f0301d23d0e839577998f27"
+      "sha256": "082c623e76b64e161d0894bb3e7879d096f235494ce3fecc8106dd2723e33902"
     },
     "runtimeAssets": [
       {
@@ -137,11 +137,11 @@
       },
       {
         "path": "playwright.config.ts",
-        "sha256": "2a9a8e25a097ed7878bf18009177accb318d50b27996a99762fd8a992a6a0ae0"
+        "sha256": "1077ae72b2c746b48e29755ab5cdfa31950a35c54778d772bcc2cef91f9d7582"
       },
       {
         "path": "scripts/i18n/locale-delivery.mjs",
-        "sha256": "d9023ec244cc79d2744526d7111e25b1dd506731e9c260ab997ff4c38c421ee5"
+        "sha256": "144a85e31f94bef9a559277450e8fb96a22495ceb317b109d28f7797f278925c"
       },
       {
         "path": "scripts/i18n/package-lock-runtime-fingerprint.cjs",
@@ -157,11 +157,11 @@
       },
       {
         "path": "tests/e2e/i18n/access-fallback.spec.ts",
-        "sha256": "709bac7281a50150bcf5e15c19b6b6b934d84ca1f3eb4e401d5cebe090695bc3"
+        "sha256": "2932c63d44789a1a547dd326f8c422125875888813dbd07adacd0ad4a4e668a5"
       },
       {
         "path": "tests/e2e/i18n/auth.ts",
-        "sha256": "e2a34b56f3f3941b538e865dd585e9ae15e20da862083c0e8dc43e57266ac09d"
+        "sha256": "e6d91504067d07aa87fde8d389596c59bb0d3c10e75c380d05e0922fe84924f9"
       },
       {
         "path": "tests/e2e/i18n/candidate-readiness.ts",
@@ -181,11 +181,11 @@
       },
       {
         "path": "tests/e2e/i18n/evidence-reporter.ts",
-        "sha256": "0abdfa350560a8eebc2f3a6eb10553c4003ed24533dd24da48f699198fa6d874"
+        "sha256": "007ea76dec2301fb40e7e943b59c28ccff66267b9f84339e68d1241ef0d0f28d"
       },
       {
         "path": "tests/e2e/i18n/fixtures.ts",
-        "sha256": "988286acae9adfb9b19a4c3fc2cfa511d25ef52500f99291c2948766246ab89e"
+        "sha256": "de09ce12b3da4b312fae27fd44baf0f38b0181c8c41cc4df541d48016c56c60e"
       },
       {
         "path": "tests/e2e/i18n/global-setup.ts",
@@ -193,7 +193,15 @@
       },
       {
         "path": "tests/e2e/i18n/global-teardown.ts",
-        "sha256": "c54a161cfb0c341b1a3b1b5d2bfa5e12d8429582fe466d332430c7036c718972"
+        "sha256": "dd9b5a81b291f83e40080b8afa6538c668039cb01e1f1cfad9db82170830245f"
+      },
+      {
+        "path": "tests/e2e/i18n/harness-contract.ts",
+        "sha256": "a9a2641c42a697fce435cb6661e5f64289b831d9b40405f0c3585b1396d20408"
+      },
+      {
+        "path": "tests/e2e/i18n/harness-qualification.spec.ts",
+        "sha256": "441c58d53a1902a7a1f522120fad33e5c4d7035816883ab7b2c12311452981f9"
       },
       {
         "path": "tests/e2e/i18n/locale-capability-scenarios.ts",
@@ -209,11 +217,11 @@
       },
       {
         "path": "tests/e2e/i18n/process-lifecycle.spec.ts",
-        "sha256": "2dbdcaa8d8690b9995200457fffccc2569205d98cc3a91c7a7910fcdbeb1daf4"
+        "sha256": "3251262985e55c5c8ac80f94d2f1fa6a83d48cd33dad9f3ae20c16147559cd30"
       },
       {
         "path": "tests/e2e/i18n/process-persisted-authoring.spec.ts",
-        "sha256": "a3ecf3ca7e0026742757a663d5dcbe3b97b69f80ba8f74ab435d4f00c9d1b91d"
+        "sha256": "d8ed9fa0793fcba6ac2efab3b2786269b94ba16c1634ea462f889c6b0dd76c55"
       },
       {
         "path": "tests/e2e/i18n/production-backend-target.ts",
@@ -221,7 +229,7 @@
       },
       {
         "path": "tests/e2e/i18n/production-data-ledger.ts",
-        "sha256": "dc85d963d17a03ccf5c2bdad8bcf119744963325dce9f5a09d83eb8efe29f7f6"
+        "sha256": "94682853a0a2a5ce2559cf7215dec96117b178504f8b16b6cc966c67d4312b13"
       },
       {
         "path": "tests/e2e/i18n/production-data-safety.ts",
@@ -229,7 +237,11 @@
       },
       {
         "path": "tests/e2e/i18n/production-request-guard.ts",
-        "sha256": "85a0104185632363b49423aef0c813c6413e2bbb07df4a73bdbddc33e46de8e8"
+        "sha256": "714dd934f25a6cb234496a3b6f41d2c9d3bb9bb0876270e8ac5222f63818bfda"
+      },
+      {
+        "path": "tests/e2e/i18n/qualification-reporter.ts",
+        "sha256": "49c6e98c0ced03587c2118f64bf2265aeb6d9807e2bf70ba6396e1ca7d46a90d"
       },
       {
         "path": "tests/e2e/i18n/query-responsive.spec.ts",
@@ -241,7 +253,7 @@
       },
       {
         "path": "tests/e2e/i18n/reference-refresh.spec.ts",
-        "sha256": "15448007da83a3d7869714e3f6c73d219746ddbc44694a175d9d185881701eab"
+        "sha256": "245bb073e04b91c6de8524e7323a36b94d3f66cc1854cf72dc9ef333090f9c21"
       },
       {
         "path": "tests/e2e/i18n/responsive-layout.spec.ts",
@@ -257,7 +269,11 @@
       },
       {
         "path": "tests/e2e/i18n/route-inventory.spec.ts",
-        "sha256": "6fe86ce2715bd2397199be2f0b4b4bf2fbfe49408a56e7343d09da1aa99a59e6"
+        "sha256": "702477e78e14b2c6822b5c78f57753ad5c374bc8fb3b4746d04a6134462aa409"
+      },
+      {
+        "path": "tests/e2e/i18n/semantic-backend-simulator.ts",
+        "sha256": "35e0b220453ec603345d04d3baabdf372dfc263e1af2efd08054430d8084d35b"
       },
       {
         "path": "tests/e2e/i18n/semantic-critical.spec.ts",
@@ -265,7 +281,7 @@
       },
       {
         "path": "tests/e2e/i18n/state-semantics.spec.ts",
-        "sha256": "bf52e5d0a0ecf1ea39087a36311d04bb9578d02c3ecc56b1a2d3df27b8d03b2e"
+        "sha256": "246ab3a91ed5e637cf7fe537538c0ac6b25fa47ded3ce415e6959302a7f77008"
       },
       {
         "path": "tests/e2e/i18n/typed-view-readonly-fixture.ts",
@@ -273,7 +289,7 @@
       },
       {
         "path": "tests/e2e/i18n/typed-view-variants.spec.ts",
-        "sha256": "3d6a03deba0368ec35cdbbb7b3f9378811557bbb9286ed5c3b2df132dadcdac4"
+        "sha256": "d46194896a0f29175e253131bf6fb1885c495bf97d368db7a47dbf33a8009875"
       },
       {
         "path": "tests/unit/app.test.tsx",
@@ -325,7 +341,7 @@
       },
       {
         "path": "tests/unit/e2e/evidenceReporter.test.ts",
-        "sha256": "994f4be1b4f23c29fd7d483971e369d3fa179c4432187e60d0f2f0114692cf9f"
+        "sha256": "47e44220a81a0a4f8a10dabd687929bd699fff34ee9829927043a749fdd2922c"
       },
       {
         "path": "tests/unit/e2e/productionDataLedger.test.ts",
@@ -333,15 +349,15 @@
       },
       {
         "path": "tests/unit/e2e/productionRequestGuard.test.ts",
-        "sha256": "d0a31f6d6d6ac840dd2e8bdda1f72b68ce4a9df733e244ab5a1356002f43abc8"
+        "sha256": "4286f37e6b8132aa49ad4afecd16490e9d55427ba7d3167603a58fbf5e2a7b5a"
       },
       {
         "path": "tests/unit/e2e/referenceRefreshContract.test.ts",
-        "sha256": "12e7b526cac4447bc848c6f5eb3f151d35155e65da1b55a24433b02465ffe853"
+        "sha256": "2c97cc104c0687e498515bfe5acad7c6b11a10a35beea959df7d1a040b51f2bb"
       },
       {
         "path": "tests/unit/i18n/localeDeliveryContracts.test.ts",
-        "sha256": "a5581fbbe9a23cf98a20086f2f4c318d3ab053d53a39bac12bd81ea3904a6fb5"
+        "sha256": "7bbc1317683c8a2418134a59c0de7735973fe74b42ecf76a0ea6b0a79c0b180e"
       },
       {
         "path": "tests/unit/i18n/packageLockRuntimeFingerprint.test.js",
@@ -361,7 +377,7 @@
       },
       {
         "path": "tests/unit/pages/DataProcessing/index.test.tsx",
-        "sha256": "765ec7886d96df4d4ad6e85ce209e79d5c5238678c8df016caa1739310c7a711"
+        "sha256": "d93017c1d6ca6a9c8d800fefd2236f4b8d51b49e0dcfe04354c02ec04ad623e1"
       },
       {
         "path": "tests/unit/pages/Flowproperties/index.test.tsx",
@@ -503,7 +519,7 @@
       },
       {
         "path": "src/locales/en-US/pages.ts",
-        "sha256": "51a70bc17810a3d756f8d36174c3bdea921b191cf7306690eb315287370004d0"
+        "sha256": "fa55d56b7a0cb208a9a11d064ae69f7ba8c6d0d55759399e19628a6f70e0fb23"
       },
       {
         "path": "src/locales/en-US/pages_general.ts",
@@ -527,7 +543,7 @@
       },
       {
         "path": "src/pages/DataProcessing/index.tsx",
-        "sha256": "cfc8344f148b14a474594237913e16ac462b357838efe29b76ab7f080f12004f"
+        "sha256": "3a091d4e615be66d04e347b3baa53bbbe4d2fada93d1986ae469d4cb6f238caf"
       },
       {
         "path": "src/pages/Flowproperties/index.tsx",

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "72b8266014c3a76b7d4b33dd858d1fffb478229336388e9cc41b6fdecfa0bcea"
+    "runResultSha256": "2dbcfc64a9fcfa0c24a715c8071c83e68657943e7133be23cd86d4acdf040983"
   },
-  "environmentManifestSha256": "88192656e4d46eddcf12f4b53b423a59c0e2e66e36b619ce8535fbc37d2c05ad",
+  "environmentManifestSha256": "95c6d32067c68c776b38b23feb2eeef810ecb448b3befc6a9c617c4c202b40d9",
   "externalRequests": 0,
-  "generatedAt": "2026-07-29T18:38:16.753Z",
+  "generatedAt": "2026-07-29T19:34:17.028Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "b37fcaab86674353c2c7d4ad22c2712da7a8d6fca8ae783cb1d55af1767ed155",
-  "qualifiedCommit": "730aa5493125450367564d96ea3da1cc500d71dc",
-  "qualifiedTree": "3bb8c2415105ea31ec392ad6c44b02a26125ae01",
+  "qualificationInputSha256": "4c91fb91060b0c81191e2350c2fcc507df56a1d826b19e41e845df04af2a4abf",
+  "qualifiedCommit": "d6e1c29e8e7b5e2434391d1f6c96b029abd10765",
+  "qualifiedTree": "461299c00e5ab1662461742fd714c86be4f2fc5a",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }


### PR DESCRIPTION
Closes #724

## Summary

- records canonical authenticated production E2E evidence for candidate `82ed0855eed7c855c5298f6568c707b3e3b4eced`
- updates the evidence source hash and regenerates all locale delivery artifacts
- refreshes the clean-candidate qualification receipt
- retires two digest-compatibility entries superseded by exact production evidence

## Production proof

- 60 passed / 24 designed skips across Chromium, Firefox, and WebKit
- 49 stable semantic assertion IDs
- production fixture ledger: created 1 / cleaned 1 / leaked 0
- recovery ledger absent after successful finalization
- no credentials or raw backend identifiers are stored; target identity is SHA-256 bound

## Validation

- `npm run i18n:evidence:canonical:check`
- `npm run i18n:locale:artifacts:idempotence`
- `npm run e2e:qualification:check`
- `npm run release:preflight`
- focused locale/evidence contract suites: 32/32
- managed pre-push gate: 405/405 suites, 5486/5486 tests
- coverage: 456/456 files at 100% statements/branches/functions/lines
- Docpact strict validation and 26-path/27-rule lint

## Risk and rollback

This PR changes tracked evidence, derived locale artifacts, qualification metadata, and removes expired compatibility records. It does not change runtime behavior or production data. Revert the PR to roll back the evidence update.