### PR TITLE
test: refresh semantic harness qualification

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-07-30'
-lastReviewedCommit: '2d582c989f8f6965236b9e464631d5e2256744f0'
-lastReviewedNote: 'Reviewed for Issue #735: retired Process search query-field residue is removed without changing v2 RPC, extracted_md, or managed release boundaries.'
+lastReviewedCommit: 'a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe'
+lastReviewedNote: 'Reviewed for Issue #735 qualification refresh: the new semantic-harness receipt is bound to the merged cleanup candidate; v2 RPC, extracted_md, and managed release boundaries remain unchanged.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-30
-lastReviewedCommit: 2d582c989f8f6965236b9e464631d5e2256744f0
-lastReviewedNote: 'Reviewed for Issue #735: Process search retains the indexed v2 RPC and database-owned extracted_md contract while retired query-field residue is removed from current tests and docs.'
+lastReviewedCommit: a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe
+lastReviewedNote: 'Reviewed for Issue #735 qualification refresh: the merged cleanup retains the indexed v2 RPC and database-owned extracted_md contract and now has current hermetic three-browser evidence.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-07-30
-lastReviewedCommit: 2d582c989f8f6965236b9e464631d5e2256744f0
-lastReviewedNote: 'Reviewed for Issue #735: the test/docs-only search residue cleanup follows the normal dev PR, full gate, promotion, and workspace-integration sequence.'
+lastReviewedCommit: a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe
+lastReviewedNote: 'Reviewed for Issue #735 qualification refresh: the regenerated semantic-harness receipt follows the documented dev PR, release-gate, promotion, and workspace-integration sequence.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-07-30
-lastReviewedCommit: 2d582c989f8f6965236b9e464631d5e2256744f0
-lastReviewedNote: 'Reviewed for Issue #735: a simulator allowlist contraction still requires the normal clean managed gate; production-write authorization remains fail closed.'
+lastReviewedCommit: a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe
+lastReviewedNote: 'Reviewed for Issue #735 qualification refresh: the simulator allowlist contraction has a current three-browser receipt; the clean managed gate and production-write fail-closed rules remain unchanged.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-30
-lastReviewedCommit: 2d582c989f8f6965236b9e464631d5e2256744f0
-lastReviewedNote: 'Reviewed for Issue #735: validation positively asserts the Process v2 RPC and absence of app-side field filtering; release gates remain unchanged.'
+lastReviewedCommit: a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe
+lastReviewedNote: 'Reviewed for Issue #735 qualification refresh: the Process v2 cleanup candidate passed the hermetic three-browser harness and receipt validation; release gates remain unchanged.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-07-30
-lastReviewedCommit: 2d582c989f8f6965236b9e464631d5e2256744f0
-lastReviewedNote: 'Reviewed for Issue #735: the existing Process RPC and semantic simulator coverage are sufficient; no test-strategy expansion is required.'
+lastReviewedCommit: a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe
+lastReviewedNote: 'Reviewed for Issue #735 qualification refresh: the current 84-position three-browser execution confirms the existing Process RPC and simulator coverage remain sufficient.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-30
-lastReviewedCommit: 2d582c989f8f6965236b9e464631d5e2256744f0
-lastReviewedNote: 'Reviewed for Issue #735: the residue cleanup creates no new coverage backlog item.'
+lastReviewedCommit: a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe
+lastReviewedNote: 'Reviewed for Issue #735 qualification refresh: the successful hermetic receipt closes the cleanup evidence gap and creates no new coverage backlog item.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-30
-lastReviewedCommit: 2d582c989f8f6965236b9e464631d5e2256744f0
-lastReviewedNote: 'Reviewed for Issue #735: exact request-key allowlists remain the correct semantic simulator pattern.'
+lastReviewedCommit: a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe
+lastReviewedNote: 'Reviewed for Issue #735 qualification refresh: the current receipt confirms exact request-key allowlists remain the correct semantic simulator pattern.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-30
-lastReviewedCommit: 2d582c989f8f6965236b9e464631d5e2256744f0
-lastReviewedNote: 'Reviewed for Issue #735: removed simulator query keys should fail as unexpected requests; no troubleshooting exception is added.'
+lastReviewedCommit: a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe
+lastReviewedNote: 'Reviewed for Issue #735 qualification refresh: the regenerated receipt followed the documented stale-receipt recovery path; no troubleshooting exception is added.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "2dbcfc64a9fcfa0c24a715c8071c83e68657943e7133be23cd86d4acdf040983"
+    "runResultSha256": "b9432cc33efd078e607746b30d7551acc4e7b79a9de37e8381a238cfc13c7f3c"
   },
-  "environmentManifestSha256": "95c6d32067c68c776b38b23feb2eeef810ecb448b3befc6a9c617c4c202b40d9",
+  "environmentManifestSha256": "09ffdd3b0b71be3469be44752a7ecfbc67a8dd48906fe4c52ab75f4f560fb446",
   "externalRequests": 0,
-  "generatedAt": "2026-07-29T19:34:17.028Z",
+  "generatedAt": "2026-07-30T08:39:37.672Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "4c91fb91060b0c81191e2350c2fcc507df56a1d826b19e41e845df04af2a4abf",
-  "qualifiedCommit": "d6e1c29e8e7b5e2434391d1f6c96b029abd10765",
-  "qualifiedTree": "461299c00e5ab1662461742fd714c86be4f2fc5a",
+  "qualificationInputSha256": "2edabd13e6557cc5641f895648ba963283171bde8d5613f2e9b12650927fa4b5",
+  "qualifiedCommit": "a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe",
+  "qualifiedTree": "2668c26e08b32ec878aaf67d325d0fdf97f9746f",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }


### PR DESCRIPTION
Refs #735

## Summary

- refresh the checked-in semantic harness qualification receipt for current `dev` after the retired-contract simulator cleanup
- bind the receipt to exact candidate `a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe`, qualified tree `2668c26e14759dc4aec48dc672b2b0f0f02372c6`, and the current qualification input digest
- refresh governed review metadata for the qualification-only change

## Validation

- `npm run e2e:qualify`: 84 positions; 60 passed; 24 qualification-mode skips; Chromium, Firefox, and WebKit; zero external requests and zero production writes
- managed pre-push gate: 405 suites / 5,486 tests passed; 100% statements, branches, functions, and lines across 456 source files
- strict Docpact validation and lint passed

## Delivery note

This repairs the stale qualification evidence that correctly blocked promotion PR #737. After this PR merges to `dev`, #737 must rerun and pass the full main-candidate Release Gate before merge.