### PR TITLE
test: qualify release harness for v0.0.64

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-07-30'
-lastReviewedCommit: '30e31e7ad2f69444e80b2a042ec173c7857ce360'
-lastReviewedNote: 'Reviewed for Issue #734 after the Issue #735 production-evidence and Docker-snapshot closures: the Welcome LCA quick start, locale artifacts, and responsive proof remain within existing frontend, i18n, testing, and managed release boundaries.'
+lastReviewedAt: "2026-07-31"
+lastReviewedCommit: "cbf47c8612a9c7a2fd1386e9bfa161754a3d4d6e"
+lastReviewedNote: 'Reviewed for Issue #743 after refreshing the credential-free semantic-harness qualification on dev commit 3ac0ca60: existing routing, testing-gate, release, and workspace-integration boundaries remain accurate.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,9 +31,9 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-07-30
-lastReviewedCommit: 30e31e7ad2f69444e80b2a042ec173c7857ce360
-lastReviewedNote: 'Reviewed for Issue #734 after the Issue #735 production-evidence and Docker-snapshot closures: Welcome copy and responsive layout changes do not alter repository ownership, branch policy, delivery rules, schema ownership, or workspace integration.'
+lastReviewedAt: 2026-07-31
+lastReviewedCommit: cbf47c8612a9c7a2fd1386e9bfa161754a3d4d6e
+lastReviewedNote: 'Reviewed for Issue #743 after qualifying dev commit 3ac0ca60: the refreshed credential-free receipt does not alter repository ownership, branch policy, delivery rules, production-write authorization, or workspace integration.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -28,9 +28,9 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - .nvmrc
-lastReviewedAt: 2026-07-30
-lastReviewedCommit: 30e31e7ad2f69444e80b2a042ec173c7857ce360
-lastReviewedNote: 'Reviewed for Issue #734 after the Issue #735 production-evidence and Docker-snapshot closures: the Welcome quick-start change follows the existing dev work loop, clean managed gate, promotion, and workspace-integration sequence.'
+lastReviewedAt: 2026-07-31
+lastReviewedCommit: cbf47c8612a9c7a2fd1386e9bfa161754a3d4d6e
+lastReviewedNote: 'Reviewed for Issue #743 after qualifying dev commit 3ac0ca60: the generated receipt follows the existing clean qualification, dev PR, production-preflight, promotion, and workspace-integration sequence.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-07-30
-lastReviewedCommit: 30e31e7ad2f69444e80b2a042ec173c7857ce360
-lastReviewedNote: 'Reviewed for Issue #734 after the Issue #735 production-evidence and Docker-snapshot closures: Welcome and locale-artifact changes use the existing clean managed gate; production-write authorization, release, and trigger policy remain unchanged.'
+lastReviewedAt: 2026-07-31
+lastReviewedCommit: cbf47c8612a9c7a2fd1386e9bfa161754a3d4d6e
+lastReviewedNote: 'Reviewed for Issue #743 after qualifying dev commit 3ac0ca60: the generated receipt follows the existing dev PR and managed-gate path; production-write authorization, release, and trigger policy remain unchanged.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-07-30
-lastReviewedCommit: 30e31e7ad2f69444e80b2a042ec173c7857ce360
-lastReviewedNote: 'Reviewed for Issue #734 after the Issue #735 production-evidence and Docker-snapshot closures: locale audits, focused Welcome tests, responsive browser proof, lint, build, and the clean managed gate remain the applicable validation set.'
+lastReviewedAt: 2026-07-31
+lastReviewedCommit: cbf47c8612a9c7a2fd1386e9bfa161754a3d4d6e
+lastReviewedNote: 'Reviewed for Issue #743 after the credential-free qualification of dev commit 3ac0ca60: 60 browser cases passed, 24 designed cases skipped, and the existing receipt, PR, preflight, and managed-gate validation flow remains accurate.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -26,9 +26,9 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - package.json
-lastReviewedAt: 2026-07-30
-lastReviewedCommit: 30e31e7ad2f69444e80b2a042ec173c7857ce360
-lastReviewedNote: 'Reviewed for Issue #734 after the Issue #735 production closure: focused page, semantic-contract, responsive-layout, authenticated, and hermetic proof remain sufficient; no testing-strategy expansion is required.'
+lastReviewedAt: 2026-07-31
+lastReviewedCommit: cbf47c8612a9c7a2fd1386e9bfa161754a3d4d6e
+lastReviewedNote: 'Reviewed for Issue #743 after the credential-free qualification of dev commit 3ac0ca60: the hermetic 60-pass/24-designed-skip result fits the maintained strategy and requires no testing-strategy expansion.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -28,9 +28,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-07-30
-lastReviewedCommit: 30e31e7ad2f69444e80b2a042ec173c7857ce360
-lastReviewedNote: 'Reviewed for Issue #734 after the Issue #735 production closure: the Welcome quick-start change and refreshed production evidence create no new coverage or test-execution backlog item.'
+lastReviewedAt: 2026-07-31
+lastReviewedCommit: cbf47c8612a9c7a2fd1386e9bfa161754a3d4d6e
+lastReviewedNote: 'Reviewed for Issue #743 after qualifying dev commit 3ac0ca60: the refreshed receipt closes the current hermetic qualification checkpoint without creating a coverage or test-execution backlog item.'
 ---
 
 # Testing Execution State
@@ -60,7 +60,7 @@ This is a checked-in reference, not a per-PR execution ledger. A delivery's post
 - Issue #635 adds a separate Playwright semantic localization proof surface: `npm run test:e2e:i18n` derives all locale/content-language expectations from registries, binds 49 stable route/view assertion IDs, runs Chromium across the complete matrix, and requires the login/selector, team authoring, and process lifecycle critical scenarios in Chromium, Firefox, and WebKit
 - semantic E2E GitHub Actions is credential-free/read-only and runs only contract discovery plus three-browser public semantics; it is optional through `workflow_dispatch`, mandatory for the exact release SHA, and absent from routine PR/dev triggers, while authenticated candidate-local/production-backend closure is restricted to an explicitly authorized local operator session with authenticated mode, both production-write guards, and an explicit verified-evidence opt-in
 - Issue #654 adds `e2e:env:install`, read-only `e2e:env:doctor`, exact-candidate `e2e:release`, argument-free bounded `e2e:release:resume`, owned cleanup, and focused `e2e:dev`; release mode archives only a clean Next commit, uses a digest-pinned container and cached production build, performs all safe checks before fixture intent, and never mounts the workspace
-- Issue #722 records the current credential-free semantic-harness qualification for the exact post-mirror `dev` inputs: 48 canonical cases and 12 harness-control cases executed, 24 designed cases skipped, all 49 assertion IDs closed, and external requests, production writes, and cleanup residue all zero. The generated receipt must merge before the clean authorized production run.
+- Issue #743 records the current credential-free semantic-harness qualification for exact `dev` commit `3ac0ca60a7370d767ca003342180bb51f1b2dd7d`: 48 canonical cases and 12 harness-control cases executed, 24 designed cases skipped, all 49 assertion IDs closed, and external requests, production writes, and cleanup residue all zero. The generated receipt must merge before any clean authorized production run for the v0.0.64 candidate.
 - Issue #704 tracks two harness defects observed during authenticated production evidence refreshes. The evidence-writer repair now resolves the repository-owned Prettier configuration independently of `/e2e-output` and gives the checker a read-only external-artifact path, so raw container bytes can satisfy the same canonical contract without host normalization. The separate argument-free `e2e:release:resume` dispatch defect remains open under #704.
 - Issue #660 keeps production-data E2E fail-closed on real CI hosts while allowing an authorized local run to override only the release image's inherited `CI`/`GITHUB_ACTIONS` markers before the unchanged in-container authorization and ledger checks
 - tracked semantic evidence remains fail closed for production readiness until one full local authenticated execution closes every assertion, matches the declared source/test/route bindings, writes its intent ledger before create, verifies UUID + owner + all five multilingual field markers before delete, and reports `created=cleaned` with `leaked=0`; routine pre-push checks validate the record structurally without requiring current production-proof hashes, package-lock verification rejects all executable dependency drift while tolerating only root release-version metadata after proving the evidence's raw lock at its recorded commit, and adding a registry locale still invalidates older evidence rather than silently shrinking coverage

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -29,9 +29,9 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-07-30
-lastReviewedCommit: 30e31e7ad2f69444e80b2a042ec173c7857ce360
-lastReviewedNote: 'Reviewed for Issue #734 after the Issue #735 production closure: route-view assertions and responsive grid checks remain the focused Welcome pattern, while exact request keys, digest binding, and ledger-controlled mutation remain the semantic E2E pattern.'
+lastReviewedAt: 2026-07-31
+lastReviewedCommit: cbf47c8612a9c7a2fd1386e9bfa161754a3d4d6e
+lastReviewedNote: 'Reviewed for Issue #743 after qualifying dev commit 3ac0ca60: the credential-free receipt flow, 49-ID digest binding, and separately authorized ledger-controlled production mutation remain the correct semantic E2E patterns.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -26,9 +26,9 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-07-30
-lastReviewedCommit: 30e31e7ad2f69444e80b2a042ec173c7857ce360
-lastReviewedNote: 'Reviewed for Issue #734 after the Issue #735 production closure: existing locale-artifact, digest-mismatch, clean-candidate qualification, and serial Umi-test recovery guidance covers the merged state without a new exception.'
+lastReviewedAt: 2026-07-31
+lastReviewedCommit: cbf47c8612a9c7a2fd1386e9bfa161754a3d4d6e
+lastReviewedNote: 'Reviewed for Issue #743 after qualifying dev commit 3ac0ca60: the existing stale-receipt, clean-candidate, Docker, and serial-gate recovery guidance covers the refreshed qualification without a new exception.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "946b03f89cd5f5b97f082855d16280ef76956e3caed71e73d63e5697315f7a93"
+    "runResultSha256": "8da6cdfe8cce49d89fc9737076e6cca6fa4cbf37b61f30d5a04f7c198ab22394"
   },
-  "environmentManifestSha256": "81474f872b2163e2953c6d69a88f679d134d5a1a66cce6916d43ac43c50fcae5",
+  "environmentManifestSha256": "49a6ced6c668260c9dc7ab2f166de9e8bf43fe9168da2d16221635a72d197f1d",
   "externalRequests": 0,
-  "generatedAt": "2026-07-30T15:49:48.289Z",
+  "generatedAt": "2026-07-31T02:08:48.750Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "2936d54371a20ad4fe5ddc80f8ff6fc42d8cb79c58695205bd22e734577c0139",
-  "qualifiedCommit": "f9b3c23322c12c8df9448af43fda0eaea377f809",
-  "qualifiedTree": "200955f241332da640484e19b9a810adbe90e6eb",
+  "qualificationInputSha256": "ef41eced48bfa405453ba9f05358db30c9e3ef088da4164c6b73d9e75da0636c",
+  "qualifiedCommit": "3ac0ca60a7370d767ca003342180bb51f1b2dd7d",
+  "qualifiedTree": "087d3776916fdf8a25c6ae3aa8f125c91d65a83c",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }


### PR DESCRIPTION
## Summary

- refresh the credential-free semantic-harness qualification receipt for the exact post-#738 `dev` candidate
- record the completed Docpact review for the testing, gate, bootstrap, and release contracts
- update the current testing-state note to bind Issue #743 and `dev@3ac0ca60a7370d767ca003342180bb51f1b2dd7d`

## Why

The v0.0.64 promotion must start from a clean commit whose semantic harness inputs have a current checked-in qualification receipt. The generated receipt changes tracked state, so it must land through the normal reviewed `dev` PR flow before release preflight or any separately authorized authenticated production proof.

## Impact

No shipped product behavior or release policy changes. This PR refreshes the hermetic qualification evidence and governance review metadata needed to continue the release candidate.

## Validation

- `npm run e2e:qualify`
  - 60 passed, 24 designed cases skipped across Chromium, Firefox, and WebKit
  - all 49 stable assertion IDs closed
  - external requests: 0
  - production writes: 0
- `npm run e2e:qualification:check`
- Docpact strict config validation and lint: 0 active findings, 0 uncovered paths, 0 stale docs
- managed `push:checked` gate:
  - LCIA cache verification passed
  - reference-data reproducibility passed
  - lint, Prettier, and TypeScript passed
  - 405 suites / 5,486 tests passed
  - 456/456 tracked source files at 100% statements, branches, functions, and lines

No production credentials or production data were used.

Refs #743