### PR TITLE
fix(ci): ignore audited Gitleaks false positives

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,11 @@
+# Verified false positives from the Edge mirror sync in commit 251e9aa1.
+# Each entry is scoped to one commit, path, rule, and start line. See issue #728.
+251e9aa1fdf4ae140c45a1d0ac609e717f5ff0c8:docker/volumes/functions/_shared/auth.ts:generic-api-key:205
+251e9aa1fdf4ae140c45a1d0ac609e717f5ff0c8:docker/volumes/functions/_shared/auth.ts:generic-api-key:214
+251e9aa1fdf4ae140c45a1d0ac609e717f5ff0c8:docker/volumes/functions/_shared/auth.ts:generic-api-key:451
+251e9aa1fdf4ae140c45a1d0ac609e717f5ff0c8:docker/volumes/functions/_shared/auth.ts:generic-api-key:511
+251e9aa1fdf4ae140c45a1d0ac609e717f5ff0c8:docker/volumes/functions/_shared/hybrid_search_rpc_context.ts:generic-api-key:54
+251e9aa1fdf4ae140c45a1d0ac609e717f5ff0c8:docker/volumes/functions/_shared/supabase_client.ts:generic-api-key:107
+251e9aa1fdf4ae140c45a1d0ac609e717f5ff0c8:docker/volumes/functions/_shared/hybrid_search_handler.ts:generic-api-key:67
+251e9aa1fdf4ae140c45a1d0ac609e717f5ff0c8:docker/volumes/functions/_shared/hybrid_search_handler.ts:generic-api-key:68
+251e9aa1fdf4ae140c45a1d0ac609e717f5ff0c8:docker/volumes/functions/lca_release_results/index.ts:generic-api-key:74


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#728

## Summary
- Add nine exact commit/path/rule/start-line fingerprints for audited false positives from Edge mirror commit 251e9aa1.
- Leave runtime source, credentials, and the detector configuration unchanged.

## Key Decisions
- Use .gitleaksignore commit-scoped fingerprints as the narrowest supported release unblock.
- Track generic-rule precision and dev scan-range hardening separately in #729.

## Validation
- DOCKER_CONFIG=/tmp/tiangong-next-e2e-docker.iSwmij docker run ... zricethezav/gitleaks:v8.24.3 detect ... exact failing 3-commit range: 3 commits scanned, no leaks found.
- /Users/davidli/projects/workspace/scripts/docpact lint --root /Users/davidli/projects/workspace/tiangong-lca-next --files .gitleaksignore --format json: passed with zero findings.
- Node 24.18.0 managed npm run push:checked -- origin codex/fix-issue-728-gitleaks-fingerprints: Docpact passed; 405/405 suites and 5486/5486 tests passed; 456/456 source files at 100% statements/branches/functions/lines.
- Initial SSH transport disconnected after gates; the exact receipt-bound npm run push:retry succeeded.

## Risks / Rollback
- Low: the file suppresses only nine historical fingerprints. Removing it restores the previous scan failure.

## Follow-ups
- #729 will add positive/negative detector fixtures and correct routine dev scan coverage.

## Workspace Integration
- After merge to dev, rebuild PR #727 from the new canonical dev head and rerun all main-candidate checks; root integration remains tracked by tiangong-lca/workspace#513.