### PR TITLE
test: refresh production semantic E2E evidence

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-07-30'
-lastReviewedCommit: 'a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe'
-lastReviewedNote: 'Reviewed for Issue #735 qualification refresh: the new semantic-harness receipt is bound to the merged cleanup candidate; v2 RPC, extracted_md, and managed release boundaries remain unchanged.'
+lastReviewedCommit: 'a965fee5f94cfdf41a3683b561f486a5eef7bd04'
+lastReviewedNote: 'Reviewed for Issue #735 production closure: tracked semantic evidence now binds the merged cleanup candidate and its refreshed qualification receipt; routing, validation ownership, and managed release boundaries remain unchanged.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-07-30
-lastReviewedCommit: a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe
-lastReviewedNote: 'Reviewed for Issue #735 qualification refresh: the merged cleanup retains the indexed v2 RPC and database-owned extracted_md contract and now has current hermetic three-browser evidence.'
+lastReviewedCommit: ebd2abf106f131c7846f581fc39e8af766cc2c56
+lastReviewedNote: 'Reviewed for Issue #735 production closure: the refreshed three-browser evidence and qualification receipt preserve the repo contract, dev-to-main promotion path, and database-owned extracted_md boundary.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-07-30
-lastReviewedCommit: a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe
-lastReviewedNote: 'Reviewed for Issue #735 qualification refresh: the regenerated semantic-harness receipt follows the documented dev PR, release-gate, promotion, and workspace-integration sequence.'
+lastReviewedCommit: ebd2abf106f131c7846f581fc39e8af766cc2c56
+lastReviewedNote: 'Reviewed for Issue #735 production closure: the refreshed semantic-harness evidence still follows the documented managed push, dev PR, release-gate, promotion, and workspace-integration loop.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -57,8 +57,8 @@ checkPaths:
   - .github/workflows/build.yml
   - package.json
 lastReviewedAt: 2026-07-30
-lastReviewedCommit: 2d582c989f8f6965236b9e464631d5e2256744f0
-lastReviewedNote: 'Reviewed for Issue #735: removing one obsolete simulator query key changes no locale, assertion-ID, credential, write-safety, or cleanup contract.'
+lastReviewedCommit: a965fee5f94cfdf41a3683b561f486a5eef7bd04
+lastReviewedNote: 'Reviewed for Issue #735 production closure: fresh authenticated evidence preserves the four-locale, 49-assertion, candidate-local/production-backend, exact-write, and zero-leak contracts.'
 baselineObservedAt: 2026-07-18
 related:
   - ../../AGENTS.md

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-07-30
-lastReviewedCommit: a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe
-lastReviewedNote: 'Reviewed for Issue #735 qualification refresh: the simulator allowlist contraction has a current three-browser receipt; the clean managed gate and production-write fail-closed rules remain unchanged.'
+lastReviewedCommit: a965fee5f94cfdf41a3683b561f486a5eef7bd04
+lastReviewedNote: 'Reviewed for Issue #735 production closure: refreshed verified evidence and the follow-up three-browser receipt still require the normal clean managed gate; production-write authorization remains fail closed.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-07-30
-lastReviewedCommit: a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe
-lastReviewedNote: 'Reviewed for Issue #735 qualification refresh: the Process v2 cleanup candidate passed the hermetic three-browser harness and receipt validation; release gates remain unchanged.'
+lastReviewedCommit: a965fee5f94cfdf41a3683b561f486a5eef7bd04
+lastReviewedNote: 'Reviewed for Issue #735 production closure: authenticated production E2E, canonical evidence, deterministic artifacts, qualification, and release preflight follow the documented proof order without changing gate commands.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-07-30
-lastReviewedCommit: a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe
-lastReviewedNote: 'Reviewed for Issue #735 qualification refresh: the current 84-position three-browser execution confirms the existing Process RPC and simulator coverage remain sufficient.'
+lastReviewedCommit: a965fee5f94cfdf41a3683b561f486a5eef7bd04
+lastReviewedNote: 'Reviewed for Issue #735 production closure: the authenticated 84-position run and refreshed hermetic qualification confirm the existing semantic E2E strategy remains sufficient; no strategy expansion is needed.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-30
-lastReviewedCommit: a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe
-lastReviewedNote: 'Reviewed for Issue #735 qualification refresh: the successful hermetic receipt closes the cleanup evidence gap and creates no new coverage backlog item.'
+lastReviewedCommit: a965fee5f94cfdf41a3683b561f486a5eef7bd04
+lastReviewedNote: 'Reviewed for Issue #735 production closure: verified production evidence and the current hermetic receipt close the cleanup proof gap without creating a new coverage backlog item.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-30
-lastReviewedCommit: a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe
-lastReviewedNote: 'Reviewed for Issue #735 qualification refresh: the current receipt confirms exact request-key allowlists remain the correct semantic simulator pattern.'
+lastReviewedCommit: a965fee5f94cfdf41a3683b561f486a5eef7bd04
+lastReviewedNote: 'Reviewed for Issue #735 production closure: fresh production and hermetic evidence confirm exact request-key allowlists, digest binding, and ledger-controlled mutation remain the correct semantic E2E patterns.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-07-30
-lastReviewedCommit: a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe
-lastReviewedNote: 'Reviewed for Issue #735 qualification refresh: the regenerated receipt followed the documented stale-receipt recovery path; no troubleshooting exception is added.'
+lastReviewedCommit: a965fee5f94cfdf41a3683b561f486a5eef7bd04
+lastReviewedNote: 'Reviewed for Issue #735 production closure: the digest-mismatch recovery used a fresh authenticated run, copied canonical evidence, deterministic artifact refresh, clean-candidate qualification, and no exception path.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
+    "digest": "d471c8d599a509ee1855d8dbbb2df9085327f2b876e4f2e907dbec2fc9dca428",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "b1f06a7a21386777a7054605fbcbcdfb89b062741b816cdd1b39b9e71898b1fb",
+          "sha256": "43f425878d8dd3a194b0c8b2a3a57d3d3dd8f44179723c5f93d9204f05029532",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
+    "docs/plans/i18n/route-view-coverage.json": "d471c8d599a509ee1855d8dbbb2df9085327f2b876e4f2e907dbec2fc9dca428",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-de-DE/glossary.json": "a5fd4e759af2713fbec83f2b95171c7b32206d7218da0401d28d2eecefccce3a",
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "d9a0eb321f19e3ebb6f2698af7eee4a09a9d15672c284d53c4a1cac93c02ae82"
+  "contextDigest": "40414c9ca138fce2674bf40aed529a678f6d832a81d8918e44e72f587d7ab6b1"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "d9a0eb321f19e3ebb6f2698af7eee4a09a9d15672c284d53c4a1cac93c02ae82",
-    "qualityDigest": "4cc8b6a6abdac782e9e1ca02eec185e031f59c0b7145ed24567496bfdce9c1d5",
+    "contextDigest": "40414c9ca138fce2674bf40aed529a678f6d832a81d8918e44e72f587d7ab6b1",
+    "qualityDigest": "3f6eab5cfa9bb17191a91dad1da2663cf6bcb21942bd0c2a78255b3224029362",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
+    "routeViewCoverageDigest": "d471c8d599a509ee1855d8dbbb2df9085327f2b876e4f2e907dbec2fc9dca428",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "22556c8fa0bbe771cf03e2f4c73c0c4441b00084a3dafeea739b73c19befbde6"
+  "activationDigest": "46992a5fa9466035d6ec378fa8592a1e0dd4b2ff0a2c4e987d553c2a6e9d5480"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "417a8237335eab473a84bbb9e80a690763e7f77e8e38ab86716202eb55ac8d7d",
-    "contextDigest": "d9a0eb321f19e3ebb6f2698af7eee4a09a9d15672c284d53c4a1cac93c02ae82"
+    "contextDigest": "40414c9ca138fce2674bf40aed529a678f6d832a81d8918e44e72f587d7ab6b1"
   },
   "catalog": {
     "messageCount": 3079,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "4cc8b6a6abdac782e9e1ca02eec185e031f59c0b7145ed24567496bfdce9c1d5"
+  "qualityDigest": "3f6eab5cfa9bb17191a91dad1da2663cf6bcb21942bd0c2a78255b3224029362"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
+    "digest": "d471c8d599a509ee1855d8dbbb2df9085327f2b876e4f2e907dbec2fc9dca428",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "b1f06a7a21386777a7054605fbcbcdfb89b062741b816cdd1b39b9e71898b1fb",
+          "sha256": "43f425878d8dd3a194b0c8b2a3a57d3d3dd8f44179723c5f93d9204f05029532",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
+    "docs/plans/i18n/route-view-coverage.json": "d471c8d599a509ee1855d8dbbb2df9085327f2b876e4f2e907dbec2fc9dca428",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-en-US/glossary.json": "4b8443ea3f91f15383683e9ece6221e40e24ceb75442ea830964b06c12559970",
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "72dda494bbcff1bf360442174d1225b74250939db28d98db1d7c5a775e980bce"
+  "contextDigest": "eb142526f585b83aec8c377fcfaec89383dc1bb0a9132eceed8aac9e4d0a314e"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "72dda494bbcff1bf360442174d1225b74250939db28d98db1d7c5a775e980bce",
-    "qualityDigest": "b1a78161f0ad30af8e06b272b515ee15caf27bd7dcbd412347b69c4f16e6c815",
+    "contextDigest": "eb142526f585b83aec8c377fcfaec89383dc1bb0a9132eceed8aac9e4d0a314e",
+    "qualityDigest": "d76d429768a2ba42d3ca86177863f22185886728c79bb69c999e04f32b7bf145",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
+    "routeViewCoverageDigest": "d471c8d599a509ee1855d8dbbb2df9085327f2b876e4f2e907dbec2fc9dca428",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "a7b25bb55ffaad54d449000974af91f126ad4cee7a3d26d379e67434f366c10a"
+  "activationDigest": "40c7584ce79d85c986bb0e88ae6bea10887adacbc20e70f4d922d4f2e248f7e9"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "417a8237335eab473a84bbb9e80a690763e7f77e8e38ab86716202eb55ac8d7d",
-    "contextDigest": "72dda494bbcff1bf360442174d1225b74250939db28d98db1d7c5a775e980bce"
+    "contextDigest": "eb142526f585b83aec8c377fcfaec89383dc1bb0a9132eceed8aac9e4d0a314e"
   },
   "catalog": {
     "messageCount": 3079,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "b1a78161f0ad30af8e06b272b515ee15caf27bd7dcbd412347b69c4f16e6c815"
+  "qualityDigest": "d76d429768a2ba42d3ca86177863f22185886728c79bb69c999e04f32b7bf145"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
+    "digest": "d471c8d599a509ee1855d8dbbb2df9085327f2b876e4f2e907dbec2fc9dca428",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "b1f06a7a21386777a7054605fbcbcdfb89b062741b816cdd1b39b9e71898b1fb",
+          "sha256": "43f425878d8dd3a194b0c8b2a3a57d3d3dd8f44179723c5f93d9204f05029532",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
+    "docs/plans/i18n/route-view-coverage.json": "d471c8d599a509ee1855d8dbbb2df9085327f2b876e4f2e907dbec2fc9dca428",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-fr-FR/glossary.json": "057cb494f02d980106469f6a16befc102d26db5ac362b9777cd5f97c7729c91b",
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "dfeb7a300d075cc1cbd38596b854f7c7b09a05093a0895f5ded10640b61a612e"
+  "contextDigest": "f7eac8128e6de3dd5dbc6d58b0049ce525a25b04f41f29d986e24770d3897c73"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "dfeb7a300d075cc1cbd38596b854f7c7b09a05093a0895f5ded10640b61a612e",
-    "qualityDigest": "f98ac09331b5b69e7087eae2df09bac0a6eaf14115af0bf67899e28d97e4989d",
+    "contextDigest": "f7eac8128e6de3dd5dbc6d58b0049ce525a25b04f41f29d986e24770d3897c73",
+    "qualityDigest": "a09896ab2bd074d6940cdc33d711f223895d51c8d58ac6b9194ee8ffdc957058",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
+    "routeViewCoverageDigest": "d471c8d599a509ee1855d8dbbb2df9085327f2b876e4f2e907dbec2fc9dca428",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "dd4feb88c0e33fe574e4c062be38db36a65f9e48298f8dab379fc31261ebd2ee"
+  "activationDigest": "2408b5d86f223dbf19ecc07df9396aa2b634d979b1e15b93001f7497d3dd7c88"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "417a8237335eab473a84bbb9e80a690763e7f77e8e38ab86716202eb55ac8d7d",
-    "contextDigest": "dfeb7a300d075cc1cbd38596b854f7c7b09a05093a0895f5ded10640b61a612e"
+    "contextDigest": "f7eac8128e6de3dd5dbc6d58b0049ce525a25b04f41f29d986e24770d3897c73"
   },
   "catalog": {
     "messageCount": 3079,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "f98ac09331b5b69e7087eae2df09bac0a6eaf14115af0bf67899e28d97e4989d"
+  "qualityDigest": "a09896ab2bd074d6940cdc33d711f223895d51c8d58ac6b9194ee8ffdc957058"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
+    "digest": "d471c8d599a509ee1855d8dbbb2df9085327f2b876e4f2e907dbec2fc9dca428",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "b1f06a7a21386777a7054605fbcbcdfb89b062741b816cdd1b39b9e71898b1fb",
+          "sha256": "43f425878d8dd3a194b0c8b2a3a57d3d3dd8f44179723c5f93d9204f05029532",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
+    "docs/plans/i18n/route-view-coverage.json": "d471c8d599a509ee1855d8dbbb2df9085327f2b876e4f2e907dbec2fc9dca428",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-zh-CN/glossary.json": "c891add0ee4bd6d24c0213d0c839474e145d85867426df796763b8e038053d9b",
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "93e89e5e9114c8bc8c20256b6e5b3ee75f1dbdccaa5d6b9bba670278ba00a0f7"
+  "contextDigest": "6e14d110e204e3e48ddc8c471b0ecdd36ad1f6cc42911b89ab55f4b0e8c4de3d"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "93e89e5e9114c8bc8c20256b6e5b3ee75f1dbdccaa5d6b9bba670278ba00a0f7",
-    "qualityDigest": "d1df859533e630901476f2ba172b22a13ed86a691073ce3a464b93cb76fae1f7",
+    "contextDigest": "6e14d110e204e3e48ddc8c471b0ecdd36ad1f6cc42911b89ab55f4b0e8c4de3d",
+    "qualityDigest": "94af1ee600382bf6a9b1cc71574f1180e95ac93c1f5eaa3d971448a0f0cd68fb",
     "correctionLedgerDigest": "af8bed7cc80fddd36ad049f8ae9a17e4f3f9a960bcc50f31d6df42c169807fb2",
-    "routeViewCoverageDigest": "b2131ac31bc6b4b54e1597f99ec0efb78822deb314d5f559c7dc213718c78d4e",
+    "routeViewCoverageDigest": "d471c8d599a509ee1855d8dbbb2df9085327f2b876e4f2e907dbec2fc9dca428",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "fe3f5c1761fcab7d9592e43bf5f3673815768ea0c6b81c76cc8740800e2a67ec"
+  "activationDigest": "513f3758c31ba7b30606c240efa7467f3c89eeeb79b09aca9fccb9379ccc0306"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "417a8237335eab473a84bbb9e80a690763e7f77e8e38ab86716202eb55ac8d7d",
-    "contextDigest": "93e89e5e9114c8bc8c20256b6e5b3ee75f1dbdccaa5d6b9bba670278ba00a0f7"
+    "contextDigest": "6e14d110e204e3e48ddc8c471b0ecdd36ad1f6cc42911b89ab55f4b0e8c4de3d"
   },
   "catalog": {
     "messageCount": 3079,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "d1df859533e630901476f2ba172b22a13ed86a691073ce3a464b93cb76fae1f7"
+  "qualityDigest": "94af1ee600382bf6a9b1cc71574f1180e95ac93c1f5eaa3d971448a0f0cd68fb"
 }

--- a/docs/plans/i18n/route-view-coverage.json
+++ b/docs/plans/i18n/route-view-coverage.json
@@ -353,7 +353,7 @@
       "executedEvidence": [
         {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "b1f06a7a21386777a7054605fbcbcdfb89b062741b816cdd1b39b9e71898b1fb"
+          "sha256": "43f425878d8dd3a194b0c8b2a3a57d3d3dd8f44179723c5f93d9204f05029532"
         }
       ]
     }

--- a/docs/plans/i18n/semantic-e2e-evidence.json
+++ b/docs/plans/i18n/semantic-e2e-evidence.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": "tiangong.i18n-semantic-e2e-evidence.v1",
   "status": "verified",
-  "generatedAt": "2026-07-29T19:13:51.968Z",
-  "runId": "local-81f1343b-0a88-4f61-a7ad-7649568ff953",
+  "generatedAt": "2026-07-30T15:33:52.111Z",
+  "runId": "local-2d365dbf-8958-454b-b5d7-430930f45976",
   "candidate": {
     "configTreeDigest": "c79878bbed6dfb7becc3cedae0fdd08e0926b674293a6f9656469ac8682cc804",
-    "observedHeadCommit": "82ed0855eed7c855c5298f6568c707b3e3b4eced",
-    "packageManifestDigest": "57389d83ac34ff293f1312ba4dcfdc76b5a1ac32fa71ef5449bca6e7a358dbdf",
+    "observedHeadCommit": "bf14d3e3227e48181ccb540ee66b2dc0da913312",
+    "packageManifestDigest": "be54f5b04df8858db21ebc7933a2a3d99fbe8f78f34b8cca98f734ef8b1358ed",
     "sourceTreeDigest": "f0ebaaf11f0cf19c979f2c118189d4779f65600289152ee68d7e9d653727a1d6",
     "unitTestTreeDigest": "f5e5024efa50109a81c9daca0b1d4cb3fbb5371dc9ce0cdcdddcf359307476e6"
   },
@@ -34,7 +34,7 @@
   "digests": {
     "packageLock": {
       "path": "package-lock.json",
-      "sha256": "082c623e76b64e161d0894bb3e7879d096f235494ce3fecc8106dd2723e33902"
+      "sha256": "03ca78dbd4f5d71ce7872dae69b239953ffb281240134950e71e5d7e21bccd77"
     },
     "runtimeAssets": [
       {
@@ -273,7 +273,7 @@
       },
       {
         "path": "tests/e2e/i18n/semantic-backend-simulator.ts",
-        "sha256": "35e0b220453ec603345d04d3baabdf372dfc263e1af2efd08054430d8084d35b"
+        "sha256": "5d4658259b1265e237a0db96bcd8cc50f3ac206dece7eaf993f10826baacd64a"
       },
       {
         "path": "tests/e2e/i18n/semantic-critical.spec.ts",

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "b9432cc33efd078e607746b30d7551acc4e7b79a9de37e8381a238cfc13c7f3c"
+    "runResultSha256": "946b03f89cd5f5b97f082855d16280ef76956e3caed71e73d63e5697315f7a93"
   },
-  "environmentManifestSha256": "09ffdd3b0b71be3469be44752a7ecfbc67a8dd48906fe4c52ab75f4f560fb446",
+  "environmentManifestSha256": "81474f872b2163e2953c6d69a88f679d134d5a1a66cce6916d43ac43c50fcae5",
   "externalRequests": 0,
-  "generatedAt": "2026-07-30T08:39:37.672Z",
+  "generatedAt": "2026-07-30T15:49:48.289Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "2edabd13e6557cc5641f895648ba963283171bde8d5613f2e9b12650927fa4b5",
-  "qualifiedCommit": "a0ea7d6f7e83d4abe84f783109d67a4b4fe40bfe",
-  "qualifiedTree": "2668c26e08b32ec878aaf67d325d0fdf97f9746f",
+  "qualificationInputSha256": "2936d54371a20ad4fe5ddc80f8ff6fc42d8cb79c58695205bd22e734577c0139",
+  "qualifiedCommit": "f9b3c23322c12c8df9448af43fda0eaea377f809",
+  "qualifiedTree": "200955f241332da640484e19b9a810adbe90e6eb",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }


### PR DESCRIPTION
## Summary
- refresh the tracked production semantic E2E evidence after the retired search-contract cleanup reached production
- record the clean-commit qualification receipt and update its route-view descriptor digest
- review the affected repo, bootstrap, and test-governance documents against the current delivery contract

## Validation
- authorized production E2E: 60 passed, 24 designed skips across Chromium, Firefox, and WebKit; created 1, cleaned 1, leaked 0
- clean-commit qualification: 60 passed, 24 designed skips; `productionWrites=0`, `externalRequests=0`
- `npm run release:preflight`
- managed pre-push gate: Docpact passed; 405 suites / 5,486 tests passed; statements, branches, functions, and lines all 100%

## Scope
This PR changes evidence, qualification receipts, and governance review metadata only. Product search behavior remains on the indexed v2 RPC and database-owned `extracted_md` contract.

Refs #735
