### PR TITLE
test: qualify dev candidate for v0.0.65

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-01"
-lastReviewedCommit: "b8b32228f6debd2165512c26fc186801bd3bcfe2"
-lastReviewedNote: 'Reviewed for Issues #745 and #748: the unified dataset-review routes and the exact-commit, loopback-only scope-closure qualification test surface preserve the existing production-write, branch, release, and workspace-integration boundaries.'
+lastReviewedAt: "2026-08-02"
+lastReviewedCommit: "4680e5a7ab67800268ae1627af999a4480cea646"
+lastReviewedNote: 'Reviewed for Issue #756 after qualifying the current dev candidate: the 60-pass/24-designed-skip, zero-external-request, zero-production-write result preserves the existing routing, testing-gate, release, and workspace-integration boundaries.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,9 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-08-01
-lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
-lastReviewedNote: 'Reviewed for Issues #745 and #748: unified dataset review and the isolated exact-commit scope-closure adapter preserve frontend ownership, dev-first branch policy, production-write authorization, validation gates, and root integration ownership.'
+lastReviewedAt: 2026-08-02
+lastReviewedCommit: 4680e5a7ab67800268ae1627af999a4480cea646
+lastReviewedNote: 'Reviewed for Issue #756 after qualifying the current dev candidate: the credential-free 60-pass/24-designed-skip receipt does not alter frontend ownership, dev-first branch policy, production-write authorization, validation gates, or root integration ownership.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -28,9 +28,9 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - .nvmrc
-lastReviewedAt: 2026-08-01
-lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
-lastReviewedNote: 'Reviewed for Issues #745 and #748: local bootstrap now includes isolated exact-commit browser qualification while retaining the focused validation, dev PR, managed gate, promotion, production-data, and workspace-integration sequence.'
+lastReviewedAt: 2026-08-02
+lastReviewedCommit: 4680e5a7ab67800268ae1627af999a4480cea646
+lastReviewedNote: 'Reviewed for Issue #756 after qualifying the current dev candidate: the generated credential-free receipt follows the existing clean qualification, normal dev PR, production-preflight, promotion, and workspace-integration sequence.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-08-01
-lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
-lastReviewedNote: 'Reviewed for Issues #745 and #748: unified dataset review and the isolated qualification adapter retain the existing dev PR, docpact, lint, coverage, build, and managed-gate policy.'
+lastReviewedAt: 2026-08-02
+lastReviewedCommit: 4680e5a7ab67800268ae1627af999a4480cea646
+lastReviewedNote: 'Reviewed for Issue #756 after qualifying the current dev candidate: the generated credential-free receipt follows the existing normal dev PR, managed-push, production-authorization, and release-trigger policy.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-08-01
-lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
-lastReviewedNote: 'Reviewed for Issues #745 and #748: retain focused unified-review proof and the managed full gate, and add exact-clean-commit loopback browser qualification that emits only non-sensitive Next consumer leaves for Worker aggregation.'
+lastReviewedAt: 2026-08-02
+lastReviewedCommit: 4680e5a7ab67800268ae1627af999a4480cea646
+lastReviewedNote: 'Reviewed for Issue #756 after qualifying the current dev candidate: 60 browser cases passed, 24 designed cases skipped, all 49 IDs closed, and external requests and production writes stayed zero; the receipt, preflight, and managed-gate flow remains accurate.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -26,9 +26,9 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - package.json
-lastReviewedAt: 2026-08-01
-lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
-lastReviewedNote: 'Reviewed for Issues #745 and #748: both changes follow the maintained focused-test plus final-gate strategy and require no testing-strategy expansion.'
+lastReviewedAt: 2026-08-02
+lastReviewedCommit: 4680e5a7ab67800268ae1627af999a4480cea646
+lastReviewedNote: 'Reviewed for Issue #756 after qualifying the current dev candidate: the credential-free 60-pass/24-designed-skip, 49-ID result validates the maintained strategy and requires no testing-strategy expansion.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -28,9 +28,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-01
-lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
-lastReviewedNote: 'Reviewed for Issues #745 and #748: focused unified-review coverage and isolated Chromium proof for artifact states, direct downloads, localization, and every relevant role create no repository-wide coverage backlog item.'
+lastReviewedAt: 2026-08-02
+lastReviewedCommit: 4680e5a7ab67800268ae1627af999a4480cea646
+lastReviewedNote: 'Reviewed for Issue #756 after qualifying the current dev candidate: 60 passes, 24 designed skips, complete 49-ID closure, zero external requests, and zero production writes create no repository-wide coverage backlog item.'
 ---
 
 # Testing Execution State
@@ -61,6 +61,7 @@ This is a checked-in reference, not a per-PR execution ledger. A delivery's post
 - Issue #635 adds a separate Playwright semantic localization proof surface: `npm run test:e2e:i18n` derives all locale/content-language expectations from registries, binds 49 stable route/view assertion IDs, runs Chromium across the complete matrix, and requires the login/selector, team authoring, and process lifecycle critical scenarios in Chromium, Firefox, and WebKit
 - semantic E2E GitHub Actions is credential-free/read-only and runs only contract discovery plus three-browser public semantics; it is optional through `workflow_dispatch`, mandatory for the exact release SHA, and absent from routine PR/dev triggers, while authenticated candidate-local/production-backend closure is restricted to an explicitly authorized local operator session with authenticated mode, both production-write guards, and an explicit verified-evidence opt-in
 - Issue #654 adds `e2e:env:install`, read-only `e2e:env:doctor`, exact-candidate `e2e:release`, argument-free bounded `e2e:release:resume`, owned cleanup, and focused `e2e:dev`; release mode archives only a clean Next commit, uses a digest-pinned container and cached production build, performs all safe checks before fixture intent, and never mounts the workspace
+- Issue #756 qualifies exact `dev` commit `4680e5a7ab67800268ae1627af999a4480cea646` for the v0.0.65 promotion: 48 canonical cases plus 12 harness-control cases passed across Chromium, Firefox, and WebKit, 24 designed cases skipped, all 49 assertion IDs closed, and external requests and production writes remained zero. The generated receipt must merge through the normal `dev` PR flow before production-readiness proof resumes from the resulting clean candidate.
 - Issue #743 first refreshed the credential-free semantic-harness qualification for exact `dev` commit `3ac0ca60a7370d767ca003342180bb51f1b2dd7d`; that receipt merged through PR #744 before the clean production run. The evidence-bearing v0.0.64 commit `1cf3f5accdbf4ef745022ed69d8815e851df833f` was then requalified with 48 canonical cases plus 12 harness-control cases passed, 24 designed cases skipped, all 49 assertion IDs closed, and external requests, production writes, and cleanup residue all zero. The receipt path remains outside its own qualification digest, so committing this generated receipt preserves the qualified input identity.
 - Issue #704 tracks two harness defects observed during authenticated production evidence refreshes. The evidence-writer repair now resolves the repository-owned Prettier configuration independently of `/e2e-output` and gives the checker a read-only external-artifact path, so raw container bytes can satisfy the same canonical contract without host normalization. The separate argument-free `e2e:release:resume` dispatch defect remains open under #704.
 - Issue #660 keeps production-data E2E fail-closed on real CI hosts while allowing an authorized local run to override only the release image's inherited `CI`/`GITHUB_ACTIONS` markers before the unchanged in-container authorization and ledger checks

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -29,9 +29,9 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-01
-lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
-lastReviewedNote: 'Reviewed for Issues #745 and #748: retain focused unit, service-boundary, locale, semantic localization E2E, and managed-gate patterns while adding the exact-commit loopback-only scope-closure qualification pattern.'
+lastReviewedAt: 2026-08-02
+lastReviewedCommit: 4680e5a7ab67800268ae1627af999a4480cea646
+lastReviewedNote: 'Reviewed for Issue #756 after qualifying the current dev candidate: the credential-free 60-pass/24-designed-skip receipt and complete 49-ID binding validate the existing semantic E2E and managed-gate patterns.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -26,9 +26,9 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-01
-lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
-lastReviewedNote: 'Reviewed for Issues #745 and #748: retain Watchman-free focused Jest and serial managed-gate guidance, and add the shortest clean-commit loopback adapter recovery path without changing release-E2E troubleshooting.'
+lastReviewedAt: 2026-08-02
+lastReviewedCommit: 4680e5a7ab67800268ae1627af999a4480cea646
+lastReviewedNote: 'Reviewed for Issue #756 after qualifying the current dev candidate: the existing clean-candidate, stale-receipt, Docker, and serial-gate guidance covered the 60-pass/24-designed-skip run without a new exception.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "0a610273e4a23d7c253b424402358d9dfd1a3822f5f87802d8a9872f765d14a6"
+    "runResultSha256": "3532f8ba44bf7fe3f7d5164351cbed1aa4e0f82c43e8f86643b43b71cddf2bcc"
   },
-  "environmentManifestSha256": "0c6f7d99fbd2c1072a3943da942ed5570c1746886e48ca7f2619955aafb9ca8c",
+  "environmentManifestSha256": "6e65688213d0c52cc2fb68f2e1fc842b29bf95b9c896e12beedb004a7101a00a",
   "externalRequests": 0,
-  "generatedAt": "2026-07-31T04:11:30.974Z",
+  "generatedAt": "2026-08-01T16:51:24.130Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "834a4ca3967caac433eb71674ff943f75de5a21335dd947a76c353cc0879ab11",
-  "qualifiedCommit": "1cf3f5accdbf4ef745022ed69d8815e851df833f",
-  "qualifiedTree": "6549269511a66228771f2704d4a5762785f7bf0f",
+  "qualificationInputSha256": "3abc6f198a615d2e00e63456a2c6b57cbd27a3c4c7ad13f2926d12e13aef697b",
+  "qualifiedCommit": "4680e5a7ab67800268ae1627af999a4480cea646",
+  "qualifiedTree": "d070e63a4175224c643a274d6ed85c9e391c2d91",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }


### PR DESCRIPTION
## Summary
- Refs #756. Records the credential-free semantic-harness qualification for exact dev commit 4680e5a7ab67800268ae1627af999a4480cea646.
- Updates the governed testing and release documentation review metadata required by Docpact; no product code or release version changes.

## Key Decisions
- Keep the generated qualification receipt in a separate normal dev PR before resuming production-readiness proof from a clean merged candidate.
- Preserve the existing production-write authorization boundary: this qualification made zero external requests and zero production writes.

## Validation
- npm run e2e:qualify: 60 passed, 24 designed skips, all 49 assertion IDs closed across Chromium, Firefox, and WebKit.
- npm run e2e:qualification:check: passed.
- Docpact enforce lint and strict config validation: passed.
- Managed push gate: lint/type checks passed; 459/459 source files reached 100% statements, branches, functions, and lines.

## Risks / Rollback
- Low: generated evidence and documentation review metadata only. Roll back by reverting aff8d8ad.

## Follow-ups
- Merge this PR into dev, then rerun release:preflight from the resulting clean candidate. Issue #756 remains open for v0.0.65 promotion.

## Workspace Integration
- No root submodule update is eligible from this dev-only receipt PR; workspace integration waits for the eventual v0.0.65 commit on Next main.