### PR TITLE
chore: backmerge v0.0.63 release into dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-07-29'
-lastReviewedCommit: 'af58e108e6bd350fca71f070c245f2ee0a26b527'
-lastReviewedNote: 'Reviewed for Issue #724: obsolete semantic-evidence digest compatibility entries are removed after exact production evidence supersedes them; required-doc and ownership sets remain correct.'
+lastReviewedAt: '2026-07-30'
+lastReviewedCommit: '96ac5d91d44c4b2d5d0181d0e9ccf7dc237943ab'
+lastReviewedNote: 'Reviewed for the v0.0.63 main-to-dev backmerge: the release-only package version change does not alter routing, ownership, required-doc, or validation rules.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,9 +31,9 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-07-29
-lastReviewedCommit: af58e108e6bd350fca71f070c245f2ee0a26b527
-lastReviewedNote: 'Reviewed for Issue #724: retiring superseded semantic-evidence compatibility entries remains within the existing repository ownership, release-evidence, and managed-push boundaries.'
+lastReviewedAt: 2026-07-30
+lastReviewedCommit: 96ac5d91d44c4b2d5d0181d0e9ccf7dc237943ab
+lastReviewedNote: 'Reviewed for the v0.0.63 main-to-dev backmerge: the version-only release delta leaves repository ownership, branch policy, release automation, and managed-push boundaries unchanged.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -28,9 +28,9 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - .nvmrc
-lastReviewedAt: 2026-07-29
-lastReviewedCommit: af58e108e6bd350fca71f070c245f2ee0a26b527
-lastReviewedNote: 'Reviewed for Issue #724: retiring superseded digest compatibility entries follows the existing canonical-evidence, focused-contract-test, and managed-push sequence.'
+lastReviewedAt: 2026-07-30
+lastReviewedCommit: 96ac5d91d44c4b2d5d0181d0e9ccf7dc237943ab
+lastReviewedNote: 'Reviewed for the v0.0.63 main-to-dev backmerge: bootstrap commands and the managed validation sequence remain unchanged after the release-only version update.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-07-29
-lastReviewedCommit: af58e108e6bd350fca71f070c245f2ee0a26b527
-lastReviewedNote: 'Reviewed for Issue #724: removing superseded compatibility entries still requires a new clean managed push; production-write authorization and release-evidence policies remain fail closed.'
+lastReviewedAt: 2026-07-30
+lastReviewedCommit: 96ac5d91d44c4b2d5d0181d0e9ccf7dc237943ab
+lastReviewedNote: 'Reviewed for the v0.0.63 main-to-dev backmerge: the release-only package version change leaves hook, receipt, preflight, and protected-branch behavior unchanged.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-07-29
-lastReviewedCommit: af58e108e6bd350fca71f070c245f2ee0a26b527
-lastReviewedNote: 'Reviewed for Issue #724: obsolete digest compatibility entries are removed only after exact evidence hashes match and focused contract tests pass; validation commands remain unchanged.'
+lastReviewedAt: 2026-07-30
+lastReviewedCommit: 96ac5d91d44c4b2d5d0181d0e9ccf7dc237943ab
+lastReviewedNote: 'Reviewed for the v0.0.63 main-to-dev backmerge: release, smoke, and validation commands remain current after the version-only release delta.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -26,9 +26,9 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - package.json
-lastReviewedAt: 2026-07-29
-lastReviewedCommit: af58e108e6bd350fca71f070c245f2ee0a26b527
-lastReviewedNote: 'Reviewed for Issue #724: exact production evidence eliminates two temporary digest compatibility entries; no strategy or matrix expansion is required.'
+lastReviewedAt: 2026-07-30
+lastReviewedCommit: 96ac5d91d44c4b2d5d0181d0e9ccf7dc237943ab
+lastReviewedNote: 'Reviewed for the v0.0.63 main-to-dev backmerge: the version-only release delta does not reopen testing strategy or require matrix expansion.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -28,9 +28,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-07-29
-lastReviewedCommit: af58e108e6bd350fca71f070c245f2ee0a26b527
-lastReviewedNote: 'Reviewed for Issue #724: the coverage queue remains empty after removing superseded digest compatibility entries; no new testing backlog item is required.'
+lastReviewedAt: 2026-07-30
+lastReviewedCommit: 96ac5d91d44c4b2d5d0181d0e9ccf7dc237943ab
+lastReviewedNote: 'Reviewed for the v0.0.63 main-to-dev backmerge: the release gate remains green and the version-only delta adds no testing backlog item.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -29,9 +29,9 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-07-29
-lastReviewedCommit: af58e108e6bd350fca71f070c245f2ee0a26b527
-lastReviewedNote: 'Reviewed for Issue #724: compatibility entries sunset when verified evidence directly matches the current input hash, following the existing exact-digest proof pattern.'
+lastReviewedAt: 2026-07-30
+lastReviewedCommit: 96ac5d91d44c4b2d5d0181d0e9ccf7dc237943ab
+lastReviewedNote: 'Reviewed for the v0.0.63 main-to-dev backmerge: the version-only release delta does not change reusable test-selection or exact-digest proof patterns.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -26,9 +26,9 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-07-29
-lastReviewedCommit: af58e108e6bd350fca71f070c245f2ee0a26b527
-lastReviewedNote: 'Reviewed for Issue #724: a compatibility entry whose evidence hash already equals the current file correctly fails closed and is resolved by retiring the obsolete entry.'
+lastReviewedAt: 2026-07-30
+lastReviewedCommit: 96ac5d91d44c4b2d5d0181d0e9ccf7dc237943ab
+lastReviewedNote: 'Reviewed for the v0.0.63 main-to-dev backmerge: the version-only release delta introduces no new failure mode or recovery command.'
 ---
 
 # Testing Troubleshooting


### PR DESCRIPTION
## Summary

- reconcile the canonical v0.0.63 release-only version fields from `main` back into the daily `dev` trunk
- preserve the exact released tree at `96ac5d91d44c4b2d5d0181d0e9ccf7dc237943ab`
- keep this as the repository-standard normal `main -> dev` PR; no force push, tag, release, or deployment action is included

## Release evidence

- Promote PR #731 merged to `main` as `96ac5d91d44c4b2d5d0181d0e9ccf7dc237943ab`
- canonical Build/release run 30509722340 completed successfully
- `v0.0.63` points exactly to the release SHA
- Release Gate and credential-free semantic E2E passed for Chromium, Firefox, and WebKit
- EdgeOne Web deploy passed
- the unique Electron draft release passed the exact 12 non-empty asset verification
- read-only production smoke passed for root/protected-route login redirects and all four locale selector options, with zero console errors and zero production writes

## Diff boundary

The normal merge commit brings the released version fields from `main`:

- `package.json`
- root package/version fields in `package-lock.json`

Both move the repository release version from `0.0.62` to `0.0.63`.

The branch also refreshes review metadata, as required by the fail-closed Docpact gate for the version-file change, in `.docpact/config.yaml`, `AGENTS.md`, `DEV.md`, and seven validation/testing contracts. These are review-date/commit/note updates only; they do not change policy, validation behavior, or product code.

## Validation and handoff

- immutable Docpact comparison: `44a36e55aeb624427f4d0b1222a434dd2de8abb0..11f012b8470619a01ac3659d5dbaf2098da37105` — 11 changed paths, 10 matched rules, zero findings
- LCIA cache verification and reference-resource pipeline check passed
- ESLint, deprecated-API lint, Prettier, and TypeScript passed
- managed full gate passed: 405 suites / 5,486 tests
- full coverage passed: 456/456 tracked source files at 100/100/100/100; 26,010 statements, 16,600 branches, 5,900 functions, and 24,920 lines covered
- the initial post-gate Git transport failed; the repository's bounded receipt-only retry pushed the exact unchanged SHA successfully
- No production-writing E2E was rerun.
- No manual release, tag, or deploy was triggered.
- Merge this PR normally into `dev` after its checks pass.

Refs #704
Refs #711
Refs tiangong-lca/workspace#511
Refs tiangong-lca/workspace#512
