### PR TITLE
Task Center: expand closure task details and artifact downloads

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-07-31'
-lastReviewedCommit: '8f09c891329717994571de0ca01fa2fdfdebb76b'
+lastReviewedAt: "2026-08-01"
+lastReviewedCommit: "b8b32228f6debd2165512c26fc186801bd3bcfe2"
 lastReviewedNote: 'Reviewed for Issues #745 and #748: the unified dataset-review routes and the exact-commit, loopback-only scope-closure qualification test surface preserve the existing production-write, branch, release, and workspace-integration boundaries.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-07-31
-lastReviewedCommit: 8f09c891329717994571de0ca01fa2fdfdebb76b
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
 lastReviewedNote: 'Reviewed for Issues #745 and #748: unified dataset review and the isolated exact-commit scope-closure adapter preserve frontend ownership, dev-first branch policy, production-write authorization, validation gates, and root integration ownership.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -28,8 +28,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - .nvmrc
-lastReviewedAt: 2026-07-31
-lastReviewedCommit: 8f09c891329717994571de0ca01fa2fdfdebb76b
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
 lastReviewedNote: 'Reviewed for Issues #745 and #748: local bootstrap now includes isolated exact-commit browser qualification while retaining the focused validation, dev PR, managed gate, promotion, production-data, and workspace-integration sequence.'
 ---
 

--- a/docs/agents/contribution-path-analysis-design.md
+++ b/docs/agents/contribution-path-analysis-design.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-07-28
-lastReviewedCommit: df5f4c9fbbe4132b4eaa22264e69cb6da61dd22c
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
 lastReviewedNote: 'Reviewed for Issue #701: Data Product closure failure rendering does not change the proposed async contribution-path result contract.'
 ---
 

--- a/docs/agents/lca-analysis-visualization-plan.md
+++ b/docs/agents/lca-analysis-visualization-plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-07-28
-lastReviewedCommit: df5f4c9fbbe4132b4eaa22264e69cb6da61dd22c
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
 lastReviewedNote: 'Reviewed for Issue #701: Data Product closure failure rendering does not change the proposed analysis views, chart rules, or traceability contract.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-07-31
-lastReviewedCommit: 31081bd3fbbcaacacd53613860af49941935953c
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
 lastReviewedNote: 'Reviewed for Issues #745 and #748: unified dataset review and the isolated qualification adapter retain the existing dev PR, docpact, lint, coverage, build, and managed-gate policy.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,9 +25,9 @@ checkPaths:
   - playwright.config.ts
   - config/docs-capture/**
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-07-31
-lastReviewedCommit: 38a8539074b6c51ac5f99c53f01640c9509f0c9e
-lastReviewedNote: 'Reviewed for Issues #745 and #748: document the unified dataset-review experience while keeping the scope-closure adapter in the repo testing layer without taking ownership from Database, Edge, Worker, or root orchestration.'
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
+lastReviewedNote: 'Reviewed for Issue #754: document inline Task Center closure-detail recovery and capability-gated artifact downloads without changing backend or result-package ownership.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -103,7 +103,7 @@ The task-center recovery path is:
 
 `src/components/LcaTaskCenter/index.tsx -> src/services/dataProducts/taskCenter.ts -> app_data_product_commands:list_task_feed`
 
-Next owns scope selection, command orchestration, curated closure-issue presentation, artifact-state presentation, task-summary rendering, and deep-link navigation. It maps the backend's typed artifact states to explicit preparing, available, expired, and unavailable UI states, keeps the bounded human XLSX action separate from the complete machine-result manifest action, and navigates directly to short-lived signed URLs without fetching or buffering artifact bytes. Requested LCIA methods cross the command boundary as exact `{ id, version }` identities derived from the reviewed static catalog; Next must not collapse them to identifier-only strings. Result-package generation remains unavailable until the selected closure check reports `passed`, a `valid` certificate, a `complete` scan, and matching scope/policy evidence; the backend revalidates those facts when it accepts `create_build`.
+Next owns scope selection, command orchestration, curated closure-issue presentation, artifact-state presentation, task-summary rendering, inline Task Center closure-detail recovery, and result-package deep-link navigation. Expanding a `lcia.scope_closure_check` task resolves its safe `closureCheckId` through `get_closure_check`, keeps lifecycle polling and artifact expiry client-bounded, and exposes only role-specific signed downloads allowed by the task capability projection; it does not decode raw worker or storage data. Next maps the backend's typed artifact states to explicit preparing, available, expired, failed, and unavailable UI states, keeps the bounded human XLSX action separate from the complete machine-result manifest action, and navigates directly to short-lived signed URLs without fetching or buffering artifact bytes. Requested LCIA methods cross the command boundary as exact `{ id, version }` identities derived from the reviewed static catalog; Next must not collapse them to identifier-only strings. Result-package generation remains unavailable until the selected closure check reports `passed`, a `valid` certificate, a `complete` scan, and matching scope/policy evidence; the backend revalidates those facts when it accepts `create_build`.
 
 The repo-owned qualification adapter runs this actual page from an exact clean detached commit with a loopback-only backend contract. It proves the established anonymous, standard-user, admin/owner, and Data Product Manager route boundary plus artifact lifecycle, metadata, direct-navigation, and localized 410 behavior. Its provider-owned record contributes only Next consumer assertions; root and Worker orchestration remain authoritative for cross-provider aggregation and release qualification.
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-07-31
-lastReviewedCommit: 8f09c891329717994571de0ca01fa2fdfdebb76b
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
 lastReviewedNote: 'Reviewed for Issues #745 and #748: retain focused unified-review proof and the managed full gate, and add exact-clean-commit loopback browser qualification that emits only non-sensitive Next consumer leaves for Worker aggregation.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -26,8 +26,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - package.json
-lastReviewedAt: 2026-07-31
-lastReviewedCommit: 31081bd3fbbcaacacd53613860af49941935953c
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
 lastReviewedNote: 'Reviewed for Issues #745 and #748: both changes follow the maintained focused-test plus final-gate strategy and require no testing-strategy expansion.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -28,8 +28,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-07-31
-lastReviewedCommit: 8f09c891329717994571de0ca01fa2fdfdebb76b
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
 lastReviewedNote: 'Reviewed for Issues #745 and #748: focused unified-review coverage and isolated Chromium proof for artifact states, direct downloads, localization, and every relevant role create no repository-wide coverage backlog item.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -29,8 +29,8 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-07-31
-lastReviewedCommit: 8f09c891329717994571de0ca01fa2fdfdebb76b
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
 lastReviewedNote: 'Reviewed for Issues #745 and #748: retain focused unit, service-boundary, locale, semantic localization E2E, and managed-gate patterns while adding the exact-commit loopback-only scope-closure qualification pattern.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -26,8 +26,8 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-07-31
-lastReviewedCommit: 8f09c891329717994571de0ca01fa2fdfdebb76b
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
 lastReviewedNote: 'Reviewed for Issues #745 and #748: retain Watchman-free focused Jest and serial managed-gate guidance, and add the shortest clean-commit loopback adapter recovery path without changing release-E2E troubleshooting.'
 ---
 

--- a/docs/agents/util_calculate.md
+++ b/docs/agents/util_calculate.md
@@ -20,8 +20,8 @@ checkPaths:
   - src/services/lca/**
   - src/components/LcaTaskCenter/**
   - src/pages/Processes/Analysis/**
-lastReviewedAt: 2026-07-28
-lastReviewedCommit: df5f4c9fbbe4132b4eaa22264e69cb6da61dd22c
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
 lastReviewedNote: 'Reviewed for Issue #701: Data Product closure failure rendering does not change allocation, scaling, submodel, or LCIA semantics.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "3a2e008bd652d5f01c3ac00115e1d72c8e201ebb7229d73f20b25af0d2979f74",
-    "auditedInputDigest": "d67932f5212ba9ec819334ad21c88674703a1477d1e43faf8b6d04cc7e64c5b4"
+    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb",
+    "auditedInputDigest": "bf1d21a781e4e708227e8a074b85ae03c5ae4435c0740ab76bf3f41edf0af091"
   },
   "inventory": {
-    "sourceMessageCount": 3096,
-    "localeMessageCount": 3096,
+    "sourceMessageCount": 3098,
+    "localeMessageCount": 3098,
     "leafModuleCount": 30,
     "dynamicFamilyCount": 17,
     "dynamicCallsiteCount": 39,
@@ -44,21 +44,21 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3096,
-    "completeCount": 3096,
+    "messageCount": 3098,
+    "completeCount": 3098,
     "blockedCount": 0,
-    "dossierDigest": "fc13ea3e326fd3a9cb4707016e7a31a09a194c3a632bdc45147353cd8102de9d",
-    "catalogDigest": "9ba5479bfd0eae83b0d879078587fc56f30fdd39c28b21ed959b3a8df73bb6b0",
+    "dossierDigest": "011cdb89553e700472adfefbe3edba716084133afd2cbff12ef1f3383cd773c4",
+    "catalogDigest": "df0a5502c9d3b710b4506d04cc7a18b39c4d8907f7186c7eb6e58d76fde7361c",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
     "roleCounts": {
       "error-or-validation": 361,
       "explanatory-copy": 110,
       "field-guidance": 49,
-      "label-or-body-copy": 1245,
+      "label-or-body-copy": 1246,
       "navigation-or-tab": 226,
       "reserved-catalog-copy": 276,
-      "status-or-empty-state": 98,
+      "status-or-empty-state": 99,
       "success-notification": 181,
       "title-or-heading": 239,
       "user-action": 311
@@ -69,9 +69,9 @@
       "interactive-ready": 521,
       "retained-not-currently-reachable": 355,
       "successful-completion": 181,
-      "visible": 1633
+      "visible": 1635
     },
-    "riskCounts": { "high": 1374, "low": 1500, "medium": 222 },
+    "riskCounts": { "high": 1374, "low": 1502, "medium": 222 },
     "highRiskMessageCount": 1374,
     "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb"
   },
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4082,
+    "literalReferenceCount": 4098,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale de-DE --message <MESSAGE_ID>"
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "72ac7d49b1bb2acd9513ce23856c9a39785f0debb828b9f09752e49e88140804",
+      "sourceEvidenceDigest": "cfed36e5b6b1a95d318b33e71139cef0020f930775793f82bf3e3dc3f8fb8194",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "567420ede3b5af244d73e17e1c9bf07d96e45e2439423b320273ae7a39ee7c84",
+          "sourceDigest": "6cc7d3e59e8d68f0bf31cbf273e34e523bec0b5bf35113f856cf9f6649997127",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "7b327e8dda83f7be2afee3e0ae9d43f6b8274886ffaf32a94763ca2418b8637e",
+          "sourceDigest": "f4667f4ac6398ea620fe3d7141ba6a14dd0e798398dec141b5c0491b535063d0",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "03a93ebef57fb7c33206d2953a2a38f5b611f44ca4e1beff83ca3ce66cdfa591",
+          "sourceDigest": "f43de572d115ad87c41934094ac4a68f4fb2fc4e07f2e8dce9cfc98431095b7e",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -367,7 +367,7 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "b5ca4582ff5e964b2690d86228d180eaa1bd22fc5e401fb1564419c14a5cab70",
+          "sourceDigest": "8ade645875468d9ca1d46a8192198b981f47bf2af3443fb4fd0366f94fc9a120",
           "focusedTestDigest": "342a74fe96651abf404aa2c6f2212d0c85b6057c35fa5f74d0b91ae0687fcf39",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
@@ -1042,12 +1042,12 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "935de97e8a382d582583460132a881a78986330d90b3ee40f7a20190d2f29283",
-          "focusedTestDigest": "caf3b45659e0562af41147ada8c45cdfb0219a7aa1f5f29c9769c793c1d74212",
+          "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
+          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
-          "derivedMessageCount": 131,
-          "derivedMessageDigest": "1c07d2cec87cdf8287342fe1df07044545cacbf93d533ef1c16e3202c0aba107",
+          "derivedMessageCount": 119,
+          "derivedMessageDigest": "f3f53e78726b3875411fb46e70f2c863dad1fe7cd30bc2a3337e9d040dd7ef16",
           "stateSignals": ["empty", "error", "loading", "success", "unavailable"],
           "queryParameters": ["tid"],
           "navigationTargets": [
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "cec469024fc62b5ea120fe46a0d67ed0003a9f88328812b504be5441c41400e2",
+      "rowEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "a2ad1ef7686b12973bcba8f340790ff1e9de7b743930bb6f2e40d22538745ad6"
+  "contextDigest": "227fb56e9a449cc756046de0082b318366a1b365f49740c2b9b434a880bdda59"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "3a2e008bd652d5f01c3ac00115e1d72c8e201ebb7229d73f20b25af0d2979f74"
+    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "a2ad1ef7686b12973bcba8f340790ff1e9de7b743930bb6f2e40d22538745ad6",
-    "qualityDigest": "3e7bedcc85de5d9ed07b1809fc258963a9d7905e6d4d9235ea25a71b4922abd6",
+    "contextDigest": "227fb56e9a449cc756046de0082b318366a1b365f49740c2b9b434a880bdda59",
+    "qualityDigest": "47bdea22a15f3c79cf4f54932c463814340c4b744ec2e72f91132620c453cf39",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "9e0ada8fac3a30b5e6a2a269af7d046b584588211f03456a2877ba250690d497",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "62701ab6e892c219e84b22251ba47c0fff8820ff3e4bb7cb8713c90cf425daa1"
+  "activationDigest": "98b7fd564757c2da288f02fd8395a21e36f95daa3f9df460600a74026c6275fc"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "d67932f5212ba9ec819334ad21c88674703a1477d1e43faf8b6d04cc7e64c5b4",
+    "auditedInputDigest": "bf1d21a781e4e708227e8a074b85ae03c5ae4435c0740ab76bf3f41edf0af091",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -69,13 +69,13 @@
   "summary": {
     "localeCount": 4,
     "localeLeafModuleCounts": { "en-US": 30, "zh-CN": 30, "de-DE": 30, "fr-FR": 30 },
-    "localeUniqueKeyCounts": { "en-US": 3096, "zh-CN": 3096, "de-DE": 3096, "fr-FR": 3096 },
-    "canonicalCandidateKeyCount": 3096,
-    "activeStaticKeyCount": 2092,
+    "localeUniqueKeyCounts": { "en-US": 3098, "zh-CN": 3098, "de-DE": 3098, "fr-FR": 3098 },
+    "canonicalCandidateKeyCount": 3098,
+    "activeStaticKeyCount": 2094,
     "activeDynamicKeyCount": 367,
     "reservedKeyCount": 637,
-    "productionSourceFileCount": 433,
-    "literalReferenceCount": 4082,
+    "productionSourceFileCount": 434,
+    "literalReferenceCount": 4098,
     "dynamicCallsiteCount": 39,
     "dynamicCallsiteSummaryCount": 39,
     "registeredDynamicCallsiteCount": 39,
@@ -17496,7 +17496,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 863,
+          "line": 865,
           "column": 12,
           "symbol": "packageTaskErrorText",
           "defaultMessage": "Export package is too large for the current storage upload limit. Try exporting a smaller scope, or ask an administrator to enable large-file upload support.",
@@ -17511,7 +17511,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 863,
+              "line": 865,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -20103,7 +20103,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 998,
+          "line": 1000,
           "column": 12,
           "symbol": "tidasScopeLabel",
           "defaultMessage": "Current user data",
@@ -20124,7 +20124,7 @@
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 998,
+              "line": 1000,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -20201,7 +20201,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1010,
+          "line": 1012,
           "column": 12,
           "symbol": "tidasScopeLabel",
           "defaultMessage": "Current user data + open data",
@@ -20222,7 +20222,7 @@
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1010,
+              "line": 1012,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -20299,7 +20299,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1004,
+          "line": 1006,
           "column": 12,
           "symbol": "tidasScopeLabel",
           "defaultMessage": "Open data",
@@ -20320,7 +20320,7 @@
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1004,
+              "line": 1006,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -20506,7 +20506,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1498,
+          "line": 1500,
           "column": 20,
           "symbol": "packageBusinessDetail",
           "defaultMessage": "File name",
@@ -20521,7 +20521,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1498,
+              "line": 1500,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -20589,7 +20589,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1487,
+          "line": 1489,
           "column": 9,
           "symbol": "filename",
           "defaultMessage": "Uploaded ZIP package",
@@ -20604,7 +20604,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1487,
+              "line": 1489,
               "column": 9,
               "kind": "formatMessage"
             }
@@ -20790,7 +20790,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1359,
+          "line": 1361,
           "column": 18,
           "symbol": "packageDiagnosticContent",
           "defaultMessage": "Job ID",
@@ -20805,7 +20805,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1359,
+              "line": 1361,
               "column": 18,
               "kind": "formatMessage"
             }
@@ -20873,7 +20873,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1512,
+          "line": 1514,
           "column": 20,
           "symbol": "packageBusinessDetail",
           "defaultMessage": "Root records",
@@ -20888,7 +20888,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1512,
+              "line": 1514,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -20956,7 +20956,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1522,
+          "line": 1524,
           "column": 18,
           "symbol": "packageBusinessDetail",
           "defaultMessage": "Root data",
@@ -20971,7 +20971,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1522,
+              "line": 1524,
               "column": 18,
               "kind": "formatMessage"
             }
@@ -21039,7 +21039,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1505,
+          "line": 1507,
           "column": 20,
           "symbol": "packageBusinessDetail",
           "defaultMessage": "Data scope",
@@ -21054,7 +21054,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1505,
+              "line": 1507,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -21122,7 +21122,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2457,
+          "line": 2525,
           "column": 38,
           "symbol": "LcaTaskCenter",
           "defaultMessage": "Download",
@@ -21131,7 +21131,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2463,
+          "line": 2531,
           "column": 45,
           "symbol": "LcaTaskCenter",
           "defaultMessage": "Download",
@@ -21146,13 +21146,13 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2457,
+              "line": 2525,
               "column": 38,
               "kind": "formatMessage"
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2463,
+              "line": 2531,
               "column": 45,
               "kind": "formatMessage"
             }
@@ -21220,7 +21220,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2049,
+          "line": 2055,
           "column": 11,
           "symbol": "handleDownload",
           "defaultMessage": "Failed to download TIDAS package",
@@ -21235,7 +21235,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2049,
+              "line": 2055,
               "column": 11,
               "kind": "formatMessage"
             }
@@ -21303,7 +21303,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2038,
+          "line": 2044,
           "column": 9,
           "symbol": "handleDownload",
           "defaultMessage": "Downloaded {filename}",
@@ -21318,7 +21318,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2038,
+              "line": 2044,
               "column": 9,
               "kind": "formatMessage"
             }
@@ -21445,7 +21445,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1029,
+          "line": 1031,
           "column": 12,
           "symbol": "taskTypeLabel",
           "defaultMessage": "TIDAS Export",
@@ -21460,7 +21460,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1029,
+              "line": 1031,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -21528,7 +21528,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1035,
+          "line": 1037,
           "column": 12,
           "symbol": "taskTypeLabel",
           "defaultMessage": "TIDAS Import",
@@ -21543,7 +21543,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1035,
+              "line": 1037,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -21611,7 +21611,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 225,
+          "line": 227,
           "column": 12,
           "symbol": "packagePhaseLabel",
           "defaultMessage": "Collecting related data",
@@ -21626,7 +21626,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 225,
+              "line": 227,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -21694,7 +21694,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 237,
+          "line": 239,
           "column": 12,
           "symbol": "packagePhaseLabel",
           "defaultMessage": "Building ZIP",
@@ -21709,7 +21709,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 237,
+              "line": 239,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -21777,7 +21777,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 231,
+          "line": 233,
           "column": 12,
           "symbol": "packagePhaseLabel",
           "defaultMessage": "Importing data",
@@ -21792,7 +21792,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 231,
+              "line": 233,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -21860,7 +21860,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 219,
+          "line": 221,
           "column": 12,
           "symbol": "packagePhaseLabel",
           "defaultMessage": "Queued",
@@ -21875,7 +21875,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 219,
+              "line": 221,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -21943,7 +21943,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 213,
+          "line": 215,
           "column": 12,
           "symbol": "packagePhaseLabel",
           "defaultMessage": "Submitting",
@@ -21958,7 +21958,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 213,
+              "line": 215,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -22026,7 +22026,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 721,
+          "line": 723,
           "column": 12,
           "symbol": "packageProcessStageLabel",
           "defaultMessage": "Build ZIP",
@@ -22041,7 +22041,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 721,
+              "line": 723,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -22109,7 +22109,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 715,
+          "line": 717,
           "column": 12,
           "symbol": "packageProcessStageLabel",
           "defaultMessage": "Collect related data",
@@ -22124,7 +22124,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 715,
+              "line": 717,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -22192,7 +22192,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 709,
+          "line": 711,
           "column": 12,
           "symbol": "packageProcessStageLabel",
           "defaultMessage": "Queued",
@@ -22207,7 +22207,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 709,
+              "line": 711,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -22275,7 +22275,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 726,
+          "line": 728,
           "column": 10,
           "symbol": "packageProcessStageLabel",
           "defaultMessage": "Export ready",
@@ -22290,7 +22290,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 726,
+              "line": 728,
               "column": 10,
               "kind": "formatMessage"
             }
@@ -22358,7 +22358,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 703,
+          "line": 705,
           "column": 12,
           "symbol": "packageProcessStageLabel",
           "defaultMessage": "Submit task",
@@ -22373,7 +22373,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 703,
+              "line": 705,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -22441,7 +22441,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 696,
+          "line": 698,
           "column": 12,
           "symbol": "packageProcessStageLabel",
           "defaultMessage": "Build report",
@@ -22456,7 +22456,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 696,
+              "line": 698,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -22524,7 +22524,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 691,
+          "line": 693,
           "column": 14,
           "symbol": "packageProcessStageLabel",
           "defaultMessage": "Import data",
@@ -22539,7 +22539,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 691,
+              "line": 693,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -22607,7 +22607,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 679,
+          "line": 681,
           "column": 14,
           "symbol": "packageProcessStageLabel",
           "defaultMessage": "Prepare upload",
@@ -22622,7 +22622,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 679,
+              "line": 681,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -22690,7 +22690,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 685,
+          "line": 687,
           "column": 14,
           "symbol": "packageProcessStageLabel",
           "defaultMessage": "Validate package",
@@ -22705,7 +22705,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 685,
+              "line": 687,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -23127,7 +23127,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1080,
+          "line": 1082,
           "column": 9,
           "symbol": "taskTitle",
           "defaultMessage": "Export TIDAS package",
@@ -23142,7 +23142,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1080,
+              "line": 1082,
               "column": 9,
               "kind": "formatMessage"
             }
@@ -23210,7 +23210,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1073,
+          "line": 1075,
           "column": 9,
           "symbol": "taskTitle",
           "defaultMessage": "Export package: {filename}",
@@ -23225,7 +23225,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1073,
+              "line": 1075,
               "column": 9,
               "kind": "formatMessage"
             }
@@ -23293,7 +23293,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1093,
+          "line": 1095,
           "column": 7,
           "symbol": "taskTitle",
           "defaultMessage": "Import TIDAS package",
@@ -23308,7 +23308,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1093,
+              "line": 1095,
               "column": 7,
               "kind": "formatMessage"
             }
@@ -23376,7 +23376,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1086,
+          "line": 1088,
           "column": 7,
           "symbol": "taskTitle",
           "defaultMessage": "Import package: {filename}",
@@ -23391,7 +23391,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1086,
+              "line": 1088,
               "column": 7,
               "kind": "formatMessage"
             }
@@ -56629,7 +56629,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1879,
+          "line": 1702,
           "column": 20,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Check data completeness",
@@ -56644,7 +56644,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1879,
+              "line": 1702,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -56712,7 +56712,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1896,
+          "line": 1719,
           "column": 14,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Generate result set",
@@ -56727,7 +56727,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1896,
+              "line": 1719,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -56793,11 +56793,11 @@
       },
       "references": [
         {
-          "kind": "messageHelper",
-          "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1854,
-          "column": 33,
-          "symbol": "renderBuildRequests",
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 83,
+          "column": 28,
+          "symbol": "closureMessages",
           "defaultMessage": "Download machine result manifest",
           "defaultMessageExpression": null
         }
@@ -56809,10 +56809,10 @@
           "placeholders": [],
           "locations": [
             {
-              "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1854,
-              "column": 33,
-              "kind": "messageHelper"
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 83,
+              "column": 28,
+              "kind": "formatMessage"
             }
           ]
         }
@@ -56876,11 +56876,11 @@
       },
       "references": [
         {
-          "kind": "messageHelper",
-          "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1850,
-          "column": 33,
-          "symbol": "renderBuildRequests",
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 87,
+          "column": 25,
+          "symbol": "closureMessages",
           "defaultMessage": "Download issue report",
           "defaultMessageExpression": null
         }
@@ -56892,10 +56892,10 @@
           "placeholders": [],
           "locations": [
             {
-              "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1850,
-              "column": 33,
-              "kind": "messageHelper"
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 87,
+              "column": 25,
+              "kind": "formatMessage"
             }
           ]
         }
@@ -56961,7 +56961,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1504,
+          "line": 1432,
           "column": 45,
           "symbol": "previewPackageLabel",
           "defaultMessage": "Preview result set",
@@ -56970,7 +56970,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2225,
+          "line": 2048,
           "column": 14,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Preview result set",
@@ -56985,13 +56985,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1504,
+              "line": 1432,
               "column": 45,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2225,
+              "line": 2048,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -57059,7 +57059,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2509,
+          "line": 2332,
           "column": 14,
           "symbol": "renderPublication",
           "defaultMessage": "Publish result set",
@@ -57074,7 +57074,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2509,
+              "line": 2332,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -57140,11 +57140,11 @@
       },
       "references": [
         {
-          "kind": "messageHelper",
-          "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1865,
-          "column": 30,
-          "symbol": "renderBuildRequests",
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 121,
+          "column": 12,
+          "symbol": "closureMessages",
           "defaultMessage": "Run check again",
           "defaultMessageExpression": null
         }
@@ -57156,10 +57156,10 @@
           "placeholders": [],
           "locations": [
             {
-              "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1865,
-              "column": 30,
-              "kind": "messageHelper"
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 121,
+              "column": 12,
+              "kind": "formatMessage"
             }
           ]
         }
@@ -57225,7 +57225,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2575,
+          "line": 2398,
           "column": 53,
           "symbol": "unpublishPublicationLabel",
           "defaultMessage": "Unpublish publication",
@@ -57240,7 +57240,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2575,
+              "line": 2398,
               "column": 53,
               "kind": "messageHelper"
             }
@@ -57265,7 +57265,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 352,
+            "line": 354,
             "column": 3,
             "module": "pages"
           }
@@ -57276,7 +57276,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 352,
+            "line": 354,
             "column": 3,
             "module": "pages"
           }
@@ -57287,7 +57287,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 352,
+            "line": 354,
             "column": 3,
             "module": "pages"
           }
@@ -57298,7 +57298,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 352,
+            "line": 354,
             "column": 3,
             "module": "pages"
           }
@@ -57363,7 +57363,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 360,
+            "line": 362,
             "column": 3,
             "module": "pages"
           }
@@ -57374,7 +57374,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 360,
+            "line": 362,
             "column": 3,
             "module": "pages"
           }
@@ -57385,7 +57385,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 360,
+            "line": 362,
             "column": 3,
             "module": "pages"
           }
@@ -57396,7 +57396,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 360,
+            "line": 362,
             "column": 3,
             "module": "pages"
           }
@@ -57446,7 +57446,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 340,
+            "line": 342,
             "column": 3,
             "module": "pages"
           }
@@ -57457,7 +57457,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 340,
+            "line": 342,
             "column": 3,
             "module": "pages"
           }
@@ -57468,7 +57468,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 340,
+            "line": 342,
             "column": 3,
             "module": "pages"
           }
@@ -57479,7 +57479,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 340,
+            "line": 342,
             "column": 3,
             "module": "pages"
           }
@@ -57529,7 +57529,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 339,
+            "line": 341,
             "column": 3,
             "module": "pages"
           }
@@ -57540,7 +57540,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 339,
+            "line": 341,
             "column": 3,
             "module": "pages"
           }
@@ -57551,7 +57551,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 339,
+            "line": 341,
             "column": 3,
             "module": "pages"
           }
@@ -57562,7 +57562,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 339,
+            "line": 341,
             "column": 3,
             "module": "pages"
           }
@@ -57612,7 +57612,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 344,
+            "line": 346,
             "column": 3,
             "module": "pages"
           }
@@ -57623,7 +57623,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 344,
+            "line": 346,
             "column": 3,
             "module": "pages"
           }
@@ -57634,7 +57634,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 344,
+            "line": 346,
             "column": 3,
             "module": "pages"
           }
@@ -57645,7 +57645,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 344,
+            "line": 346,
             "column": 3,
             "module": "pages"
           }
@@ -57695,7 +57695,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 338,
+            "line": 340,
             "column": 3,
             "module": "pages"
           }
@@ -57706,7 +57706,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 338,
+            "line": 340,
             "column": 3,
             "module": "pages"
           }
@@ -57717,7 +57717,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 338,
+            "line": 340,
             "column": 3,
             "module": "pages"
           }
@@ -57728,7 +57728,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 338,
+            "line": 340,
             "column": 3,
             "module": "pages"
           }
@@ -57778,7 +57778,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 349,
+            "line": 351,
             "column": 3,
             "module": "pages"
           }
@@ -57789,7 +57789,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 349,
+            "line": 351,
             "column": 3,
             "module": "pages"
           }
@@ -57800,7 +57800,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 349,
+            "line": 351,
             "column": 3,
             "module": "pages"
           }
@@ -57811,7 +57811,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 349,
+            "line": 351,
             "column": 3,
             "module": "pages"
           }
@@ -57861,7 +57861,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 362,
+            "line": 364,
             "column": 3,
             "module": "pages"
           }
@@ -57872,7 +57872,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 362,
+            "line": 364,
             "column": 3,
             "module": "pages"
           }
@@ -57883,7 +57883,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 362,
+            "line": 364,
             "column": 3,
             "module": "pages"
           }
@@ -57894,7 +57894,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 362,
+            "line": 364,
             "column": 3,
             "module": "pages"
           }
@@ -57959,7 +57959,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 361,
+            "line": 363,
             "column": 3,
             "module": "pages"
           }
@@ -57970,7 +57970,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 361,
+            "line": 363,
             "column": 3,
             "module": "pages"
           }
@@ -57981,7 +57981,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 361,
+            "line": 363,
             "column": 3,
             "module": "pages"
           }
@@ -57992,7 +57992,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 361,
+            "line": 363,
             "column": 3,
             "module": "pages"
           }
@@ -58042,7 +58042,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 355,
+            "line": 357,
             "column": 3,
             "module": "pages"
           }
@@ -58053,7 +58053,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 355,
+            "line": 357,
             "column": 3,
             "module": "pages"
           }
@@ -58064,7 +58064,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 355,
+            "line": 357,
             "column": 3,
             "module": "pages"
           }
@@ -58075,7 +58075,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 355,
+            "line": 357,
             "column": 3,
             "module": "pages"
           }
@@ -58125,7 +58125,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 353,
+            "line": 355,
             "column": 3,
             "module": "pages"
           }
@@ -58136,7 +58136,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 353,
+            "line": 355,
             "column": 3,
             "module": "pages"
           }
@@ -58147,7 +58147,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 353,
+            "line": 355,
             "column": 3,
             "module": "pages"
           }
@@ -58158,7 +58158,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 353,
+            "line": 355,
             "column": 3,
             "module": "pages"
           }
@@ -58208,7 +58208,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 354,
+            "line": 356,
             "column": 3,
             "module": "pages"
           }
@@ -58219,7 +58219,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 354,
+            "line": 356,
             "column": 3,
             "module": "pages"
           }
@@ -58230,7 +58230,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 354,
+            "line": 356,
             "column": 3,
             "module": "pages"
           }
@@ -58241,7 +58241,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 354,
+            "line": 356,
             "column": 3,
             "module": "pages"
           }
@@ -58306,7 +58306,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 359,
+            "line": 361,
             "column": 3,
             "module": "pages"
           }
@@ -58317,7 +58317,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 359,
+            "line": 361,
             "column": 3,
             "module": "pages"
           }
@@ -58328,7 +58328,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 359,
+            "line": 361,
             "column": 3,
             "module": "pages"
           }
@@ -58339,7 +58339,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 359,
+            "line": 361,
             "column": 3,
             "module": "pages"
           }
@@ -58389,7 +58389,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 346,
+            "line": 348,
             "column": 3,
             "module": "pages"
           }
@@ -58400,7 +58400,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 346,
+            "line": 348,
             "column": 3,
             "module": "pages"
           }
@@ -58411,7 +58411,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 346,
+            "line": 348,
             "column": 3,
             "module": "pages"
           }
@@ -58422,7 +58422,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 346,
+            "line": 348,
             "column": 3,
             "module": "pages"
           }
@@ -58472,7 +58472,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 342,
+            "line": 344,
             "column": 3,
             "module": "pages"
           }
@@ -58483,7 +58483,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 342,
+            "line": 344,
             "column": 3,
             "module": "pages"
           }
@@ -58494,7 +58494,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 342,
+            "line": 344,
             "column": 3,
             "module": "pages"
           }
@@ -58505,7 +58505,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 342,
+            "line": 344,
             "column": 3,
             "module": "pages"
           }
@@ -58555,7 +58555,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 365,
+            "line": 367,
             "column": 3,
             "module": "pages"
           }
@@ -58566,7 +58566,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 365,
+            "line": 367,
             "column": 3,
             "module": "pages"
           }
@@ -58577,7 +58577,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 365,
+            "line": 367,
             "column": 3,
             "module": "pages"
           }
@@ -58588,7 +58588,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 365,
+            "line": 367,
             "column": 3,
             "module": "pages"
           }
@@ -58638,7 +58638,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 351,
+            "line": 353,
             "column": 3,
             "module": "pages"
           }
@@ -58649,7 +58649,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 351,
+            "line": 353,
             "column": 3,
             "module": "pages"
           }
@@ -58660,7 +58660,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 351,
+            "line": 353,
             "column": 3,
             "module": "pages"
           }
@@ -58671,7 +58671,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 351,
+            "line": 353,
             "column": 3,
             "module": "pages"
           }
@@ -58721,7 +58721,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 347,
+            "line": 349,
             "column": 3,
             "module": "pages"
           }
@@ -58732,7 +58732,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 347,
+            "line": 349,
             "column": 3,
             "module": "pages"
           }
@@ -58743,7 +58743,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 347,
+            "line": 349,
             "column": 3,
             "module": "pages"
           }
@@ -58754,7 +58754,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 347,
+            "line": 349,
             "column": 3,
             "module": "pages"
           }
@@ -58804,7 +58804,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 358,
+            "line": 360,
             "column": 3,
             "module": "pages"
           }
@@ -58815,7 +58815,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 358,
+            "line": 360,
             "column": 3,
             "module": "pages"
           }
@@ -58826,7 +58826,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 358,
+            "line": 360,
             "column": 3,
             "module": "pages"
           }
@@ -58837,7 +58837,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 358,
+            "line": 360,
             "column": 3,
             "module": "pages"
           }
@@ -58887,7 +58887,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 345,
+            "line": 347,
             "column": 3,
             "module": "pages"
           }
@@ -58898,7 +58898,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 345,
+            "line": 347,
             "column": 3,
             "module": "pages"
           }
@@ -58909,7 +58909,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 345,
+            "line": 347,
             "column": 3,
             "module": "pages"
           }
@@ -58920,7 +58920,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 345,
+            "line": 347,
             "column": 3,
             "module": "pages"
           }
@@ -58985,7 +58985,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 341,
+            "line": 343,
             "column": 3,
             "module": "pages"
           }
@@ -58996,7 +58996,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 341,
+            "line": 343,
             "column": 3,
             "module": "pages"
           }
@@ -59007,7 +59007,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 341,
+            "line": 343,
             "column": 3,
             "module": "pages"
           }
@@ -59018,7 +59018,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 341,
+            "line": 343,
             "column": 3,
             "module": "pages"
           }
@@ -59068,7 +59068,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 363,
+            "line": 365,
             "column": 3,
             "module": "pages"
           }
@@ -59079,7 +59079,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 363,
+            "line": 365,
             "column": 3,
             "module": "pages"
           }
@@ -59090,7 +59090,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 363,
+            "line": 365,
             "column": 3,
             "module": "pages"
           }
@@ -59101,7 +59101,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 363,
+            "line": 365,
             "column": 3,
             "module": "pages"
           }
@@ -59166,7 +59166,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 364,
+            "line": 366,
             "column": 3,
             "module": "pages"
           }
@@ -59177,7 +59177,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 364,
+            "line": 366,
             "column": 3,
             "module": "pages"
           }
@@ -59188,7 +59188,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 364,
+            "line": 366,
             "column": 3,
             "module": "pages"
           }
@@ -59199,7 +59199,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 364,
+            "line": 366,
             "column": 3,
             "module": "pages"
           }
@@ -59249,7 +59249,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 337,
+            "line": 339,
             "column": 3,
             "module": "pages"
           }
@@ -59260,7 +59260,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 337,
+            "line": 339,
             "column": 3,
             "module": "pages"
           }
@@ -59271,7 +59271,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 337,
+            "line": 339,
             "column": 3,
             "module": "pages"
           }
@@ -59282,7 +59282,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 337,
+            "line": 339,
             "column": 3,
             "module": "pages"
           }
@@ -59332,7 +59332,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 356,
+            "line": 358,
             "column": 3,
             "module": "pages"
           }
@@ -59343,7 +59343,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 356,
+            "line": 358,
             "column": 3,
             "module": "pages"
           }
@@ -59354,7 +59354,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 356,
+            "line": 358,
             "column": 3,
             "module": "pages"
           }
@@ -59365,7 +59365,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 356,
+            "line": 358,
             "column": 3,
             "module": "pages"
           }
@@ -59415,7 +59415,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 343,
+            "line": 345,
             "column": 3,
             "module": "pages"
           }
@@ -59426,7 +59426,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 343,
+            "line": 345,
             "column": 3,
             "module": "pages"
           }
@@ -59437,7 +59437,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 343,
+            "line": 345,
             "column": 3,
             "module": "pages"
           }
@@ -59448,7 +59448,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 343,
+            "line": 345,
             "column": 3,
             "module": "pages"
           }
@@ -59498,7 +59498,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 357,
+            "line": 359,
             "column": 3,
             "module": "pages"
           }
@@ -59509,7 +59509,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 357,
+            "line": 359,
             "column": 3,
             "module": "pages"
           }
@@ -59520,7 +59520,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 357,
+            "line": 359,
             "column": 3,
             "module": "pages"
           }
@@ -59531,7 +59531,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 357,
+            "line": 359,
             "column": 3,
             "module": "pages"
           }
@@ -59581,7 +59581,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 336,
+            "line": 338,
             "column": 3,
             "module": "pages"
           }
@@ -59592,7 +59592,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 336,
+            "line": 338,
             "column": 3,
             "module": "pages"
           }
@@ -59603,7 +59603,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 336,
+            "line": 338,
             "column": 3,
             "module": "pages"
           }
@@ -59614,7 +59614,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 336,
+            "line": 338,
             "column": 3,
             "module": "pages"
           }
@@ -59664,7 +59664,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 350,
+            "line": 352,
             "column": 3,
             "module": "pages"
           }
@@ -59675,7 +59675,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 350,
+            "line": 352,
             "column": 3,
             "module": "pages"
           }
@@ -59686,7 +59686,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 350,
+            "line": 352,
             "column": 3,
             "module": "pages"
           }
@@ -59697,7 +59697,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 350,
+            "line": 352,
             "column": 3,
             "module": "pages"
           }
@@ -59747,7 +59747,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 348,
+            "line": 350,
             "column": 3,
             "module": "pages"
           }
@@ -59758,7 +59758,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 348,
+            "line": 350,
             "column": 3,
             "module": "pages"
           }
@@ -59769,7 +59769,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 348,
+            "line": 350,
             "column": 3,
             "module": "pages"
           }
@@ -59780,7 +59780,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 348,
+            "line": 350,
             "column": 3,
             "module": "pages"
           }
@@ -59886,11 +59886,11 @@
       },
       "references": [
         {
-          "kind": "messageHelper",
-          "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1795,
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 26,
           "column": 29,
-          "symbol": "stateMessage",
+          "symbol": "closureMessages",
           "defaultMessage": "Available until",
           "defaultMessageExpression": null
         }
@@ -59902,10 +59902,10 @@
           "placeholders": [],
           "locations": [
             {
-              "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1795,
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 26,
               "column": 29,
-              "kind": "messageHelper"
+              "kind": "formatMessage"
             }
           ]
         }
@@ -59969,11 +59969,11 @@
       },
       "references": [
         {
-          "kind": "messageHelper",
-          "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1340,
-          "column": 18,
-          "symbol": "handleDownloadClosureArtifact",
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 30,
+          "column": 29,
+          "symbol": "closureMessages",
           "defaultMessage": "This download is currently unavailable. Please try again later.",
           "defaultMessageExpression": null
         }
@@ -59985,10 +59985,10 @@
           "placeholders": [],
           "locations": [
             {
-              "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1340,
-              "column": 18,
-              "kind": "messageHelper"
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 30,
+              "column": 29,
+              "kind": "formatMessage"
             }
           ]
         }
@@ -60052,20 +60052,11 @@
       },
       "references": [
         {
-          "kind": "messageHelper",
-          "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1331,
-          "column": 20,
-          "symbol": "handleDownloadClosureArtifact",
-          "defaultMessage": "This artifact has expired. Run the data completeness check again to prepare a new download.",
-          "defaultMessageExpression": null
-        },
-        {
-          "kind": "messageHelper",
-          "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1800,
-          "column": 31,
-          "symbol": "stateMessage",
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 34,
+          "column": 22,
+          "symbol": "closureMessages",
           "defaultMessage": "This artifact has expired. Run the data completeness check again to prepare a new download.",
           "defaultMessageExpression": null
         }
@@ -60077,16 +60068,10 @@
           "placeholders": [],
           "locations": [
             {
-              "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1331,
-              "column": 20,
-              "kind": "messageHelper"
-            },
-            {
-              "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1800,
-              "column": 31,
-              "kind": "messageHelper"
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 34,
+              "column": 22,
+              "kind": "formatMessage"
             }
           ]
         }
@@ -60150,11 +60135,11 @@
       },
       "references": [
         {
-          "kind": "messageHelper",
-          "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1805,
-          "column": 33,
-          "symbol": "stateMessage",
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 39,
+          "column": 21,
+          "symbol": "closureMessages",
           "defaultMessage": "Artifact preparation failed. Run the data completeness check again.",
           "defaultMessageExpression": null
         }
@@ -60166,10 +60151,10 @@
           "placeholders": [],
           "locations": [
             {
-              "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1805,
-              "column": 33,
-              "kind": "messageHelper"
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 39,
+              "column": 21,
+              "kind": "formatMessage"
             }
           ]
         }
@@ -60233,11 +60218,11 @@
       },
       "references": [
         {
-          "kind": "messageHelper",
-          "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1780,
-          "column": 27,
-          "symbol": "roleLabel",
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 59,
+          "column": 25,
+          "symbol": "closureMessages",
           "defaultMessage": "Human issue report (XLSX)",
           "defaultMessageExpression": null
         }
@@ -60249,10 +60234,10 @@
           "placeholders": [],
           "locations": [
             {
-              "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1780,
-              "column": 27,
-              "kind": "messageHelper"
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 59,
+              "column": 25,
+              "kind": "formatMessage"
             }
           ]
         }
@@ -60316,11 +60301,11 @@
       },
       "references": [
         {
-          "kind": "messageHelper",
-          "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1784,
-          "column": 27,
-          "symbol": "roleLabel",
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 43,
+          "column": 28,
+          "symbol": "closureMessages",
           "defaultMessage": "Machine result manifest",
           "defaultMessageExpression": null
         }
@@ -60332,10 +60317,10 @@
           "placeholders": [],
           "locations": [
             {
-              "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1784,
-              "column": 27,
-              "kind": "messageHelper"
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 43,
+              "column": 28,
+              "kind": "formatMessage"
             }
           ]
         }
@@ -60399,11 +60384,11 @@
       },
       "references": [
         {
-          "kind": "messageHelper",
-          "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1790,
-          "column": 27,
-          "symbol": "stateMessage",
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 47,
+          "column": 24,
+          "symbol": "closureMessages",
           "defaultMessage": "Preparing this artifact.",
           "defaultMessageExpression": null
         }
@@ -60415,10 +60400,10 @@
           "placeholders": [],
           "locations": [
             {
-              "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1790,
-              "column": 27,
-              "kind": "messageHelper"
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 47,
+              "column": 24,
+              "kind": "formatMessage"
             }
           ]
         }
@@ -60482,11 +60467,11 @@
       },
       "references": [
         {
-          "kind": "messageHelper",
-          "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1809,
-          "column": 33,
-          "symbol": "stateMessage",
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 55,
+          "column": 26,
+          "symbol": "closureMessages",
           "defaultMessage": "This artifact is unavailable.",
           "defaultMessageExpression": null
         }
@@ -60498,10 +60483,10 @@
           "placeholders": [],
           "locations": [
             {
-              "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1809,
-              "column": 33,
-              "kind": "messageHelper"
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 55,
+              "column": 26,
+              "kind": "formatMessage"
             }
           ]
         }
@@ -60565,11 +60550,11 @@
       },
       "references": [
         {
-          "kind": "messageHelper",
-          "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1757,
-          "column": 22,
-          "symbol": "renderBuildRequests",
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 51,
+          "column": 21,
+          "symbol": "closureMessages",
           "defaultMessage": "Result artifacts",
           "defaultMessageExpression": null
         }
@@ -60581,10 +60566,10 @@
           "placeholders": [],
           "locations": [
             {
-              "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1757,
-              "column": 22,
-              "kind": "messageHelper"
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 51,
+              "column": 21,
+              "kind": "formatMessage"
             }
           ]
         }
@@ -60650,7 +60635,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1224,
+          "line": 1180,
           "column": 18,
           "symbol": "handleCreateBuild",
           "defaultMessage": "Run a complete data check for the current selection before generating a result set.",
@@ -60665,7 +60650,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1224,
+              "line": 1180,
               "column": 18,
               "kind": "messageHelper"
             }
@@ -60731,9 +60716,18 @@
       },
       "references": [
         {
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 63,
+          "column": 18,
+          "symbol": "closureMessages",
+          "defaultMessage": "Certificate",
+          "defaultMessageExpression": null
+        },
+        {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1650,
+          "line": 1578,
           "column": 28,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Certificate",
@@ -60747,8 +60741,14 @@
           "placeholders": [],
           "locations": [
             {
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 63,
+              "column": 18,
+              "kind": "formatMessage"
+            },
+            {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1650,
+              "line": 1578,
               "column": 28,
               "kind": "messageHelper"
             }
@@ -60814,9 +60814,18 @@
       },
       "references": [
         {
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 71,
+          "column": 19,
+          "symbol": "closureMessages",
+          "defaultMessage": "Scan completeness",
+          "defaultMessageExpression": null
+        },
+        {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1655,
+          "line": 1583,
           "column": 28,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Scan completeness",
@@ -60830,10 +60839,197 @@
           "placeholders": [],
           "locations": [
             {
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 71,
+              "column": 19,
+              "kind": "formatMessage"
+            },
+            {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1655,
+              "line": 1583,
               "column": 28,
               "kind": "messageHelper"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pages.dataProcessing.closure.detailLoading",
+      "category": "active-static",
+      "dynamicFamilies": [],
+      "moduleOwnership": {
+        "en-US": ["pages"],
+        "zh-CN": ["pages"],
+        "de-DE": ["pages"],
+        "fr-FR": ["pages"]
+      },
+      "translations": {
+        "en-US": {
+          "value": "Loading task details...",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/en-US/pages.ts",
+            "line": 235,
+            "column": 3,
+            "module": "pages"
+          }
+        },
+        "zh-CN": {
+          "value": "正在加载任务详情…",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/zh-CN/pages.ts",
+            "line": 235,
+            "column": 3,
+            "module": "pages"
+          }
+        },
+        "de-DE": {
+          "value": "Aufgabendetails werden geladen …",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/de-DE/pages.ts",
+            "line": 235,
+            "column": 3,
+            "module": "pages"
+          }
+        },
+        "fr-FR": {
+          "value": "Chargement des détails de la tâche…",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/fr-FR/pages.ts",
+            "line": 235,
+            "column": 3,
+            "module": "pages"
+          }
+        }
+      },
+      "references": [
+        {
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 75,
+          "column": 20,
+          "symbol": "closureMessages",
+          "defaultMessage": "Loading task details...",
+          "defaultMessageExpression": null
+        }
+      ],
+      "defaultMessages": [
+        {
+          "value": "Loading task details...",
+          "argumentSignature": [],
+          "placeholders": [],
+          "locations": [
+            {
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 75,
+              "column": 20,
+              "kind": "formatMessage"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pages.dataProcessing.closure.detailUnavailable",
+      "category": "active-static",
+      "dynamicFamilies": [],
+      "moduleOwnership": {
+        "en-US": ["pages"],
+        "zh-CN": ["pages"],
+        "de-DE": ["pages"],
+        "fr-FR": ["pages"]
+      },
+      "translations": {
+        "en-US": {
+          "value": "Task details are currently unavailable.",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/en-US/pages.ts",
+            "line": 236,
+            "column": 3,
+            "module": "pages"
+          }
+        },
+        "zh-CN": {
+          "value": "当前无法获取任务详情。",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/zh-CN/pages.ts",
+            "line": 236,
+            "column": 3,
+            "module": "pages"
+          }
+        },
+        "de-DE": {
+          "value": "Die Aufgabendetails sind derzeit nicht verfügbar.",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/de-DE/pages.ts",
+            "line": 236,
+            "column": 3,
+            "module": "pages"
+          }
+        },
+        "fr-FR": {
+          "value": "Les détails de la tâche sont actuellement indisponibles.",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/fr-FR/pages.ts",
+            "line": 236,
+            "column": 3,
+            "module": "pages"
+          }
+        }
+      },
+      "references": [
+        {
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 79,
+          "column": 24,
+          "symbol": "closureMessages",
+          "defaultMessage": "Task details are currently unavailable.",
+          "defaultMessageExpression": null
+        },
+        {
+          "kind": "formatMessage",
+          "path": "src/components/LcaTaskCenter/index.tsx",
+          "line": 2377,
+          "column": 40,
+          "symbol": "LcaTaskCenter",
+          "defaultMessage": "Task details are currently unavailable.",
+          "defaultMessageExpression": null
+        }
+      ],
+      "defaultMessages": [
+        {
+          "value": "Task details are currently unavailable.",
+          "argumentSignature": [],
+          "placeholders": [],
+          "locations": [
+            {
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 79,
+              "column": 24,
+              "kind": "formatMessage"
+            },
+            {
+              "path": "src/components/LcaTaskCenter/index.tsx",
+              "line": 2377,
+              "column": 40,
+              "kind": "formatMessage"
             }
           ]
         }
@@ -60856,7 +61052,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 235,
+            "line": 237,
             "column": 3,
             "module": "pages"
           }
@@ -60867,7 +61063,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 235,
+            "line": 237,
             "column": 3,
             "module": "pages"
           }
@@ -60878,7 +61074,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 235,
+            "line": 237,
             "column": 3,
             "module": "pages"
           }
@@ -60889,7 +61085,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 235,
+            "line": 237,
             "column": 3,
             "module": "pages"
           }
@@ -60899,7 +61095,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1168,
+          "line": 1124,
           "column": 35,
           "symbol": "closureErrorMessages",
           "defaultMessage": "The current public release or snapshot is unavailable; a certificate cannot be issued.",
@@ -60914,7 +61110,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1168,
+              "line": 1124,
               "column": 35,
               "kind": "messageHelper"
             }
@@ -60939,7 +61135,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 236,
+            "line": 238,
             "column": 3,
             "module": "pages"
           }
@@ -60950,7 +61146,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 236,
+            "line": 238,
             "column": 3,
             "module": "pages"
           }
@@ -60961,7 +61157,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 236,
+            "line": 238,
             "column": 3,
             "module": "pages"
           }
@@ -60972,7 +61168,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 236,
+            "line": 238,
             "column": 3,
             "module": "pages"
           }
@@ -60982,7 +61178,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1172,
+          "line": 1128,
           "column": 41,
           "symbol": "closureErrorMessages",
           "defaultMessage": "Closure evidence integrity verification failed.",
@@ -60997,7 +61193,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1172,
+              "line": 1128,
               "column": 41,
               "kind": "messageHelper"
             }
@@ -61022,7 +61218,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 237,
+            "line": 239,
             "column": 3,
             "module": "pages"
           }
@@ -61033,7 +61229,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 237,
+            "line": 239,
             "column": 3,
             "module": "pages"
           }
@@ -61044,7 +61240,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 237,
+            "line": 239,
             "column": 3,
             "module": "pages"
           }
@@ -61055,7 +61251,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 237,
+            "line": 239,
             "column": 3,
             "module": "pages"
           }
@@ -61065,7 +61261,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1164,
+          "line": 1120,
           "column": 39,
           "symbol": "closureErrorMessages",
           "defaultMessage": "The current public release or snapshot is unavailable; a certificate cannot be issued.",
@@ -61080,7 +61276,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1164,
+              "line": 1120,
               "column": 39,
               "kind": "messageHelper"
             }
@@ -61105,7 +61301,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 238,
+            "line": 240,
             "column": 3,
             "module": "pages"
           }
@@ -61116,7 +61312,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 238,
+            "line": 240,
             "column": 3,
             "module": "pages"
           }
@@ -61127,7 +61323,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 238,
+            "line": 240,
             "column": 3,
             "module": "pages"
           }
@@ -61138,7 +61334,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 238,
+            "line": 240,
             "column": 3,
             "module": "pages"
           }
@@ -61148,7 +61344,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1144,
+          "line": 1100,
           "column": 35,
           "symbol": "closureErrorMessages",
           "defaultMessage": "The closure scan is incomplete.",
@@ -61163,7 +61359,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1144,
+              "line": 1100,
               "column": 35,
               "kind": "messageHelper"
             }
@@ -61188,7 +61384,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 239,
+            "line": 241,
             "column": 3,
             "module": "pages"
           }
@@ -61199,7 +61395,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 239,
+            "line": 241,
             "column": 3,
             "module": "pages"
           }
@@ -61210,7 +61406,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 239,
+            "line": 241,
             "column": 3,
             "module": "pages"
           }
@@ -61221,7 +61417,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 239,
+            "line": 241,
             "column": 3,
             "module": "pages"
           }
@@ -61231,7 +61427,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1136,
+          "line": 1092,
           "column": 34,
           "symbol": "closureErrorMessages",
           "defaultMessage": "The selected closure check was not found.",
@@ -61246,7 +61442,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1136,
+              "line": 1092,
               "column": 34,
               "kind": "messageHelper"
             }
@@ -61271,7 +61467,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 240,
+            "line": 242,
             "column": 3,
             "module": "pages"
           }
@@ -61282,7 +61478,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 240,
+            "line": 242,
             "column": 3,
             "module": "pages"
           }
@@ -61293,7 +61489,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 240,
+            "line": 242,
             "column": 3,
             "module": "pages"
           }
@@ -61304,7 +61500,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 240,
+            "line": 242,
             "column": 3,
             "module": "pages"
           }
@@ -61314,7 +61510,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1140,
+          "line": 1096,
           "column": 35,
           "symbol": "closureErrorMessages",
           "defaultMessage": "The closure check has not passed.",
@@ -61329,7 +61525,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1140,
+              "line": 1096,
               "column": 35,
               "kind": "messageHelper"
             }
@@ -61354,7 +61550,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 241,
+            "line": 243,
             "column": 3,
             "module": "pages"
           }
@@ -61365,7 +61561,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 241,
+            "line": 243,
             "column": 3,
             "module": "pages"
           }
@@ -61376,7 +61572,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 241,
+            "line": 243,
             "column": 3,
             "module": "pages"
           }
@@ -61387,7 +61583,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 241,
+            "line": 243,
             "column": 3,
             "module": "pages"
           }
@@ -61397,7 +61593,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1152,
+          "line": 1108,
           "column": 40,
           "symbol": "closureErrorMessages",
           "defaultMessage": "The current policy does not match this closure check.",
@@ -61412,7 +61608,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1152,
+              "line": 1108,
               "column": 40,
               "kind": "messageHelper"
             }
@@ -61437,7 +61633,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 242,
+            "line": 244,
             "column": 3,
             "module": "pages"
           }
@@ -61448,7 +61644,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 242,
+            "line": 244,
             "column": 3,
             "module": "pages"
           }
@@ -61459,7 +61655,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 242,
+            "line": 244,
             "column": 3,
             "module": "pages"
           }
@@ -61470,7 +61666,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 242,
+            "line": 244,
             "column": 3,
             "module": "pages"
           }
@@ -61480,7 +61676,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1132,
+          "line": 1088,
           "column": 33,
           "symbol": "closureErrorMessages",
           "defaultMessage": "A closure check is required.",
@@ -61495,7 +61691,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1132,
+              "line": 1088,
               "column": 33,
               "kind": "messageHelper"
             }
@@ -61520,7 +61716,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 243,
+            "line": 245,
             "column": 3,
             "module": "pages"
           }
@@ -61531,7 +61727,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 243,
+            "line": 245,
             "column": 3,
             "module": "pages"
           }
@@ -61542,7 +61738,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 243,
+            "line": 245,
             "column": 3,
             "module": "pages"
           }
@@ -61553,7 +61749,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 243,
+            "line": 245,
             "column": 3,
             "module": "pages"
           }
@@ -61563,7 +61759,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1160,
+          "line": 1116,
           "column": 32,
           "symbol": "closureErrorMessages",
           "defaultMessage": "The closure certificate was revoked.",
@@ -61578,7 +61774,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1160,
+              "line": 1116,
               "column": 32,
               "kind": "messageHelper"
             }
@@ -61603,7 +61799,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 244,
+            "line": 246,
             "column": 3,
             "module": "pages"
           }
@@ -61614,7 +61810,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 244,
+            "line": 246,
             "column": 3,
             "module": "pages"
           }
@@ -61625,7 +61821,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 244,
+            "line": 246,
             "column": 3,
             "module": "pages"
           }
@@ -61636,7 +61832,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 244,
+            "line": 246,
             "column": 3,
             "module": "pages"
           }
@@ -61646,7 +61842,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1148,
+          "line": 1104,
           "column": 39,
           "symbol": "closureErrorMessages",
           "defaultMessage": "The current selection does not match this closure check.",
@@ -61661,7 +61857,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1148,
+              "line": 1104,
               "column": 39,
               "kind": "messageHelper"
             }
@@ -61686,7 +61882,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 245,
+            "line": 247,
             "column": 3,
             "module": "pages"
           }
@@ -61697,7 +61893,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 245,
+            "line": 247,
             "column": 3,
             "module": "pages"
           }
@@ -61708,7 +61904,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 245,
+            "line": 247,
             "column": 3,
             "module": "pages"
           }
@@ -61719,7 +61915,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 245,
+            "line": 247,
             "column": 3,
             "module": "pages"
           }
@@ -61729,7 +61925,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1156,
+          "line": 1112,
           "column": 30,
           "symbol": "closureErrorMessages",
           "defaultMessage": "The closure certificate is stale.",
@@ -61744,7 +61940,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1156,
+              "line": 1112,
               "column": 30,
               "kind": "messageHelper"
             }
@@ -61769,7 +61965,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 246,
+            "line": 248,
             "column": 3,
             "module": "pages"
           }
@@ -61780,7 +61976,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 246,
+            "line": 248,
             "column": 3,
             "module": "pages"
           }
@@ -61791,7 +61987,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 246,
+            "line": 248,
             "column": 3,
             "module": "pages"
           }
@@ -61802,7 +61998,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 246,
+            "line": 248,
             "column": 3,
             "module": "pages"
           }
@@ -61812,7 +62008,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1693,
+          "line": 1621,
           "column": 31,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Error code",
@@ -61827,7 +62023,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1693,
+              "line": 1621,
               "column": 31,
               "kind": "messageHelper"
             }
@@ -61852,7 +62048,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 247,
+            "line": 249,
             "column": 3,
             "module": "pages"
           }
@@ -61863,7 +62059,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 247,
+            "line": 249,
             "column": 3,
             "module": "pages"
           }
@@ -61874,7 +62070,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 247,
+            "line": 249,
             "column": 3,
             "module": "pages"
           }
@@ -61885,7 +62081,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 247,
+            "line": 249,
             "column": 3,
             "module": "pages"
           }
@@ -61893,9 +62089,18 @@
       },
       "references": [
         {
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 91,
+          "column": 25,
+          "symbol": "closureMessages",
+          "defaultMessage": "Data completeness check was cancelled. Run a new check to continue.",
+          "defaultMessageExpression": null
+        },
+        {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1713,
+          "line": 1641,
           "column": 28,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Data completeness check was cancelled. Run a new check to continue.",
@@ -61909,8 +62114,14 @@
           "placeholders": [],
           "locations": [
             {
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 91,
+              "column": 25,
+              "kind": "formatMessage"
+            },
+            {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1713,
+              "line": 1641,
               "column": 28,
               "kind": "messageHelper"
             }
@@ -61935,7 +62146,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 248,
+            "line": 250,
             "column": 3,
             "module": "pages"
           }
@@ -61946,7 +62157,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 248,
+            "line": 250,
             "column": 3,
             "module": "pages"
           }
@@ -61957,7 +62168,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 248,
+            "line": 250,
             "column": 3,
             "module": "pages"
           }
@@ -61968,7 +62179,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 248,
+            "line": 250,
             "column": 3,
             "module": "pages"
           }
@@ -61976,9 +62187,18 @@
       },
       "references": [
         {
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 95,
+          "column": 22,
+          "symbol": "closureMessages",
+          "defaultMessage": "Data completeness check failed to run",
+          "defaultMessageExpression": null
+        },
+        {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1679,
+          "line": 1607,
           "column": 26,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Data completeness check failed to run",
@@ -61992,8 +62212,14 @@
           "placeholders": [],
           "locations": [
             {
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 95,
+              "column": 22,
+              "kind": "formatMessage"
+            },
+            {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1679,
+              "line": 1607,
               "column": 26,
               "kind": "messageHelper"
             }
@@ -62018,7 +62244,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 249,
+            "line": 251,
             "column": 3,
             "module": "pages"
           }
@@ -62029,7 +62255,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 249,
+            "line": 251,
             "column": 3,
             "module": "pages"
           }
@@ -62040,7 +62266,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 249,
+            "line": 251,
             "column": 3,
             "module": "pages"
           }
@@ -62051,7 +62277,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 249,
+            "line": 251,
             "column": 3,
             "module": "pages"
           }
@@ -62059,9 +62285,18 @@
       },
       "references": [
         {
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 99,
+          "column": 30,
+          "symbol": "closureMessages",
+          "defaultMessage": "The check did not complete. Retry it; if it fails again, contact an administrator with the identifiers below.",
+          "defaultMessageExpression": null
+        },
+        {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1686,
+          "line": 1614,
           "column": 27,
           "symbol": "renderBuildRequests",
           "defaultMessage": "The check did not complete. Retry it; if it fails again, contact an administrator with the identifiers below.",
@@ -62075,8 +62310,14 @@
           "placeholders": [],
           "locations": [
             {
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 99,
+              "column": 30,
+              "kind": "formatMessage"
+            },
+            {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1686,
+              "line": 1614,
               "column": 27,
               "kind": "messageHelper"
             }
@@ -62101,7 +62342,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 250,
+            "line": 252,
             "column": 3,
             "module": "pages"
           }
@@ -62112,7 +62353,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 250,
+            "line": 252,
             "column": 3,
             "module": "pages"
           }
@@ -62123,7 +62364,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 250,
+            "line": 252,
             "column": 3,
             "module": "pages"
           }
@@ -62134,7 +62375,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 250,
+            "line": 252,
             "column": 3,
             "module": "pages"
           }
@@ -62142,9 +62383,18 @@
       },
       "references": [
         {
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 104,
+          "column": 23,
+          "symbol": "closureMessages",
+          "defaultMessage": "The check is still running. Closure issues will be available after it completes.",
+          "defaultMessageExpression": null
+        },
+        {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1721,
+          "line": 1649,
           "column": 28,
           "symbol": "renderBuildRequests",
           "defaultMessage": "The check is still running. Closure issues will be available after it completes.",
@@ -62158,8 +62408,14 @@
           "placeholders": [],
           "locations": [
             {
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 104,
+              "column": 23,
+              "kind": "formatMessage"
+            },
+            {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1721,
+              "line": 1649,
               "column": 28,
               "kind": "messageHelper"
             }
@@ -62184,7 +62440,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 251,
+            "line": 253,
             "column": 3,
             "module": "pages"
           }
@@ -62195,7 +62451,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 251,
+            "line": 253,
             "column": 3,
             "module": "pages"
           }
@@ -62206,7 +62462,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 251,
+            "line": 253,
             "column": 3,
             "module": "pages"
           }
@@ -62217,7 +62473,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 251,
+            "line": 253,
             "column": 3,
             "module": "pages"
           }
@@ -62227,7 +62483,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1729,
+          "line": 1657,
           "column": 28,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Closure issues",
@@ -62242,7 +62498,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1729,
+              "line": 1657,
               "column": 28,
               "kind": "messageHelper"
             }
@@ -62267,7 +62523,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 252,
+            "line": 254,
             "column": 3,
             "module": "pages"
           }
@@ -62278,7 +62534,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 252,
+            "line": 254,
             "column": 3,
             "module": "pages"
           }
@@ -62289,7 +62545,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 252,
+            "line": 254,
             "column": 3,
             "module": "pages"
           }
@@ -62300,7 +62556,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 252,
+            "line": 254,
             "column": 3,
             "module": "pages"
           }
@@ -62308,9 +62564,18 @@
       },
       "references": [
         {
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 109,
+          "column": 13,
+          "symbol": "closureMessages",
+          "defaultMessage": "Issues",
+          "defaultMessageExpression": null
+        },
+        {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1659,
+          "line": 1587,
           "column": 45,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Issues",
@@ -62324,8 +62589,14 @@
           "placeholders": [],
           "locations": [
             {
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 109,
+              "column": 13,
+              "kind": "formatMessage"
+            },
+            {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1659,
+              "line": 1587,
               "column": 45,
               "kind": "messageHelper"
             }
@@ -62350,7 +62621,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 253,
+            "line": 255,
             "column": 3,
             "module": "pages"
           }
@@ -62361,7 +62632,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 253,
+            "line": 255,
             "column": 3,
             "module": "pages"
           }
@@ -62372,7 +62643,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 253,
+            "line": 255,
             "column": 3,
             "module": "pages"
           }
@@ -62383,7 +62654,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 253,
+            "line": 255,
             "column": 3,
             "module": "pages"
           }
@@ -62393,7 +62664,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1733,
+          "line": 1661,
           "column": 24,
           "symbol": "renderBuildRequests",
           "defaultMessage": "No closure issues found.",
@@ -62408,7 +62679,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1733,
+              "line": 1661,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -62433,7 +62704,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 254,
+            "line": 256,
             "column": 3,
             "module": "pages"
           }
@@ -62444,7 +62715,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 254,
+            "line": 256,
             "column": 3,
             "module": "pages"
           }
@@ -62455,7 +62726,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 254,
+            "line": 256,
             "column": 3,
             "module": "pages"
           }
@@ -62466,7 +62737,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 254,
+            "line": 256,
             "column": 3,
             "module": "pages"
           }
@@ -62476,7 +62747,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1749,
+          "line": 1677,
           "column": 24,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Load more issues",
@@ -62491,7 +62762,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1749,
+              "line": 1677,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -62516,7 +62787,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 255,
+            "line": 257,
             "column": 3,
             "module": "pages"
           }
@@ -62527,7 +62798,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 255,
+            "line": 257,
             "column": 3,
             "module": "pages"
           }
@@ -62538,7 +62809,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 255,
+            "line": 257,
             "column": 3,
             "module": "pages"
           }
@@ -62549,7 +62820,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 255,
+            "line": 257,
             "column": 3,
             "module": "pages"
           }
@@ -62559,7 +62830,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1637,
+          "line": 1565,
           "column": 28,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Check data completeness before generation.",
@@ -62574,7 +62845,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1637,
+              "line": 1565,
               "column": 28,
               "kind": "messageHelper"
             }
@@ -62599,7 +62870,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 256,
+            "line": 258,
             "column": 3,
             "module": "pages"
           }
@@ -62610,7 +62881,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 256,
+            "line": 258,
             "column": 3,
             "module": "pages"
           }
@@ -62621,7 +62892,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 256,
+            "line": 258,
             "column": 3,
             "module": "pages"
           }
@@ -62632,7 +62903,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 256,
+            "line": 258,
             "column": 3,
             "module": "pages"
           }
@@ -62658,7 +62929,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 257,
+            "line": 259,
             "column": 3,
             "module": "pages"
           }
@@ -62669,7 +62940,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 257,
+            "line": 259,
             "column": 3,
             "module": "pages"
           }
@@ -62680,7 +62951,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 257,
+            "line": 259,
             "column": 3,
             "module": "pages"
           }
@@ -62691,7 +62962,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 257,
+            "line": 259,
             "column": 3,
             "module": "pages"
           }
@@ -62701,7 +62972,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1667,
+          "line": 1595,
           "column": 28,
           "symbol": "renderBuildRequests",
           "defaultMessage": "The current selection differs from this check. Run a new check before generating.",
@@ -62716,7 +62987,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1667,
+              "line": 1595,
               "column": 28,
               "kind": "messageHelper"
             }
@@ -62741,7 +63012,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 258,
+            "line": 260,
             "column": 3,
             "module": "pages"
           }
@@ -62752,7 +63023,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 258,
+            "line": 260,
             "column": 3,
             "module": "pages"
           }
@@ -62763,7 +63034,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 258,
+            "line": 260,
             "column": 3,
             "module": "pages"
           }
@@ -62774,7 +63045,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 258,
+            "line": 260,
             "column": 3,
             "module": "pages"
           }
@@ -62782,9 +63053,18 @@
       },
       "references": [
         {
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 125,
+          "column": 13,
+          "symbol": "closureMessages",
+          "defaultMessage": "Check status",
+          "defaultMessageExpression": null
+        },
+        {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1645,
+          "line": 1573,
           "column": 28,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Check status",
@@ -62798,8 +63078,14 @@
           "placeholders": [],
           "locations": [
             {
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 125,
+              "column": 13,
+              "kind": "formatMessage"
+            },
+            {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1645,
+              "line": 1573,
               "column": 28,
               "kind": "messageHelper"
             }
@@ -62824,7 +63110,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 259,
+            "line": 261,
             "column": 3,
             "module": "pages"
           }
@@ -62835,7 +63121,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 259,
+            "line": 261,
             "column": 3,
             "module": "pages"
           }
@@ -62846,7 +63132,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 259,
+            "line": 261,
             "column": 3,
             "module": "pages"
           }
@@ -62857,7 +63143,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 259,
+            "line": 261,
             "column": 3,
             "module": "pages"
           }
@@ -62867,7 +63153,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1630,
+          "line": 1558,
           "column": 20,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Data completeness preflight",
@@ -62882,7 +63168,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1630,
+              "line": 1558,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -62907,7 +63193,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 260,
+            "line": 262,
             "column": 3,
             "module": "pages"
           }
@@ -62918,7 +63204,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 260,
+            "line": 262,
             "column": 3,
             "module": "pages"
           }
@@ -62929,7 +63215,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 260,
+            "line": 262,
             "column": 3,
             "module": "pages"
           }
@@ -62940,7 +63226,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 260,
+            "line": 262,
             "column": 3,
             "module": "pages"
           }
@@ -62948,9 +63234,18 @@
       },
       "references": [
         {
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 129,
+          "column": 18,
+          "symbol": "closureMessages",
+          "defaultMessage": "Worker job ID",
+          "defaultMessageExpression": null
+        },
+        {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1701,
+          "line": 1629,
           "column": 31,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Worker job ID",
@@ -62964,8 +63259,14 @@
           "placeholders": [],
           "locations": [
             {
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 129,
+              "column": 18,
+              "kind": "formatMessage"
+            },
+            {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1701,
+              "line": 1629,
               "column": 31,
               "kind": "messageHelper"
             }
@@ -62990,7 +63291,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 269,
+            "line": 271,
             "column": 3,
             "module": "pages"
           }
@@ -63001,7 +63302,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 269,
+            "line": 271,
             "column": 3,
             "module": "pages"
           }
@@ -63012,7 +63313,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 269,
+            "line": 271,
             "column": 3,
             "module": "pages"
           }
@@ -63023,7 +63324,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 269,
+            "line": 271,
             "column": 3,
             "module": "pages"
           }
@@ -63033,7 +63334,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1063,
+          "line": 1019,
           "column": 9,
           "symbol": "commandSummaryRows",
           "defaultMessage": "Generation ID",
@@ -63048,7 +63349,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1063,
+              "line": 1019,
               "column": 9,
               "kind": "messageHelper"
             }
@@ -63073,7 +63374,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 263,
+            "line": 265,
             "column": 3,
             "module": "pages"
           }
@@ -63084,7 +63385,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 263,
+            "line": 265,
             "column": 3,
             "module": "pages"
           }
@@ -63095,7 +63396,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 263,
+            "line": 265,
             "column": 3,
             "module": "pages"
           }
@@ -63106,7 +63407,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 263,
+            "line": 265,
             "column": 3,
             "module": "pages"
           }
@@ -63114,9 +63415,18 @@
       },
       "references": [
         {
+          "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 67,
+          "column": 21,
+          "symbol": "closureMessages",
+          "defaultMessage": "Closure check ID",
+          "defaultMessageExpression": null
+        },
+        {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1051,
+          "line": 1007,
           "column": 9,
           "symbol": "commandSummaryRows",
           "defaultMessage": "Closure check ID",
@@ -63130,8 +63440,14 @@
           "placeholders": [],
           "locations": [
             {
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 67,
+              "column": 21,
+              "kind": "formatMessage"
+            },
+            {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1051,
+              "line": 1007,
               "column": 9,
               "kind": "messageHelper"
             }
@@ -63156,7 +63472,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 265,
+            "line": 267,
             "column": 3,
             "module": "pages"
           }
@@ -63167,7 +63483,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 265,
+            "line": 267,
             "column": 3,
             "module": "pages"
           }
@@ -63178,7 +63494,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 265,
+            "line": 267,
             "column": 3,
             "module": "pages"
           }
@@ -63189,7 +63505,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 265,
+            "line": 267,
             "column": 3,
             "module": "pages"
           }
@@ -63215,7 +63531,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 264,
+            "line": 266,
             "column": 3,
             "module": "pages"
           }
@@ -63226,7 +63542,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 264,
+            "line": 266,
             "column": 3,
             "module": "pages"
           }
@@ -63237,7 +63553,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 264,
+            "line": 266,
             "column": 3,
             "module": "pages"
           }
@@ -63248,7 +63564,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 264,
+            "line": 266,
             "column": 3,
             "module": "pages"
           }
@@ -63274,7 +63590,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 262,
+            "line": 264,
             "column": 3,
             "module": "pages"
           }
@@ -63285,7 +63601,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 262,
+            "line": 264,
             "column": 3,
             "module": "pages"
           }
@@ -63296,7 +63612,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 262,
+            "line": 264,
             "column": 3,
             "module": "pages"
           }
@@ -63307,7 +63623,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 262,
+            "line": 264,
             "column": 3,
             "module": "pages"
           }
@@ -63317,7 +63633,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1182,
+          "line": 1138,
           "column": 11,
           "symbol": "showResult",
           "defaultMessage": "Command failed",
@@ -63326,7 +63642,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1293,
+          "line": 1256,
           "column": 41,
           "symbol": "handleRecoverClosureCheck",
           "defaultMessage": "Command failed",
@@ -63341,13 +63657,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1182,
+              "line": 1138,
               "column": 11,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1293,
+              "line": 1256,
               "column": 41,
               "kind": "messageHelper"
             }
@@ -63372,7 +63688,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 271,
+            "line": 273,
             "column": 3,
             "module": "pages"
           }
@@ -63383,7 +63699,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 271,
+            "line": 273,
             "column": 3,
             "module": "pages"
           }
@@ -63394,7 +63710,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 271,
+            "line": 273,
             "column": 3,
             "module": "pages"
           }
@@ -63405,7 +63721,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 271,
+            "line": 273,
             "column": 3,
             "module": "pages"
           }
@@ -63415,7 +63731,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1089,
+          "line": 1045,
           "column": 9,
           "symbol": "commandSummaryRows",
           "defaultMessage": "Result set ID",
@@ -63430,7 +63746,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1089,
+              "line": 1045,
               "column": 9,
               "kind": "messageHelper"
             }
@@ -63455,7 +63771,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 272,
+            "line": 274,
             "column": 3,
             "module": "pages"
           }
@@ -63466,7 +63782,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 272,
+            "line": 274,
             "column": 3,
             "module": "pages"
           }
@@ -63477,7 +63793,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 272,
+            "line": 274,
             "column": 3,
             "module": "pages"
           }
@@ -63488,7 +63804,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 272,
+            "line": 274,
             "column": 3,
             "module": "pages"
           }
@@ -63514,7 +63830,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 266,
+            "line": 268,
             "column": 3,
             "module": "pages"
           }
@@ -63525,7 +63841,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 266,
+            "line": 268,
             "column": 3,
             "module": "pages"
           }
@@ -63536,7 +63852,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 266,
+            "line": 268,
             "column": 3,
             "module": "pages"
           }
@@ -63547,7 +63863,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 266,
+            "line": 268,
             "column": 3,
             "module": "pages"
           }
@@ -63573,7 +63889,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 273,
+            "line": 275,
             "column": 3,
             "module": "pages"
           }
@@ -63584,7 +63900,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 273,
+            "line": 275,
             "column": 3,
             "module": "pages"
           }
@@ -63595,7 +63911,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 273,
+            "line": 275,
             "column": 3,
             "module": "pages"
           }
@@ -63606,7 +63922,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 273,
+            "line": 275,
             "column": 3,
             "module": "pages"
           }
@@ -63616,7 +63932,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1085,
+          "line": 1041,
           "column": 9,
           "symbol": "commandSummaryRows",
           "defaultMessage": "Publication ID",
@@ -63625,7 +63941,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1097,
+          "line": 1053,
           "column": 7,
           "symbol": "commandSummaryRows",
           "defaultMessage": "Publication ID",
@@ -63640,13 +63956,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1085,
+              "line": 1041,
               "column": 9,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1097,
+              "line": 1053,
               "column": 7,
               "kind": "messageHelper"
             }
@@ -63671,7 +63987,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 267,
+            "line": 269,
             "column": 3,
             "module": "pages"
           }
@@ -63682,7 +63998,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 267,
+            "line": 269,
             "column": 3,
             "module": "pages"
           }
@@ -63693,7 +64009,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 267,
+            "line": 269,
             "column": 3,
             "module": "pages"
           }
@@ -63704,7 +64020,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 267,
+            "line": 269,
             "column": 3,
             "module": "pages"
           }
@@ -63730,7 +64046,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 274,
+            "line": 276,
             "column": 3,
             "module": "pages"
           }
@@ -63741,7 +64057,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 274,
+            "line": 276,
             "column": 3,
             "module": "pages"
           }
@@ -63752,7 +64068,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 274,
+            "line": 276,
             "column": 3,
             "module": "pages"
           }
@@ -63763,7 +64079,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 274,
+            "line": 276,
             "column": 3,
             "module": "pages"
           }
@@ -63773,7 +64089,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1092,
+          "line": 1048,
           "column": 14,
           "symbol": "commandSummaryRows",
           "defaultMessage": "Status",
@@ -63782,7 +64098,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1101,
+          "line": 1057,
           "column": 7,
           "symbol": "commandSummaryRows",
           "defaultMessage": "Status",
@@ -63791,7 +64107,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1485,
+          "line": 1413,
           "column": 20,
           "symbol": "renderBuildJobs",
           "defaultMessage": "Status",
@@ -63800,7 +64116,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2536,
+          "line": 2359,
           "column": 22,
           "symbol": "renderPublication",
           "defaultMessage": "Status",
@@ -63815,25 +64131,25 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1092,
+              "line": 1048,
               "column": 14,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1101,
+              "line": 1057,
               "column": 7,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1485,
+              "line": 1413,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2536,
+              "line": 2359,
               "column": 22,
               "kind": "messageHelper"
             }
@@ -63858,7 +64174,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 261,
+            "line": 263,
             "column": 3,
             "module": "pages"
           }
@@ -63869,7 +64185,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 261,
+            "line": 263,
             "column": 3,
             "module": "pages"
           }
@@ -63880,7 +64196,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 261,
+            "line": 263,
             "column": 3,
             "module": "pages"
           }
@@ -63891,7 +64207,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 261,
+            "line": 263,
             "column": 3,
             "module": "pages"
           }
@@ -63917,7 +64233,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 268,
+            "line": 270,
             "column": 3,
             "module": "pages"
           }
@@ -63928,7 +64244,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 268,
+            "line": 270,
             "column": 3,
             "module": "pages"
           }
@@ -63939,7 +64255,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 268,
+            "line": 270,
             "column": 3,
             "module": "pages"
           }
@@ -63950,7 +64266,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 268,
+            "line": 270,
             "column": 3,
             "module": "pages"
           }
@@ -63976,7 +64292,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 270,
+            "line": 272,
             "column": 3,
             "module": "pages"
           }
@@ -63987,7 +64303,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 270,
+            "line": 272,
             "column": 3,
             "module": "pages"
           }
@@ -63998,7 +64314,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 270,
+            "line": 272,
             "column": 3,
             "module": "pages"
           }
@@ -64009,7 +64325,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 270,
+            "line": 272,
             "column": 3,
             "module": "pages"
           }
@@ -64019,7 +64335,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1055,
+          "line": 1011,
           "column": 9,
           "symbol": "commandSummaryRows",
           "defaultMessage": "Worker job ID",
@@ -64028,7 +64344,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1067,
+          "line": 1023,
           "column": 9,
           "symbol": "commandSummaryRows",
           "defaultMessage": "Worker job ID",
@@ -64043,13 +64359,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1055,
+              "line": 1011,
               "column": 9,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1067,
+              "line": 1023,
               "column": 9,
               "kind": "messageHelper"
             }
@@ -64117,7 +64433,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1004,
+          "line": 960,
           "column": 16,
           "symbol": "coverageModeOptions",
           "defaultMessage": "Global eligible",
@@ -64132,7 +64448,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1004,
+              "line": 960,
               "column": 16,
               "kind": "messageHelper"
             }
@@ -64200,7 +64516,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1007,
+          "line": 963,
           "column": 16,
           "symbol": "coverageModeOptions",
           "defaultMessage": "Subset",
@@ -64215,7 +64531,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1007,
+              "line": 963,
               "column": 16,
               "kind": "messageHelper"
             }
@@ -64283,7 +64599,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1612,
+          "line": 1540,
           "column": 20,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Coverage mode",
@@ -64292,7 +64608,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1616,
+          "line": 1544,
           "column": 27,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Coverage mode",
@@ -64307,13 +64623,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1612,
+              "line": 1540,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1616,
+              "line": 1544,
               "column": 27,
               "kind": "messageHelper"
             }
@@ -64381,7 +64697,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1621,
+          "line": 1549,
           "column": 20,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Default impact category",
@@ -64390,7 +64706,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1625,
+          "line": 1553,
           "column": 15,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Default impact category",
@@ -64405,13 +64721,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1621,
+              "line": 1549,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1625,
+              "line": 1553,
               "column": 15,
               "kind": "messageHelper"
             }
@@ -64479,7 +64795,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1563,
+          "line": 1491,
           "column": 20,
           "symbol": "renderImpactCategorySelect",
           "defaultMessage": "Select an impact category",
@@ -64494,7 +64810,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1563,
+              "line": 1491,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -64562,7 +64878,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1597,
+          "line": 1525,
           "column": 20,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Result set name",
@@ -64571,7 +64887,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1609,
+          "line": 1537,
           "column": 32,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Result set name",
@@ -64586,13 +64902,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1597,
+              "line": 1525,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1609,
+              "line": 1537,
               "column": 32,
               "kind": "messageHelper"
             }
@@ -64660,7 +64976,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2199,
+          "line": 2022,
           "column": 19,
           "symbol": "renderPackagePreview",
           "defaultMessage": "No preview-ready result set yet. Refresh tasks or wait for the worker to complete.",
@@ -64669,7 +64985,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2455,
+          "line": 2278,
           "column": 19,
           "symbol": "renderPublication",
           "defaultMessage": "No preview-ready result set yet. Refresh tasks or wait for the worker to complete.",
@@ -64684,13 +65000,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2199,
+              "line": 2022,
               "column": 19,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2455,
+              "line": 2278,
               "column": 19,
               "kind": "messageHelper"
             }
@@ -64758,7 +65074,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1577,
+          "line": 1505,
           "column": 20,
           "symbol": "renderPackageSelect",
           "defaultMessage": "Select a preview-ready result set",
@@ -64773,7 +65089,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1577,
+              "line": 1505,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -64841,7 +65157,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2195,
+          "line": 2018,
           "column": 20,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Select result set",
@@ -64850,7 +65166,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2216,
+          "line": 2039,
           "column": 15,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Select result set",
@@ -64865,13 +65181,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2195,
+              "line": 2018,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2216,
+              "line": 2039,
               "column": 15,
               "kind": "messageHelper"
             }
@@ -64939,7 +65255,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2476,
+          "line": 2299,
           "column": 20,
           "symbol": "renderPublication",
           "defaultMessage": "Publish default impact category",
@@ -64948,7 +65264,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2492,
+          "line": 2315,
           "column": 15,
           "symbol": "renderPublication",
           "defaultMessage": "Publish default impact category",
@@ -64957,7 +65273,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2539,
+          "line": 2362,
           "column": 22,
           "symbol": "renderPublication",
           "defaultMessage": "Publish default impact category",
@@ -64972,19 +65288,19 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2476,
+              "line": 2299,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2492,
+              "line": 2315,
               "column": 15,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2539,
+              "line": 2362,
               "column": 22,
               "kind": "messageHelper"
             }
@@ -65052,7 +65368,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2451,
+          "line": 2274,
           "column": 20,
           "symbol": "renderPublication",
           "defaultMessage": "Publish result set",
@@ -65061,7 +65377,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2472,
+          "line": 2295,
           "column": 15,
           "symbol": "renderPublication",
           "defaultMessage": "Publish result set",
@@ -65076,13 +65392,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2451,
+              "line": 2274,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2472,
+              "line": 2295,
               "column": 15,
               "kind": "messageHelper"
             }
@@ -65150,7 +65466,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2499,
+          "line": 2322,
           "column": 20,
           "symbol": "renderPublication",
           "defaultMessage": "Publish reason",
@@ -65159,7 +65475,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2502,
+          "line": 2325,
           "column": 32,
           "symbol": "renderPublication",
           "defaultMessage": "Publish reason",
@@ -65174,13 +65490,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2499,
+              "line": 2322,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2502,
+              "line": 2325,
               "column": 32,
               "kind": "messageHelper"
             }
@@ -65323,7 +65639,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 287,
+            "line": 289,
             "column": 3,
             "module": "pages"
           }
@@ -65334,7 +65650,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 287,
+            "line": 289,
             "column": 3,
             "module": "pages"
           }
@@ -65345,7 +65661,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 287,
+            "line": 289,
             "column": 3,
             "module": "pages"
           }
@@ -65356,7 +65672,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 287,
+            "line": 289,
             "column": 3,
             "module": "pages"
           }
@@ -65366,7 +65682,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1493,
+          "line": 1421,
           "column": 44,
           "symbol": "renderBuildJobs",
           "defaultMessage": "Action",
@@ -65375,7 +65691,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2550,
+          "line": 2373,
           "column": 46,
           "symbol": "renderPublication",
           "defaultMessage": "Action",
@@ -65390,13 +65706,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1493,
+              "line": 1421,
               "column": 44,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2550,
+              "line": 2373,
               "column": 46,
               "kind": "messageHelper"
             }
@@ -65421,7 +65737,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 284,
+            "line": 286,
             "column": 3,
             "module": "pages"
           }
@@ -65432,7 +65748,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 284,
+            "line": 286,
             "column": 3,
             "module": "pages"
           }
@@ -65443,7 +65759,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 284,
+            "line": 286,
             "column": 3,
             "module": "pages"
           }
@@ -65454,7 +65770,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 284,
+            "line": 286,
             "column": 3,
             "module": "pages"
           }
@@ -65480,7 +65796,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 282,
+            "line": 284,
             "column": 3,
             "module": "pages"
           }
@@ -65491,7 +65807,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 282,
+            "line": 284,
             "column": 3,
             "module": "pages"
           }
@@ -65502,7 +65818,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 282,
+            "line": 284,
             "column": 3,
             "module": "pages"
           }
@@ -65513,7 +65829,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 282,
+            "line": 284,
             "column": 3,
             "module": "pages"
           }
@@ -65523,7 +65839,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1476,
+          "line": 1404,
           "column": 16,
           "symbol": "renderBuildJobs",
           "defaultMessage": "No result generation tasks",
@@ -65538,7 +65854,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1476,
+              "line": 1404,
               "column": 16,
               "kind": "messageHelper"
             }
@@ -65563,7 +65879,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 292,
+            "line": 294,
             "column": 3,
             "module": "pages"
           }
@@ -65574,7 +65890,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 292,
+            "line": 294,
             "column": 3,
             "module": "pages"
           }
@@ -65585,7 +65901,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 292,
+            "line": 294,
             "column": 3,
             "module": "pages"
           }
@@ -65596,7 +65912,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 292,
+            "line": 294,
             "column": 3,
             "module": "pages"
           }
@@ -65622,7 +65938,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 291,
+            "line": 293,
             "column": 3,
             "module": "pages"
           }
@@ -65633,7 +65949,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 291,
+            "line": 293,
             "column": 3,
             "module": "pages"
           }
@@ -65644,7 +65960,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 291,
+            "line": 293,
             "column": 3,
             "module": "pages"
           }
@@ -65655,7 +65971,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 291,
+            "line": 293,
             "column": 3,
             "module": "pages"
           }
@@ -65681,7 +65997,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 285,
+            "line": 287,
             "column": 3,
             "module": "pages"
           }
@@ -65692,7 +66008,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 285,
+            "line": 287,
             "column": 3,
             "module": "pages"
           }
@@ -65703,7 +66019,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 285,
+            "line": 287,
             "column": 3,
             "module": "pages"
           }
@@ -65714,7 +66030,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 285,
+            "line": 287,
             "column": 3,
             "module": "pages"
           }
@@ -65724,7 +66040,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1468,
+          "line": 1396,
           "column": 14,
           "symbol": "renderBuildJobs",
           "defaultMessage": "Result set generation runs asynchronously. Refresh tasks to update progress, then preview or publish the result set after completion.",
@@ -65739,7 +66055,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1468,
+              "line": 1396,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -65764,7 +66080,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 286,
+            "line": 288,
             "column": 3,
             "module": "pages"
           }
@@ -65775,7 +66091,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 286,
+            "line": 288,
             "column": 3,
             "module": "pages"
           }
@@ -65786,7 +66102,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 286,
+            "line": 288,
             "column": 3,
             "module": "pages"
           }
@@ -65797,7 +66113,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 286,
+            "line": 288,
             "column": 3,
             "module": "pages"
           }
@@ -65807,7 +66123,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1488,
+          "line": 1416,
           "column": 20,
           "symbol": "renderBuildJobs",
           "defaultMessage": "Inputs",
@@ -65816,7 +66132,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2548,
+          "line": 2371,
           "column": 22,
           "symbol": "renderPublication",
           "defaultMessage": "Inputs",
@@ -65831,13 +66147,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1488,
+              "line": 1416,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2548,
+              "line": 2371,
               "column": 22,
               "kind": "messageHelper"
             }
@@ -65862,7 +66178,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 289,
+            "line": 291,
             "column": 3,
             "module": "pages"
           }
@@ -65873,7 +66189,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 289,
+            "line": 291,
             "column": 3,
             "module": "pages"
           }
@@ -65884,7 +66200,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 289,
+            "line": 291,
             "column": 3,
             "module": "pages"
           }
@@ -65895,7 +66211,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 289,
+            "line": 291,
             "column": 3,
             "module": "pages"
           }
@@ -65905,7 +66221,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1502,
+          "line": 1430,
           "column": 19,
           "symbol": "resultSetLabel",
           "defaultMessage": "Result set generation",
@@ -65920,7 +66236,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1502,
+              "line": 1430,
               "column": 19,
               "kind": "messageHelper"
             }
@@ -65945,7 +66261,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 283,
+            "line": 285,
             "column": 3,
             "module": "pages"
           }
@@ -65956,7 +66272,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 283,
+            "line": 285,
             "column": 3,
             "module": "pages"
           }
@@ -65967,7 +66283,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 283,
+            "line": 285,
             "column": 3,
             "module": "pages"
           }
@@ -65978,7 +66294,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 283,
+            "line": 285,
             "column": 3,
             "module": "pages"
           }
@@ -65988,7 +66304,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1461,
+          "line": 1389,
           "column": 12,
           "symbol": "renderBuildJobs",
           "defaultMessage": "Refresh jobs",
@@ -66003,7 +66319,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1461,
+              "line": 1389,
               "column": 12,
               "kind": "messageHelper"
             }
@@ -66028,7 +66344,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 288,
+            "line": 290,
             "column": 3,
             "module": "pages"
           }
@@ -66039,7 +66355,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 288,
+            "line": 290,
             "column": 3,
             "module": "pages"
           }
@@ -66050,7 +66366,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 288,
+            "line": 290,
             "column": 3,
             "module": "pages"
           }
@@ -66061,7 +66377,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 288,
+            "line": 290,
             "column": 3,
             "module": "pages"
           }
@@ -66071,7 +66387,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1482,
+          "line": 1410,
           "column": 20,
           "symbol": "renderBuildJobs",
           "defaultMessage": "Result set",
@@ -66080,7 +66396,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2533,
+          "line": 2356,
           "column": 22,
           "symbol": "renderPublication",
           "defaultMessage": "Result set",
@@ -66095,13 +66411,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1482,
+              "line": 1410,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2533,
+              "line": 2356,
               "column": 22,
               "kind": "messageHelper"
             }
@@ -66126,7 +66442,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 280,
+            "line": 282,
             "column": 3,
             "module": "pages"
           }
@@ -66137,7 +66453,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 280,
+            "line": 282,
             "column": 3,
             "module": "pages"
           }
@@ -66148,7 +66464,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 280,
+            "line": 282,
             "column": 3,
             "module": "pages"
           }
@@ -66159,7 +66475,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 280,
+            "line": 282,
             "column": 3,
             "module": "pages"
           }
@@ -66169,7 +66485,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1458,
+          "line": 1386,
           "column": 14,
           "symbol": "renderBuildJobs",
           "defaultMessage": "Result generation tasks",
@@ -66184,7 +66500,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1458,
+              "line": 1386,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -66209,7 +66525,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 294,
+            "line": 296,
             "column": 3,
             "module": "pages"
           }
@@ -66220,7 +66536,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 294,
+            "line": 296,
             "column": 3,
             "module": "pages"
           }
@@ -66231,7 +66547,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 294,
+            "line": 296,
             "column": 3,
             "module": "pages"
           }
@@ -66242,7 +66558,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 294,
+            "line": 296,
             "column": 3,
             "module": "pages"
           }
@@ -66252,7 +66568,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1491,
+          "line": 1419,
           "column": 20,
           "symbol": "renderBuildJobs",
           "defaultMessage": "Updated at",
@@ -66267,7 +66583,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1491,
+              "line": 1419,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -66292,7 +66608,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 290,
+            "line": 292,
             "column": 3,
             "module": "pages"
           }
@@ -66303,7 +66619,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 290,
+            "line": 292,
             "column": 3,
             "module": "pages"
           }
@@ -66314,7 +66630,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 290,
+            "line": 292,
             "column": 3,
             "module": "pages"
           }
@@ -66325,7 +66641,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 290,
+            "line": 292,
             "column": 3,
             "module": "pages"
           }
@@ -66351,7 +66667,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 293,
+            "line": 295,
             "column": 3,
             "module": "pages"
           }
@@ -66362,7 +66678,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 293,
+            "line": 295,
             "column": 3,
             "module": "pages"
           }
@@ -66373,7 +66689,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 293,
+            "line": 295,
             "column": 3,
             "module": "pages"
           }
@@ -66384,7 +66700,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 293,
+            "line": 295,
             "column": 3,
             "module": "pages"
           }
@@ -66394,7 +66710,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1453,
+          "line": 1381,
           "column": 9,
           "symbol": "renderJobPhase",
           "defaultMessage": "Waiting for worker processing",
@@ -66409,7 +66725,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1453,
+              "line": 1381,
               "column": 9,
               "kind": "messageHelper"
             }
@@ -66434,7 +66750,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 328,
+            "line": 330,
             "column": 3,
             "module": "pages"
           }
@@ -66445,7 +66761,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 328,
+            "line": 330,
             "column": 3,
             "module": "pages"
           }
@@ -66456,7 +66772,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 328,
+            "line": 330,
             "column": 3,
             "module": "pages"
           }
@@ -66467,7 +66783,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 328,
+            "line": 330,
             "column": 3,
             "module": "pages"
           }
@@ -66477,7 +66793,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2398,
+          "line": 2221,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Manifest version",
@@ -66492,7 +66808,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2398,
+              "line": 2221,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -66517,7 +66833,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 327,
+            "line": 329,
             "column": 3,
             "module": "pages"
           }
@@ -66528,7 +66844,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 327,
+            "line": 329,
             "column": 3,
             "module": "pages"
           }
@@ -66539,7 +66855,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 327,
+            "line": 329,
             "column": 3,
             "module": "pages"
           }
@@ -66550,7 +66866,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 327,
+            "line": 329,
             "column": 3,
             "module": "pages"
           }
@@ -66560,7 +66876,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2391,
+          "line": 2214,
           "column": 20,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Artifact verification",
@@ -66575,7 +66891,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2391,
+              "line": 2214,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -66600,7 +66916,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 333,
+            "line": 335,
             "column": 3,
             "module": "pages"
           }
@@ -66611,7 +66927,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 333,
+            "line": 335,
             "column": 3,
             "module": "pages"
           }
@@ -66622,7 +66938,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 333,
+            "line": 335,
             "column": 3,
             "module": "pages"
           }
@@ -66633,7 +66949,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 333,
+            "line": 335,
             "column": 3,
             "module": "pages"
           }
@@ -66643,7 +66959,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2423,
+          "line": 2246,
           "column": 41,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Artifacts",
@@ -66658,7 +66974,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2423,
+              "line": 2246,
               "column": 41,
               "kind": "messageHelper"
             }
@@ -66683,7 +66999,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 299,
+            "line": 301,
             "column": 3,
             "module": "pages"
           }
@@ -66694,7 +67010,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 299,
+            "line": 301,
             "column": 3,
             "module": "pages"
           }
@@ -66705,7 +67021,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 299,
+            "line": 301,
             "column": 3,
             "module": "pages"
           }
@@ -66716,7 +67032,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 299,
+            "line": 301,
             "column": 3,
             "module": "pages"
           }
@@ -66726,7 +67042,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2248,
+          "line": 2071,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Coverage mode",
@@ -66741,7 +67057,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2248,
+              "line": 2071,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -66766,7 +67082,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 300,
+            "line": 302,
             "column": 3,
             "module": "pages"
           }
@@ -66777,7 +67093,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 300,
+            "line": 302,
             "column": 3,
             "module": "pages"
           }
@@ -66788,7 +67104,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 300,
+            "line": 302,
             "column": 3,
             "module": "pages"
           }
@@ -66799,7 +67115,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 300,
+            "line": 302,
             "column": 3,
             "module": "pages"
           }
@@ -66809,7 +67125,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2253,
+          "line": 2076,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Default impact category",
@@ -66824,7 +67140,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2253,
+              "line": 2076,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -66849,7 +67165,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 303,
+            "line": 305,
             "column": 3,
             "module": "pages"
           }
@@ -66860,7 +67176,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 303,
+            "line": 305,
             "column": 3,
             "module": "pages"
           }
@@ -66871,7 +67187,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 303,
+            "line": 305,
             "column": 3,
             "module": "pages"
           }
@@ -66882,7 +67198,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 303,
+            "line": 305,
             "column": 3,
             "module": "pages"
           }
@@ -66892,7 +67208,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2271,
+          "line": 2094,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Eligible inputs",
@@ -66907,7 +67223,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2271,
+              "line": 2094,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -66932,7 +67248,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 323,
+            "line": 325,
             "column": 3,
             "module": "pages"
           }
@@ -66943,7 +67259,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 323,
+            "line": 325,
             "column": 3,
             "module": "pages"
           }
@@ -66954,7 +67270,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 323,
+            "line": 325,
             "column": 3,
             "module": "pages"
           }
@@ -66965,7 +67281,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 323,
+            "line": 325,
             "column": 3,
             "module": "pages"
           }
@@ -66975,7 +67291,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2334,
+          "line": 2157,
           "column": 20,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Export Excel",
@@ -66990,7 +67306,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2334,
+              "line": 2157,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -67015,7 +67331,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 324,
+            "line": 326,
             "column": 3,
             "module": "pages"
           }
@@ -67026,7 +67342,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 324,
+            "line": 326,
             "column": 3,
             "module": "pages"
           }
@@ -67037,7 +67353,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 324,
+            "line": 326,
             "column": 3,
             "module": "pages"
           }
@@ -67048,7 +67364,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 324,
+            "line": 326,
             "column": 3,
             "module": "pages"
           }
@@ -67058,7 +67374,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2039,
+          "line": 1862,
           "column": 15,
           "symbol": "handleExportPreview",
           "defaultMessage": "Failed to export result details",
@@ -67073,7 +67389,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2039,
+              "line": 1862,
               "column": 15,
               "kind": "messageHelper"
             }
@@ -67098,7 +67414,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 304,
+            "line": 306,
             "column": 3,
             "module": "pages"
           }
@@ -67109,7 +67425,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 304,
+            "line": 306,
             "column": 3,
             "module": "pages"
           }
@@ -67120,7 +67436,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 304,
+            "line": 306,
             "column": 3,
             "module": "pages"
           }
@@ -67131,7 +67447,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 304,
+            "line": 306,
             "column": 3,
             "module": "pages"
           }
@@ -67141,7 +67457,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2276,
+          "line": 2099,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Impact category count",
@@ -67156,7 +67472,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2276,
+              "line": 2099,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -67181,7 +67497,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 302,
+            "line": 304,
             "column": 3,
             "module": "pages"
           }
@@ -67192,7 +67508,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 302,
+            "line": 304,
             "column": 3,
             "module": "pages"
           }
@@ -67203,7 +67519,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 302,
+            "line": 304,
             "column": 3,
             "module": "pages"
           }
@@ -67214,7 +67530,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 302,
+            "line": 304,
             "column": 3,
             "module": "pages"
           }
@@ -67224,7 +67540,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2266,
+          "line": 2089,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Included inputs",
@@ -67239,7 +67555,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2266,
+              "line": 2089,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -67264,7 +67580,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 301,
+            "line": 303,
             "column": 3,
             "module": "pages"
           }
@@ -67275,7 +67591,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 301,
+            "line": 303,
             "column": 3,
             "module": "pages"
           }
@@ -67286,7 +67602,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 301,
+            "line": 303,
             "column": 3,
             "module": "pages"
           }
@@ -67297,7 +67613,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 301,
+            "line": 303,
             "column": 3,
             "module": "pages"
           }
@@ -67307,7 +67623,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2261,
+          "line": 2084,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Input manifest hash",
@@ -67322,7 +67638,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2261,
+              "line": 2084,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -67347,7 +67663,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 305,
+            "line": 307,
             "column": 3,
             "module": "pages"
           }
@@ -67358,7 +67674,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 305,
+            "line": 307,
             "column": 3,
             "module": "pages"
           }
@@ -67369,7 +67685,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 305,
+            "line": 307,
             "column": 3,
             "module": "pages"
           }
@@ -67380,7 +67696,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 305,
+            "line": 307,
             "column": 3,
             "module": "pages"
           }
@@ -67390,7 +67706,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2289,
+          "line": 2112,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Input scope",
@@ -67405,7 +67721,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2289,
+              "line": 2112,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -67430,7 +67746,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 317,
+            "line": 319,
             "column": 3,
             "module": "pages"
           }
@@ -67441,7 +67757,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 317,
+            "line": 319,
             "column": 3,
             "module": "pages"
           }
@@ -67452,7 +67768,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 317,
+            "line": 319,
             "column": 3,
             "module": "pages"
           }
@@ -67463,7 +67779,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 317,
+            "line": 319,
             "column": 3,
             "module": "pages"
           }
@@ -67473,7 +67789,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2341,
+          "line": 2164,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "LCIA method",
@@ -67482,7 +67798,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2343,
+          "line": 2166,
           "column": 31,
           "symbol": "renderPackagePreview",
           "defaultMessage": "LCIA method",
@@ -67497,13 +67813,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2341,
+              "line": 2164,
               "column": 24,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2343,
+              "line": 2166,
               "column": 31,
               "kind": "messageHelper"
             }
@@ -67528,7 +67844,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 318,
+            "line": 320,
             "column": 3,
             "module": "pages"
           }
@@ -67539,7 +67855,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 318,
+            "line": 320,
             "column": 3,
             "module": "pages"
           }
@@ -67550,7 +67866,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 318,
+            "line": 320,
             "column": 3,
             "module": "pages"
           }
@@ -67561,7 +67877,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 318,
+            "line": 320,
             "column": 3,
             "module": "pages"
           }
@@ -67587,7 +67903,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 322,
+            "line": 324,
             "column": 3,
             "module": "pages"
           }
@@ -67598,7 +67914,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 322,
+            "line": 324,
             "column": 3,
             "module": "pages"
           }
@@ -67609,7 +67925,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 322,
+            "line": 324,
             "column": 3,
             "module": "pages"
           }
@@ -67620,7 +67936,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 322,
+            "line": 324,
             "column": 3,
             "module": "pages"
           }
@@ -67630,7 +67946,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2154,
+          "line": 1977,
           "column": 12,
           "symbol": "renderPreviewPager",
           "defaultMessage": "Next",
@@ -67645,7 +67961,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2154,
+              "line": 1977,
               "column": 12,
               "kind": "messageHelper"
             }
@@ -67670,7 +67986,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 295,
+            "line": 297,
             "column": 3,
             "module": "pages"
           }
@@ -67681,7 +67997,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 295,
+            "line": 297,
             "column": 3,
             "module": "pages"
           }
@@ -67692,7 +68008,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 295,
+            "line": 297,
             "column": 3,
             "module": "pages"
           }
@@ -67703,7 +68019,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 295,
+            "line": 297,
             "column": 3,
             "module": "pages"
           }
@@ -67713,7 +68029,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2235,
+          "line": 2058,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Result set ID",
@@ -67728,7 +68044,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2235,
+              "line": 2058,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -67753,7 +68069,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 296,
+            "line": 298,
             "column": 3,
             "module": "pages"
           }
@@ -67764,7 +68080,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 296,
+            "line": 298,
             "column": 3,
             "module": "pages"
           }
@@ -67775,7 +68091,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 296,
+            "line": 298,
             "column": 3,
             "module": "pages"
           }
@@ -67786,7 +68102,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 296,
+            "line": 298,
             "column": 3,
             "module": "pages"
           }
@@ -67796,7 +68112,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2240,
+          "line": 2063,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Result set version",
@@ -67811,7 +68127,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2240,
+              "line": 2063,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -67836,7 +68152,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 308,
+            "line": 310,
             "column": 3,
             "module": "pages"
           }
@@ -67847,7 +68163,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 308,
+            "line": 310,
             "column": 3,
             "module": "pages"
           }
@@ -67858,7 +68174,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 308,
+            "line": 310,
             "column": 3,
             "module": "pages"
           }
@@ -67869,7 +68185,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 308,
+            "line": 310,
             "column": 3,
             "module": "pages"
           }
@@ -67879,7 +68195,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2302,
+          "line": 2125,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Predicate version",
@@ -67894,7 +68210,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2302,
+              "line": 2125,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -67919,7 +68235,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 321,
+            "line": 323,
             "column": 3,
             "module": "pages"
           }
@@ -67930,7 +68246,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 321,
+            "line": 323,
             "column": 3,
             "module": "pages"
           }
@@ -67941,7 +68257,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 321,
+            "line": 323,
             "column": 3,
             "module": "pages"
           }
@@ -67952,7 +68268,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 321,
+            "line": 323,
             "column": 3,
             "module": "pages"
           }
@@ -67962,7 +68278,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2150,
+          "line": 1973,
           "column": 12,
           "symbol": "renderPreviewPager",
           "defaultMessage": "Previous",
@@ -67977,7 +68293,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2150,
+              "line": 1973,
               "column": 12,
               "kind": "messageHelper"
             }
@@ -68002,7 +68318,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 306,
+            "line": 308,
             "column": 3,
             "module": "pages"
           }
@@ -68013,7 +68329,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 306,
+            "line": 308,
             "column": 3,
             "module": "pages"
           }
@@ -68024,7 +68340,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 306,
+            "line": 308,
             "column": 3,
             "module": "pages"
           }
@@ -68035,7 +68351,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 306,
+            "line": 308,
             "column": 3,
             "module": "pages"
           }
@@ -68045,7 +68361,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2292,
+          "line": 2115,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Process count",
@@ -68060,7 +68376,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2292,
+              "line": 2115,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -68085,7 +68401,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 312,
+            "line": 314,
             "column": 3,
             "module": "pages"
           }
@@ -68096,7 +68412,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 312,
+            "line": 314,
             "column": 3,
             "module": "pages"
           }
@@ -68107,7 +68423,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 312,
+            "line": 314,
             "column": 3,
             "module": "pages"
           }
@@ -68118,7 +68434,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 312,
+            "line": 314,
             "column": 3,
             "module": "pages"
           }
@@ -68144,7 +68460,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 316,
+            "line": 318,
             "column": 3,
             "module": "pages"
           }
@@ -68155,7 +68471,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 316,
+            "line": 318,
             "column": 3,
             "module": "pages"
           }
@@ -68166,7 +68482,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 316,
+            "line": 318,
             "column": 3,
             "module": "pages"
           }
@@ -68177,7 +68493,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 316,
+            "line": 318,
             "column": 3,
             "module": "pages"
           }
@@ -68203,7 +68519,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 311,
+            "line": 313,
             "column": 3,
             "module": "pages"
           }
@@ -68214,7 +68530,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 311,
+            "line": 313,
             "column": 3,
             "module": "pages"
           }
@@ -68225,7 +68541,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 311,
+            "line": 313,
             "column": 3,
             "module": "pages"
           }
@@ -68236,7 +68552,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 311,
+            "line": 313,
             "column": 3,
             "module": "pages"
           }
@@ -68246,7 +68562,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2067,
+          "line": 1890,
           "column": 11,
           "symbol": "handleExportPreview",
           "defaultMessage": "Process",
@@ -68255,7 +68571,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2095,
+          "line": 1918,
           "column": 14,
           "symbol": "previewDetailColumns",
           "defaultMessage": "Process",
@@ -68270,13 +68586,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2067,
+              "line": 1890,
               "column": 11,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2095,
+              "line": 1918,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -68301,7 +68617,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 313,
+            "line": 315,
             "column": 3,
             "module": "pages"
           }
@@ -68312,7 +68628,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 313,
+            "line": 315,
             "column": 3,
             "module": "pages"
           }
@@ -68323,7 +68639,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 313,
+            "line": 315,
             "column": 3,
             "module": "pages"
           }
@@ -68334,7 +68650,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 313,
+            "line": 315,
             "column": 3,
             "module": "pages"
           }
@@ -68344,7 +68660,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2068,
+          "line": 1891,
           "column": 11,
           "symbol": "handleExportPreview",
           "defaultMessage": "Process UUID",
@@ -68359,7 +68675,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2068,
+              "line": 1891,
               "column": 11,
               "kind": "messageHelper"
             }
@@ -68384,7 +68700,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 314,
+            "line": 316,
             "column": 3,
             "module": "pages"
           }
@@ -68395,7 +68711,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 314,
+            "line": 316,
             "column": 3,
             "module": "pages"
           }
@@ -68406,7 +68722,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 314,
+            "line": 316,
             "column": 3,
             "module": "pages"
           }
@@ -68417,7 +68733,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 314,
+            "line": 316,
             "column": 3,
             "module": "pages"
           }
@@ -68427,7 +68743,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2069,
+          "line": 1892,
           "column": 11,
           "symbol": "handleExportPreview",
           "defaultMessage": "Version",
@@ -68436,7 +68752,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2109,
+          "line": 1932,
           "column": 14,
           "symbol": "previewDetailColumns",
           "defaultMessage": "Version",
@@ -68451,13 +68767,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2069,
+              "line": 1892,
               "column": 11,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2109,
+              "line": 1932,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -68482,7 +68798,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 334,
+            "line": 336,
             "column": 3,
             "module": "pages"
           }
@@ -68493,7 +68809,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 334,
+            "line": 336,
             "column": 3,
             "module": "pages"
           }
@@ -68504,7 +68820,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 334,
+            "line": 336,
             "column": 3,
             "module": "pages"
           }
@@ -68515,7 +68831,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 334,
+            "line": 336,
             "column": 3,
             "module": "pages"
           }
@@ -68525,7 +68841,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2426,
+          "line": 2249,
           "column": 21,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Query artifact",
@@ -68540,7 +68856,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2426,
+              "line": 2249,
               "column": 21,
               "kind": "messageHelper"
             }
@@ -68565,7 +68881,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 335,
+            "line": 337,
             "column": 3,
             "module": "pages"
           }
@@ -68576,7 +68892,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 335,
+            "line": 337,
             "column": 3,
             "module": "pages"
           }
@@ -68587,7 +68903,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 335,
+            "line": 337,
             "column": 3,
             "module": "pages"
           }
@@ -68598,7 +68914,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 335,
+            "line": 337,
             "column": 3,
             "module": "pages"
           }
@@ -68608,7 +68924,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2430,
+          "line": 2253,
           "column": 21,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Result artifact",
@@ -68623,7 +68939,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2430,
+              "line": 2253,
               "column": 21,
               "kind": "messageHelper"
             }
@@ -68648,7 +68964,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 310,
+            "line": 312,
             "column": 3,
             "module": "pages"
           }
@@ -68659,7 +68975,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 310,
+            "line": 312,
             "column": 3,
             "module": "pages"
           }
@@ -68670,7 +68986,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 310,
+            "line": 312,
             "column": 3,
             "module": "pages"
           }
@@ -68681,7 +68997,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 310,
+            "line": 312,
             "column": 3,
             "module": "pages"
           }
@@ -68691,7 +69007,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2318,
+          "line": 2141,
           "column": 20,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Result details",
@@ -68706,7 +69022,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2318,
+              "line": 2141,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -68731,7 +69047,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 326,
+            "line": 328,
             "column": 3,
             "module": "pages"
           }
@@ -68742,7 +69058,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 326,
+            "line": 328,
             "column": 3,
             "module": "pages"
           }
@@ -68753,7 +69069,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 326,
+            "line": 328,
             "column": 3,
             "module": "pages"
           }
@@ -68764,7 +69080,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 326,
+            "line": 328,
             "column": 3,
             "module": "pages"
           }
@@ -68774,7 +69090,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2366,
+          "line": 2189,
           "column": 21,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Calculation results are not available for this preview.",
@@ -68789,7 +69105,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2366,
+              "line": 2189,
               "column": 21,
               "kind": "messageHelper"
             }
@@ -68814,7 +69130,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 307,
+            "line": 309,
             "column": 3,
             "module": "pages"
           }
@@ -68825,7 +69141,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 307,
+            "line": 309,
             "column": 3,
             "module": "pages"
           }
@@ -68836,7 +69152,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 307,
+            "line": 309,
             "column": 3,
             "module": "pages"
           }
@@ -68847,7 +69163,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 307,
+            "line": 309,
             "column": 3,
             "module": "pages"
           }
@@ -68857,7 +69173,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2297,
+          "line": 2120,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Selection mode",
@@ -68872,7 +69188,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2297,
+              "line": 2120,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -68897,7 +69213,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 332,
+            "line": 334,
             "column": 3,
             "module": "pages"
           }
@@ -68908,7 +69224,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 332,
+            "line": 334,
             "column": 3,
             "module": "pages"
           }
@@ -68919,7 +69235,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 332,
+            "line": 334,
             "column": 3,
             "module": "pages"
           }
@@ -68930,7 +69246,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 332,
+            "line": 334,
             "column": 3,
             "module": "pages"
           }
@@ -68940,7 +69256,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2419,
+          "line": 2242,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Snapshot coverage",
@@ -68955,7 +69271,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2419,
+              "line": 2242,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -68980,7 +69296,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 330,
+            "line": 332,
             "column": 3,
             "module": "pages"
           }
@@ -68991,7 +69307,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 330,
+            "line": 332,
             "column": 3,
             "module": "pages"
           }
@@ -69002,7 +69318,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 330,
+            "line": 332,
             "column": 3,
             "module": "pages"
           }
@@ -69013,7 +69329,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 330,
+            "line": 332,
             "column": 3,
             "module": "pages"
           }
@@ -69023,7 +69339,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2409,
+          "line": 2232,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Snapshot ID",
@@ -69038,7 +69354,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2409,
+              "line": 2232,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -69063,7 +69379,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 331,
+            "line": 333,
             "column": 3,
             "module": "pages"
           }
@@ -69074,7 +69390,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 331,
+            "line": 333,
             "column": 3,
             "module": "pages"
           }
@@ -69085,7 +69401,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 331,
+            "line": 333,
             "column": 3,
             "module": "pages"
           }
@@ -69096,7 +69412,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 331,
+            "line": 333,
             "column": 3,
             "module": "pages"
           }
@@ -69106,7 +69422,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2414,
+          "line": 2237,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Snapshot matrix",
@@ -69121,7 +69437,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2414,
+              "line": 2237,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -69146,7 +69462,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 315,
+            "line": 317,
             "column": 3,
             "module": "pages"
           }
@@ -69157,7 +69473,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 315,
+            "line": 317,
             "column": 3,
             "module": "pages"
           }
@@ -69168,7 +69484,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 315,
+            "line": 317,
             "column": 3,
             "module": "pages"
           }
@@ -69179,7 +69495,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 315,
+            "line": 317,
             "column": 3,
             "module": "pages"
           }
@@ -69189,7 +69505,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2070,
+          "line": 1893,
           "column": 11,
           "symbol": "handleExportPreview",
           "defaultMessage": "State code",
@@ -69198,7 +69514,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2115,
+          "line": 1938,
           "column": 14,
           "symbol": "previewDetailColumns",
           "defaultMessage": "State code",
@@ -69213,13 +69529,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2070,
+              "line": 1893,
               "column": 11,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2115,
+              "line": 1938,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -69244,7 +69560,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 309,
+            "line": 311,
             "column": 3,
             "module": "pages"
           }
@@ -69255,7 +69571,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 309,
+            "line": 311,
             "column": 3,
             "module": "pages"
           }
@@ -69266,7 +69582,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 309,
+            "line": 311,
             "column": 3,
             "module": "pages"
           }
@@ -69277,7 +69593,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 309,
+            "line": 311,
             "column": 3,
             "module": "pages"
           }
@@ -69287,7 +69603,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2307,
+          "line": 2130,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "State codes",
@@ -69302,7 +69618,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2307,
+              "line": 2130,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -69327,7 +69643,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 298,
+            "line": 300,
             "column": 3,
             "module": "pages"
           }
@@ -69338,7 +69654,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 298,
+            "line": 300,
             "column": 3,
             "module": "pages"
           }
@@ -69349,7 +69665,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 298,
+            "line": 300,
             "column": 3,
             "module": "pages"
           }
@@ -69360,7 +69676,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 298,
+            "line": 300,
             "column": 3,
             "module": "pages"
           }
@@ -69370,7 +69686,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2244,
+          "line": 2067,
           "column": 41,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Status",
@@ -69385,7 +69701,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2244,
+              "line": 2067,
               "column": 41,
               "kind": "messageHelper"
             }
@@ -69410,7 +69726,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 329,
+            "line": 331,
             "column": 3,
             "module": "pages"
           }
@@ -69421,7 +69737,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 329,
+            "line": 331,
             "column": 3,
             "module": "pages"
           }
@@ -69432,7 +69748,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 329,
+            "line": 331,
             "column": 3,
             "module": "pages"
           }
@@ -69443,7 +69759,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 329,
+            "line": 331,
             "column": 3,
             "module": "pages"
           }
@@ -69453,7 +69769,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2405,
+          "line": 2228,
           "column": 41,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Storage",
@@ -69468,7 +69784,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2405,
+              "line": 2228,
               "column": 41,
               "kind": "messageHelper"
             }
@@ -69493,7 +69809,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 297,
+            "line": 299,
             "column": 3,
             "module": "pages"
           }
@@ -69504,7 +69820,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 297,
+            "line": 299,
             "column": 3,
             "module": "pages"
           }
@@ -69515,7 +69831,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 297,
+            "line": 299,
             "column": 3,
             "module": "pages"
           }
@@ -69526,7 +69842,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 297,
+            "line": 299,
             "column": 3,
             "module": "pages"
           }
@@ -69536,7 +69852,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2232,
+          "line": 2055,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Result set overview",
@@ -69551,7 +69867,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2232,
+              "line": 2055,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -69576,7 +69892,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 319,
+            "line": 321,
             "column": 3,
             "module": "pages"
           }
@@ -69587,7 +69903,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 319,
+            "line": 321,
             "column": 3,
             "module": "pages"
           }
@@ -69598,7 +69914,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 319,
+            "line": 321,
             "column": 3,
             "module": "pages"
           }
@@ -69609,7 +69925,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 319,
+            "line": 321,
             "column": 3,
             "module": "pages"
           }
@@ -69635,7 +69951,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 320,
+            "line": 322,
             "column": 3,
             "module": "pages"
           }
@@ -69646,7 +69962,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 320,
+            "line": 322,
             "column": 3,
             "module": "pages"
           }
@@ -69657,7 +69973,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 320,
+            "line": 322,
             "column": 3,
             "module": "pages"
           }
@@ -69668,7 +69984,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 320,
+            "line": 322,
             "column": 3,
             "module": "pages"
           }
@@ -69678,7 +69994,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2012,
+          "line": 1835,
           "column": 10,
           "symbol": "previewValueTitle",
           "defaultMessage": "Value",
@@ -69687,7 +70003,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2013,
+          "line": 1836,
           "column": 7,
           "symbol": "previewValueTitle",
           "defaultMessage": "Value",
@@ -69702,13 +70018,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2012,
+              "line": 1835,
               "column": 10,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2013,
+              "line": 1836,
               "column": 7,
               "kind": "messageHelper"
             }
@@ -69733,7 +70049,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 325,
+            "line": 327,
             "column": 3,
             "module": "pages"
           }
@@ -69744,7 +70060,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 325,
+            "line": 327,
             "column": 3,
             "module": "pages"
           }
@@ -69755,7 +70071,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 325,
+            "line": 327,
             "column": 3,
             "module": "pages"
           }
@@ -69766,7 +70082,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 325,
+            "line": 327,
             "column": 3,
             "module": "pages"
           }
@@ -69776,7 +70092,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2355,
+          "line": 2178,
           "column": 28,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Some preview data could not be loaded",
@@ -69791,7 +70107,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2355,
+              "line": 2178,
               "column": 28,
               "kind": "messageHelper"
             }
@@ -69816,7 +70132,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 386,
+            "line": 388,
             "column": 3,
             "module": "pages"
           }
@@ -69827,7 +70143,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 386,
+            "line": 388,
             "column": 3,
             "module": "pages"
           }
@@ -69838,7 +70154,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 386,
+            "line": 388,
             "column": 3,
             "module": "pages"
           }
@@ -69849,7 +70165,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 386,
+            "line": 388,
             "column": 3,
             "module": "pages"
           }
@@ -69859,7 +70175,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2602,
+          "line": 2425,
           "column": 30,
           "symbol": "renderPublication",
           "defaultMessage": "Current",
@@ -69874,7 +70190,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2602,
+              "line": 2425,
               "column": 30,
               "kind": "messageHelper"
             }
@@ -69899,7 +70215,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 385,
+            "line": 387,
             "column": 3,
             "module": "pages"
           }
@@ -69910,7 +70226,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 385,
+            "line": 387,
             "column": 3,
             "module": "pages"
           }
@@ -69921,7 +70237,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 385,
+            "line": 387,
             "column": 3,
             "module": "pages"
           }
@@ -69932,7 +70248,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 385,
+            "line": 387,
             "column": 3,
             "module": "pages"
           }
@@ -69942,7 +70258,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2527,
+          "line": 2350,
           "column": 18,
           "symbol": "renderPublication",
           "defaultMessage": "No publications yet",
@@ -69957,7 +70273,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2527,
+              "line": 2350,
               "column": 18,
               "kind": "messageHelper"
             }
@@ -69982,7 +70298,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 382,
+            "line": 384,
             "column": 3,
             "module": "pages"
           }
@@ -69993,7 +70309,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 382,
+            "line": 384,
             "column": 3,
             "module": "pages"
           }
@@ -70004,7 +70320,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 382,
+            "line": 384,
             "column": 3,
             "module": "pages"
           }
@@ -70015,7 +70331,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 382,
+            "line": 384,
             "column": 3,
             "module": "pages"
           }
@@ -70025,7 +70341,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2448,
+          "line": 2271,
           "column": 20,
           "symbol": "renderPublication",
           "defaultMessage": "Legacy LCIA publication",
@@ -70040,7 +70356,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2448,
+              "line": 2271,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -70065,7 +70381,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 387,
+            "line": 389,
             "column": 3,
             "module": "pages"
           }
@@ -70076,7 +70392,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 387,
+            "line": 389,
             "column": 3,
             "module": "pages"
           }
@@ -70087,7 +70403,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 387,
+            "line": 389,
             "column": 3,
             "module": "pages"
           }
@@ -70098,7 +70414,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 387,
+            "line": 389,
             "column": 3,
             "module": "pages"
           }
@@ -70108,7 +70424,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2545,
+          "line": 2368,
           "column": 22,
           "symbol": "renderPublication",
           "defaultMessage": "Published at",
@@ -70123,7 +70439,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2545,
+              "line": 2368,
               "column": 22,
               "kind": "messageHelper"
             }
@@ -70148,7 +70464,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 384,
+            "line": 386,
             "column": 3,
             "module": "pages"
           }
@@ -70159,7 +70475,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 384,
+            "line": 386,
             "column": 3,
             "module": "pages"
           }
@@ -70170,7 +70486,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 384,
+            "line": 386,
             "column": 3,
             "module": "pages"
           }
@@ -70181,7 +70497,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 384,
+            "line": 386,
             "column": 3,
             "module": "pages"
           }
@@ -70191,7 +70507,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2518,
+          "line": 2341,
           "column": 14,
           "symbol": "renderPublication",
           "defaultMessage": "Refresh publications",
@@ -70206,7 +70522,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2518,
+              "line": 2341,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -70231,7 +70547,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 383,
+            "line": 385,
             "column": 3,
             "module": "pages"
           }
@@ -70242,7 +70558,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 383,
+            "line": 385,
             "column": 3,
             "module": "pages"
           }
@@ -70253,7 +70569,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 383,
+            "line": 385,
             "column": 3,
             "module": "pages"
           }
@@ -70264,7 +70580,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 383,
+            "line": 385,
             "column": 3,
             "module": "pages"
           }
@@ -70274,7 +70590,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2515,
+          "line": 2338,
           "column": 16,
           "symbol": "renderPublication",
           "defaultMessage": "Publication management",
@@ -70289,7 +70605,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2515,
+              "line": 2338,
               "column": 16,
               "kind": "messageHelper"
             }
@@ -70314,7 +70630,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 379,
+            "line": 381,
             "column": 3,
             "module": "pages"
           }
@@ -70325,7 +70641,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 379,
+            "line": 381,
             "column": 3,
             "module": "pages"
           }
@@ -70336,7 +70652,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 379,
+            "line": 381,
             "column": 3,
             "module": "pages"
           }
@@ -70347,7 +70663,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 379,
+            "line": 381,
             "column": 3,
             "module": "pages"
           }
@@ -70397,7 +70713,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 376,
+            "line": 378,
             "column": 3,
             "module": "pages"
           }
@@ -70408,7 +70724,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 376,
+            "line": 378,
             "column": 3,
             "module": "pages"
           }
@@ -70419,7 +70735,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 376,
+            "line": 378,
             "column": 3,
             "module": "pages"
           }
@@ -70430,7 +70746,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 376,
+            "line": 378,
             "column": 3,
             "module": "pages"
           }
@@ -70480,7 +70796,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 380,
+            "line": 382,
             "column": 3,
             "module": "pages"
           }
@@ -70491,7 +70807,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 380,
+            "line": 382,
             "column": 3,
             "module": "pages"
           }
@@ -70502,7 +70818,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 380,
+            "line": 382,
             "column": 3,
             "module": "pages"
           }
@@ -70513,7 +70829,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 380,
+            "line": 382,
             "column": 3,
             "module": "pages"
           }
@@ -70563,7 +70879,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 381,
+            "line": 383,
             "column": 3,
             "module": "pages"
           }
@@ -70574,7 +70890,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 381,
+            "line": 383,
             "column": 3,
             "module": "pages"
           }
@@ -70585,7 +70901,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 381,
+            "line": 383,
             "column": 3,
             "module": "pages"
           }
@@ -70596,7 +70912,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 381,
+            "line": 383,
             "column": 3,
             "module": "pages"
           }
@@ -70646,7 +70962,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 368,
+            "line": 370,
             "column": 3,
             "module": "pages"
           }
@@ -70657,7 +70973,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 368,
+            "line": 370,
             "column": 3,
             "module": "pages"
           }
@@ -70668,7 +70984,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 368,
+            "line": 370,
             "column": 3,
             "module": "pages"
           }
@@ -70679,7 +70995,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 368,
+            "line": 370,
             "column": 3,
             "module": "pages"
           }
@@ -70729,7 +71045,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 378,
+            "line": 380,
             "column": 3,
             "module": "pages"
           }
@@ -70740,7 +71056,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 378,
+            "line": 380,
             "column": 3,
             "module": "pages"
           }
@@ -70751,7 +71067,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 378,
+            "line": 380,
             "column": 3,
             "module": "pages"
           }
@@ -70762,7 +71078,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 378,
+            "line": 380,
             "column": 3,
             "module": "pages"
           }
@@ -70812,7 +71128,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 375,
+            "line": 377,
             "column": 3,
             "module": "pages"
           }
@@ -70823,7 +71139,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 375,
+            "line": 377,
             "column": 3,
             "module": "pages"
           }
@@ -70834,7 +71150,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 375,
+            "line": 377,
             "column": 3,
             "module": "pages"
           }
@@ -70845,7 +71161,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 375,
+            "line": 377,
             "column": 3,
             "module": "pages"
           }
@@ -70895,7 +71211,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 367,
+            "line": 369,
             "column": 3,
             "module": "pages"
           }
@@ -70906,7 +71222,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 367,
+            "line": 369,
             "column": 3,
             "module": "pages"
           }
@@ -70917,7 +71233,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 367,
+            "line": 369,
             "column": 3,
             "module": "pages"
           }
@@ -70928,7 +71244,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 367,
+            "line": 369,
             "column": 3,
             "module": "pages"
           }
@@ -70978,7 +71294,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 373,
+            "line": 375,
             "column": 3,
             "module": "pages"
           }
@@ -70989,7 +71305,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 373,
+            "line": 375,
             "column": 3,
             "module": "pages"
           }
@@ -71000,7 +71316,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 373,
+            "line": 375,
             "column": 3,
             "module": "pages"
           }
@@ -71011,7 +71327,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 373,
+            "line": 375,
             "column": 3,
             "module": "pages"
           }
@@ -71061,7 +71377,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 369,
+            "line": 371,
             "column": 3,
             "module": "pages"
           }
@@ -71072,7 +71388,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 369,
+            "line": 371,
             "column": 3,
             "module": "pages"
           }
@@ -71083,7 +71399,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 369,
+            "line": 371,
             "column": 3,
             "module": "pages"
           }
@@ -71094,7 +71410,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 369,
+            "line": 371,
             "column": 3,
             "module": "pages"
           }
@@ -71144,7 +71460,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 370,
+            "line": 372,
             "column": 3,
             "module": "pages"
           }
@@ -71155,7 +71471,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 370,
+            "line": 372,
             "column": 3,
             "module": "pages"
           }
@@ -71166,7 +71482,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 370,
+            "line": 372,
             "column": 3,
             "module": "pages"
           }
@@ -71177,7 +71493,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 370,
+            "line": 372,
             "column": 3,
             "module": "pages"
           }
@@ -71227,7 +71543,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 377,
+            "line": 379,
             "column": 3,
             "module": "pages"
           }
@@ -71238,7 +71554,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 377,
+            "line": 379,
             "column": 3,
             "module": "pages"
           }
@@ -71249,7 +71565,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 377,
+            "line": 379,
             "column": 3,
             "module": "pages"
           }
@@ -71260,7 +71576,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 377,
+            "line": 379,
             "column": 3,
             "module": "pages"
           }
@@ -71310,7 +71626,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 372,
+            "line": 374,
             "column": 3,
             "module": "pages"
           }
@@ -71321,7 +71637,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 372,
+            "line": 374,
             "column": 3,
             "module": "pages"
           }
@@ -71332,7 +71648,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 372,
+            "line": 374,
             "column": 3,
             "module": "pages"
           }
@@ -71343,7 +71659,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 372,
+            "line": 374,
             "column": 3,
             "module": "pages"
           }
@@ -71393,7 +71709,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 366,
+            "line": 368,
             "column": 3,
             "module": "pages"
           }
@@ -71404,7 +71720,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 366,
+            "line": 368,
             "column": 3,
             "module": "pages"
           }
@@ -71415,7 +71731,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 366,
+            "line": 368,
             "column": 3,
             "module": "pages"
           }
@@ -71426,7 +71742,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 366,
+            "line": 368,
             "column": 3,
             "module": "pages"
           }
@@ -71476,7 +71792,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 374,
+            "line": 376,
             "column": 3,
             "module": "pages"
           }
@@ -71487,7 +71803,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 374,
+            "line": 376,
             "column": 3,
             "module": "pages"
           }
@@ -71498,7 +71814,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 374,
+            "line": 376,
             "column": 3,
             "module": "pages"
           }
@@ -71509,7 +71825,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 374,
+            "line": 376,
             "column": 3,
             "module": "pages"
           }
@@ -71559,7 +71875,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 371,
+            "line": 373,
             "column": 3,
             "module": "pages"
           }
@@ -71570,7 +71886,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 371,
+            "line": 373,
             "column": 3,
             "module": "pages"
           }
@@ -71581,7 +71897,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 371,
+            "line": 373,
             "column": 3,
             "module": "pages"
           }
@@ -71592,7 +71908,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 371,
+            "line": 373,
             "column": 3,
             "module": "pages"
           }
@@ -71685,7 +72001,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2654,
+          "line": 2477,
           "column": 24,
           "symbol": "DataProcessing",
           "defaultMessage": "Result Generation",
@@ -71700,7 +72016,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2654,
+              "line": 2477,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -71768,7 +72084,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2659,
+          "line": 2482,
           "column": 24,
           "symbol": "DataProcessing",
           "defaultMessage": "Result Preview",
@@ -71783,7 +72099,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2659,
+              "line": 2482,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -71851,7 +72167,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2664,
+          "line": 2487,
           "column": 24,
           "symbol": "DataProcessing",
           "defaultMessage": "Publication",
@@ -71866,7 +72182,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2664,
+              "line": 2487,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -71891,7 +72207,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 281,
+            "line": 283,
             "column": 3,
             "module": "pages"
           }
@@ -71902,7 +72218,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 281,
+            "line": 283,
             "column": 3,
             "module": "pages"
           }
@@ -71913,7 +72229,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 281,
+            "line": 283,
             "column": 3,
             "module": "pages"
           }
@@ -71924,7 +72240,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 281,
+            "line": 283,
             "column": 3,
             "module": "pages"
           }
@@ -71934,7 +72250,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1047,
+          "line": 1049,
           "column": 12,
           "symbol": "taskTypeLabel",
           "defaultMessage": "Data Product",
@@ -71949,7 +72265,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1047,
+              "line": 1049,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -72017,7 +72333,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2643,
+          "line": 2466,
           "column": 27,
           "symbol": "DataProcessing",
           "defaultMessage": "Data Processing",
@@ -72032,7 +72348,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2643,
+              "line": 2466,
               "column": 27,
               "kind": "messageHelper"
             }
@@ -72057,7 +72373,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 278,
+            "line": 280,
             "column": 3,
             "module": "pages"
           }
@@ -72068,7 +72384,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 278,
+            "line": 280,
             "column": 3,
             "module": "pages"
           }
@@ -72079,7 +72395,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 278,
+            "line": 280,
             "column": 3,
             "module": "pages"
           }
@@ -72090,7 +72406,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 278,
+            "line": 280,
             "column": 3,
             "module": "pages"
           }
@@ -72100,7 +72416,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1267,
+          "line": 1223,
           "column": 20,
           "symbol": "handleRecoverClosureCheck",
           "defaultMessage": "The selected impact category is unavailable or has no valid version.",
@@ -72115,7 +72431,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1267,
+              "line": 1223,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -72140,7 +72456,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 277,
+            "line": 279,
             "column": 3,
             "module": "pages"
           }
@@ -72151,7 +72467,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 277,
+            "line": 279,
             "column": 3,
             "module": "pages"
           }
@@ -72162,7 +72478,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 277,
+            "line": 279,
             "column": 3,
             "module": "pages"
           }
@@ -72173,7 +72489,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 277,
+            "line": 279,
             "column": 3,
             "module": "pages"
           }
@@ -72183,7 +72499,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2484,
+          "line": 2307,
           "column": 26,
           "symbol": "renderPublication",
           "defaultMessage": "Default impact category is required",
@@ -72198,7 +72514,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2484,
+              "line": 2307,
               "column": 26,
               "kind": "messageHelper"
             }
@@ -72223,7 +72539,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 276,
+            "line": 278,
             "column": 3,
             "module": "pages"
           }
@@ -72234,7 +72550,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 276,
+            "line": 278,
             "column": 3,
             "module": "pages"
           }
@@ -72245,7 +72561,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 276,
+            "line": 278,
             "column": 3,
             "module": "pages"
           }
@@ -72256,7 +72572,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 276,
+            "line": 278,
             "column": 3,
             "module": "pages"
           }
@@ -72266,7 +72582,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2208,
+          "line": 2031,
           "column": 26,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Result set is required",
@@ -72275,7 +72591,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2464,
+          "line": 2287,
           "column": 26,
           "symbol": "renderPublication",
           "defaultMessage": "Result set is required",
@@ -72290,13 +72606,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2208,
+              "line": 2031,
               "column": 26,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2464,
+              "line": 2287,
               "column": 26,
               "kind": "messageHelper"
             }
@@ -72321,7 +72637,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 275,
+            "line": 277,
             "column": 3,
             "module": "pages"
           }
@@ -72332,7 +72648,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 275,
+            "line": 277,
             "column": 3,
             "module": "pages"
           }
@@ -72343,7 +72659,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 275,
+            "line": 277,
             "column": 3,
             "module": "pages"
           }
@@ -72354,7 +72670,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 275,
+            "line": 277,
             "column": 3,
             "module": "pages"
           }
@@ -72364,7 +72680,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1602,
+          "line": 1530,
           "column": 26,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Result set name is required",
@@ -72379,7 +72695,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1602,
+              "line": 1530,
               "column": 26,
               "kind": "messageHelper"
             }
@@ -72404,7 +72720,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 279,
+            "line": 281,
             "column": 3,
             "module": "pages"
           }
@@ -72415,7 +72731,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 279,
+            "line": 281,
             "column": 3,
             "module": "pages"
           }
@@ -72426,7 +72742,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 279,
+            "line": 281,
             "column": 3,
             "module": "pages"
           }
@@ -72437,7 +72753,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 279,
+            "line": 281,
             "column": 3,
             "module": "pages"
           }
@@ -141797,7 +142113,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 983,
+          "line": 985,
           "column": 7,
           "symbol": "lcaModeLabel",
           "defaultMessage": "All Processes (Reference Flow = 1)",
@@ -141821,7 +142137,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 983,
+              "line": 985,
               "column": 7,
               "kind": "formatMessage"
             },
@@ -141895,7 +142211,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 987,
+          "line": 989,
           "column": 7,
           "symbol": "lcaModeLabel",
           "defaultMessage": "Single-Process Calculation",
@@ -141910,7 +142226,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 987,
+              "line": 989,
               "column": 7,
               "kind": "formatMessage"
             }
@@ -152425,7 +152741,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2158,
+          "line": 2164,
           "column": 12,
           "symbol": "modalTitle",
           "defaultMessage": "Clear finished",
@@ -152440,7 +152756,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2158,
+              "line": 2164,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -152567,7 +152883,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1276,
+          "line": 1278,
           "column": 18,
           "symbol": "lcaDiagnosticContent",
           "defaultMessage": "Build job ID",
@@ -152582,7 +152898,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1276,
+              "line": 1278,
               "column": 18,
               "kind": "formatMessage"
             }
@@ -152768,7 +153084,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1929,
+          "line": 1931,
           "column": 16,
           "symbol": "TaskDiagnosticsPopoverContent",
           "defaultMessage": "Debug information",
@@ -152783,7 +153099,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1929,
+              "line": 1931,
               "column": 16,
               "kind": "formatMessage"
             }
@@ -152851,7 +153167,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1465,
+          "line": 1467,
           "column": 18,
           "symbol": "lcaBusinessDetail",
           "defaultMessage": "Failure reason",
@@ -152860,7 +153176,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1534,
+          "line": 1536,
           "column": 18,
           "symbol": "packageBusinessDetail",
           "defaultMessage": "Failure reason",
@@ -152875,13 +153191,13 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1465,
+              "line": 1467,
               "column": 18,
               "kind": "formatMessage"
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1534,
+              "line": 1536,
               "column": 18,
               "kind": "formatMessage"
             }
@@ -152949,7 +153265,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1900,
+          "line": 1902,
           "column": 16,
           "symbol": "TaskDetailPopoverContent",
           "defaultMessage": "Detail information",
@@ -152964,7 +153280,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1900,
+              "line": 1902,
               "column": 16,
               "kind": "formatMessage"
             }
@@ -153032,7 +153348,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1440,
+          "line": 1442,
           "column": 20,
           "symbol": "lcaBusinessDetail",
           "defaultMessage": "Demand type",
@@ -153047,7 +153363,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1440,
+              "line": 1442,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -153115,7 +153431,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1457,
+          "line": 1459,
           "column": 12,
           "symbol": "lcaBusinessDetail",
           "defaultMessage": "The task completed without a returned result.",
@@ -153130,7 +153446,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1457,
+              "line": 1459,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -153257,7 +153573,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1297,
+          "line": 1299,
           "column": 18,
           "symbol": "lcaDiagnosticContent",
           "defaultMessage": "Result ID",
@@ -153299,7 +153615,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1297,
+              "line": 1299,
               "column": 18,
               "kind": "formatMessage"
             },
@@ -153444,7 +153760,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1447,
+          "line": 1449,
           "column": 20,
           "symbol": "lcaBusinessDetail",
           "defaultMessage": "Data scope",
@@ -153459,7 +153775,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1447,
+              "line": 1449,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -153527,7 +153843,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1290,
+          "line": 1292,
           "column": 18,
           "symbol": "lcaDiagnosticContent",
           "defaultMessage": "Snapshot ID",
@@ -153569,7 +153885,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1290,
+              "line": 1292,
               "column": 18,
               "kind": "formatMessage"
             },
@@ -153655,7 +153971,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1283,
+          "line": 1285,
           "column": 18,
           "symbol": "lcaDiagnosticContent",
           "defaultMessage": "Calculation job ID",
@@ -153670,7 +153986,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1283,
+              "line": 1285,
               "column": 18,
               "kind": "formatMessage"
             }
@@ -153915,7 +154231,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2363,
+          "line": 2431,
           "column": 38,
           "symbol": "LcaTaskCenter",
           "defaultMessage": "Diagnostics",
@@ -153924,7 +154240,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2369,
+          "line": 2437,
           "column": 45,
           "symbol": "LcaTaskCenter",
           "defaultMessage": "Diagnostics",
@@ -153939,13 +154255,13 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2363,
+              "line": 2431,
               "column": 38,
               "kind": "formatMessage"
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2369,
+              "line": 2437,
               "column": 45,
               "kind": "formatMessage"
             }
@@ -154013,7 +154329,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1201,
+          "line": 1203,
           "column": 10,
           "symbol": "DiagnosticRows",
           "defaultMessage": "No diagnostics available",
@@ -154028,7 +154344,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1201,
+              "line": 1203,
               "column": 10,
               "kind": "formatMessage"
             }
@@ -154096,7 +154412,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1269,
+          "line": 1271,
           "column": 18,
           "symbol": "lcaDiagnosticContent",
           "defaultMessage": "Worker job kind",
@@ -154105,7 +154421,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1352,
+          "line": 1354,
           "column": 18,
           "symbol": "packageDiagnosticContent",
           "defaultMessage": "Worker job kind",
@@ -154120,13 +154436,13 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1269,
+              "line": 1271,
               "column": 18,
               "kind": "formatMessage"
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1352,
+              "line": 1354,
               "column": 18,
               "kind": "formatMessage"
             }
@@ -154194,7 +154510,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1304,
+          "line": 1306,
           "column": 18,
           "symbol": "lcaDiagnosticContent",
           "defaultMessage": "Request",
@@ -154203,7 +154519,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1366,
+          "line": 1368,
           "column": 18,
           "symbol": "packageDiagnosticContent",
           "defaultMessage": "Request",
@@ -154218,13 +154534,13 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1304,
+              "line": 1306,
               "column": 18,
               "kind": "formatMessage"
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1366,
+              "line": 1368,
               "column": 18,
               "kind": "formatMessage"
             }
@@ -154292,7 +154608,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1262,
+          "line": 1264,
           "column": 18,
           "symbol": "lcaDiagnosticContent",
           "defaultMessage": "Root job ID",
@@ -154307,7 +154623,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1262,
+              "line": 1264,
               "column": 18,
               "kind": "formatMessage"
             }
@@ -154375,7 +154691,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1248,
+          "line": 1250,
           "column": 18,
           "symbol": "lcaDiagnosticContent",
           "defaultMessage": "Sequence",
@@ -154384,7 +154700,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1331,
+          "line": 1333,
           "column": 18,
           "symbol": "packageDiagnosticContent",
           "defaultMessage": "Sequence",
@@ -154399,13 +154715,13 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1248,
+              "line": 1250,
               "column": 18,
               "kind": "formatMessage"
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1331,
+              "line": 1333,
               "column": 18,
               "kind": "formatMessage"
             }
@@ -154473,7 +154789,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1241,
+          "line": 1243,
           "column": 18,
           "symbol": "lcaDiagnosticContent",
           "defaultMessage": "Task ID",
@@ -154482,7 +154798,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1324,
+          "line": 1326,
           "column": 18,
           "symbol": "packageDiagnosticContent",
           "defaultMessage": "Task ID",
@@ -154497,13 +154813,13 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1241,
+              "line": 1243,
               "column": 18,
               "kind": "formatMessage"
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1324,
+              "line": 1326,
               "column": 18,
               "kind": "formatMessage"
             }
@@ -154571,7 +154887,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1338,
+          "line": 1340,
           "column": 18,
           "symbol": "packageDiagnosticContent",
           "defaultMessage": "Task kind",
@@ -154586,7 +154902,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1338,
+              "line": 1340,
               "column": 18,
               "kind": "formatMessage"
             }
@@ -154654,7 +154970,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1255,
+          "line": 1257,
           "column": 18,
           "symbol": "lcaDiagnosticContent",
           "defaultMessage": "Worker job ID",
@@ -154663,7 +154979,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1345,
+          "line": 1347,
           "column": 18,
           "symbol": "packageDiagnosticContent",
           "defaultMessage": "Worker job ID",
@@ -154678,13 +154994,13 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1255,
+              "line": 1257,
               "column": 18,
               "kind": "formatMessage"
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1345,
+              "line": 1347,
               "column": 18,
               "kind": "formatMessage"
             }
@@ -154811,7 +155127,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2396,
+          "line": 2464,
           "column": 26,
           "symbol": "LcaTaskCenter",
           "defaultMessage": "Elapsed",
@@ -154826,7 +155142,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2396,
+              "line": 2464,
               "column": 26,
               "kind": "formatMessage"
             }
@@ -154894,7 +155210,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2217,
+          "line": 2223,
           "column": 32,
           "symbol": "LcaTaskCenter",
           "defaultMessage": "No tasks",
@@ -154909,7 +155225,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2217,
+              "line": 2223,
               "column": 32,
               "kind": "formatMessage"
             }
@@ -154977,7 +155293,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1052,
+          "line": 1054,
           "column": 10,
           "symbol": "taskTypeLabel",
           "defaultMessage": "All",
@@ -154992,7 +155308,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1052,
+              "line": 1054,
               "column": 10,
               "kind": "formatMessage"
             }
@@ -155143,7 +155459,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1015,
+          "line": 1017,
           "column": 10,
           "symbol": "tidasScopeLabel",
           "defaultMessage": "Not specified",
@@ -155158,7 +155474,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1015,
+              "line": 1017,
               "column": 10,
               "kind": "formatMessage"
             }
@@ -155226,8 +155542,8 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2311,
-          "column": 28,
+          "line": 2350,
+          "column": 30,
           "symbol": "LcaTaskCenter",
           "defaultMessage": "Open",
           "defaultMessageExpression": null
@@ -155241,8 +155557,8 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2311,
-              "column": 28,
+              "line": 2350,
+              "column": 30,
               "kind": "formatMessage"
             }
           ]
@@ -155368,7 +155684,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 188,
+          "line": 190,
           "column": 12,
           "symbol": "lcaPhaseLabel",
           "defaultMessage": "Building snapshot",
@@ -155383,7 +155699,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 188,
+              "line": 190,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -155451,7 +155767,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 200,
+          "line": 202,
           "column": 12,
           "symbol": "lcaPhaseLabel",
           "defaultMessage": "Completed",
@@ -155460,7 +155776,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 243,
+          "line": 245,
           "column": 12,
           "symbol": "packagePhaseLabel",
           "defaultMessage": "Completed",
@@ -155475,13 +155791,13 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 200,
+              "line": 202,
               "column": 12,
               "kind": "formatMessage"
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 243,
+              "line": 245,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -155549,7 +155865,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 205,
+          "line": 207,
           "column": 10,
           "symbol": "lcaPhaseLabel",
           "defaultMessage": "Failed",
@@ -155558,7 +155874,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 248,
+          "line": 250,
           "column": 10,
           "symbol": "packagePhaseLabel",
           "defaultMessage": "Failed",
@@ -155573,13 +155889,13 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 205,
+              "line": 207,
               "column": 10,
               "kind": "formatMessage"
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 248,
+              "line": 250,
               "column": 10,
               "kind": "formatMessage"
             }
@@ -155647,7 +155963,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 194,
+          "line": 196,
           "column": 12,
           "symbol": "lcaPhaseLabel",
           "defaultMessage": "Solving",
@@ -155662,7 +155978,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 194,
+              "line": 196,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -155789,7 +156105,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 182,
+          "line": 184,
           "column": 12,
           "symbol": "lcaPhaseLabel",
           "defaultMessage": "Submitting",
@@ -155804,7 +156120,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 182,
+              "line": 184,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -155871,8 +156187,17 @@
       "references": [
         {
           "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 113,
+          "column": 12,
+          "symbol": "closureMessages",
+          "defaultMessage": "Phase:",
+          "defaultMessageExpression": null
+        },
+        {
+          "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2405,
+          "line": 2473,
           "column": 30,
           "symbol": "LcaTaskCenter",
           "defaultMessage": "Phase:",
@@ -155886,8 +156211,14 @@
           "placeholders": [],
           "locations": [
             {
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 113,
+              "column": 12,
+              "kind": "formatMessage"
+            },
+            {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2405,
+              "line": 2473,
               "column": 30,
               "kind": "formatMessage"
             }
@@ -155955,7 +156286,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 580,
+          "line": 582,
           "column": 12,
           "symbol": "processStepMeta",
           "defaultMessage": "Took {duration}",
@@ -155970,7 +156301,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 580,
+              "line": 582,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -156038,7 +156369,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 571,
+          "line": 573,
           "column": 12,
           "symbol": "processStepMeta",
           "defaultMessage": "Running · {duration}",
@@ -156053,7 +156384,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 571,
+              "line": 573,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -156121,7 +156452,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 371,
+          "line": 373,
           "column": 12,
           "symbol": "processStateLabel",
           "defaultMessage": "Completed",
@@ -156136,7 +156467,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 371,
+              "line": 373,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -156204,7 +156535,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 383,
+          "line": 385,
           "column": 12,
           "symbol": "processStateLabel",
           "defaultMessage": "Stopped",
@@ -156219,7 +156550,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 383,
+              "line": 385,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -156287,7 +156618,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 377,
+          "line": 379,
           "column": 12,
           "symbol": "processStateLabel",
           "defaultMessage": "In progress",
@@ -156302,7 +156633,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 377,
+              "line": 379,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -156370,7 +156701,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 388,
+          "line": 390,
           "column": 10,
           "symbol": "processStateLabel",
           "defaultMessage": "Waiting",
@@ -156385,7 +156716,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 388,
+              "line": 390,
               "column": 10,
               "kind": "formatMessage"
             }
@@ -156453,7 +156784,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 602,
+          "line": 604,
           "column": 12,
           "symbol": "lcaProcessStageLabel",
           "defaultMessage": "Build snapshot",
@@ -156468,7 +156799,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 602,
+              "line": 604,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -156536,7 +156867,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 613,
+          "line": 615,
           "column": 10,
           "symbol": "lcaProcessStageLabel",
           "defaultMessage": "Organize result",
@@ -156551,7 +156882,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 613,
+              "line": 615,
               "column": 10,
               "kind": "formatMessage"
             }
@@ -156619,7 +156950,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 608,
+          "line": 610,
           "column": 12,
           "symbol": "lcaProcessStageLabel",
           "defaultMessage": "Solve",
@@ -156634,7 +156965,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 608,
+              "line": 610,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -156702,7 +157033,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 596,
+          "line": 598,
           "column": 12,
           "symbol": "lcaProcessStageLabel",
           "defaultMessage": "Submit task",
@@ -156717,7 +157048,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 596,
+              "line": 598,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -156785,7 +157116,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1860,
+          "line": 1862,
           "column": 16,
           "symbol": "taskProcessDetailContent",
           "defaultMessage": "Execution stages",
@@ -156794,7 +157125,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1872,
+          "line": 1874,
           "column": 16,
           "symbol": "taskProcessDetailContent",
           "defaultMessage": "Execution stages",
@@ -156803,7 +157134,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1883,
+          "line": 1885,
           "column": 14,
           "symbol": "taskProcessDetailContent",
           "defaultMessage": "Execution stages",
@@ -156818,19 +157149,19 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1860,
+              "line": 1862,
               "column": 16,
               "kind": "formatMessage"
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1872,
+              "line": 1874,
               "column": 16,
               "kind": "formatMessage"
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1883,
+              "line": 1885,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -156897,8 +157228,17 @@
       "references": [
         {
           "kind": "formatMessage",
+          "path": "src/components/ClosureTaskDetail/index.tsx",
+          "line": 117,
+          "column": 14,
+          "symbol": "closureMessages",
+          "defaultMessage": "Refresh",
+          "defaultMessageExpression": null
+        },
+        {
+          "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2146,
+          "line": 2152,
           "column": 12,
           "symbol": "modalTitle",
           "defaultMessage": "Refresh",
@@ -156912,8 +157252,14 @@
           "placeholders": [],
           "locations": [
             {
+              "path": "src/components/ClosureTaskDetail/index.tsx",
+              "line": 117,
+              "column": 14,
+              "kind": "formatMessage"
+            },
+            {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2146,
+              "line": 2152,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -157099,7 +157445,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 153,
+          "line": 155,
           "column": 10,
           "symbol": "statusTag",
           "defaultMessage": "Completed",
@@ -157114,7 +157460,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 153,
+              "line": 155,
               "column": 10,
               "kind": "formatMessage"
             }
@@ -157182,7 +157528,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 163,
+          "line": 165,
           "column": 10,
           "symbol": "statusTag",
           "defaultMessage": "Failed",
@@ -157197,7 +157543,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 163,
+              "line": 165,
               "column": 10,
               "kind": "formatMessage"
             }
@@ -157265,7 +157611,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 172,
+          "line": 174,
           "column": 8,
           "symbol": "statusTag",
           "defaultMessage": "Running",
@@ -157280,7 +157626,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 172,
+              "line": 174,
               "column": 8,
               "kind": "formatMessage"
             }
@@ -157761,7 +158107,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2133,
+          "line": 2139,
           "column": 10,
           "symbol": "modalTitle",
           "defaultMessage": "Task Center",
@@ -157770,7 +158116,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2170,
+          "line": 2176,
           "column": 16,
           "symbol": "LcaTaskCenter",
           "defaultMessage": "Task Center",
@@ -157785,13 +158131,13 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2133,
+              "line": 2139,
               "column": 10,
               "kind": "formatMessage"
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2170,
+              "line": 2176,
               "column": 16,
               "kind": "formatMessage"
             }
@@ -157859,7 +158205,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1060,
+          "line": 1062,
           "column": 12,
           "symbol": "taskTitle",
           "defaultMessage": "LCA calculation",
@@ -157874,7 +158220,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1060,
+              "line": 1062,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -158001,7 +158347,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1023,
+          "line": 1025,
           "column": 12,
           "symbol": "taskTypeLabel",
           "defaultMessage": "LCA Calculation",
@@ -158016,7 +158362,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1023,
+              "line": 1025,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -158084,7 +158430,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2388,
+          "line": 2456,
           "column": 28,
           "symbol": "LcaTaskCenter",
           "defaultMessage": "Updated",
@@ -158099,7 +158445,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2388,
+              "line": 2456,
               "column": 28,
               "kind": "formatMessage"
             }
@@ -158167,7 +158513,25 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2430,
+          "line": 2325,
+          "column": 36,
+          "symbol": "LcaTaskCenter",
+          "defaultMessage": "View",
+          "defaultMessageExpression": null
+        },
+        {
+          "kind": "formatMessage",
+          "path": "src/components/LcaTaskCenter/index.tsx",
+          "line": 2331,
+          "column": 43,
+          "symbol": "LcaTaskCenter",
+          "defaultMessage": "View",
+          "defaultMessageExpression": null
+        },
+        {
+          "kind": "formatMessage",
+          "path": "src/components/LcaTaskCenter/index.tsx",
+          "line": 2498,
           "column": 34,
           "symbol": "LcaTaskCenter",
           "defaultMessage": "View",
@@ -158176,7 +158540,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2436,
+          "line": 2504,
           "column": 41,
           "symbol": "LcaTaskCenter",
           "defaultMessage": "View",
@@ -158191,13 +158555,25 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2430,
+              "line": 2325,
+              "column": 36,
+              "kind": "formatMessage"
+            },
+            {
+              "path": "src/components/LcaTaskCenter/index.tsx",
+              "line": 2331,
+              "column": 43,
+              "kind": "formatMessage"
+            },
+            {
+              "path": "src/components/LcaTaskCenter/index.tsx",
+              "line": 2498,
               "column": 34,
               "kind": "formatMessage"
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2436,
+              "line": 2504,
               "column": 41,
               "kind": "formatMessage"
             }
@@ -164935,7 +165311,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1669,
+          "line": 1671,
           "column": 21,
           "symbol": "codeLabel",
           "defaultMessage": "code",
@@ -164950,7 +165326,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1669,
+              "line": 1671,
               "column": 21,
               "kind": "formatMessage"
             }
@@ -165018,7 +165394,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1677,
+          "line": 1679,
           "column": 24,
           "symbol": "detailsLabel",
           "defaultMessage": "details",
@@ -165033,7 +165409,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1677,
+              "line": 1679,
               "column": 24,
               "kind": "formatMessage"
             }
@@ -165101,7 +165477,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1691,
+          "line": 1693,
           "column": 9,
           "symbol": "reviewSubmitDiagnosticsContent",
           "defaultMessage": "error",
@@ -165116,7 +165492,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1691,
+              "line": 1693,
               "column": 9,
               "kind": "formatMessage"
             }
@@ -165243,7 +165619,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1673,
+          "line": 1675,
           "column": 24,
           "symbol": "messageLabel",
           "defaultMessage": "message",
@@ -165258,7 +165634,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1673,
+              "line": 1675,
               "column": 24,
               "kind": "formatMessage"
             }
@@ -165326,7 +165702,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1708,
+          "line": 1710,
           "column": 14,
           "symbol": "reviewSubmitDiagnosticsContent",
           "defaultMessage": "reason {index}",
@@ -165341,7 +165717,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1708,
+              "line": 1710,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -165527,7 +165903,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1685,
+          "line": 1687,
           "column": 10,
           "symbol": "reviewSubmitDiagnosticsContent",
           "defaultMessage": "Diagnostics",
@@ -165542,7 +165918,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1685,
+              "line": 1687,
               "column": 10,
               "kind": "formatMessage"
             }
@@ -169285,7 +169661,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 911,
+          "line": 913,
           "column": 5,
           "symbol": "reasonMessage",
           "defaultMessage": "No detailed message returned.",
@@ -169309,7 +169685,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 911,
+              "line": 913,
               "column": 5,
               "kind": "formatMessage"
             },
@@ -170302,7 +170678,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2479,
+          "line": 2547,
           "column": 36,
           "symbol": "LcaTaskCenter",
           "defaultMessage": "Cancel",
@@ -170311,7 +170687,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2485,
+          "line": 2553,
           "column": 43,
           "symbol": "LcaTaskCenter",
           "defaultMessage": "Cancel",
@@ -170326,13 +170702,13 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2479,
+              "line": 2547,
               "column": 36,
               "kind": "formatMessage"
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2485,
+              "line": 2553,
               "column": 43,
               "kind": "formatMessage"
             }
@@ -170400,7 +170776,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2089,
+          "line": 2095,
           "column": 11,
           "symbol": "handleCancelReviewSubmit",
           "defaultMessage": "Failed to cancel review-submit task",
@@ -170415,7 +170791,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2089,
+              "line": 2095,
               "column": 11,
               "kind": "formatMessage"
             }
@@ -170483,7 +170859,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2081,
+          "line": 2087,
           "column": 9,
           "symbol": "handleCancelReviewSubmit",
           "defaultMessage": "Review-submit task cancelled",
@@ -170498,7 +170874,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2081,
+              "line": 2087,
               "column": 9,
               "kind": "formatMessage"
             }
@@ -170566,7 +170942,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1825,
+          "line": 1827,
           "column": 20,
           "symbol": "reviewSubmitDetailContent",
           "defaultMessage": "Dataset",
@@ -170581,7 +170957,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1825,
+              "line": 1827,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -170649,7 +171025,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1778,
+          "line": 1780,
           "column": 20,
           "symbol": "reviewSubmitDiagnosticContent",
           "defaultMessage": "Gate run ID",
@@ -170664,7 +171040,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1778,
+              "line": 1780,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -170732,7 +171108,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1764,
+          "line": 1766,
           "column": 20,
           "symbol": "reviewSubmitDiagnosticContent",
           "defaultMessage": "Gate worker job ID",
@@ -170747,7 +171123,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1764,
+              "line": 1766,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -170815,7 +171191,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1792,
+          "line": 1794,
           "column": 20,
           "symbol": "reviewSubmitDiagnosticContent",
           "defaultMessage": "Progress",
@@ -170830,7 +171206,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1792,
+              "line": 1794,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -170898,7 +171274,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1771,
+          "line": 1773,
           "column": 20,
           "symbol": "reviewSubmitDiagnosticContent",
           "defaultMessage": "Review submission job ID",
@@ -170913,7 +171289,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1771,
+              "line": 1773,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -170981,7 +171357,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1785,
+          "line": 1787,
           "column": 20,
           "symbol": "reviewSubmitDiagnosticContent",
           "defaultMessage": "Revision checksum",
@@ -170996,7 +171372,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1785,
+              "line": 1787,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -171064,7 +171440,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1757,
+          "line": 1759,
           "column": 20,
           "symbol": "reviewSubmitDiagnosticContent",
           "defaultMessage": "Root job ID",
@@ -171079,7 +171455,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1757,
+              "line": 1759,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -171147,7 +171523,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1750,
+          "line": 1752,
           "column": 20,
           "symbol": "reviewSubmitDiagnosticContent",
           "defaultMessage": "Submit worker job ID",
@@ -171162,7 +171538,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1750,
+              "line": 1752,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -171230,7 +171606,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1743,
+          "line": 1745,
           "column": 20,
           "symbol": "reviewSubmitDiagnosticContent",
           "defaultMessage": "Task ID",
@@ -171245,7 +171621,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1743,
+              "line": 1745,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -171313,7 +171689,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1832,
+          "line": 1834,
           "column": 20,
           "symbol": "reviewSubmitDetailContent",
           "defaultMessage": "Version",
@@ -171328,7 +171704,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1832,
+              "line": 1834,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -171396,7 +171772,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 896,
+          "line": 898,
           "column": 13,
           "symbol": "formatReviewSubmitFallbackSummary",
           "defaultMessage": "Save the data and retry. If it still fails, contact an administrator.",
@@ -171420,7 +171796,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 896,
+              "line": 898,
               "column": 13,
               "kind": "formatMessage"
             },
@@ -171494,7 +171870,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 892,
+          "line": 894,
           "column": 18,
           "symbol": "formatReviewSubmitFallbackSummary",
           "defaultMessage": "The current data could not complete the pre-review check.",
@@ -171518,7 +171894,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 892,
+              "line": 894,
               "column": 18,
               "kind": "formatMessage"
             },
@@ -171592,7 +171968,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 888,
+          "line": 890,
           "column": 12,
           "symbol": "formatReviewSubmitFallbackSummary",
           "defaultMessage": "Review submission did not complete",
@@ -171616,7 +171992,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 888,
+              "line": 890,
               "column": 12,
               "kind": "formatMessage"
             },
@@ -171690,7 +172066,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1041,
+          "line": 1043,
           "column": 12,
           "symbol": "taskTypeLabel",
           "defaultMessage": "Review Submit",
@@ -171705,7 +172081,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1041,
+              "line": 1043,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -171773,7 +172149,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 287,
+          "line": 289,
           "column": 14,
           "symbol": "reviewSubmitPhaseLabel",
           "defaultMessage": "Blocked",
@@ -171788,7 +172164,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 287,
+              "line": 289,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -171856,7 +172232,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 297,
+          "line": 299,
           "column": 14,
           "symbol": "reviewSubmitPhaseLabel",
           "defaultMessage": "Cancelled",
@@ -171871,7 +172247,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 297,
+              "line": 299,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -171939,7 +172315,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 303,
+          "line": 305,
           "column": 14,
           "symbol": "reviewSubmitPhaseLabel",
           "defaultMessage": "Error",
@@ -171954,7 +172330,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 303,
+              "line": 305,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -172022,7 +172398,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 282,
+          "line": 284,
           "column": 14,
           "symbol": "reviewSubmitPhaseLabel",
           "defaultMessage": "Gate passed",
@@ -172037,7 +172413,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 282,
+              "line": 284,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -172105,7 +172481,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 257,
+          "line": 259,
           "column": 14,
           "symbol": "reviewSubmitPhaseLabel",
           "defaultMessage": "Queued",
@@ -172120,7 +172496,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 257,
+              "line": 259,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -172188,7 +172564,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 262,
+          "line": 264,
           "column": 14,
           "symbol": "reviewSubmitPhaseLabel",
           "defaultMessage": "Gate running",
@@ -172203,7 +172579,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 262,
+              "line": 264,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -172271,7 +172647,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 292,
+          "line": 294,
           "column": 14,
           "symbol": "reviewSubmitPhaseLabel",
           "defaultMessage": "Stale",
@@ -172286,7 +172662,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 292,
+              "line": 294,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -172354,7 +172730,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 277,
+          "line": 279,
           "column": 14,
           "symbol": "reviewSubmitPhaseLabel",
           "defaultMessage": "Submitted",
@@ -172369,7 +172745,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 277,
+              "line": 279,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -172437,7 +172813,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 272,
+          "line": 274,
           "column": 14,
           "symbol": "reviewSubmitPhaseLabel",
           "defaultMessage": "Submitting review",
@@ -172452,7 +172828,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 272,
+              "line": 274,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -172520,7 +172896,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 267,
+          "line": 269,
           "column": 14,
           "symbol": "reviewSubmitPhaseLabel",
           "defaultMessage": "Waiting for gate",
@@ -172535,7 +172911,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 267,
+              "line": 269,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -172603,7 +172979,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 798,
+          "line": 800,
           "column": 10,
           "symbol": "reviewSubmitProcessStageLabel",
           "defaultMessage": "Finish",
@@ -172618,7 +172994,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 798,
+              "line": 800,
               "column": 10,
               "kind": "formatMessage"
             }
@@ -172686,7 +173062,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 787,
+          "line": 789,
           "column": 12,
           "symbol": "reviewSubmitProcessStageLabel",
           "defaultMessage": "Run gate",
@@ -172701,7 +173077,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 787,
+              "line": 789,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -172769,7 +173145,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 781,
+          "line": 783,
           "column": 12,
           "symbol": "reviewSubmitProcessStageLabel",
           "defaultMessage": "Queue task",
@@ -172784,7 +173160,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 781,
+              "line": 783,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -172852,7 +173228,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 793,
+          "line": 795,
           "column": 12,
           "symbol": "reviewSubmitProcessStageLabel",
           "defaultMessage": "Submit review",
@@ -172867,7 +173243,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 793,
+              "line": 795,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -172935,7 +173311,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2066,
+          "line": 2072,
           "column": 11,
           "symbol": "handleRefreshTasks",
           "defaultMessage": "Failed to refresh review-submit tasks",
@@ -172950,7 +173326,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2066,
+              "line": 2072,
               "column": 11,
               "kind": "formatMessage"
             }
@@ -173018,7 +173394,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2502,
+          "line": 2570,
           "column": 36,
           "symbol": "LcaTaskCenter",
           "defaultMessage": "Retry",
@@ -173027,7 +173403,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2508,
+          "line": 2576,
           "column": 43,
           "symbol": "LcaTaskCenter",
           "defaultMessage": "Retry",
@@ -173042,13 +173418,13 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2502,
+              "line": 2570,
               "column": 36,
               "kind": "formatMessage"
             },
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2508,
+              "line": 2576,
               "column": 43,
               "kind": "formatMessage"
             }
@@ -173116,7 +173492,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2112,
+          "line": 2118,
           "column": 11,
           "symbol": "handleRetryReviewSubmit",
           "defaultMessage": "Failed to retry review-submit task",
@@ -173131,7 +173507,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2112,
+              "line": 2118,
               "column": 11,
               "kind": "formatMessage"
             }
@@ -173199,7 +173575,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 2104,
+          "line": 2110,
           "column": 9,
           "symbol": "handleRetryReviewSubmit",
           "defaultMessage": "Review-submit task restarted",
@@ -173214,7 +173590,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 2104,
+              "line": 2110,
               "column": 9,
               "kind": "formatMessage"
             }
@@ -173754,7 +174130,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/LcaTaskCenter/index.tsx",
-          "line": 1066,
+          "line": 1068,
           "column": 12,
           "symbol": "taskTitle",
           "defaultMessage": "Submit for review",
@@ -173769,7 +174145,7 @@
           "locations": [
             {
               "path": "src/components/LcaTaskCenter/index.tsx",
-              "line": 1066,
+              "line": 1068,
               "column": 12,
               "kind": "formatMessage"
             }
@@ -205185,7 +205561,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages.ts",
-            "line": 388,
+            "line": 390,
             "column": 3,
             "module": "pages"
           }
@@ -205196,7 +205572,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages.ts",
-            "line": 388,
+            "line": 390,
             "column": 3,
             "module": "pages"
           }
@@ -205207,7 +205583,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages.ts",
-            "line": 388,
+            "line": 390,
             "column": 3,
             "module": "pages"
           }
@@ -205218,7 +205594,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages.ts",
-            "line": 388,
+            "line": 390,
             "column": 3,
             "module": "pages"
           }
@@ -259538,7 +259914,7 @@
       "count": 1,
       "file": "src/components/LcaTaskCenter/index.tsx",
       "expression": "guidance.actionId",
-      "locations": ["939:13"],
+      "locations": ["941:13"],
       "category": "active-dynamic",
       "family": "reviewGateGuidance",
       "reviewStatus": "reviewed"
@@ -259548,7 +259924,7 @@
       "count": 1,
       "file": "src/components/LcaTaskCenter/index.tsx",
       "expression": "guidance.descriptionId",
-      "locations": ["935:18"],
+      "locations": ["937:18"],
       "category": "active-dynamic",
       "family": "reviewGateGuidance",
       "reviewStatus": "reviewed"
@@ -259558,7 +259934,7 @@
       "count": 1,
       "file": "src/components/LcaTaskCenter/index.tsx",
       "expression": "guidance.titleId",
-      "locations": ["931:12"],
+      "locations": ["933:12"],
       "category": "active-dynamic",
       "family": "reviewGateGuidance",
       "reviewStatus": "reviewed"
@@ -259598,7 +259974,7 @@
       "count": 1,
       "file": "src/pages/DataProcessing/index.tsx",
       "expression": "id",
-      "locations": ["618:45"],
+      "locations": ["606:45"],
       "category": "active-dynamic",
       "family": "dataProcessing",
       "reviewStatus": "reviewed"
@@ -259608,7 +259984,7 @@
       "count": 1,
       "file": "src/pages/DataProcessing/index.tsx",
       "expression": "messages[action].id",
-      "locations": ["1035:12"],
+      "locations": ["991:12"],
       "category": "active-dynamic",
       "family": "dataProcessing",
       "reviewStatus": "reviewed"

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,12 +3,12 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "3a2e008bd652d5f01c3ac00115e1d72c8e201ebb7229d73f20b25af0d2979f74",
-    "contextDigest": "a2ad1ef7686b12973bcba8f340790ff1e9de7b743930bb6f2e40d22538745ad6"
+    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb",
+    "contextDigest": "227fb56e9a449cc756046de0082b318366a1b365f49740c2b9b434a880bdda59"
   },
   "catalog": {
-    "messageCount": 3096,
-    "catalogDigest": "9ba5479bfd0eae83b0d879078587fc56f30fdd39c28b21ed959b3a8df73bb6b0",
+    "messageCount": 3098,
+    "catalogDigest": "df0a5502c9d3b710b4506d04cc7a18b39c4d8907f7186c7eb6e58d76fde7361c",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
@@ -21,7 +21,7 @@
     "acceptedDeclaredSourceEqualityDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
     "forbiddenGlossaryMatchCount": 0,
     "forbiddenGlossaryMatchDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
-    "suspiciousSourceEqualityRatio": 0.011304909560723515,
+    "suspiciousSourceEqualityRatio": 0.011297611362169141,
     "maxSuspiciousSourceEqualityRatio": 0.02
   },
   "automatedChecks": {
@@ -41,10 +41,10 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "913564c8838f44ce2e0e727efd36b72573ab289f71daf86ac68bd7b61fc4b54d",
-    "validationDigest": "accde4381de7716f44997fe9a3186bfe66f9011526e991c3253670077f7e16cf",
+    "digest": "bf7c3b67a822a1bb574e76580f89a25783d50e7fd0cbae5d94a2476f4eef4c7f",
+    "validationDigest": "0b3df317260e9a2ad9ff755fe75238c6c80884b9ce303b6e661b738e7da05f96",
     "laneCount": 1,
-    "validatedMessageCount": 3096,
+    "validatedMessageCount": 3098,
     "validatedModuleCount": 31,
     "highRiskMessageCount": 1374,
     "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "3e7bedcc85de5d9ed07b1809fc258963a9d7905e6d4d9235ea25a71b4922abd6"
+  "qualityDigest": "47bdea22a15f3c79cf4f54932c463814340c4b744ec2e72f91132620c453cf39"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "d67932f5212ba9ec819334ad21c88674703a1477d1e43faf8b6d04cc7e64c5b4",
-    "validatedMessageCount": 3096,
+    "auditedInputDigest": "bf1d21a781e4e708227e8a074b85ae03c5ae4435c0740ab76bf3f41edf0af091",
+    "validatedMessageCount": 3098,
     "validatedModules": [
       "$entry",
       "component",
@@ -40,10 +40,10 @@
     ],
     "highRiskMessageCount": 1374,
     "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
-    "catalogDigest": "9ba5479bfd0eae83b0d879078587fc56f30fdd39c28b21ed959b3a8df73bb6b0",
-    "dossierDigest": "fc13ea3e326fd3a9cb4707016e7a31a09a194c3a632bdc45147353cd8102de9d",
+    "catalogDigest": "df0a5502c9d3b710b4506d04cc7a18b39c4d8907f7186c7eb6e58d76fde7361c",
+    "dossierDigest": "011cdb89553e700472adfefbe3edba716084133afd2cbff12ef1f3383cd773c4",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "cec469024fc62b5ea120fe46a0d67ed0003a9f88328812b504be5441c41400e2",
+    "routeEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -92,11 +92,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3096,
-        "messageDigest": "1fcf8b76c7e6ab67e9071370ed52636a19d4549a63b28e491ad4562c901d4d59",
+        "messageCount": 3098,
+        "messageDigest": "5120aa22622b7730b9e96f4cab159adde8950b8353606f00b164af870b82483b",
         "highRiskMessageCount": 1374,
         "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
-        "dossierDigest": "fc13ea3e326fd3a9cb4707016e7a31a09a194c3a632bdc45147353cd8102de9d",
+        "dossierDigest": "011cdb89553e700472adfefbe3edba716084133afd2cbff12ef1f3383cd773c4",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "accde4381de7716f44997fe9a3186bfe66f9011526e991c3253670077f7e16cf"
+  "validationDigest": "0b3df317260e9a2ad9ff755fe75238c6c80884b9ce303b6e661b738e7da05f96"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "3a2e008bd652d5f01c3ac00115e1d72c8e201ebb7229d73f20b25af0d2979f74",
-    "auditedInputDigest": "d67932f5212ba9ec819334ad21c88674703a1477d1e43faf8b6d04cc7e64c5b4"
+    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb",
+    "auditedInputDigest": "bf1d21a781e4e708227e8a074b85ae03c5ae4435c0740ab76bf3f41edf0af091"
   },
   "inventory": {
-    "sourceMessageCount": 3096,
-    "localeMessageCount": 3096,
+    "sourceMessageCount": 3098,
+    "localeMessageCount": 3098,
     "leafModuleCount": 30,
     "dynamicFamilyCount": 17,
     "dynamicCallsiteCount": 39,
@@ -44,21 +44,21 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3096,
-    "completeCount": 3096,
+    "messageCount": 3098,
+    "completeCount": 3098,
     "blockedCount": 0,
-    "dossierDigest": "37a12cf69a13883a55f193627ccdc8cbfd93c2aee6195dedec6afa2693357089",
-    "catalogDigest": "6e0d96c60692c53d3a476b6e3525315807311df16ba298f304efc3ce560c2c25",
+    "dossierDigest": "5a216b1988241933c19990a7674ec9c91bb40acbfcbb4451e5cc93eb372d3b90",
+    "catalogDigest": "a3c224f555eb03d69f18241734ed2da7bd391a59956b1df1e99f70a5c9b08014",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
     "roleCounts": {
       "error-or-validation": 361,
       "explanatory-copy": 110,
       "field-guidance": 49,
-      "label-or-body-copy": 1245,
+      "label-or-body-copy": 1246,
       "navigation-or-tab": 226,
       "reserved-catalog-copy": 276,
-      "status-or-empty-state": 98,
+      "status-or-empty-state": 99,
       "success-notification": 181,
       "title-or-heading": 239,
       "user-action": 311
@@ -69,9 +69,9 @@
       "interactive-ready": 521,
       "retained-not-currently-reachable": 355,
       "successful-completion": 181,
-      "visible": 1633
+      "visible": 1635
     },
-    "riskCounts": { "high": 1374, "low": 1521, "medium": 201 },
+    "riskCounts": { "high": 1374, "low": 1523, "medium": 201 },
     "highRiskMessageCount": 1374,
     "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb"
   },
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4082,
+    "literalReferenceCount": 4098,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale en-US --message <MESSAGE_ID>"
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "72ac7d49b1bb2acd9513ce23856c9a39785f0debb828b9f09752e49e88140804",
+      "sourceEvidenceDigest": "cfed36e5b6b1a95d318b33e71139cef0020f930775793f82bf3e3dc3f8fb8194",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "567420ede3b5af244d73e17e1c9bf07d96e45e2439423b320273ae7a39ee7c84",
+          "sourceDigest": "6cc7d3e59e8d68f0bf31cbf273e34e523bec0b5bf35113f856cf9f6649997127",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "7b327e8dda83f7be2afee3e0ae9d43f6b8274886ffaf32a94763ca2418b8637e",
+          "sourceDigest": "f4667f4ac6398ea620fe3d7141ba6a14dd0e798398dec141b5c0491b535063d0",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "03a93ebef57fb7c33206d2953a2a38f5b611f44ca4e1beff83ca3ce66cdfa591",
+          "sourceDigest": "f43de572d115ad87c41934094ac4a68f4fb2fc4e07f2e8dce9cfc98431095b7e",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -367,7 +367,7 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "b5ca4582ff5e964b2690d86228d180eaa1bd22fc5e401fb1564419c14a5cab70",
+          "sourceDigest": "8ade645875468d9ca1d46a8192198b981f47bf2af3443fb4fd0366f94fc9a120",
           "focusedTestDigest": "342a74fe96651abf404aa2c6f2212d0c85b6057c35fa5f74d0b91ae0687fcf39",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
@@ -1042,12 +1042,12 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "935de97e8a382d582583460132a881a78986330d90b3ee40f7a20190d2f29283",
-          "focusedTestDigest": "caf3b45659e0562af41147ada8c45cdfb0219a7aa1f5f29c9769c793c1d74212",
+          "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
+          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
-          "derivedMessageCount": 131,
-          "derivedMessageDigest": "1c07d2cec87cdf8287342fe1df07044545cacbf93d533ef1c16e3202c0aba107",
+          "derivedMessageCount": 119,
+          "derivedMessageDigest": "f3f53e78726b3875411fb46e70f2c863dad1fe7cd30bc2a3337e9d040dd7ef16",
           "stateSignals": ["empty", "error", "loading", "success", "unavailable"],
           "queryParameters": ["tid"],
           "navigationTargets": [
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "cec469024fc62b5ea120fe46a0d67ed0003a9f88328812b504be5441c41400e2",
+      "rowEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "9b31b72681e51c30bda95e2b7ff8dbdb6978d650a3ce0a6d4b9828cd46f57b4f"
+  "contextDigest": "0615a78f680d2a5ad59cc80d0770286c049f01dac5850dc89ad572664459a795"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "3a2e008bd652d5f01c3ac00115e1d72c8e201ebb7229d73f20b25af0d2979f74"
+    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "9b31b72681e51c30bda95e2b7ff8dbdb6978d650a3ce0a6d4b9828cd46f57b4f",
-    "qualityDigest": "52e92489507e37e3357d854484c176a3022be39ff4247e284c8485bb3f575835",
+    "contextDigest": "0615a78f680d2a5ad59cc80d0770286c049f01dac5850dc89ad572664459a795",
+    "qualityDigest": "fb07369ed8e162df9d2ea469bacfa1a72f0f5c4660fcf96d6c353f4156828a6b",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "9e0ada8fac3a30b5e6a2a269af7d046b584588211f03456a2877ba250690d497",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "a6f266f2626f1859464c81b28b80f6fd8c7237166636538fe4fbb9b426187e0a"
+  "activationDigest": "554b91cc966e3c4066b996a9cd9cda43a10c71817a0aec615f9591929370c1ca"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,25 +3,25 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "3a2e008bd652d5f01c3ac00115e1d72c8e201ebb7229d73f20b25af0d2979f74",
-    "contextDigest": "9b31b72681e51c30bda95e2b7ff8dbdb6978d650a3ce0a6d4b9828cd46f57b4f"
+    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb",
+    "contextDigest": "0615a78f680d2a5ad59cc80d0770286c049f01dac5850dc89ad572664459a795"
   },
   "catalog": {
-    "messageCount": 3096,
-    "catalogDigest": "6e0d96c60692c53d3a476b6e3525315807311df16ba298f304efc3ce560c2c25",
+    "messageCount": 3098,
+    "catalogDigest": "a3c224f555eb03d69f18241734ed2da7bd391a59956b1df1e99f70a5c9b08014",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
     "cjkLeakCount": 0,
-    "suspiciousSourceEqualityCount": 3018,
-    "suspiciousSourceEqualityDigest": "97cc3e8cdbae9b757bbf5b812d62ccfe3c93ac996315fed1d1b7ba8d4706bb4c",
+    "suspiciousSourceEqualityCount": 3020,
+    "suspiciousSourceEqualityDigest": "39b56dd23ca974843f75e50c414693b6385d40fda80d9e2e7234e43763594be5",
     "acceptedTechnicalSourceEqualityCount": 77,
     "acceptedTechnicalSourceEqualityDigest": "2c498f32e45a368d8f4ddb6987df879250152a55da7babd4f4dbeb717b3d0583",
     "acceptedDeclaredSourceEqualityCount": 0,
     "acceptedDeclaredSourceEqualityDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
     "forbiddenGlossaryMatchCount": 0,
     "forbiddenGlossaryMatchDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
-    "suspiciousSourceEqualityRatio": 0.9748062015503876,
+    "suspiciousSourceEqualityRatio": 0.9748224661071659,
     "maxSuspiciousSourceEqualityRatio": 1
   },
   "automatedChecks": {
@@ -41,10 +41,10 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "fa1ad195ea32d6c4014c218ae29022a0719b3f5b63afcb5b033f2f3f45a07110",
-    "validationDigest": "de498650205fd713671a1cb8d5b269b607310e8b5d8c726f0a4840b2869d510f",
+    "digest": "0e761cca58db921f5b9d2792ccf6b7e5b0c9e9ad66416c0b5d1558d6d95e982d",
+    "validationDigest": "e8665d7046c37e27400c06079f83df6dbea377e024315561ad5755915a64b966",
     "laneCount": 1,
-    "validatedMessageCount": 3096,
+    "validatedMessageCount": 3098,
     "validatedModuleCount": 31,
     "highRiskMessageCount": 1374,
     "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "52e92489507e37e3357d854484c176a3022be39ff4247e284c8485bb3f575835"
+  "qualityDigest": "fb07369ed8e162df9d2ea469bacfa1a72f0f5c4660fcf96d6c353f4156828a6b"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "d67932f5212ba9ec819334ad21c88674703a1477d1e43faf8b6d04cc7e64c5b4",
-    "validatedMessageCount": 3096,
+    "auditedInputDigest": "bf1d21a781e4e708227e8a074b85ae03c5ae4435c0740ab76bf3f41edf0af091",
+    "validatedMessageCount": 3098,
     "validatedModules": [
       "$entry",
       "component",
@@ -40,10 +40,10 @@
     ],
     "highRiskMessageCount": 1374,
     "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
-    "catalogDigest": "6e0d96c60692c53d3a476b6e3525315807311df16ba298f304efc3ce560c2c25",
-    "dossierDigest": "37a12cf69a13883a55f193627ccdc8cbfd93c2aee6195dedec6afa2693357089",
+    "catalogDigest": "a3c224f555eb03d69f18241734ed2da7bd391a59956b1df1e99f70a5c9b08014",
+    "dossierDigest": "5a216b1988241933c19990a7674ec9c91bb40acbfcbb4451e5cc93eb372d3b90",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "cec469024fc62b5ea120fe46a0d67ed0003a9f88328812b504be5441c41400e2",
+    "routeEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -92,11 +92,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3096,
-        "messageDigest": "1fcf8b76c7e6ab67e9071370ed52636a19d4549a63b28e491ad4562c901d4d59",
+        "messageCount": 3098,
+        "messageDigest": "5120aa22622b7730b9e96f4cab159adde8950b8353606f00b164af870b82483b",
         "highRiskMessageCount": 1374,
         "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
-        "dossierDigest": "37a12cf69a13883a55f193627ccdc8cbfd93c2aee6195dedec6afa2693357089",
+        "dossierDigest": "5a216b1988241933c19990a7674ec9c91bb40acbfcbb4451e5cc93eb372d3b90",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "de498650205fd713671a1cb8d5b269b607310e8b5d8c726f0a4840b2869d510f"
+  "validationDigest": "e8665d7046c37e27400c06079f83df6dbea377e024315561ad5755915a64b966"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "3a2e008bd652d5f01c3ac00115e1d72c8e201ebb7229d73f20b25af0d2979f74",
-    "auditedInputDigest": "d67932f5212ba9ec819334ad21c88674703a1477d1e43faf8b6d04cc7e64c5b4"
+    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb",
+    "auditedInputDigest": "bf1d21a781e4e708227e8a074b85ae03c5ae4435c0740ab76bf3f41edf0af091"
   },
   "inventory": {
-    "sourceMessageCount": 3096,
-    "localeMessageCount": 3096,
+    "sourceMessageCount": 3098,
+    "localeMessageCount": 3098,
     "leafModuleCount": 30,
     "dynamicFamilyCount": 17,
     "dynamicCallsiteCount": 39,
@@ -44,21 +44,21 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3096,
-    "completeCount": 3096,
+    "messageCount": 3098,
+    "completeCount": 3098,
     "blockedCount": 0,
-    "dossierDigest": "740dd6e07d12ef28538211f3c46858ec6934ba74e9f8eb8dff4e4d410e7895f0",
-    "catalogDigest": "b596063fcd72e07d203b0936b0bc70e27d2b7c1ffbaf915c7539711369d3017a",
+    "dossierDigest": "65a1fcc5f1ba97ab505830d262709aa986c695318ff75e8ff54c4163cd8d1e4a",
+    "catalogDigest": "58420e05cff95c7300d1f8b3dc9f1132c53b067e4b864f195c3f5a5296b81cd0",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
     "roleCounts": {
       "error-or-validation": 361,
       "explanatory-copy": 110,
       "field-guidance": 49,
-      "label-or-body-copy": 1245,
+      "label-or-body-copy": 1246,
       "navigation-or-tab": 226,
       "reserved-catalog-copy": 276,
-      "status-or-empty-state": 98,
+      "status-or-empty-state": 99,
       "success-notification": 181,
       "title-or-heading": 239,
       "user-action": 311
@@ -69,9 +69,9 @@
       "interactive-ready": 521,
       "retained-not-currently-reachable": 355,
       "successful-completion": 181,
-      "visible": 1633
+      "visible": 1635
     },
-    "riskCounts": { "high": 1374, "low": 1499, "medium": 223 },
+    "riskCounts": { "high": 1374, "low": 1501, "medium": 223 },
     "highRiskMessageCount": 1374,
     "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb"
   },
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4082,
+    "literalReferenceCount": 4098,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale fr-FR --message <MESSAGE_ID>"
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "72ac7d49b1bb2acd9513ce23856c9a39785f0debb828b9f09752e49e88140804",
+      "sourceEvidenceDigest": "cfed36e5b6b1a95d318b33e71139cef0020f930775793f82bf3e3dc3f8fb8194",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "567420ede3b5af244d73e17e1c9bf07d96e45e2439423b320273ae7a39ee7c84",
+          "sourceDigest": "6cc7d3e59e8d68f0bf31cbf273e34e523bec0b5bf35113f856cf9f6649997127",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "7b327e8dda83f7be2afee3e0ae9d43f6b8274886ffaf32a94763ca2418b8637e",
+          "sourceDigest": "f4667f4ac6398ea620fe3d7141ba6a14dd0e798398dec141b5c0491b535063d0",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "03a93ebef57fb7c33206d2953a2a38f5b611f44ca4e1beff83ca3ce66cdfa591",
+          "sourceDigest": "f43de572d115ad87c41934094ac4a68f4fb2fc4e07f2e8dce9cfc98431095b7e",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -367,7 +367,7 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "b5ca4582ff5e964b2690d86228d180eaa1bd22fc5e401fb1564419c14a5cab70",
+          "sourceDigest": "8ade645875468d9ca1d46a8192198b981f47bf2af3443fb4fd0366f94fc9a120",
           "focusedTestDigest": "342a74fe96651abf404aa2c6f2212d0c85b6057c35fa5f74d0b91ae0687fcf39",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
@@ -1042,12 +1042,12 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "935de97e8a382d582583460132a881a78986330d90b3ee40f7a20190d2f29283",
-          "focusedTestDigest": "caf3b45659e0562af41147ada8c45cdfb0219a7aa1f5f29c9769c793c1d74212",
+          "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
+          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
-          "derivedMessageCount": 131,
-          "derivedMessageDigest": "1c07d2cec87cdf8287342fe1df07044545cacbf93d533ef1c16e3202c0aba107",
+          "derivedMessageCount": 119,
+          "derivedMessageDigest": "f3f53e78726b3875411fb46e70f2c863dad1fe7cd30bc2a3337e9d040dd7ef16",
           "stateSignals": ["empty", "error", "loading", "success", "unavailable"],
           "queryParameters": ["tid"],
           "navigationTargets": [
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "cec469024fc62b5ea120fe46a0d67ed0003a9f88328812b504be5441c41400e2",
+      "rowEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "9dc19010ad82238214fbeb419af55f92263ab546f171afc0769fa186f0822f2f"
+  "contextDigest": "308ad76a062c5f5316117e22e69800c0828999e43a1071747de049e979185f52"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "3a2e008bd652d5f01c3ac00115e1d72c8e201ebb7229d73f20b25af0d2979f74"
+    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "9dc19010ad82238214fbeb419af55f92263ab546f171afc0769fa186f0822f2f",
-    "qualityDigest": "4ca3e40f775db9c92c7be59e05a7380a77bdfeea99feeb743eb9726cc525d859",
+    "contextDigest": "308ad76a062c5f5316117e22e69800c0828999e43a1071747de049e979185f52",
+    "qualityDigest": "6ac272eed130ea63e2c7b114587d552193dcb988f5daa1fe06fa285942bc3c81",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "9e0ada8fac3a30b5e6a2a269af7d046b584588211f03456a2877ba250690d497",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "101feaa473762440aed7d72af2b533d01a2726a01fff22613db3165e8830c679"
+  "activationDigest": "1977e43db078e37dff0cc47680020264c0248e6fd538d6d4bf1e3c9459bf63f1"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,12 +3,12 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "3a2e008bd652d5f01c3ac00115e1d72c8e201ebb7229d73f20b25af0d2979f74",
-    "contextDigest": "9dc19010ad82238214fbeb419af55f92263ab546f171afc0769fa186f0822f2f"
+    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb",
+    "contextDigest": "308ad76a062c5f5316117e22e69800c0828999e43a1071747de049e979185f52"
   },
   "catalog": {
-    "messageCount": 3096,
-    "catalogDigest": "b596063fcd72e07d203b0936b0bc70e27d2b7c1ffbaf915c7539711369d3017a",
+    "messageCount": 3098,
+    "catalogDigest": "58420e05cff95c7300d1f8b3dc9f1132c53b067e4b864f195c3f5a5296b81cd0",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
@@ -41,10 +41,10 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "375d3d8e8183921247a3f7f72f99c1cb6a713881672b1d965aff18e020b78ef4",
-    "validationDigest": "e1af3c6a4ed2f8a494b56baf5496e154286487d9bdea4362a6425035e02b84e0",
+    "digest": "162aa9c9802d319261844fa83f5aa583e41240e70d4891178de23b2026553a19",
+    "validationDigest": "728e12502e9386c509a057bae12de81b9a1a3f2d60fe7d750655928612b38113",
     "laneCount": 1,
-    "validatedMessageCount": 3096,
+    "validatedMessageCount": 3098,
     "validatedModuleCount": 31,
     "highRiskMessageCount": 1374,
     "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "4ca3e40f775db9c92c7be59e05a7380a77bdfeea99feeb743eb9726cc525d859"
+  "qualityDigest": "6ac272eed130ea63e2c7b114587d552193dcb988f5daa1fe06fa285942bc3c81"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "d67932f5212ba9ec819334ad21c88674703a1477d1e43faf8b6d04cc7e64c5b4",
-    "validatedMessageCount": 3096,
+    "auditedInputDigest": "bf1d21a781e4e708227e8a074b85ae03c5ae4435c0740ab76bf3f41edf0af091",
+    "validatedMessageCount": 3098,
     "validatedModules": [
       "$entry",
       "component",
@@ -40,10 +40,10 @@
     ],
     "highRiskMessageCount": 1374,
     "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
-    "catalogDigest": "b596063fcd72e07d203b0936b0bc70e27d2b7c1ffbaf915c7539711369d3017a",
-    "dossierDigest": "740dd6e07d12ef28538211f3c46858ec6934ba74e9f8eb8dff4e4d410e7895f0",
+    "catalogDigest": "58420e05cff95c7300d1f8b3dc9f1132c53b067e4b864f195c3f5a5296b81cd0",
+    "dossierDigest": "65a1fcc5f1ba97ab505830d262709aa986c695318ff75e8ff54c4163cd8d1e4a",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "cec469024fc62b5ea120fe46a0d67ed0003a9f88328812b504be5441c41400e2",
+    "routeEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -92,11 +92,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3096,
-        "messageDigest": "1fcf8b76c7e6ab67e9071370ed52636a19d4549a63b28e491ad4562c901d4d59",
+        "messageCount": 3098,
+        "messageDigest": "5120aa22622b7730b9e96f4cab159adde8950b8353606f00b164af870b82483b",
         "highRiskMessageCount": 1374,
         "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
-        "dossierDigest": "740dd6e07d12ef28538211f3c46858ec6934ba74e9f8eb8dff4e4d410e7895f0",
+        "dossierDigest": "65a1fcc5f1ba97ab505830d262709aa986c695318ff75e8ff54c4163cd8d1e4a",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "e1af3c6a4ed2f8a494b56baf5496e154286487d9bdea4362a6425035e02b84e0"
+  "validationDigest": "728e12502e9386c509a057bae12de81b9a1a3f2d60fe7d750655928612b38113"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "3a2e008bd652d5f01c3ac00115e1d72c8e201ebb7229d73f20b25af0d2979f74",
-    "auditedInputDigest": "d67932f5212ba9ec819334ad21c88674703a1477d1e43faf8b6d04cc7e64c5b4"
+    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb",
+    "auditedInputDigest": "bf1d21a781e4e708227e8a074b85ae03c5ae4435c0740ab76bf3f41edf0af091"
   },
   "inventory": {
-    "sourceMessageCount": 3096,
-    "localeMessageCount": 3096,
+    "sourceMessageCount": 3098,
+    "localeMessageCount": 3098,
     "leafModuleCount": 30,
     "dynamicFamilyCount": 17,
     "dynamicCallsiteCount": 39,
@@ -44,21 +44,21 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3096,
-    "completeCount": 3096,
+    "messageCount": 3098,
+    "completeCount": 3098,
     "blockedCount": 0,
-    "dossierDigest": "e1bed1c1cba0ccebba9a3bc3b51b788fc1c4b4f69024368278e5de4e6c3466f2",
-    "catalogDigest": "e952ef6494e17e447600d7c16849e4e33690d6df82045eecc033fcefbabc4528",
+    "dossierDigest": "07514073fdf7d9342d4f32f1984ba5d6e76bc2d44f145d5463f0fedea2beee72",
+    "catalogDigest": "fc8ca32e41215b0ee38ba57c2f414c679fea664f5711119f714e20c481cc2f73",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
     "roleCounts": {
       "error-or-validation": 361,
       "explanatory-copy": 110,
       "field-guidance": 49,
-      "label-or-body-copy": 1245,
+      "label-or-body-copy": 1246,
       "navigation-or-tab": 226,
       "reserved-catalog-copy": 276,
-      "status-or-empty-state": 98,
+      "status-or-empty-state": 99,
       "success-notification": 181,
       "title-or-heading": 239,
       "user-action": 311
@@ -69,9 +69,9 @@
       "interactive-ready": 521,
       "retained-not-currently-reachable": 355,
       "successful-completion": 181,
-      "visible": 1633
+      "visible": 1635
     },
-    "riskCounts": { "high": 1374, "low": 1554, "medium": 168 },
+    "riskCounts": { "high": 1374, "low": 1556, "medium": 168 },
     "highRiskMessageCount": 1374,
     "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb"
   },
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4082,
+    "literalReferenceCount": 4098,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale zh-CN --message <MESSAGE_ID>"
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "72ac7d49b1bb2acd9513ce23856c9a39785f0debb828b9f09752e49e88140804",
+      "sourceEvidenceDigest": "cfed36e5b6b1a95d318b33e71139cef0020f930775793f82bf3e3dc3f8fb8194",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "567420ede3b5af244d73e17e1c9bf07d96e45e2439423b320273ae7a39ee7c84",
+          "sourceDigest": "6cc7d3e59e8d68f0bf31cbf273e34e523bec0b5bf35113f856cf9f6649997127",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "7b327e8dda83f7be2afee3e0ae9d43f6b8274886ffaf32a94763ca2418b8637e",
+          "sourceDigest": "f4667f4ac6398ea620fe3d7141ba6a14dd0e798398dec141b5c0491b535063d0",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "03a93ebef57fb7c33206d2953a2a38f5b611f44ca4e1beff83ca3ce66cdfa591",
+          "sourceDigest": "f43de572d115ad87c41934094ac4a68f4fb2fc4e07f2e8dce9cfc98431095b7e",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -367,7 +367,7 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "b5ca4582ff5e964b2690d86228d180eaa1bd22fc5e401fb1564419c14a5cab70",
+          "sourceDigest": "8ade645875468d9ca1d46a8192198b981f47bf2af3443fb4fd0366f94fc9a120",
           "focusedTestDigest": "342a74fe96651abf404aa2c6f2212d0c85b6057c35fa5f74d0b91ae0687fcf39",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
@@ -1042,12 +1042,12 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "935de97e8a382d582583460132a881a78986330d90b3ee40f7a20190d2f29283",
-          "focusedTestDigest": "caf3b45659e0562af41147ada8c45cdfb0219a7aa1f5f29c9769c793c1d74212",
+          "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
+          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
-          "derivedMessageCount": 131,
-          "derivedMessageDigest": "1c07d2cec87cdf8287342fe1df07044545cacbf93d533ef1c16e3202c0aba107",
+          "derivedMessageCount": 119,
+          "derivedMessageDigest": "f3f53e78726b3875411fb46e70f2c863dad1fe7cd30bc2a3337e9d040dd7ef16",
           "stateSignals": ["empty", "error", "loading", "success", "unavailable"],
           "queryParameters": ["tid"],
           "navigationTargets": [
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "cec469024fc62b5ea120fe46a0d67ed0003a9f88328812b504be5441c41400e2",
+      "rowEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "bec02edd455f092138ff39555faae7b1e58d5d187fa9caed4feb8abed8b876b0"
+  "contextDigest": "5b04b2b120a8177f532f3efd1e213e9c13fbd1f72c26ce44db70ca6834e6e6a9"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "3a2e008bd652d5f01c3ac00115e1d72c8e201ebb7229d73f20b25af0d2979f74"
+    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "bec02edd455f092138ff39555faae7b1e58d5d187fa9caed4feb8abed8b876b0",
-    "qualityDigest": "32881ebfe5ef096191181e84524e00b952506de97fffa48ec36ebacba802eead",
+    "contextDigest": "5b04b2b120a8177f532f3efd1e213e9c13fbd1f72c26ce44db70ca6834e6e6a9",
+    "qualityDigest": "eda0b4a345d7658db25cc473f8b66e8dd633fb50b666927d864567fa36c99edb",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "9e0ada8fac3a30b5e6a2a269af7d046b584588211f03456a2877ba250690d497",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "126ea6f657ac5f063151b02be0b0f1b7b1ed502a2718af6f045c453cc3a95810"
+  "activationDigest": "2f6aea2895190ef0a5ed3e39eca91fa7da4f5b332103d7fea85bdb0ad90369c6"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,12 +3,12 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "3a2e008bd652d5f01c3ac00115e1d72c8e201ebb7229d73f20b25af0d2979f74",
-    "contextDigest": "bec02edd455f092138ff39555faae7b1e58d5d187fa9caed4feb8abed8b876b0"
+    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb",
+    "contextDigest": "5b04b2b120a8177f532f3efd1e213e9c13fbd1f72c26ce44db70ca6834e6e6a9"
   },
   "catalog": {
-    "messageCount": 3096,
-    "catalogDigest": "e952ef6494e17e447600d7c16849e4e33690d6df82045eecc033fcefbabc4528",
+    "messageCount": 3098,
+    "catalogDigest": "fc8ca32e41215b0ee38ba57c2f414c679fea664f5711119f714e20c481cc2f73",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
@@ -41,10 +41,10 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "35e5180f9a58f65f4037487b1ca0fb78e1521885774901a775dface81f3c25ce",
-    "validationDigest": "0653c3f20b475503b13a58b0fd7390cc797d34fc8e2d8b9c32938099b283f534",
+    "digest": "a37ac71eb1ab5cc70f8ed38bca5129d4538de5dbf34f3edca6a804032cf5cd20",
+    "validationDigest": "45cb432c01f7cc87a1920a7070fc8622f1c74dc9439adf576524caa9848c5921",
     "laneCount": 1,
-    "validatedMessageCount": 3096,
+    "validatedMessageCount": 3098,
     "validatedModuleCount": 31,
     "highRiskMessageCount": 1374,
     "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "32881ebfe5ef096191181e84524e00b952506de97fffa48ec36ebacba802eead"
+  "qualityDigest": "eda0b4a345d7658db25cc473f8b66e8dd633fb50b666927d864567fa36c99edb"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "d67932f5212ba9ec819334ad21c88674703a1477d1e43faf8b6d04cc7e64c5b4",
-    "validatedMessageCount": 3096,
+    "auditedInputDigest": "bf1d21a781e4e708227e8a074b85ae03c5ae4435c0740ab76bf3f41edf0af091",
+    "validatedMessageCount": 3098,
     "validatedModules": [
       "$entry",
       "component",
@@ -40,10 +40,10 @@
     ],
     "highRiskMessageCount": 1374,
     "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
-    "catalogDigest": "e952ef6494e17e447600d7c16849e4e33690d6df82045eecc033fcefbabc4528",
-    "dossierDigest": "e1bed1c1cba0ccebba9a3bc3b51b788fc1c4b4f69024368278e5de4e6c3466f2",
+    "catalogDigest": "fc8ca32e41215b0ee38ba57c2f414c679fea664f5711119f714e20c481cc2f73",
+    "dossierDigest": "07514073fdf7d9342d4f32f1984ba5d6e76bc2d44f145d5463f0fedea2beee72",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "cec469024fc62b5ea120fe46a0d67ed0003a9f88328812b504be5441c41400e2",
+    "routeEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -92,11 +92,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3096,
-        "messageDigest": "1fcf8b76c7e6ab67e9071370ed52636a19d4549a63b28e491ad4562c901d4d59",
+        "messageCount": 3098,
+        "messageDigest": "5120aa22622b7730b9e96f4cab159adde8950b8353606f00b164af870b82483b",
         "highRiskMessageCount": 1374,
         "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
-        "dossierDigest": "e1bed1c1cba0ccebba9a3bc3b51b788fc1c4b4f69024368278e5de4e6c3466f2",
+        "dossierDigest": "07514073fdf7d9342d4f32f1984ba5d6e76bc2d44f145d5463f0fedea2beee72",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "0653c3f20b475503b13a58b0fd7390cc797d34fc8e2d8b9c32938099b283f534"
+  "validationDigest": "45cb432c01f7cc87a1920a7070fc8622f1c74dc9439adf576524caa9848c5921"
 }

--- a/src/components/ClosureTaskDetail/index.tsx
+++ b/src/components/ClosureTaskDetail/index.tsx
@@ -1,0 +1,521 @@
+import {
+  createClosureReportDownload,
+  getClosureCheck,
+  type ClosureArtifactLifecycleState,
+  type ClosureArtifactRole,
+  type ClosureArtifactV1,
+  type ClosureCheckSummaryV1,
+} from '@/services/dataProducts';
+import { DownloadOutlined, ReloadOutlined } from '@ant-design/icons';
+import { Alert, Button, Descriptions, Space, Spin, Tag, Typography, message, theme } from 'antd';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useIntl } from 'umi';
+
+export const closureCheckPollIntervalMs = 2_000;
+export const closureCheckPollMaxAttempts = 30;
+
+const closureArtifactRoles: ClosureArtifactRole[] = [
+  'closure_report_xlsx',
+  'closure_issue_manifest',
+];
+
+type IntlShapeLike = ReturnType<typeof useIntl>;
+
+function closureMessages(intl: IntlShapeLike) {
+  return {
+    artifactAvailableUntil: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.artifact.availableUntil',
+      defaultMessage: 'Available until',
+    }),
+    artifactDownloadFailed: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.artifact.downloadFailed',
+      defaultMessage: 'This download is currently unavailable. Please try again later.',
+    }),
+    artifactExpired: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.artifact.expiredGuidance',
+      defaultMessage:
+        'This artifact has expired. Run the data completeness check again to prepare a new download.',
+    }),
+    artifactFailed: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.artifact.failedGuidance',
+      defaultMessage: 'Artifact preparation failed. Run the data completeness check again.',
+    }),
+    artifactMachineResult: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.artifact.machineResult',
+      defaultMessage: 'Machine result manifest',
+    }),
+    artifactPreparing: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.artifact.preparing',
+      defaultMessage: 'Preparing this artifact.',
+    }),
+    artifactsTitle: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.artifacts.title',
+      defaultMessage: 'Result artifacts',
+    }),
+    artifactUnavailable: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.artifact.unavailable',
+      defaultMessage: 'This artifact is unavailable.',
+    }),
+    artifactXlsxReport: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.artifact.humanReport',
+      defaultMessage: 'Human issue report (XLSX)',
+    }),
+    certificate: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.certificate',
+      defaultMessage: 'Certificate',
+    }),
+    closureCheckId: intl.formatMessage({
+      id: 'pages.dataProcessing.command.closureCheckId',
+      defaultMessage: 'Closure check ID',
+    }),
+    completeness: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.completeness',
+      defaultMessage: 'Scan completeness',
+    }),
+    detailLoading: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.detailLoading',
+      defaultMessage: 'Loading task details...',
+    }),
+    detailUnavailable: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.detailUnavailable',
+      defaultMessage: 'Task details are currently unavailable.',
+    }),
+    downloadMachineResult: intl.formatMessage({
+      id: 'pages.dataProcessing.action.downloadClosureMachineResult',
+      defaultMessage: 'Download machine result manifest',
+    }),
+    downloadXlsxReport: intl.formatMessage({
+      id: 'pages.dataProcessing.action.downloadClosureReport',
+      defaultMessage: 'Download issue report',
+    }),
+    executionCancelled: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.executionCancelled',
+      defaultMessage: 'Data completeness check was cancelled. Run a new check to continue.',
+    }),
+    executionFailed: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.executionFailed',
+      defaultMessage: 'Data completeness check failed to run',
+    }),
+    executionFailedFallback: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.executionFailedFallback',
+      defaultMessage:
+        'The check did not complete. Retry it; if it fails again, contact an administrator with the identifiers below.',
+    }),
+    executionPending: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.executionPending',
+      defaultMessage:
+        'The check is still running. Closure issues will be available after it completes.',
+    }),
+    issues: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.issues',
+      defaultMessage: 'Issues',
+    }),
+    phase: intl.formatMessage({
+      id: 'pages.process.lca.taskCenter.phasePrefix',
+      defaultMessage: 'Phase:',
+    }),
+    refresh: intl.formatMessage({
+      id: 'pages.process.lca.taskCenter.refresh',
+      defaultMessage: 'Refresh',
+    }),
+    rerun: intl.formatMessage({
+      id: 'pages.dataProcessing.action.rerunClosureCheck',
+      defaultMessage: 'Run check again',
+    }),
+    status: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.status',
+      defaultMessage: 'Check status',
+    }),
+    workerJobId: intl.formatMessage({
+      id: 'pages.dataProcessing.closure.workerJobId',
+      defaultMessage: 'Worker job ID',
+    }),
+  };
+}
+
+export function closureCheckNeedsPolling(closureCheck: ClosureCheckSummaryV1 | null): boolean {
+  return Boolean(
+    closureCheck &&
+    (['queued', 'running'].includes(closureCheck.runStatus) ||
+      closureCheck.artifacts?.some((artifact) => artifact.artifactState === 'pending')),
+  );
+}
+
+export function closureArtifactLifecycleState(
+  artifact: ClosureArtifactV1 | undefined,
+  now: number,
+  forcedExpired = false,
+): ClosureArtifactLifecycleState {
+  if (forcedExpired) return 'expired';
+  if (!artifact) return 'unavailable';
+  if (artifact.artifactState === 'pending') return 'preparing';
+  if (artifact.artifactState === 'ready') {
+    return Date.parse(artifact.artifactExpiresAt) > now ? 'available' : 'expired';
+  }
+  if (artifact.artifactState === 'expired') return 'expired';
+  if (artifact.artifactState === 'failed') return 'failed';
+  return 'unavailable';
+}
+
+export function formatClosureArtifactByteSize(value: unknown): string {
+  const bytes = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(bytes) || bytes < 0) return '-';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+export function formatClosureTimestamp(value: unknown): string {
+  if (typeof value !== 'string' || !value) return '-';
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) return value;
+  return new Date(timestamp).toISOString().slice(0, 16).replace('T', ' ');
+}
+
+type ClosureArtifactListProps = {
+  closureCheck: ClosureCheckSummaryV1;
+  canDownloadReport: boolean;
+  className?: string;
+  artifactClassName?: string;
+  onDownloadError?: (messageText: string) => void;
+  onRerun?: () => void;
+  rerunDisabled?: boolean;
+  rerunLoading?: boolean;
+};
+
+export const ClosureArtifactList: React.FC<ClosureArtifactListProps> = ({
+  closureCheck,
+  canDownloadReport,
+  className,
+  artifactClassName,
+  onDownloadError,
+  onRerun,
+  rerunDisabled,
+  rerunLoading,
+}) => {
+  const intl = useIntl();
+  const { token } = theme.useToken();
+  const [artifactClockNow, setArtifactClockNow] = useState(() => Date.now());
+  const [downloadingRole, setDownloadingRole] = useState<ClosureArtifactRole | null>(null);
+  const [expiredRoles, setExpiredRoles] = useState<ClosureArtifactRole[]>([]);
+  const artifactExpiryKey = useMemo(
+    () =>
+      closureCheck.artifacts
+        ?.map((artifact) => `${artifact.artifactRole}:${artifact.artifactExpiresAt ?? ''}`)
+        .join('|') ?? '',
+    [closureCheck.artifacts],
+  );
+
+  const messages = closureMessages(intl);
+
+  useEffect(() => {
+    setExpiredRoles([]);
+    setArtifactClockNow(Date.now());
+  }, [closureCheck.closureCheckId]);
+
+  useEffect(() => {
+    setArtifactClockNow(Date.now());
+  }, [artifactExpiryKey]);
+
+  useEffect(() => {
+    const now = Date.now();
+    const nextExpiry = closureCheck.artifacts
+      ?.flatMap((artifact) => {
+        if (artifact.artifactState !== 'ready') return [];
+        const expiresAt = Date.parse(artifact.artifactExpiresAt);
+        return expiresAt > now ? [expiresAt] : [];
+      })
+      .sort((left, right) => left - right)[0];
+    if (nextExpiry === undefined) return undefined;
+    const timer = window.setTimeout(
+      () => setArtifactClockNow(Date.now()),
+      Math.max(0, nextExpiry - now),
+    );
+    return () => window.clearTimeout(timer);
+  }, [artifactClockNow, artifactExpiryKey, closureCheck.artifacts]);
+
+  const notifyDownloadError = (messageText: string) => {
+    if (onDownloadError) {
+      onDownloadError(messageText);
+      return;
+    }
+    message.error(messageText);
+  };
+
+  const handleDownload = async (artifact: ClosureArtifactV1) => {
+    setDownloadingRole(artifact.artifactRole);
+    try {
+      const result = await createClosureReportDownload(
+        closureCheck.closureCheckId,
+        artifact.artifactRole,
+      );
+      if (result.error || !result.data?.signedDownloadUrl) {
+        if (result.status === 410 || result.error?.code === 'closure_report_expired') {
+          setExpiredRoles((current) =>
+            current.includes(artifact.artifactRole) ? current : [...current, artifact.artifactRole],
+          );
+          notifyDownloadError(messages.artifactExpired);
+          return;
+        }
+        notifyDownloadError(messages.artifactDownloadFailed);
+        return;
+      }
+      const anchor = document.createElement('a');
+      anchor.href = result.data.signedDownloadUrl;
+      anchor.target = '_self';
+      anchor.rel = 'noopener noreferrer';
+      if (result.data.filename) anchor.download = result.data.filename;
+      anchor.click();
+    } catch (_error) {
+      notifyDownloadError(messages.artifactDownloadFailed);
+    } finally {
+      setDownloadingRole(null);
+    }
+  };
+
+  return (
+    <div
+      className={className}
+      data-testid='closure-artifacts'
+      style={
+        className
+          ? undefined
+          : {
+              display: 'grid',
+              gap: 10,
+              gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+              width: '100%',
+            }
+      }
+    >
+      <strong style={className ? undefined : { gridColumn: '1 / -1' }}>
+        {messages.artifactsTitle}
+      </strong>
+      {closureArtifactRoles.map((artifactRole) => {
+        const artifact = closureCheck.artifacts?.find(
+          (candidate) => candidate.artifactRole === artifactRole,
+        );
+        const lifecycleState = closureArtifactLifecycleState(
+          artifact,
+          artifactClockNow,
+          expiredRoles.includes(artifactRole),
+        );
+        const roleLabel =
+          artifactRole === 'closure_report_xlsx'
+            ? messages.artifactXlsxReport
+            : messages.artifactMachineResult;
+        const stateMessage =
+          lifecycleState === 'preparing'
+            ? messages.artifactPreparing
+            : lifecycleState === 'available'
+              ? messages.artifactAvailableUntil
+              : lifecycleState === 'expired'
+                ? messages.artifactExpired
+                : lifecycleState === 'failed'
+                  ? messages.artifactFailed
+                  : messages.artifactUnavailable;
+        return (
+          <section
+            key={artifactRole}
+            className={artifactClassName}
+            data-testid={`closure-artifact-${artifactRole}`}
+            style={
+              artifactClassName
+                ? undefined
+                : {
+                    background: token.colorBgContainer,
+                    border: `1px solid ${token.colorBorderSecondary}`,
+                    borderRadius: 6,
+                    display: 'grid',
+                    gap: 6,
+                    minWidth: 0,
+                    overflowWrap: 'anywhere',
+                    padding: 12,
+                  }
+            }
+          >
+            <strong>{roleLabel}</strong>
+            <span data-testid={`closure-artifact-state-${artifactRole}`}>
+              {lifecycleState === 'available'
+                ? `${stateMessage}: ${formatClosureTimestamp(artifact?.artifactExpiresAt)}`
+                : stateMessage}
+            </span>
+            {artifact?.filename ? <span>{artifact.filename}</span> : null}
+            {artifact?.format || artifact?.mediaType || artifact?.size !== undefined ? (
+              <span>
+                {[artifact.format, artifact.mediaType, formatClosureArtifactByteSize(artifact.size)]
+                  .filter((value) => value && value !== '-')
+                  .join(' · ')}
+              </span>
+            ) : null}
+            {artifact?.checksumSha256 ? <code>{artifact.checksumSha256}</code> : null}
+            {lifecycleState === 'available' && artifact && canDownloadReport ? (
+              <Button
+                icon={<DownloadOutlined />}
+                loading={downloadingRole === artifactRole}
+                onClick={() => void handleDownload(artifact)}
+              >
+                {artifactRole === 'closure_report_xlsx'
+                  ? messages.downloadXlsxReport
+                  : messages.downloadMachineResult}
+              </Button>
+            ) : (lifecycleState === 'expired' || lifecycleState === 'failed') && onRerun ? (
+              <Button disabled={rerunDisabled} loading={rerunLoading} onClick={onRerun}>
+                {messages.rerun}
+              </Button>
+            ) : null}
+          </section>
+        );
+      })}
+    </div>
+  );
+};
+
+type ClosureTaskDetailProps = {
+  closureCheckId: string;
+  canDownloadReport: boolean;
+  errorSummary?: string;
+  refreshSignal?: string;
+};
+
+export const ClosureTaskDetail: React.FC<ClosureTaskDetailProps> = ({
+  closureCheckId,
+  canDownloadReport,
+  errorSummary,
+  refreshSignal,
+}) => {
+  const intl = useIntl();
+  const [closureCheck, setClosureCheck] = useState<ClosureCheckSummaryV1 | null>(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [retryGeneration, setRetryGeneration] = useState(0);
+
+  const messages = closureMessages(intl);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let attempts = 0;
+
+    const refresh = async (initial: boolean) => {
+      if (initial) setLoading(true);
+      let result: Awaited<ReturnType<typeof getClosureCheck>>;
+      try {
+        result = await getClosureCheck(closureCheckId);
+      } catch (requestError) {
+        if (cancelled) return;
+        setLoading(false);
+        setError(requestError instanceof Error ? requestError.message : messages.detailUnavailable);
+        return;
+      }
+      if (cancelled) return;
+      setLoading(false);
+      if (result.error || !result.data) {
+        setError(result.error?.message ?? messages.detailUnavailable);
+        return;
+      }
+      setClosureCheck(result.data);
+      setError('');
+      attempts += 1;
+      if (closureCheckNeedsPolling(result.data) && attempts < closureCheckPollMaxAttempts) {
+        timer = setTimeout(() => void refresh(false), closureCheckPollIntervalMs);
+      }
+    };
+
+    void refresh(true);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [closureCheckId, refreshSignal, retryGeneration]);
+
+  if (loading && !closureCheck) {
+    return (
+      <Space data-testid='closure-task-detail-loading'>
+        <Spin size='small' />
+        <span>{messages.detailLoading}</span>
+      </Space>
+    );
+  }
+
+  if (!closureCheck) {
+    return (
+      <Alert
+        type='error'
+        message={error}
+        action={
+          <Button
+            icon={<ReloadOutlined />}
+            size='small'
+            onClick={() => setRetryGeneration((current) => current + 1)}
+          >
+            {messages.refresh}
+          </Button>
+        }
+      />
+    );
+  }
+
+  const progressFraction = closureCheck.workerJob?.progressFraction;
+  const progressPercent =
+    typeof progressFraction === 'number'
+      ? Math.max(0, Math.min(100, Math.round(progressFraction * 100)))
+      : undefined;
+
+  return (
+    <Space
+      data-testid={`closure-task-detail-${closureCheck.closureCheckId}`}
+      direction='vertical'
+      size={12}
+      style={{ width: '100%' }}
+    >
+      {error ? <Alert type='warning' message={error} /> : null}
+      <Descriptions bordered column={1} size='small'>
+        <Descriptions.Item label={messages.status}>{closureCheck.runStatus}</Descriptions.Item>
+        <Descriptions.Item label={messages.certificate}>
+          {closureCheck.certificateValidity}
+        </Descriptions.Item>
+        <Descriptions.Item label={messages.completeness}>
+          {closureCheck.scanCompleteness}
+        </Descriptions.Item>
+        <Descriptions.Item label={messages.issues}>
+          <Space size={4} wrap>
+            {(closureCheck.blockerCodes ?? []).length === 0
+              ? '0 blockers'
+              : closureCheck.blockerCodes?.map((code) => <Tag key={code}>{code}</Tag>)}
+          </Space>
+        </Descriptions.Item>
+        {closureCheck.workerJob?.phase ? (
+          <Descriptions.Item label={messages.phase}>
+            {closureCheck.workerJob.phase}
+            {progressPercent === undefined ? '' : ` · ${progressPercent}%`}
+          </Descriptions.Item>
+        ) : null}
+        <Descriptions.Item label={messages.closureCheckId}>
+          <Typography.Text>{closureCheck.closureCheckId}</Typography.Text>
+        </Descriptions.Item>
+        {closureCheck.workerJob?.jobId ? (
+          <Descriptions.Item label={messages.workerJobId}>
+            <Typography.Text>{closureCheck.workerJob.jobId}</Typography.Text>
+          </Descriptions.Item>
+        ) : null}
+      </Descriptions>
+      {closureCheck.runStatus === 'failed' ? (
+        <Alert
+          type='error'
+          message={messages.executionFailed}
+          description={
+            errorSummary ?? closureCheck.workerJob?.errorCode ?? messages.executionFailedFallback
+          }
+        />
+      ) : closureCheck.runStatus === 'cancelled' ? (
+        <Alert type='warning' message={messages.executionCancelled} />
+      ) : ['queued', 'running'].includes(closureCheck.runStatus) ? (
+        <Alert type='info' message={messages.executionPending} />
+      ) : null}
+      <ClosureArtifactList canDownloadReport={canDownloadReport} closureCheck={closureCheck} />
+    </Space>
+  );
+};
+
+export default ClosureTaskDetail;

--- a/src/components/LcaTaskCenter/index.tsx
+++ b/src/components/LcaTaskCenter/index.tsx
@@ -1,3 +1,4 @@
+import ClosureTaskDetail from '@/components/ClosureTaskDetail';
 import HeaderActionIcon, { getHeaderBadgeStyle } from '@/components/HeaderActionIcon';
 import {
   listDataProductTasks,
@@ -59,6 +60,7 @@ import {
   ReloadOutlined,
 } from '@ant-design/icons';
 import {
+  Alert,
   Button,
   Empty,
   Modal,
@@ -2026,9 +2028,13 @@ const LcaTaskCenter: React.FC = () => {
 
   useEffect(() => {
     setExpandedTaskKeys((current) =>
-      current.filter((key) => items.some((item) => taskItemKey(item) === key)),
+      current.filter(
+        (key) =>
+          items.some((item) => taskItemKey(item) === key) ||
+          dataProductTasks.some((task) => `data-product:${task.id}` === key),
+      ),
     );
-  }, [items]);
+  }, [dataProductTasks, items]);
 
   const handleDownload = async (task: TidasPackageBackgroundTask) => {
     try {
@@ -2223,6 +2229,13 @@ const LcaTaskCenter: React.FC = () => {
             ) : (
               <>
                 {visibleDataProductTasks.map((task, index) => {
+                  const itemKey = `data-product:${task.id}`;
+                  const isClosureCheck = task.jobKind === 'lcia.scope_closure_check';
+                  const closureCheckId =
+                    task.deepLink?.routeKey === 'data_product.closure_check'
+                      ? task.deepLink.params.closureCheckId
+                      : task.closureCheckId;
+                  const expanded = expandedTaskKeys.includes(itemKey);
                   const taskHref = `/data-processing?${new URLSearchParams({
                     tab: 'builds',
                     ...(task.deepLink?.routeKey === 'data_product.closure_check' &&
@@ -2307,13 +2320,68 @@ const LcaTaskCenter: React.FC = () => {
                         </div>
                       </Space>
                       <Space size={6} wrap>
-                        <Button size='small' type='link' href={taskHref} icon={<EyeOutlined />}>
-                          {intl.formatMessage({
-                            id: 'pages.process.lca.taskCenter.openWorkbench',
-                            defaultMessage: 'Open',
-                          })}
-                        </Button>
+                        {isClosureCheck ? (
+                          <Tooltip
+                            title={intl.formatMessage({
+                              id: 'pages.process.lca.taskCenter.view',
+                              defaultMessage: 'View',
+                            })}
+                          >
+                            <Button
+                              aria-label={intl.formatMessage({
+                                id: 'pages.process.lca.taskCenter.view',
+                                defaultMessage: 'View',
+                              })}
+                              icon={<EyeOutlined />}
+                              size='small'
+                              type='text'
+                              style={expanded ? { color: token.colorPrimary } : undefined}
+                              onClick={() => {
+                                setExpandedTaskKeys((current) =>
+                                  current.includes(itemKey)
+                                    ? current.filter((key) => key !== itemKey)
+                                    : [...current, itemKey],
+                                );
+                              }}
+                            />
+                          </Tooltip>
+                        ) : (
+                          <Button size='small' type='link' href={taskHref} icon={<EyeOutlined />}>
+                            {intl.formatMessage({
+                              id: 'pages.process.lca.taskCenter.openWorkbench',
+                              defaultMessage: 'Open',
+                            })}
+                          </Button>
+                        )}
                       </Space>
+                      {expanded && isClosureCheck ? (
+                        <div
+                          style={{
+                            background: token.colorFillSecondary,
+                            borderRadius: 6,
+                            gridColumn: '1 / -1',
+                            marginTop: 2,
+                            padding: '12px 14px',
+                          }}
+                        >
+                          {closureCheckId ? (
+                            <ClosureTaskDetail
+                              canDownloadReport={task.capabilities.canDownloadReport}
+                              closureCheckId={closureCheckId}
+                              errorSummary={task.errorSummary}
+                              refreshSignal={`${task.workerStatus}:${task.updatedAt}`}
+                            />
+                          ) : (
+                            <Alert
+                              type='error'
+                              message={intl.formatMessage({
+                                id: 'pages.dataProcessing.closure.detailUnavailable',
+                                defaultMessage: 'Task details are currently unavailable.',
+                              })}
+                            />
+                          )}
+                        </div>
+                      ) : null}
                     </div>
                   );
                 })}

--- a/src/locales/de-DE/pages.ts
+++ b/src/locales/de-DE/pages.ts
@@ -232,6 +232,8 @@ export default {
   'pages.dataProcessing.closure.artifact.unavailable': 'Dieses Artefakt ist nicht verfügbar.',
   'pages.dataProcessing.closure.certificate': 'Zertifikat',
   'pages.dataProcessing.closure.completeness': 'Vollständigkeit des Scans',
+  'pages.dataProcessing.closure.detailLoading': 'Aufgabendetails werden geladen …',
+  'pages.dataProcessing.closure.detailUnavailable': 'Die Aufgabendetails sind derzeit nicht verfügbar.',
   'pages.dataProcessing.closure.error.currentReleaseRequired': 'Die aktuelle öffentliche Veröffentlichung oder Momentaufnahme ist nicht verfügbar; ein Zertifikat kann nicht ausgestellt werden.',
   'pages.dataProcessing.closure.error.evidenceHashMismatch': 'Die Integritätsprüfung der Vollständigkeitsnachweise ist fehlgeschlagen.',
   'pages.dataProcessing.closure.error.evidenceUnavailable': 'Die aktuelle öffentliche Veröffentlichung oder Momentaufnahme ist nicht verfügbar; ein Zertifikat kann nicht ausgestellt werden.',

--- a/src/locales/en-US/pages.ts
+++ b/src/locales/en-US/pages.ts
@@ -232,6 +232,8 @@ export default {
   'pages.dataProcessing.closure.artifact.unavailable': 'This artifact is unavailable.',
   'pages.dataProcessing.closure.certificate': 'Certificate',
   'pages.dataProcessing.closure.completeness': 'Scan completeness',
+  'pages.dataProcessing.closure.detailLoading': 'Loading task details...',
+  'pages.dataProcessing.closure.detailUnavailable': 'Task details are currently unavailable.',
   'pages.dataProcessing.closure.error.currentReleaseRequired': 'The current public release or snapshot is unavailable; a certificate cannot be issued.',
   'pages.dataProcessing.closure.error.evidenceHashMismatch': 'Closure evidence integrity verification failed.',
   'pages.dataProcessing.closure.error.evidenceUnavailable': 'The current public release or snapshot is unavailable; a certificate cannot be issued.',

--- a/src/locales/fr-FR/pages.ts
+++ b/src/locales/fr-FR/pages.ts
@@ -232,6 +232,8 @@ export default {
   'pages.dataProcessing.closure.artifact.unavailable': 'Cet artefact est indisponible.',
   'pages.dataProcessing.closure.certificate': 'Certificat',
   'pages.dataProcessing.closure.completeness': 'Exhaustivité de l’analyse',
+  'pages.dataProcessing.closure.detailLoading': 'Chargement des détails de la tâche…',
+  'pages.dataProcessing.closure.detailUnavailable': 'Les détails de la tâche sont actuellement indisponibles.',
   'pages.dataProcessing.closure.error.currentReleaseRequired': 'La version publique actuelle ou l’instantané est indisponible ; aucun certificat ne peut être émis.',
   'pages.dataProcessing.closure.error.evidenceHashMismatch': 'Échec de la vérification de l’intégrité des preuves de complétude.',
   'pages.dataProcessing.closure.error.evidenceUnavailable': 'La version publique actuelle ou l’instantané est indisponible ; aucun certificat ne peut être émis.',

--- a/src/locales/zh-CN/pages.ts
+++ b/src/locales/zh-CN/pages.ts
@@ -232,6 +232,8 @@ export default {
   'pages.dataProcessing.closure.artifact.unavailable': '此产物不可用。',
   'pages.dataProcessing.closure.certificate': '证书',
   'pages.dataProcessing.closure.completeness': '扫描完整性',
+  'pages.dataProcessing.closure.detailLoading': '正在加载任务详情…',
+  'pages.dataProcessing.closure.detailUnavailable': '当前无法获取任务详情。',
   'pages.dataProcessing.closure.error.currentReleaseRequired': '当前公开发布版本或快照不可用，无法签发证书。',
   'pages.dataProcessing.closure.error.evidenceHashMismatch': '完整性证据完整性验证失败。',
   'pages.dataProcessing.closure.error.evidenceUnavailable': '当前公开发布版本或快照不可用，无法签发证书。',

--- a/src/pages/DataProcessing/index.tsx
+++ b/src/pages/DataProcessing/index.tsx
@@ -1,8 +1,13 @@
 import AccessDenied from '@/components/AccessDenied';
+import {
+  ClosureArtifactList,
+  closureCheckNeedsPolling,
+  closureCheckPollIntervalMs,
+  closureCheckPollMaxAttempts,
+} from '@/components/ClosureTaskDetail';
 import LcaReleaseReadPanel from '@/components/LcaReleaseReadPanel';
 import {
   createClosureCheck,
-  createClosureReportDownload,
   createLciaResultBuildRequest,
   getClosureCheck,
   listClosureCheckIssues,
@@ -10,8 +15,6 @@ import {
   previewLciaResultPackage,
   publishLciaResultPackage,
   unpublishLciaResultPublication,
-  type ClosureArtifactRole,
-  type ClosureArtifactV1,
   type ClosureCheckIssueV1,
   type ClosureCheckSummaryV1,
   type ClosureScopeIdentityV1,
@@ -121,21 +124,6 @@ type StatusTone = 'success' | 'error' | 'processing' | 'warning' | 'default';
 const submittedBuildPendingPhase = 'waiting_for_worker_processing';
 const previewPageSize = 25;
 const previewExportPageSize = 100;
-const closureArtifactRoles: ClosureArtifactRole[] = [
-  'closure_report_xlsx',
-  'closure_issue_manifest',
-];
-export const closureCheckPollIntervalMs = 2_000;
-export const closureCheckPollMaxAttempts = 30;
-
-function closureCheckNeedsPolling(closureCheck: ClosureCheckSummaryV1 | null): boolean {
-  return Boolean(
-    closureCheck &&
-    (['queued', 'running'].includes(closureCheck.runStatus) ||
-      closureCheck.artifacts?.some((artifact) => artifact.artifactState === 'pending')),
-  );
-}
-
 function isTerminalTaskStatus(status: TaskSummaryV2['workerStatus'] | undefined): boolean {
   return Boolean(
     status && ['completed', 'blocked', 'stale', 'failed', 'cancelled'].includes(status),
@@ -648,7 +636,6 @@ const DataProcessing = () => {
   const closurePollAttemptRef = useRef<{ closureCheckId?: string; count: number }>({ count: 0 });
   const recoveryInFlightRef = useRef(false);
   const [recoveryLoading, setRecoveryLoading] = useState(false);
-  const [artifactClockNow, setArtifactClockNow] = useState(() => Date.now());
   const closureTask = useMemo(
     () =>
       closureCheck?.workerJob?.jobId
@@ -662,9 +649,6 @@ const DataProcessing = () => {
   const [closureIssuesLoading, setClosureIssuesLoading] = useState(false);
   const [closureIssuesError, setClosureIssuesError] = useState<string | null>(null);
   const [closureSelectionKey, setClosureSelectionKey] = useState<string | null>(null);
-  const [expiredClosureArtifactRoles, setExpiredClosureArtifactRoles] = useState<
-    ClosureArtifactRole[]
-  >([]);
   const [currentSelectionKey, setCurrentSelectionKey] = useState<string>(scopeSelectionKey({}));
   const [selectedPackageId, setSelectedPackageId] = useState<string | undefined>(
     deepLink.packageId,
@@ -683,10 +667,6 @@ const DataProcessing = () => {
   useEffect(() => {
     setActiveTabKey(deepLink.activeTabKey);
   }, [deepLink.activeTabKey]);
-
-  useEffect(() => {
-    setExpiredClosureArtifactRoles([]);
-  }, [closureCheck?.closureCheckId]);
 
   useEffect(
     () => () => {
@@ -907,30 +887,6 @@ const DataProcessing = () => {
       void refreshClosureCheck(closureCheck.closureCheckId);
     }
   }, [closureCheck, closureTask?.workerStatus, refreshClosureCheck]);
-
-  const closureArtifactExpiryKey =
-    closureCheck?.artifacts
-      ?.map((artifact) => `${artifact.artifactRole}:${artifact.artifactExpiresAt ?? ''}`)
-      .join('|') ?? '';
-  useEffect(() => {
-    setArtifactClockNow(Date.now());
-  }, [closureArtifactExpiryKey, closureCheck?.closureCheckId]);
-
-  useEffect(() => {
-    const now = Date.now();
-    const nextExpiry = closureCheck?.artifacts
-      ?.filter(
-        (artifact) =>
-          artifact.artifactState === 'ready' &&
-          typeof artifact.artifactExpiresAt === 'string' &&
-          Date.parse(artifact.artifactExpiresAt) > now,
-      )
-      .map((artifact) => Date.parse(artifact.artifactExpiresAt!))
-      .sort((left, right) => left - right)[0];
-    if (nextExpiry === undefined) return;
-    const timer = setTimeout(() => setArtifactClockNow(Date.now()), Math.max(0, nextExpiry - now));
-    return () => clearTimeout(timer);
-  }, [artifactClockNow, closureArtifactExpiryKey, closureCheck?.closureCheckId]);
 
   useEffect(() => {
     setCurrentSelectionKey(
@@ -1284,6 +1240,13 @@ const DataProcessing = () => {
       if (result && !result.error && result.data) {
         const closureCheckId = result.data.closureCheckId;
         activateClosureCheckId(closureCheckId);
+        const searchParams = new URLSearchParams(location.search);
+        searchParams.set('tab', 'builds');
+        searchParams.set('closureCheckId', closureCheckId);
+        history.replace({
+          pathname: location.pathname,
+          search: `?${searchParams.toString()}`,
+        });
         const summary = await refreshClosureCheck(closureCheckId);
         if (activeClosureCheckIdRef.current !== closureCheckId) return;
         if (summary.error || !summary.data) {
@@ -1294,7 +1257,6 @@ const DataProcessing = () => {
           });
           return;
         }
-        setExpiredClosureArtifactRoles([]);
         setClosurePrerequisiteUnavailable(false);
         setClosureSelectionKey(selectionKey);
         setCurrentSelectionKey(selectionKey);
@@ -1316,40 +1278,6 @@ const DataProcessing = () => {
       recoveryInFlightRef.current = false;
       if (mountedRef.current) setRecoveryLoading(false);
     }
-  };
-
-  const handleDownloadClosureArtifact = async (artifact: ClosureArtifactV1) => {
-    const result = await createClosureReportDownload(
-      closureCheck!.closureCheckId,
-      artifact.artifactRole,
-    );
-    if (result.error || !result.data?.signedDownloadUrl) {
-      if (result.status === 410 || result.error?.code === 'closure_report_expired') {
-        setExpiredClosureArtifactRoles((current) => [...current, artifact.artifactRole]);
-        setCommandStatus({
-          kind: 'error',
-          message: t(
-            'pages.dataProcessing.closure.artifact.expiredGuidance',
-            'This artifact has expired. Run the data completeness check again to prepare a new download.',
-          ),
-        });
-        return;
-      }
-      setCommandStatus({
-        kind: 'error',
-        message: t(
-          'pages.dataProcessing.closure.artifact.downloadFailed',
-          'This download is currently unavailable. Please try again later.',
-        ),
-      });
-      return;
-    }
-    const anchor = document.createElement('a');
-    anchor.href = result.data.signedDownloadUrl;
-    anchor.target = '_self';
-    anchor.rel = 'noopener noreferrer';
-    if (result.data.filename) anchor.download = result.data.filename;
-    anchor.click();
   };
 
   const previewPackageById = async (
@@ -1752,123 +1680,18 @@ const DataProcessing = () => {
                 </div>
               ) : null}
               {closureCheck ? (
-                <div className={styles.closureArtifacts} data-testid='closure-artifacts'>
-                  <strong>
-                    {t('pages.dataProcessing.closure.artifacts.title', 'Result artifacts')}
-                  </strong>
-                  {closureArtifactRoles.map((artifactRole) => {
-                    const decodedArtifact = closureCheck.artifacts?.find(
-                      (artifact) => artifact.artifactRole === artifactRole,
-                    );
-                    const lifecycleState = expiredClosureArtifactRoles.includes(artifactRole)
-                      ? 'expired'
-                      : !decodedArtifact
-                        ? 'unavailable'
-                        : decodedArtifact.artifactState === 'pending'
-                          ? 'preparing'
-                          : decodedArtifact.artifactState === 'ready'
-                            ? Date.parse(decodedArtifact.artifactExpiresAt) > artifactClockNow
-                              ? 'available'
-                              : 'expired'
-                            : decodedArtifact.artifactState === 'expired'
-                              ? 'expired'
-                              : decodedArtifact.artifactState === 'failed'
-                                ? 'failed'
-                                : 'unavailable';
-                    const roleLabel =
-                      artifactRole === 'closure_report_xlsx'
-                        ? t(
-                            'pages.dataProcessing.closure.artifact.humanReport',
-                            'Human issue report (XLSX)',
-                          )
-                        : t(
-                            'pages.dataProcessing.closure.artifact.machineResult',
-                            'Machine result manifest',
-                          );
-                    const stateMessage =
-                      lifecycleState === 'preparing'
-                        ? t(
-                            'pages.dataProcessing.closure.artifact.preparing',
-                            'Preparing this artifact.',
-                          )
-                        : lifecycleState === 'available'
-                          ? t(
-                              'pages.dataProcessing.closure.artifact.availableUntil',
-                              'Available until',
-                            )
-                          : lifecycleState === 'expired'
-                            ? t(
-                                'pages.dataProcessing.closure.artifact.expiredGuidance',
-                                'This artifact has expired. Run the data completeness check again to prepare a new download.',
-                              )
-                            : lifecycleState === 'failed'
-                              ? t(
-                                  'pages.dataProcessing.closure.artifact.failedGuidance',
-                                  'Artifact preparation failed. Run the data completeness check again.',
-                                )
-                              : t(
-                                  'pages.dataProcessing.closure.artifact.unavailable',
-                                  'This artifact is unavailable.',
-                                );
-                    return (
-                      <section
-                        key={artifactRole}
-                        className={styles.closureArtifact}
-                        data-testid={`closure-artifact-${artifactRole}`}
-                      >
-                        <strong>{roleLabel}</strong>
-                        <span data-testid={`closure-artifact-state-${artifactRole}`}>
-                          {lifecycleState === 'available'
-                            ? `${stateMessage}: ${formatTimestamp(
-                                decodedArtifact?.artifactExpiresAt,
-                              )}`
-                            : stateMessage}
-                        </span>
-                        {decodedArtifact?.filename ? <span>{decodedArtifact.filename}</span> : null}
-                        {decodedArtifact?.format ||
-                        decodedArtifact?.mediaType ||
-                        decodedArtifact?.size !== undefined ? (
-                          <span>
-                            {[
-                              decodedArtifact.format,
-                              decodedArtifact.mediaType,
-                              formatArtifactByteSize(decodedArtifact.size),
-                            ]
-                              .filter((value) => value && value !== '-')
-                              .join(' · ')}
-                          </span>
-                        ) : null}
-                        {decodedArtifact?.checksumSha256 ? (
-                          <code>{decodedArtifact.checksumSha256}</code>
-                        ) : null}
-                        {lifecycleState === 'available' && decodedArtifact ? (
-                          <Button
-                            onClick={() => void handleDownloadClosureArtifact(decodedArtifact)}
-                            icon={<DownloadOutlined />}
-                          >
-                            {artifactRole === 'closure_report_xlsx'
-                              ? t(
-                                  'pages.dataProcessing.action.downloadClosureReport',
-                                  'Download issue report',
-                                )
-                              : t(
-                                  'pages.dataProcessing.action.downloadClosureMachineResult',
-                                  'Download machine result manifest',
-                                )}
-                          </Button>
-                        ) : lifecycleState === 'expired' || lifecycleState === 'failed' ? (
-                          <Button
-                            disabled={recoveryLoading}
-                            loading={recoveryLoading}
-                            onClick={handleRecoverClosureCheck}
-                          >
-                            {t('pages.dataProcessing.action.rerunClosureCheck', 'Run check again')}
-                          </Button>
-                        ) : null}
-                      </section>
-                    );
-                  })}
-                </div>
+                <ClosureArtifactList
+                  artifactClassName={styles.closureArtifact}
+                  canDownloadReport
+                  className={styles.closureArtifacts}
+                  closureCheck={closureCheck}
+                  onDownloadError={(messageText) =>
+                    setCommandStatus({ kind: 'error', message: messageText })
+                  }
+                  onRerun={handleRecoverClosureCheck}
+                  rerunDisabled={recoveryLoading}
+                  rerunLoading={recoveryLoading}
+                />
               ) : null}
               <Space wrap>
                 <Button

--- a/tests/unit/components/ClosureTaskDetail.test.tsx
+++ b/tests/unit/components/ClosureTaskDetail.test.tsx
@@ -1,0 +1,427 @@
+import ClosureTaskDetail, {
+  closureArtifactLifecycleState,
+  closureCheckNeedsPolling,
+  closureCheckPollIntervalMs,
+  formatClosureArtifactByteSize,
+  formatClosureTimestamp,
+} from '@/components/ClosureTaskDetail';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const mockGetClosureCheck = jest.fn();
+const mockCreateClosureReportDownload = jest.fn();
+
+jest.mock('@/services/dataProducts', () => ({
+  __esModule: true,
+  createClosureReportDownload: (...args: any[]) =>
+    Reflect.apply(mockCreateClosureReportDownload, undefined, args),
+  getClosureCheck: (...args: any[]) => Reflect.apply(mockGetClosureCheck, undefined, args),
+}));
+
+jest.mock('umi', () => ({
+  __esModule: true,
+  useIntl: () => ({
+    formatMessage: ({ defaultMessage, id }: any) => defaultMessage ?? id,
+  }),
+}));
+
+jest.mock('@ant-design/icons', () => ({
+  __esModule: true,
+  DownloadOutlined: () => <span>download-icon</span>,
+  ReloadOutlined: () => <span>reload-icon</span>,
+}));
+
+jest.mock('antd', () => {
+  const antd = require('../../mocks/antd').createAntdMock();
+  return {
+    ...antd,
+    Alert: ({ action, description, message, type }: any) => (
+      <div data-testid={`alert-${type}`} role='alert'>
+        <div>{message}</div>
+        {description ? <div>{description}</div> : null}
+        {action}
+      </div>
+    ),
+    Tag: ({ children }: any) => <span>{children}</span>,
+  };
+});
+
+const { message } = jest.requireMock('antd') as {
+  message: { error: jest.Mock };
+};
+
+const checksum = 'a'.repeat(64);
+const readyArtifacts = [
+  {
+    artifactRole: 'closure_report_xlsx',
+    artifactState: 'ready',
+    filename: 'closure.xlsx',
+    format: 'xlsx',
+    mediaType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    size: 1536,
+    checksumSha256: checksum,
+    artifactExpiresAt: '2099-01-01T00:00:00Z',
+  },
+  {
+    artifactRole: 'closure_issue_manifest',
+    artifactState: 'ready',
+    filename: 'closure.json',
+    format: 'json',
+    mediaType: 'application/vnd.tiangong.scope-closure-manifest+json',
+    size: 512,
+    checksumSha256: checksum,
+    artifactExpiresAt: '2099-01-01T00:00:00Z',
+  },
+];
+
+const closureSummary = (overrides: Record<string, any> = {}): any => ({
+  schemaVersion: 'lcia.scope-closure-check.v1',
+  closureCheckId: 'closure-1',
+  runStatus: 'passed',
+  certificateValidity: 'valid',
+  scanCompleteness: 'complete',
+  blockerCodes: [],
+  artifacts: readyArtifacts,
+  workerJob: {
+    jobId: 'worker-1',
+    phase: 'complete',
+    progressFraction: 1,
+  },
+  ...overrides,
+});
+
+describe('ClosureTaskDetail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetClosureCheck.mockReset().mockResolvedValue({ data: closureSummary(), error: null });
+    mockCreateClosureReportDownload
+      .mockReset()
+      .mockImplementation(async (_closureCheckId: string, artifactRole: string) => ({
+        data: {
+          signedDownloadUrl: `https://downloads.example/${artifactRole}`,
+          filename: artifactRole === 'closure_report_xlsx' ? 'closure.xlsx' : 'closure.json',
+        },
+        error: null,
+      }));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('classifies polling and artifact lifecycle states', () => {
+    expect(closureCheckNeedsPolling(null)).toBe(false);
+    expect(closureCheckNeedsPolling(closureSummary())).toBe(false);
+    expect(closureCheckNeedsPolling(closureSummary({ runStatus: 'running' }))).toBe(true);
+    expect(
+      closureCheckNeedsPolling(
+        closureSummary({
+          artifacts: [
+            { artifactRole: 'closure_report_xlsx', artifactState: 'pending' },
+            readyArtifacts[1],
+          ],
+        }),
+      ),
+    ).toBe(true);
+
+    expect(closureArtifactLifecycleState(undefined, 0)).toBe('unavailable');
+    expect(
+      closureArtifactLifecycleState(
+        { artifactRole: 'closure_report_xlsx', artifactState: 'pending' } as any,
+        0,
+      ),
+    ).toBe('preparing');
+    expect(closureArtifactLifecycleState(readyArtifacts[0] as any, 0)).toBe('available');
+    expect(
+      closureArtifactLifecycleState(
+        { ...readyArtifacts[0], artifactExpiresAt: '2000-01-01T00:00:00Z' } as any,
+        Date.now(),
+      ),
+    ).toBe('expired');
+    expect(
+      closureArtifactLifecycleState(
+        { artifactRole: 'closure_report_xlsx', artifactState: 'expired' } as any,
+        Date.now(),
+      ),
+    ).toBe('expired');
+    expect(closureArtifactLifecycleState(readyArtifacts[0] as any, Date.now(), true)).toBe(
+      'expired',
+    );
+    expect(
+      closureArtifactLifecycleState(
+        { artifactRole: 'closure_report_xlsx', artifactState: 'failed' } as any,
+        0,
+      ),
+    ).toBe('failed');
+    expect(
+      closureArtifactLifecycleState(
+        { artifactRole: 'closure_report_xlsx', artifactState: 'deleted' } as any,
+        0,
+      ),
+    ).toBe('unavailable');
+
+    expect(formatClosureArtifactByteSize(-1)).toBe('-');
+    expect(formatClosureArtifactByteSize('invalid')).toBe('-');
+    expect(formatClosureArtifactByteSize(512)).toBe('512 B');
+    expect(formatClosureArtifactByteSize(1536)).toBe('1.5 KB');
+    expect(formatClosureArtifactByteSize(2 * 1024 * 1024)).toBe('2.00 MB');
+    expect(formatClosureTimestamp(undefined)).toBe('-');
+    expect(formatClosureTimestamp('invalid')).toBe('invalid');
+    expect(formatClosureTimestamp('2026-08-01T01:02:03Z')).toBe('2026-08-01 01:02');
+  });
+
+  it('loads exact closure detail and downloads both role-specific artifacts', async () => {
+    const anchor = document.createElement('a');
+    const anchorClick = jest.fn();
+    Object.defineProperty(anchor, 'click', { configurable: true, value: anchorClick });
+    const createElement = document.createElement.bind(document);
+    jest
+      .spyOn(document, 'createElement')
+      .mockImplementation((tagName: any, options?: any) =>
+        tagName === 'a' ? anchor : createElement(tagName, options),
+      );
+
+    render(
+      <ClosureTaskDetail
+        canDownloadReport
+        closureCheckId='closure-1'
+        refreshSignal='completed:2026-07-22T00:00:00Z'
+      />,
+    );
+
+    expect(await screen.findByTestId('closure-task-detail-closure-1')).toBeInTheDocument();
+    expect(mockGetClosureCheck).toHaveBeenCalledWith('closure-1');
+    expect(screen.getByText('worker-1')).toBeInTheDocument();
+    expect(screen.getByText('complete · 100%')).toBeInTheDocument();
+    expect(screen.getByText('closure.xlsx')).toBeInTheDocument();
+    expect(screen.getByText(/1\.5 KB/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Download issue report/ }));
+    await waitFor(() =>
+      expect(mockCreateClosureReportDownload).toHaveBeenNthCalledWith(
+        1,
+        'closure-1',
+        'closure_report_xlsx',
+      ),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Download machine result manifest/ }));
+    await waitFor(() =>
+      expect(mockCreateClosureReportDownload).toHaveBeenNthCalledWith(
+        2,
+        'closure-1',
+        'closure_issue_manifest',
+      ),
+    );
+    expect(anchorClick).toHaveBeenCalledTimes(2);
+  });
+
+  it('polls a running check until its artifacts become ready', async () => {
+    jest.useFakeTimers();
+    mockGetClosureCheck
+      .mockResolvedValueOnce({
+        data: closureSummary({
+          runStatus: 'running',
+          certificateValidity: 'unavailable',
+          scanCompleteness: 'unknown',
+          artifacts: [
+            { artifactRole: 'closure_report_xlsx', artifactState: 'pending' },
+            { artifactRole: 'closure_issue_manifest', artifactState: 'pending' },
+          ],
+        }),
+        error: null,
+      })
+      .mockResolvedValueOnce({ data: closureSummary(), error: null });
+
+    render(<ClosureTaskDetail canDownloadReport closureCheckId='closure-1' />);
+    await act(async () => undefined);
+    expect(screen.getAllByText('Preparing this artifact.')).toHaveLength(2);
+
+    await act(async () => {
+      jest.advanceTimersByTime(closureCheckPollIntervalMs);
+      await Promise.resolve();
+    });
+
+    expect(mockGetClosureCheck).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole('button', { name: /Download issue report/ })).toBeInTheDocument();
+  });
+
+  it('shows an opaque load error and retries without navigating', async () => {
+    mockGetClosureCheck
+      .mockResolvedValueOnce({ data: null, error: { message: 'Detail request failed' } })
+      .mockResolvedValueOnce({ data: closureSummary(), error: null });
+
+    render(<ClosureTaskDetail canDownloadReport closureCheckId='closure-1' />);
+
+    expect(await screen.findByText('Detail request failed')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Refresh/ }));
+    expect(await screen.findByTestId('closure-task-detail-closure-1')).toBeInTheDocument();
+    expect(mockGetClosureCheck).toHaveBeenCalledTimes(2);
+  });
+
+  it('normalizes thrown detail failures and permits repeated retry', async () => {
+    mockGetClosureCheck
+      .mockRejectedValueOnce(new Error('Connection failed'))
+      .mockRejectedValueOnce('opaque failure')
+      .mockResolvedValueOnce({ data: closureSummary(), error: null });
+
+    render(<ClosureTaskDetail canDownloadReport closureCheckId='closure-1' />);
+
+    expect(await screen.findByText('Connection failed')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Refresh/ }));
+    expect(await screen.findByText('Task details are currently unavailable.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Refresh/ }));
+    expect(await screen.findByTestId('closure-task-detail-closure-1')).toBeInTheDocument();
+  });
+
+  it('uses the safe fallback when the detail response has no data or error', async () => {
+    mockGetClosureCheck.mockResolvedValueOnce({ data: null, error: null });
+
+    render(<ClosureTaskDetail canDownloadReport closureCheckId='closure-1' />);
+
+    expect(await screen.findByText('Task details are currently unavailable.')).toBeInTheDocument();
+  });
+
+  it('ignores both resolved and rejected detail requests after unmount', async () => {
+    let resolveRequest: ((value: any) => void) | undefined;
+    const resolvedAfterUnmount = new Promise((resolve) => {
+      resolveRequest = resolve;
+    });
+    mockGetClosureCheck.mockReturnValueOnce(resolvedAfterUnmount);
+    const first = render(<ClosureTaskDetail canDownloadReport closureCheckId='closure-1' />);
+    first.unmount();
+    await act(async () => {
+      resolveRequest?.({ data: closureSummary(), error: null });
+      await resolvedAfterUnmount;
+    });
+
+    let rejectRequest: ((reason: unknown) => void) | undefined;
+    const rejectedAfterUnmount = new Promise((_resolve, reject) => {
+      rejectRequest = reject;
+    });
+    mockGetClosureCheck.mockReturnValueOnce(rejectedAfterUnmount);
+    const second = render(<ClosureTaskDetail canDownloadReport closureCheckId='closure-1' />);
+    second.unmount();
+    await act(async () => {
+      rejectRequest?.(new Error('ignored after unmount'));
+      await Promise.resolve();
+    });
+  });
+
+  it('renders blockers, sparse progress, terminal guidance, and retained refresh errors', async () => {
+    mockGetClosureCheck
+      .mockResolvedValueOnce({
+        data: closureSummary({
+          runStatus: 'failed',
+          workerJob: { jobId: 'worker-1', errorCode: 'CLOSURE_FAILED' },
+        }),
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: closureSummary({
+          runStatus: 'failed',
+          workerJob: { jobId: 'worker-1', errorCode: 'CLOSURE_FAILED' },
+        }),
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: closureSummary({ runStatus: 'failed', workerJob: { jobId: 'worker-1' } }),
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: closureSummary({ runStatus: 'cancelled', blockerCodes: undefined, workerJob: null }),
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: closureSummary({
+          blockerCodes: ['MISSING_EXCHANGE'],
+          workerJob: { jobId: 'worker-sparse', phase: 'waiting' },
+        }),
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: closureSummary({ blockerCodes: ['MISSING_EXCHANGE'], workerJob: null }),
+        error: null,
+      })
+      .mockResolvedValueOnce({ data: null, error: { message: 'Refresh failed' } });
+
+    const { rerender } = render(
+      <ClosureTaskDetail
+        canDownloadReport
+        closureCheckId='closure-1'
+        errorSummary='Curated failure summary'
+        refreshSignal='1'
+      />,
+    );
+    expect(await screen.findByText('Curated failure summary')).toBeInTheDocument();
+
+    rerender(<ClosureTaskDetail canDownloadReport closureCheckId='closure-1' refreshSignal='2' />);
+    expect(await screen.findByText('CLOSURE_FAILED')).toBeInTheDocument();
+
+    rerender(<ClosureTaskDetail canDownloadReport closureCheckId='closure-1' refreshSignal='3' />);
+    expect(await screen.findByText(/The check did not complete\. Retry it/)).toBeInTheDocument();
+
+    rerender(<ClosureTaskDetail canDownloadReport closureCheckId='closure-1' refreshSignal='4' />);
+    expect(
+      await screen.findByText(
+        'Data completeness check was cancelled. Run a new check to continue.',
+      ),
+    ).toBeInTheDocument();
+
+    rerender(<ClosureTaskDetail canDownloadReport closureCheckId='closure-1' refreshSignal='5' />);
+    expect(await screen.findByText('MISSING_EXCHANGE')).toBeInTheDocument();
+    expect(screen.getByText('waiting')).toBeInTheDocument();
+    expect(screen.queryByText(/waiting ·/)).not.toBeInTheDocument();
+
+    rerender(<ClosureTaskDetail canDownloadReport closureCheckId='closure-1' refreshSignal='6' />);
+    await waitFor(() => expect(screen.queryByText('worker-sparse')).not.toBeInTheDocument());
+
+    rerender(<ClosureTaskDetail canDownloadReport closureCheckId='closure-1' refreshSignal='7' />);
+    expect(await screen.findByText('Refresh failed')).toBeInTheDocument();
+    expect(screen.getByTestId('closure-task-detail-closure-1')).toBeInTheDocument();
+  });
+
+  it('does not expose download actions without the feed capability', async () => {
+    render(<ClosureTaskDetail canDownloadReport={false} closureCheckId='closure-1' />);
+
+    expect(await screen.findByTestId('closure-task-detail-closure-1')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Download issue report/ })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Download machine result manifest/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('marks an expired role after 410 and normalizes thrown download failures', async () => {
+    mockCreateClosureReportDownload
+      .mockResolvedValueOnce({
+        data: null,
+        error: { code: 'expired_by_status' },
+        status: 410,
+      })
+      .mockResolvedValueOnce({
+        data: null,
+        error: { code: 'closure_report_expired' },
+        status: 400,
+      })
+      .mockRejectedValueOnce(new Error('private transport detail'));
+
+    render(<ClosureTaskDetail canDownloadReport closureCheckId='closure-1' />);
+    expect(await screen.findByTestId('closure-task-detail-closure-1')).toBeInTheDocument();
+
+    const reportButton = screen.getByRole('button', { name: /Download issue report/ });
+    fireEvent.click(reportButton);
+    fireEvent.click(reportButton);
+    await waitFor(() =>
+      expect(screen.getByTestId('closure-artifact-state-closure_report_xlsx')).toHaveTextContent(
+        'This artifact has expired.',
+      ),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Download machine result manifest/ }));
+    await waitFor(() =>
+      expect(message.error).toHaveBeenLastCalledWith(
+        'This download is currently unavailable. Please try again later.',
+      ),
+    );
+    expect(screen.queryByText('private transport detail')).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/LcaTaskCenter.test.tsx
+++ b/tests/unit/components/LcaTaskCenter.test.tsx
@@ -26,6 +26,15 @@ const mockSubscribeLcaTaskCenterOpenRequests = jest.fn(() => jest.fn());
 const mockRefreshDataProductTasks = jest.fn();
 const mockSubscribeDataProductTasks = jest.fn(() => jest.fn());
 
+jest.mock('@/components/ClosureTaskDetail', () => ({
+  __esModule: true,
+  default: ({ canDownloadReport, closureCheckId, refreshSignal }: any) => (
+    <div data-testid={`mock-closure-detail-${closureCheckId}`}>
+      {`${canDownloadReport}:${refreshSignal}`}
+    </div>
+  ),
+}));
+
 const formatWithValues = (message: string, values?: Record<string, any>) =>
   Object.entries(values ?? {}).reduce((text, [key, value]) => {
     return text.replace(`{${key}}`, String(value));
@@ -94,6 +103,8 @@ jest.mock('@ant-design/icons', () => ({
 
 jest.mock('antd', () => {
   const React = require('react');
+
+  const Alert = ({ message: alertMessage }: any) => <div role='alert'>{alertMessage}</div>;
 
   const Badge = ({ count, children }: any) => (
     <div>
@@ -214,6 +225,7 @@ jest.mock('antd', () => {
 
   return {
     __esModule: true,
+    Alert,
     Badge,
     Button,
     Empty,
@@ -1604,5 +1616,94 @@ describe('LcaTaskCenter', () => {
     expect(screen.queryByText('Closure passed')).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('tab', { name: 'Data Product' }));
     expect(screen.getByText('Package running')).toBeInTheDocument();
+  });
+
+  it('expands closure details in place and keeps them open across feed refreshes', () => {
+    const closureTask = {
+      schemaVersion: 'task-summary.v2',
+      category: 'data_product',
+      jobId: 'closure-job',
+      id: 'closure-job',
+      jobKind: 'lcia.scope_closure_check',
+      title: 'Recoverable closure check',
+      workerStatus: 'running',
+      runState: 'active',
+      domainValidity: 'pending',
+      projectionUpdatedAt: '2026-07-22T00:00:00Z',
+      progressFraction: 0.25,
+      capabilities: {
+        canCancel: false,
+        canDownloadReport: true,
+        canOpenWorkbench: true,
+        canPreviewResult: false,
+      },
+      deepLink: {
+        routeKey: 'data_product.closure_check',
+        params: { closureCheckId: 'closure-1' },
+      },
+      createdAt: '2026-07-22T00:00:00Z',
+      updatedAt: '2026-07-22T00:00:00Z',
+    };
+    mockDataProductTasks = [closureTask];
+
+    const { rerender } = render(<LcaTaskCenter />);
+    fireEvent.click(screen.getByRole('button', { name: 'open-lca-task-center' }));
+
+    expect(screen.queryByRole('button', { name: 'Open' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('mock-closure-detail-closure-1')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'View' }));
+    expect(screen.getByTestId('mock-closure-detail-closure-1')).toHaveTextContent(
+      'true:running:2026-07-22T00:00:00Z',
+    );
+
+    mockDataProductTasks = [
+      {
+        ...closureTask,
+        workerStatus: 'completed',
+        runState: 'succeeded',
+        updatedAt: '2026-07-22T00:01:00Z',
+      },
+    ];
+    rerender(<LcaTaskCenter />);
+
+    expect(screen.getByTestId('mock-closure-detail-closure-1')).toHaveTextContent(
+      'true:completed:2026-07-22T00:01:00Z',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'View' }));
+    expect(screen.queryByTestId('mock-closure-detail-closure-1')).not.toBeInTheDocument();
+  });
+
+  it('fails closed in place when a closure task has no safe closure id', () => {
+    mockDataProductTasks = [
+      {
+        schemaVersion: 'task-summary.v2',
+        category: 'data_product',
+        jobId: 'closure-without-id',
+        id: 'closure-without-id',
+        jobKind: 'lcia.scope_closure_check',
+        title: 'Closure without detail identity',
+        workerStatus: 'completed',
+        runState: 'succeeded',
+        domainValidity: 'valid',
+        projectionUpdatedAt: '2026-07-22T00:00:00Z',
+        capabilities: {
+          canCancel: false,
+          canDownloadReport: false,
+          canOpenWorkbench: true,
+          canPreviewResult: false,
+        },
+        createdAt: '2026-07-22T00:00:00Z',
+        updatedAt: '2026-07-22T00:00:00Z',
+      },
+    ];
+
+    render(<LcaTaskCenter />);
+    fireEvent.click(screen.getByRole('button', { name: 'open-lca-task-center' }));
+    fireEvent.click(screen.getByRole('button', { name: 'View' }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Task details are currently unavailable.');
+    expect(screen.queryByText('Open')).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/pages/DataProcessing/index.test.tsx
+++ b/tests/unit/pages/DataProcessing/index.test.tsx
@@ -2709,6 +2709,10 @@ describe('DataProcessing page', () => {
     await waitFor(() =>
       expect(screen.getByRole('button', { name: 'Check data completeness' })).not.toBeDisabled(),
     );
+    expect(mockHistoryReplace).toHaveBeenCalledWith({
+      pathname: '/data-processing',
+      search: '?closureCheckId=closure-new&tab=builds',
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Check data completeness' }));
     await waitFor(() => expect(mockCreateClosureCheck).toHaveBeenCalledTimes(2));
     expect(mockCreateClosureCheck.mock.calls[0][0].requestIdempotencyToken).toEqual(


### PR DESCRIPTION
## Summary

- Replace the completeness-check task redirect with an inline expandable detail panel in Task Center.
- Load durable closure-check state from the backend and expose capability-gated XLSX and machine-manifest downloads in the expanded panel.
- Persist newly created closureCheckId values in the Data Processing URL so refresh restores the active check.

## Key decisions

- Reuse one ClosureTaskDetail/ClosureArtifactList implementation across Task Center and Data Processing, including bounded polling, client expiry, and role-specific signed downloads.
- Keep result-package tasks on the existing workbench navigation path; only lcia.scope_closure_check tasks expand inline.

## Validation

- Managed pre-push gate passed: docpact, LCIA cache, reference data, lint, TypeScript, 408 suites / 5517 tests, and 100% coverage for 459 tracked source files.
- Focused regression passed: ClosureTaskDetail, LcaTaskCenter, and DataProcessing (80 tests).
- Production build and locale artifact idempotence checks passed.

## Risk and rollback

UI-only consumer change. No backend schema or command contract changes. Roll back commit dc3e43ff if needed.

## Workspace integration

After merge to Next dev, promotion to Next main is required before root workspace main may update the submodule pointer.

Closes #754