### PR TITLE
chore: 重绑定持久化 Supabase Dev 项目

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-02"
-lastReviewedCommit: "92aeaa72d760ee9121d021b171a8cd7e8715fc35"
-lastReviewedNote: 'Reviewed for Issue #745 root-grouped review queues: the existing page, service, review-management, and focused-test routing covers the change without altering gate, release, or workspace-integration governance.'
+lastReviewedAt: "2026-08-05"
+lastReviewedCommit: "d9f581bb98eec6736ea1378bb9f7b00730489522"
+lastReviewedNote: 'Reviewed for Issue #768: replacing the persistent-dev URL, publishable key, and data-workflow target stays within existing frontend environment, test, gate, and workspace-integration ownership.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-SUPABASE_URL=https://fotofiyqnuyvgtotswie.supabase.co
-SUPABASE_PUBLISHABLE_KEY=sb_publishable_Im0PtYHMrb-0GYycYVyEjQ_40Ven0Ul
+SUPABASE_URL=https://submidrhbtknjxfympna.supabase.co
+SUPABASE_PUBLISHABLE_KEY=sb_publishable_TvheZTg72EqOXB_HZ_XJtg_VjyILlDP

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,9 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-08-02
-lastReviewedCommit: 92aeaa72d760ee9121d021b171a8cd7e8715fc35
-lastReviewedNote: 'Reviewed for Issue #745 root-grouped review queues: frontend ownership, dev-first delivery, database authorization, validation gates, and later root integration ownership remain unchanged.'
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: d9f581bb98eec6736ea1378bb9f7b00730489522
+lastReviewedNote: 'Reviewed for Issue #768: the persistent-dev environment identity changed after database recreation; frontend ownership, dev-first delivery, validation gates, and workspace integration remain unchanged.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -28,9 +28,9 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - .nvmrc
-lastReviewedAt: 2026-08-02
-lastReviewedCommit: 92aeaa72d760ee9121d021b171a8cd7e8715fc35
-lastReviewedNote: 'Reviewed for Issue #745 root-grouped review queues: the existing focused-validation, lint, build, managed-push, dev-PR, and later workspace-integration sequence remains accurate.'
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: d9f581bb98eec6736ea1378bb9f7b00730489522
+lastReviewedNote: 'Reviewed for Issue #768: `npm start` continues to use the checked-in development environment, now rebound to the recreated persistent Dev; bootstrap and validation commands remain unchanged.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-08-03
-lastReviewedCommit: ff84088124ed4ab54c09b0179af813888bdb6cc1
-lastReviewedNote: 'Reviewed for Issue #745 root-grouped review queues: focused tests plus the existing Docpact and managed full-gate policy remain sufficient; no trigger or quality-bar change is introduced.'
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: d9f581bb98eec6736ea1378bb9f7b00730489522
+lastReviewedNote: 'Reviewed for Issue #768: the mechanical Dev target replacement does not change protected-branch triggers, managed full-gate behavior, or the quality bar.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-08-02
-lastReviewedCommit: 92aeaa72d760ee9121d021b171a8cd7e8715fc35
-lastReviewedNote: 'Reviewed for Issue #745 root-grouped review queues: focused review-page and service suites, lint, type checking, and production build remain the correct proof; the managed full gate remains unchanged.'
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: d9f581bb98eec6736ea1378bb9f7b00730489522
+lastReviewedNote: 'Reviewed for Issue #768: data-workflow target tests plus the existing lint, type, build, coverage, and managed full gate remain the correct proof for the Dev environment rebind.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -26,9 +26,9 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - package.json
-lastReviewedAt: 2026-08-03
-lastReviewedCommit: ff84088124ed4ab54c09b0179af813888bdb6cc1
-lastReviewedNote: 'Reviewed for Issue #745 root-grouped review queues: behavior-focused component and service tests protect the changed workflow without expanding the repository testing strategy.'
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: d9f581bb98eec6736ea1378bb9f7b00730489522
+lastReviewedNote: 'Reviewed for Issue #768: updating one environment identity and its exact assertions does not expand or change the repository testing strategy.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -28,9 +28,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-03
-lastReviewedCommit: ff84088124ed4ab54c09b0179af813888bdb6cc1
-lastReviewedNote: 'Reviewed for Issue #745 root-grouped review queues: the focused passing suites and unchanged full-closure policy create no repository-wide coverage backlog item.'
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: d9f581bb98eec6736ea1378bb9f7b00730489522
+lastReviewedNote: 'Reviewed for Issue #768: exact Dev target replacement creates no new testing backlog or coverage exception; the full-closure policy remains unchanged.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -29,9 +29,9 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-03
-lastReviewedCommit: ff84088124ed4ab54c09b0179af813888bdb6cc1
-lastReviewedNote: 'Reviewed for Issue #745 root-grouped review queues: existing component/service patterns cover tab-context grouping, child actions, permissions, and error handling without a new test pattern.'
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: d9f581bb98eec6736ea1378bb9f7b00730489522
+lastReviewedNote: 'Reviewed for Issue #768: updating environment fixtures and their exact target assertions uses existing test patterns and introduces no new helper or test type.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -26,9 +26,9 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-03
-lastReviewedCommit: ff84088124ed4ab54c09b0179af813888bdb6cc1
-lastReviewedNote: 'Reviewed for Issue #745 root-grouped review queues: the existing focused Jest and serial managed-gate recovery guidance remains accurate; no new troubleshooting exception is required.'
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: d9f581bb98eec6736ea1378bb9f7b00730489522
+lastReviewedNote: 'Reviewed for Issue #768: the existing focused Jest and serial managed-gate recovery guidance remains accurate for an environment-target replacement.'
 ---
 
 # Testing Troubleshooting

--- a/tests/data-workflows/test-api-smoke.cjs
+++ b/tests/data-workflows/test-api-smoke.cjs
@@ -79,7 +79,7 @@ const FAILURE_TAIL_LINE_COUNT = 5;
 const HELP_TEXT = `API smoke workflow suite
 
 Usage:
-  npm run test:api:smoke -- --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co --supabase-publishable-key <key>
+  npm run test:api:smoke -- --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co --supabase-publishable-key <key>
   npm run test:api:smoke -- --detail-result --no-keep-data
   npm run test:api:smoke -- --list
 

--- a/tests/data-workflows/test-workflows.ts
+++ b/tests/data-workflows/test-workflows.ts
@@ -108,9 +108,9 @@ export function formatWorkflowRunnerHelp(registry: Map<string, WorkflowCommand>)
   return `Data workflow test runner
 
 Usage:
-  npm run test:workflows -- --processes:create --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co --supabase-publishable-key <key>
-  npm run test:workflows -- --processes:all --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co --supabase-publishable-key <key>
-  npm run test:workflows -- --teams:all --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co --supabase-publishable-key <key>
+  npm run test:workflows -- --processes:create --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co --supabase-publishable-key <key>
+  npm run test:workflows -- --processes:all --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co --supabase-publishable-key <key>
+  npm run test:workflows -- --teams:all --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co --supabase-publishable-key <key>
   npm run test:workflows -- --list
 
 Behavior:

--- a/tests/data-workflows/unit/contacts/contacts-check-data-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/contacts/contacts-check-data-workflow-lib.test.ts
@@ -32,7 +32,7 @@ describe('contacts-check-data-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--data-file',
@@ -48,7 +48,7 @@ describe('contacts-check-data-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.checkDataFile).toBe('/repo/fixtures/check.json');
     expect(options.keepData).toBe(true);
@@ -216,9 +216,9 @@ describe('contacts-check-data-workflow-lib', () => {
           userId: 'user-1',
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
         updateStep: {
@@ -254,7 +254,7 @@ describe('contacts-check-data-workflow-lib', () => {
       version: '01.01.000',
     });
     expect(runtimeRecord.create.runtimeId).toBe('contact-1');
-    expect(runtimeRecord.supabase.projectId).toBe('fotofiyqnuyvgtotswie');
+    expect(runtimeRecord.supabase.projectId).toBe('submidrhbtknjxfympna');
   });
 
   it('runs the create-then-update workflow against one contact record and writes a runtime record', async () => {
@@ -490,7 +490,7 @@ describe('contacts-check-data-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/contacts/contacts-create-contribute-team-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/contacts/contacts-create-contribute-team-workflow-lib.test.ts
@@ -106,7 +106,7 @@ describe('contacts-create-contribute-team-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--keep-created',
@@ -120,7 +120,7 @@ describe('contacts-create-contribute-team-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
@@ -254,9 +254,9 @@ describe('contacts-create-contribute-team-workflow-lib', () => {
           userId: 'user-1',
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
       },
@@ -439,7 +439,7 @@ describe('contacts-create-contribute-team-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/contacts/contacts-create-version-update-reference-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/contacts/contacts-create-version-update-reference-workflow-lib.test.ts
@@ -170,7 +170,7 @@ describe('contacts-create-version-update-reference-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--data-file',
         'fixtures/004.json',
         '--keep-created',
@@ -183,7 +183,7 @@ describe('contacts-create-version-update-reference-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.dataFile).toBe('/repo/fixtures/004.json');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
@@ -319,9 +319,9 @@ describe('contacts-create-version-update-reference-workflow-lib', () => {
           userId: 'user-1',
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
         updateReferenceStep: {
@@ -533,7 +533,7 @@ describe('contacts-create-version-update-reference-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/contacts/contacts-create-view-copy-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/contacts/contacts-create-view-copy-workflow-lib.test.ts
@@ -127,7 +127,7 @@ describe('contacts-create-view-copy-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--keep-created',
@@ -141,7 +141,7 @@ describe('contacts-create-view-copy-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
@@ -313,9 +313,9 @@ describe('contacts-create-view-copy-workflow-lib', () => {
           expectationResults: [{ actual: true, label: 'view source', passed: true }],
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
         viewCopyStep: {
@@ -533,7 +533,7 @@ describe('contacts-create-view-copy-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/contacts/contacts-create-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/contacts/contacts-create-workflow-lib.test.ts
@@ -25,7 +25,7 @@ describe('contacts-create-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--keep-data',
         '--generate-id',
         '--no-verify-frontend',
@@ -35,7 +35,7 @@ describe('contacts-create-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
     expect(options.verifyFrontend).toBe(false);
@@ -175,16 +175,16 @@ describe('contacts-create-workflow-lib', () => {
       {
         supabaseProjectUrl: undefined,
         supabasePublishableKey: undefined,
-        supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
       },
       {
         SUPABASE_PUBLISHABLE_KEY: 'sb_publishable_test_key',
       } as NodeJS.ProcessEnv,
     );
 
-    expect(target.apiUrl).toBe('https://fotofiyqnuyvgtotswie.supabase.co');
-    expect(target.dashboardUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
-    expect(target.projectId).toBe('fotofiyqnuyvgtotswie');
+    expect(target.apiUrl).toBe('https://submidrhbtknjxfympna.supabase.co');
+    expect(target.dashboardUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
+    expect(target.projectId).toBe('submidrhbtknjxfympna');
     expect(target.publishableKey).toBe('sb_publishable_test_key');
   });
 
@@ -380,9 +380,9 @@ describe('contacts-create-workflow-lib', () => {
           },
           submittedRuleVerification: false,
           supabaseTarget: {
-            apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-            dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-            projectId: 'fotofiyqnuyvgtotswie',
+            apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+            dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+            projectId: 'submidrhbtknjxfympna',
             publishableKey: 'sb_publishable_test_key',
           },
         },

--- a/tests/data-workflows/unit/contacts/contacts-edit-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/contacts/contacts-edit-workflow-lib.test.ts
@@ -29,7 +29,7 @@ describe('contacts-edit-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--success-data-file',
@@ -47,7 +47,7 @@ describe('contacts-edit-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.successDataFile).toBe('/repo/fixtures/success.json');
     expect(options.editDataFile).toBe('/repo/fixtures/fail.json');
@@ -222,9 +222,9 @@ describe('contacts-edit-workflow-lib', () => {
           unRuleVerificationCount: 0,
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
       },
@@ -558,7 +558,7 @@ describe('contacts-edit-workflow-lib', () => {
           successDataFile,
           successExpectedFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/flowproperties/flowproperties-create-contribute-team-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/flowproperties/flowproperties-create-contribute-team-workflow-lib.test.ts
@@ -217,7 +217,7 @@ describe('flowproperties-create-contribute-team-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/flows/flows-check-data-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/flows/flows-check-data-workflow-lib.test.ts
@@ -32,7 +32,7 @@ describe('flows-check-data-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--data-file',
@@ -48,7 +48,7 @@ describe('flows-check-data-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.checkDataFile).toBe('/repo/fixtures/check.json');
     expect(options.keepData).toBe(true);
@@ -215,9 +215,9 @@ describe('flows-check-data-workflow-lib', () => {
           userId: 'user-1',
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
         updateStep: {
@@ -253,7 +253,7 @@ describe('flows-check-data-workflow-lib', () => {
       user_id: 'user-1',
       version: '01.01.000',
     });
-    expect(runtimeRecord.supabase.projectId).toBe('fotofiyqnuyvgtotswie');
+    expect(runtimeRecord.supabase.projectId).toBe('submidrhbtknjxfympna');
   });
 
   it('runs the create-then-update workflow against one flow record and writes a runtime record', async () => {
@@ -491,7 +491,7 @@ describe('flows-check-data-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/flows/flows-create-contribute-team-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/flows/flows-create-contribute-team-workflow-lib.test.ts
@@ -108,7 +108,7 @@ describe('flows-create-contribute-team-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--keep-created',
@@ -122,7 +122,7 @@ describe('flows-create-contribute-team-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
@@ -256,9 +256,9 @@ describe('flows-create-contribute-team-workflow-lib', () => {
           userId: 'user-1',
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
       },
@@ -442,7 +442,7 @@ describe('flows-create-contribute-team-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/flows/flows-create-version-update-reference-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/flows/flows-create-version-update-reference-workflow-lib.test.ts
@@ -140,7 +140,7 @@ describe('flows-create-version-update-reference-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--data-file',
         'fixtures/004.json',
         '--keep-created',
@@ -153,7 +153,7 @@ describe('flows-create-version-update-reference-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.dataFile).toBe('/repo/fixtures/004.json');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
@@ -311,9 +311,9 @@ describe('flows-create-version-update-reference-workflow-lib', () => {
           userId: 'user-1',
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
         updateReferenceStep: {
@@ -526,7 +526,7 @@ describe('flows-create-version-update-reference-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/flows/flows-create-view-copy-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/flows/flows-create-view-copy-workflow-lib.test.ts
@@ -129,7 +129,7 @@ describe('flows-create-view-copy-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--keep-created',
@@ -143,7 +143,7 @@ describe('flows-create-view-copy-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
@@ -307,9 +307,9 @@ describe('flows-create-view-copy-workflow-lib', () => {
           expectationResults: [{ actual: true, label: 'view source', passed: true }],
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
         viewCopyStep: {
@@ -523,7 +523,7 @@ describe('flows-create-view-copy-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/flows/flows-create-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/flows/flows-create-workflow-lib.test.ts
@@ -25,7 +25,7 @@ describe('flows-create-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--keep-data',
         '--generate-id',
         '--no-verify-frontend',
@@ -35,7 +35,7 @@ describe('flows-create-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
     expect(options.verifyFrontend).toBe(false);
@@ -173,16 +173,16 @@ describe('flows-create-workflow-lib', () => {
       {
         supabaseProjectUrl: undefined,
         supabasePublishableKey: undefined,
-        supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
       },
       {
         SUPABASE_PUBLISHABLE_KEY: 'sb_publishable_test_key',
       } as NodeJS.ProcessEnv,
     );
 
-    expect(target.apiUrl).toBe('https://fotofiyqnuyvgtotswie.supabase.co');
-    expect(target.dashboardUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
-    expect(target.projectId).toBe('fotofiyqnuyvgtotswie');
+    expect(target.apiUrl).toBe('https://submidrhbtknjxfympna.supabase.co');
+    expect(target.dashboardUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
+    expect(target.projectId).toBe('submidrhbtknjxfympna');
     expect(target.publishableKey).toBe('sb_publishable_test_key');
   });
 
@@ -364,9 +364,9 @@ describe('flows-create-workflow-lib', () => {
           },
           submittedRuleVerification: false,
           supabaseTarget: {
-            apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-            dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-            projectId: 'fotofiyqnuyvgtotswie',
+            apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+            dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+            projectId: 'submidrhbtknjxfympna',
             publishableKey: 'sb_publishable_test_key',
           },
         },

--- a/tests/data-workflows/unit/flows/flows-edit-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/flows/flows-edit-workflow-lib.test.ts
@@ -29,7 +29,7 @@ describe('flows-edit-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--success-data-file',
@@ -47,7 +47,7 @@ describe('flows-edit-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.successDataFile).toBe('/repo/fixtures/success.json');
     expect(options.editDataFile).toBe('/repo/fixtures/fail.json');
@@ -222,9 +222,9 @@ describe('flows-edit-workflow-lib', () => {
           unRuleVerificationCount: 0,
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
       },
@@ -542,7 +542,7 @@ describe('flows-edit-workflow-lib', () => {
           successDataFile,
           successExpectedFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/lifecyclemodels/lifecyclemodels-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/lifecyclemodels/lifecyclemodels-workflow-lib.test.ts
@@ -119,7 +119,7 @@ describe('lifecyclemodels-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--supabase-publishable-key',
         'sb_publishable_test_key',
         '--seed-process-data-file',
@@ -132,7 +132,7 @@ describe('lifecyclemodels-workflow-lib', () => {
 
     expect(options.role).toBe('team-member');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.supabasePublishableKey).toBe('sb_publishable_test_key');
     expect(options.keepData).toBe(false);
     expect(options.seedProcessDataFile).toBe(
@@ -242,7 +242,7 @@ describe('lifecyclemodels-workflow-lib', () => {
             'tests/data-workflows/fixtures/data/processes/002_check_data_success.json',
           ),
           supabasePublishableKey: 'sb_publishable_test_key',
-          supabaseUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
+          supabaseUrl: 'https://submidrhbtknjxfympna.supabase.co',
           usersFile: path.join(tempRoot, 'missing-users.json'),
           verifyFrontend: false,
           writeRuntime: true,
@@ -379,7 +379,7 @@ describe('lifecyclemodels-workflow-lib', () => {
             'tests/data-workflows/fixtures/data/processes/002_check_data_success.json',
           ),
           supabasePublishableKey: 'sb_publishable_test_key',
-          supabaseUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
+          supabaseUrl: 'https://submidrhbtknjxfympna.supabase.co',
           usersFile: path.join(tempRoot, 'missing-users.json'),
           verifyFrontend: false,
           writeRuntime: true,
@@ -473,7 +473,7 @@ describe('lifecyclemodels-workflow-lib', () => {
             'tests/data-workflows/fixtures/data/processes/002_check_data_success.json',
           ),
           supabasePublishableKey: 'sb_publishable_test_key',
-          supabaseUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
+          supabaseUrl: 'https://submidrhbtknjxfympna.supabase.co',
           usersFile: path.join(tempRoot, 'missing-users.json'),
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/processes/processes-check-data-runtime-references-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/processes/processes-check-data-runtime-references-workflow-lib.test.ts
@@ -621,7 +621,7 @@ describe('processes-check-data-runtime-references-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--contact-data-file',
         'fixtures/contact.json',
         '--flow-data-file',
@@ -636,7 +636,7 @@ describe('processes-check-data-runtime-references-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.contactDataFile).toBe('/repo/fixtures/contact.json');
     expect(options.flowDataFile).toBe('/repo/fixtures/flow.json');
     expect(options.checkDataFile).toBe('/repo/fixtures/process-check.json');
@@ -900,9 +900,9 @@ describe('processes-check-data-runtime-references-workflow-lib', () => {
           submittedRuleVerification: true,
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
         validation: {
@@ -1381,7 +1381,7 @@ describe('processes-check-data-runtime-references-workflow-lib', () => {
           sourceDataFile,
           sourceExpectedFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/processes/processes-check-data-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/processes/processes-check-data-workflow-lib.test.ts
@@ -32,7 +32,7 @@ describe('processes-check-data-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--data-file',
@@ -48,7 +48,7 @@ describe('processes-check-data-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.checkDataFile).toBe('/repo/fixtures/check.json');
     expect(options.keepData).toBe(true);
@@ -216,9 +216,9 @@ describe('processes-check-data-workflow-lib', () => {
           userId: 'user-1',
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
         updateStep: {
@@ -254,7 +254,7 @@ describe('processes-check-data-workflow-lib', () => {
       user_id: 'user-1',
       version: '01.01.000',
     });
-    expect(runtimeRecord.supabase.projectId).toBe('fotofiyqnuyvgtotswie');
+    expect(runtimeRecord.supabase.projectId).toBe('submidrhbtknjxfympna');
   });
 
   it('runs the create-then-update workflow against one process record and writes a runtime record', async () => {
@@ -492,7 +492,7 @@ describe('processes-check-data-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/processes/processes-create-contribute-team-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/processes/processes-create-contribute-team-workflow-lib.test.ts
@@ -108,7 +108,7 @@ describe('processes-create-contribute-team-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--keep-created',
@@ -122,7 +122,7 @@ describe('processes-create-contribute-team-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
@@ -256,9 +256,9 @@ describe('processes-create-contribute-team-workflow-lib', () => {
           userId: 'user-1',
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
       },
@@ -441,7 +441,7 @@ describe('processes-create-contribute-team-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/processes/processes-create-version-update-reference-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/processes/processes-create-version-update-reference-workflow-lib.test.ts
@@ -140,7 +140,7 @@ describe('processes-create-version-update-reference-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--data-file',
         'fixtures/004.json',
         '--keep-created',
@@ -153,7 +153,7 @@ describe('processes-create-version-update-reference-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.dataFile).toBe('/repo/fixtures/004.json');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
@@ -311,9 +311,9 @@ describe('processes-create-version-update-reference-workflow-lib', () => {
           userId: 'user-1',
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
         updateReferenceStep: {
@@ -525,7 +525,7 @@ describe('processes-create-version-update-reference-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/processes/processes-create-view-copy-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/processes/processes-create-view-copy-workflow-lib.test.ts
@@ -129,7 +129,7 @@ describe('processes-create-view-copy-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--keep-created',
@@ -143,7 +143,7 @@ describe('processes-create-view-copy-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
@@ -316,9 +316,9 @@ describe('processes-create-view-copy-workflow-lib', () => {
           expectationResults: [{ actual: true, label: 'view source', passed: true }],
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
         viewCopyStep: {
@@ -536,7 +536,7 @@ describe('processes-create-view-copy-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/processes/processes-create-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/processes/processes-create-workflow-lib.test.ts
@@ -25,7 +25,7 @@ describe('processes-create-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--keep-data',
         '--generate-id',
         '--no-verify-frontend',
@@ -35,7 +35,7 @@ describe('processes-create-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
     expect(options.verifyFrontend).toBe(false);
@@ -175,16 +175,16 @@ describe('processes-create-workflow-lib', () => {
       {
         supabaseProjectUrl: undefined,
         supabasePublishableKey: undefined,
-        supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
       },
       {
         SUPABASE_PUBLISHABLE_KEY: 'sb_publishable_test_key',
       } as NodeJS.ProcessEnv,
     );
 
-    expect(target.apiUrl).toBe('https://fotofiyqnuyvgtotswie.supabase.co');
-    expect(target.dashboardUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
-    expect(target.projectId).toBe('fotofiyqnuyvgtotswie');
+    expect(target.apiUrl).toBe('https://submidrhbtknjxfympna.supabase.co');
+    expect(target.dashboardUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
+    expect(target.projectId).toBe('submidrhbtknjxfympna');
     expect(target.publishableKey).toBe('sb_publishable_test_key');
   });
 
@@ -366,9 +366,9 @@ describe('processes-create-workflow-lib', () => {
           },
           submittedRuleVerification: false,
           supabaseTarget: {
-            apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-            dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-            projectId: 'fotofiyqnuyvgtotswie',
+            apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+            dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+            projectId: 'submidrhbtknjxfympna',
             publishableKey: 'sb_publishable_test_key',
           },
         },

--- a/tests/data-workflows/unit/processes/processes-edit-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/processes/processes-edit-workflow-lib.test.ts
@@ -29,7 +29,7 @@ describe('processes-edit-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--success-data-file',
@@ -47,7 +47,7 @@ describe('processes-edit-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.successDataFile).toBe('/repo/fixtures/success.json');
     expect(options.editDataFile).toBe('/repo/fixtures/fail.json');
@@ -222,9 +222,9 @@ describe('processes-edit-workflow-lib', () => {
           unRuleVerificationCount: 0,
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
       },
@@ -542,7 +542,7 @@ describe('processes-edit-workflow-lib', () => {
           successDataFile,
           successExpectedFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/processes/processes-full-text-search-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/processes/processes-full-text-search-workflow-lib.test.ts
@@ -26,7 +26,7 @@ describe('processes-full-text-search-workflow-lib', () => {
         'admin',
         '--frontend-url=http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--data-file',
         'custom/search.json',
         '--seed-data-file',
@@ -39,7 +39,7 @@ describe('processes-full-text-search-workflow-lib', () => {
 
     expect(options.role).toBe('admin');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.dataFile).toBe('/repo/custom/search.json');
     expect(options.seedDataFile).toBe('/repo/custom/seed.json');
     expect(options.keepData).toBe(false);
@@ -185,7 +185,7 @@ describe('processes-full-text-search-workflow-lib', () => {
             'tests/data-workflows/fixtures/result/processes/001_create.md',
           ),
           supabasePublishableKey: 'publishable-key',
-          supabaseUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
+          supabaseUrl: 'https://submidrhbtknjxfympna.supabase.co',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,
@@ -197,7 +197,7 @@ describe('processes-full-text-search-workflow-lib', () => {
       );
 
       expect(createClientImpl).toHaveBeenCalledWith(
-        'https://fotofiyqnuyvgtotswie.supabase.co',
+        'https://submidrhbtknjxfympna.supabase.co',
         'publishable-key',
         expect.objectContaining({
           auth: expect.objectContaining({ persistSession: false }),
@@ -321,7 +321,7 @@ describe('processes-full-text-search-workflow-lib', () => {
             'tests/data-workflows/fixtures/result/processes/001_create.md',
           ),
           supabasePublishableKey: 'publishable-key',
-          supabaseUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
+          supabaseUrl: 'https://submidrhbtknjxfympna.supabase.co',
           usersFile,
           verifyFrontend: false,
           writeRuntime: false,

--- a/tests/data-workflows/unit/sources/sources-check-data-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/sources/sources-check-data-workflow-lib.test.ts
@@ -32,7 +32,7 @@ describe('sources-check-data-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--data-file',
@@ -48,7 +48,7 @@ describe('sources-check-data-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.checkDataFile).toBe('/repo/fixtures/check.json');
     expect(options.keepData).toBe(true);
@@ -216,9 +216,9 @@ describe('sources-check-data-workflow-lib', () => {
           userId: 'user-1',
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
         updateStep: {
@@ -254,7 +254,7 @@ describe('sources-check-data-workflow-lib', () => {
       version: '01.01.000',
     });
     expect(runtimeRecord.create.runtimeId).toBe('source-1');
-    expect(runtimeRecord.supabase.projectId).toBe('fotofiyqnuyvgtotswie');
+    expect(runtimeRecord.supabase.projectId).toBe('submidrhbtknjxfympna');
   });
 
   it('runs the create-then-update workflow against one source record and writes a runtime record', async () => {
@@ -490,7 +490,7 @@ describe('sources-check-data-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/sources/sources-create-contribute-team-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/sources/sources-create-contribute-team-workflow-lib.test.ts
@@ -106,7 +106,7 @@ describe('sources-create-contribute-team-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--keep-created',
@@ -120,7 +120,7 @@ describe('sources-create-contribute-team-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
@@ -254,9 +254,9 @@ describe('sources-create-contribute-team-workflow-lib', () => {
           userId: 'user-1',
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
       },
@@ -439,7 +439,7 @@ describe('sources-create-contribute-team-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/sources/sources-create-version-update-reference-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/sources/sources-create-version-update-reference-workflow-lib.test.ts
@@ -158,7 +158,7 @@ describe('sources-create-version-update-reference-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--data-file',
         'fixtures/004.json',
         '--keep-created',
@@ -171,7 +171,7 @@ describe('sources-create-version-update-reference-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.dataFile).toBe('/repo/fixtures/004.json');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
@@ -307,9 +307,9 @@ describe('sources-create-version-update-reference-workflow-lib', () => {
           userId: 'user-1',
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
         updateReferenceStep: {
@@ -521,7 +521,7 @@ describe('sources-create-version-update-reference-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/sources/sources-create-view-copy-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/sources/sources-create-view-copy-workflow-lib.test.ts
@@ -127,7 +127,7 @@ describe('sources-create-view-copy-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--keep-created',
@@ -141,7 +141,7 @@ describe('sources-create-view-copy-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
@@ -305,9 +305,9 @@ describe('sources-create-view-copy-workflow-lib', () => {
           expectationResults: [{ actual: true, label: 'view source', passed: true }],
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
         viewCopyStep: {
@@ -525,7 +525,7 @@ describe('sources-create-view-copy-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/sources/sources-create-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/sources/sources-create-workflow-lib.test.ts
@@ -25,7 +25,7 @@ describe('sources-create-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--keep-data',
         '--generate-id',
         '--no-verify-frontend',
@@ -35,7 +35,7 @@ describe('sources-create-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
     expect(options.verifyFrontend).toBe(false);
@@ -175,16 +175,16 @@ describe('sources-create-workflow-lib', () => {
       {
         supabaseProjectUrl: undefined,
         supabasePublishableKey: undefined,
-        supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
       },
       {
         SUPABASE_PUBLISHABLE_KEY: 'sb_publishable_test_key',
       } as NodeJS.ProcessEnv,
     );
 
-    expect(target.apiUrl).toBe('https://fotofiyqnuyvgtotswie.supabase.co');
-    expect(target.dashboardUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
-    expect(target.projectId).toBe('fotofiyqnuyvgtotswie');
+    expect(target.apiUrl).toBe('https://submidrhbtknjxfympna.supabase.co');
+    expect(target.dashboardUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
+    expect(target.projectId).toBe('submidrhbtknjxfympna');
     expect(target.publishableKey).toBe('sb_publishable_test_key');
   });
 
@@ -384,9 +384,9 @@ describe('sources-create-workflow-lib', () => {
           },
           submittedRuleVerification: false,
           supabaseTarget: {
-            apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-            dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-            projectId: 'fotofiyqnuyvgtotswie',
+            apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+            dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+            projectId: 'submidrhbtknjxfympna',
             publishableKey: 'sb_publishable_test_key',
           },
         },

--- a/tests/data-workflows/unit/sources/sources-edit-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/sources/sources-edit-workflow-lib.test.ts
@@ -29,7 +29,7 @@ describe('sources-edit-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--success-data-file',
@@ -47,7 +47,7 @@ describe('sources-edit-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.successDataFile).toBe('/repo/fixtures/success.json');
     expect(options.editDataFile).toBe('/repo/fixtures/fail.json');
@@ -222,9 +222,9 @@ describe('sources-edit-workflow-lib', () => {
           unRuleVerificationCount: 0,
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
       },
@@ -558,7 +558,7 @@ describe('sources-edit-workflow-lib', () => {
           successDataFile,
           successExpectedFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/teams/team-workflow-shared.test.ts
+++ b/tests/data-workflows/unit/teams/team-workflow-shared.test.ts
@@ -194,9 +194,9 @@ describe('team-workflow-shared', () => {
         },
       },
       supabaseTarget: {
-        apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-        dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-        projectId: 'fotofiyqnuyvgtotswie',
+        apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+        dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+        projectId: 'submidrhbtknjxfympna',
         publishableKey: 'sb_publishable_test_key',
       },
       team: {
@@ -220,9 +220,9 @@ describe('team-workflow-shared', () => {
       userId: 'owner-user-id',
     });
     expect(workspace.supabase).toEqual({
-      apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-      dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-      projectId: 'fotofiyqnuyvgtotswie',
+      apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+      dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+      projectId: 'submidrhbtknjxfympna',
     });
     expect(workspace.teamId).toBe('team-id');
     expect(workspace.latestTeamSnapshot).toEqual({

--- a/tests/data-workflows/unit/unitgroups/unitgroups-check-data-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/unitgroups/unitgroups-check-data-workflow-lib.test.ts
@@ -32,7 +32,7 @@ describe('unitgroups-check-data-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--data-file',
@@ -48,7 +48,7 @@ describe('unitgroups-check-data-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.checkDataFile).toBe('/repo/fixtures/check.json');
     expect(options.keepData).toBe(true);
@@ -216,9 +216,9 @@ describe('unitgroups-check-data-workflow-lib', () => {
           userId: 'user-1',
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
         updateStep: {
@@ -254,7 +254,7 @@ describe('unitgroups-check-data-workflow-lib', () => {
       version: '01.01.000',
     });
     expect(runtimeRecord.create.runtimeId).toBe('unitgroup-1');
-    expect(runtimeRecord.supabase.projectId).toBe('fotofiyqnuyvgtotswie');
+    expect(runtimeRecord.supabase.projectId).toBe('submidrhbtknjxfympna');
   });
 
   it('runs the create-then-update workflow against one unit group record and writes a runtime record', async () => {
@@ -492,7 +492,7 @@ describe('unitgroups-check-data-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/unitgroups/unitgroups-create-contribute-team-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/unitgroups/unitgroups-create-contribute-team-workflow-lib.test.ts
@@ -107,7 +107,7 @@ describe('unitgroups-create-contribute-team-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--keep-created',
@@ -121,7 +121,7 @@ describe('unitgroups-create-contribute-team-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
@@ -257,9 +257,9 @@ describe('unitgroups-create-contribute-team-workflow-lib', () => {
           userId: 'user-1',
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
       },
@@ -442,7 +442,7 @@ describe('unitgroups-create-contribute-team-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/unitgroups/unitgroups-create-version-update-reference-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/unitgroups/unitgroups-create-version-update-reference-workflow-lib.test.ts
@@ -190,7 +190,7 @@ describe('unitgroups-create-version-update-reference-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--data-file',
         'fixtures/004.json',
         '--keep-created',
@@ -203,7 +203,7 @@ describe('unitgroups-create-version-update-reference-workflow-lib', () => {
 
     expect(options.role).toBe('system-admin');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.dataFile).toBe('/repo/fixtures/004.json');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
@@ -339,9 +339,9 @@ describe('unitgroups-create-version-update-reference-workflow-lib', () => {
           userId: 'user-1',
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
         updateReferenceStep: {
@@ -552,7 +552,7 @@ describe('unitgroups-create-version-update-reference-workflow-lib', () => {
           role: 'system-admin',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/unitgroups/unitgroups-create-view-copy-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/unitgroups/unitgroups-create-view-copy-workflow-lib.test.ts
@@ -122,7 +122,7 @@ describe('unitgroups-create-view-copy-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--keep-created',
@@ -136,7 +136,7 @@ describe('unitgroups-create-view-copy-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
@@ -316,9 +316,9 @@ describe('unitgroups-create-view-copy-workflow-lib', () => {
           expectationResults: [{ actual: true, label: 'view source', passed: true }],
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
         viewCopyStep: {
@@ -536,7 +536,7 @@ describe('unitgroups-create-view-copy-workflow-lib', () => {
           role: 'user',
           runtimeRecordFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/unit/unitgroups/unitgroups-create-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/unitgroups/unitgroups-create-workflow-lib.test.ts
@@ -25,7 +25,7 @@ describe('unitgroups-create-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--keep-data',
         '--generate-id',
         '--no-verify-frontend',
@@ -35,7 +35,7 @@ describe('unitgroups-create-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.keepData).toBe(true);
     expect(options.generateId).toBe(true);
     expect(options.verifyFrontend).toBe(false);
@@ -175,16 +175,16 @@ describe('unitgroups-create-workflow-lib', () => {
       {
         supabaseProjectUrl: undefined,
         supabasePublishableKey: undefined,
-        supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
       },
       {
         SUPABASE_PUBLISHABLE_KEY: 'sb_publishable_test_key',
       } as NodeJS.ProcessEnv,
     );
 
-    expect(target.apiUrl).toBe('https://fotofiyqnuyvgtotswie.supabase.co');
-    expect(target.dashboardUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
-    expect(target.projectId).toBe('fotofiyqnuyvgtotswie');
+    expect(target.apiUrl).toBe('https://submidrhbtknjxfympna.supabase.co');
+    expect(target.dashboardUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
+    expect(target.projectId).toBe('submidrhbtknjxfympna');
     expect(target.publishableKey).toBe('sb_publishable_test_key');
   });
 
@@ -376,9 +376,9 @@ describe('unitgroups-create-workflow-lib', () => {
           },
           submittedRuleVerification: false,
           supabaseTarget: {
-            apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-            dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-            projectId: 'fotofiyqnuyvgtotswie',
+            apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+            dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+            projectId: 'submidrhbtknjxfympna',
             publishableKey: 'sb_publishable_test_key',
           },
         },

--- a/tests/data-workflows/unit/unitgroups/unitgroups-edit-workflow-lib.test.ts
+++ b/tests/data-workflows/unit/unitgroups/unitgroups-edit-workflow-lib.test.ts
@@ -29,7 +29,7 @@ describe('unitgroups-edit-workflow-lib', () => {
         '--frontend-url',
         'http://127.0.0.1:8000',
         '--supabase-url',
-        'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+        'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
         '--create-data-file',
         'fixtures/create.json',
         '--success-data-file',
@@ -47,7 +47,7 @@ describe('unitgroups-edit-workflow-lib', () => {
 
     expect(options.role).toBe('user');
     expect(options.frontendUrl).toBe('http://127.0.0.1:8000');
-    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie');
+    expect(options.supabaseUrl).toBe('https://supabase.com/dashboard/project/submidrhbtknjxfympna');
     expect(options.createDataFile).toBe('/repo/fixtures/create.json');
     expect(options.successDataFile).toBe('/repo/fixtures/success.json');
     expect(options.editDataFile).toBe('/repo/fixtures/fail.json');
@@ -222,9 +222,9 @@ describe('unitgroups-edit-workflow-lib', () => {
           unRuleVerificationCount: 0,
         },
         supabaseTarget: {
-          apiUrl: 'https://fotofiyqnuyvgtotswie.supabase.co',
-          dashboardUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
-          projectId: 'fotofiyqnuyvgtotswie',
+          apiUrl: 'https://submidrhbtknjxfympna.supabase.co',
+          dashboardUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
+          projectId: 'submidrhbtknjxfympna',
           publishableKey: 'sb_publishable_test',
         },
       },
@@ -552,7 +552,7 @@ describe('unitgroups-edit-workflow-lib', () => {
           successDataFile,
           successExpectedFile,
           supabasePublishableKey: 'sb_publishable_test',
-          supabaseUrl: 'https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie',
+          supabaseUrl: 'https://supabase.com/dashboard/project/submidrhbtknjxfympna',
           usersFile,
           verifyFrontend: false,
           writeRuntime: true,

--- a/tests/data-workflows/workflows/contacts/contacts-all-workflow.ts
+++ b/tests/data-workflows/workflows/contacts/contacts-all-workflow.ts
@@ -39,7 +39,7 @@ export const CONTACT_DATA_WORKFLOWS = [
 export const CONTACT_ALL_DATA_WORKFLOW_HELP = `Contacts data workflow suite
 
 Usage:
-  npm run test:workflows -- --contacts:all --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co --supabase-publishable-key <key>
+  npm run test:workflows -- --contacts:all --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co --supabase-publishable-key <key>
   npm run test:workflows -- --contacts:all --detail-result --no-keep-data
 
 Behavior:

--- a/tests/data-workflows/workflows/contacts/contacts-check-data-workflow-lib.ts
+++ b/tests/data-workflows/workflows/contacts/contacts-check-data-workflow-lib.ts
@@ -194,8 +194,8 @@ type LoadedValidationModules = {
 export const CONTACT_CHECK_DATA_WORKFLOW_HELP = `Contact check-data data workflow
 
 Usage:
-  npm run test:workflows -- --contacts:check-data --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --contacts:check-data --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --contacts:check-data --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --contacts:check-data --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one contact from tests/data-workflows/fixtures/data/contacts/001_create.json

--- a/tests/data-workflows/workflows/contacts/contacts-create-contribute-team-workflow-lib.ts
+++ b/tests/data-workflows/workflows/contacts/contacts-create-contribute-team-workflow-lib.ts
@@ -235,8 +235,8 @@ const EXPECTATION_KEYS = new Set<ExpectationKey>([
 export const CONTACT_CREATE_CONTRIBUTE_TEAM_DATA_WORKFLOW_HELP = `Contact create-contribute-team data workflow
 
 Usage:
-  npm run test:workflows -- --contacts:create-contribute-team --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --contacts:create-contribute-team --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --contacts:create-contribute-team --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --contacts:create-contribute-team --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one contact from tests/data-workflows/fixtures/data/contacts/005_create_contribute_team.json

--- a/tests/data-workflows/workflows/contacts/contacts-create-version-update-reference-workflow-lib.ts
+++ b/tests/data-workflows/workflows/contacts/contacts-create-version-update-reference-workflow-lib.ts
@@ -269,8 +269,8 @@ export type ContactCreateVersionUpdateReferenceDependencies = {
 export const CONTACT_CREATE_VERSION_UPDATE_REFERENCE_DATA_WORKFLOW_HELP = `Contact create-version-update-reference data workflow
 
 Usage:
-  npm run test:workflows -- --contacts:create-version-update-reference --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --contacts:create-version-update-reference --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --contacts:create-version-update-reference --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --contacts:create-version-update-reference --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one contact from tests/data-workflows/fixtures/data/contacts/004_create_version_update_reference.json

--- a/tests/data-workflows/workflows/contacts/contacts-create-view-copy-workflow-lib.ts
+++ b/tests/data-workflows/workflows/contacts/contacts-create-view-copy-workflow-lib.ts
@@ -306,8 +306,8 @@ const EXPECTATION_KEYS = new Set<ExpectationKey>([
 export const CONTACT_CREATE_VIEW_COPY_DATA_WORKFLOW_HELP = `Contact create-view-copy data workflow
 
 Usage:
-  npm run test:workflows -- --contacts:create-view-copy --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --contacts:create-view-copy --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --contacts:create-view-copy --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --contacts:create-view-copy --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one contact from tests/data-workflows/fixtures/data/contacts/001_create_view_copy.json

--- a/tests/data-workflows/workflows/contacts/contacts-create-workflow-lib.ts
+++ b/tests/data-workflows/workflows/contacts/contacts-create-workflow-lib.ts
@@ -207,8 +207,8 @@ export type RuntimeRecord = {
 export const CONTACT_CREATE_DATA_WORKFLOW_HELP = `Contact create data workflow
 
 Usage:
-  npm run test:workflows -- --contacts:create --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --contacts:create --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie --no-keep-data
+  npm run test:workflows -- --contacts:create --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --contacts:create --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna --no-keep-data
 
 Flags:
   --role <name>                    Role key from .env.users.local / TEST_USERS_JSON / TEST_<ROLE>_* (defaults to "user")

--- a/tests/data-workflows/workflows/contacts/contacts-edit-workflow-lib.ts
+++ b/tests/data-workflows/workflows/contacts/contacts-edit-workflow-lib.ts
@@ -206,8 +206,8 @@ export type ContactEditDependencies = {
 export const CONTACT_EDIT_DATA_WORKFLOW_HELP = `Contact edit data workflow
 
 Usage:
-  npm run test:workflows -- --contacts:edit --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --contacts:edit --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --contacts:edit --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --contacts:edit --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one contact from tests/data-workflows/fixtures/data/contacts/001_create.json

--- a/tests/data-workflows/workflows/flowproperties/flowproperties-all-workflow.ts
+++ b/tests/data-workflows/workflows/flowproperties/flowproperties-all-workflow.ts
@@ -42,7 +42,7 @@ export const FLOWPROPERTY_DATA_WORKFLOWS = [
 export const FLOWPROPERTY_ALL_DATA_WORKFLOW_HELP = `Flowproperties data workflow suite
 
 Usage:
-  npm run test:workflows -- --flowproperties:all --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co --supabase-publishable-key <key>
+  npm run test:workflows -- --flowproperties:all --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co --supabase-publishable-key <key>
   npm run test:workflows -- --flowproperties:all --detail-result --no-keep-data
 
 Behavior:

--- a/tests/data-workflows/workflows/flowproperties/flowproperties-check-data-workflow-lib.ts
+++ b/tests/data-workflows/workflows/flowproperties/flowproperties-check-data-workflow-lib.ts
@@ -194,8 +194,8 @@ type LoadedValidationModules = {
 export const FLOWPROPERTY_CHECK_DATA_WORKFLOW_HELP = `Flowproperty check-data data workflow
 
 Usage:
-  npm run test:workflows -- --flowproperties:check-data --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --flowproperties:check-data --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --flowproperties:check-data --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --flowproperties:check-data --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one flowproperty from tests/data-workflows/fixtures/data/flowProperties/001_create.json

--- a/tests/data-workflows/workflows/flowproperties/flowproperties-create-contribute-team-workflow-lib.ts
+++ b/tests/data-workflows/workflows/flowproperties/flowproperties-create-contribute-team-workflow-lib.ts
@@ -235,8 +235,8 @@ const EXPECTATION_KEYS = new Set<ExpectationKey>([
 export const FLOWPROPERTY_CREATE_CONTRIBUTE_TEAM_DATA_WORKFLOW_HELP = `Flowproperty create-contribute-team data workflow
 
 Usage:
-  npm run test:workflows -- --flowproperties:create-contribute-team --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --flowproperties:create-contribute-team --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --flowproperties:create-contribute-team --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --flowproperties:create-contribute-team --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one flowproperty from tests/data-workflows/fixtures/data/flowProperties/005_create_contribute_team.json

--- a/tests/data-workflows/workflows/flowproperties/flowproperties-create-version-update-reference-workflow-lib.ts
+++ b/tests/data-workflows/workflows/flowproperties/flowproperties-create-version-update-reference-workflow-lib.ts
@@ -270,8 +270,8 @@ export type FlowpropertyCreateVersionUpdateReferenceDependencies = {
 export const FLOWPROPERTY_CREATE_VERSION_UPDATE_REFERENCE_DATA_WORKFLOW_HELP = `Flowproperty create-version-update-reference data workflow
 
 Usage:
-  npm run test:workflows -- --flowproperties:create-version-update-reference --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --flowproperties:create-version-update-reference --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --flowproperties:create-version-update-reference --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --flowproperties:create-version-update-reference --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one flowproperty from tests/data-workflows/fixtures/data/flowProperties/004_create_version_update_reference.json

--- a/tests/data-workflows/workflows/flowproperties/flowproperties-create-view-copy-workflow-lib.ts
+++ b/tests/data-workflows/workflows/flowproperties/flowproperties-create-view-copy-workflow-lib.ts
@@ -306,8 +306,8 @@ const EXPECTATION_KEYS = new Set<ExpectationKey>([
 export const FLOWPROPERTY_CREATE_VIEW_COPY_DATA_WORKFLOW_HELP = `Flowproperty create-view-copy data workflow
 
 Usage:
-  npm run test:workflows -- --flowproperties:create-view-copy --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --flowproperties:create-view-copy --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --flowproperties:create-view-copy --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --flowproperties:create-view-copy --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one flowproperty from tests/data-workflows/fixtures/data/flowProperties/001_create_view_copy.json

--- a/tests/data-workflows/workflows/flowproperties/flowproperties-create-workflow-lib.ts
+++ b/tests/data-workflows/workflows/flowproperties/flowproperties-create-workflow-lib.ts
@@ -208,8 +208,8 @@ export type RuntimeRecord = {
 export const FLOWPROPERTY_CREATE_DATA_WORKFLOW_HELP = `Flowproperty create data workflow
 
 Usage:
-  npm run test:workflows -- --flowproperties:create --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --flowproperties:create --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie --no-keep-data
+  npm run test:workflows -- --flowproperties:create --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --flowproperties:create --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna --no-keep-data
 
 Flags:
   --role <name>                    Role key from .env.users.local / TEST_USERS_JSON / TEST_<ROLE>_* (defaults to "user")

--- a/tests/data-workflows/workflows/flowproperties/flowproperties-edit-workflow-lib.ts
+++ b/tests/data-workflows/workflows/flowproperties/flowproperties-edit-workflow-lib.ts
@@ -206,8 +206,8 @@ export type FlowpropertyEditDependencies = {
 export const FLOWPROPERTY_EDIT_DATA_WORKFLOW_HELP = `Flowproperty edit data workflow
 
 Usage:
-  npm run test:workflows -- --flowproperties:edit --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --flowproperties:edit --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --flowproperties:edit --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --flowproperties:edit --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one flowproperty from tests/data-workflows/fixtures/data/flowProperties/001_create.json

--- a/tests/data-workflows/workflows/flows/flows-all-workflow.ts
+++ b/tests/data-workflows/workflows/flows/flows-all-workflow.ts
@@ -38,7 +38,7 @@ export const FLOW_DATA_WORKFLOWS = [
 export const FLOW_ALL_DATA_WORKFLOW_HELP = `Flows data workflow suite
 
 Usage:
-  npm run test:workflows -- --flows:all --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co --supabase-publishable-key <key>
+  npm run test:workflows -- --flows:all --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co --supabase-publishable-key <key>
   npm run test:workflows -- --flows:all --detail-result --no-keep-data
 
 Behavior:

--- a/tests/data-workflows/workflows/flows/flows-check-data-workflow-lib.ts
+++ b/tests/data-workflows/workflows/flows/flows-check-data-workflow-lib.ts
@@ -194,8 +194,8 @@ type LoadedValidationModules = {
 export const FLOW_CHECK_DATA_WORKFLOW_HELP = `Flow check-data data workflow
 
 Usage:
-  npm run test:workflows -- --flows:check-data --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --flows:check-data --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --flows:check-data --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --flows:check-data --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one flow from tests/data-workflows/fixtures/data/flows/001_create.json

--- a/tests/data-workflows/workflows/flows/flows-create-contribute-team-workflow-lib.ts
+++ b/tests/data-workflows/workflows/flows/flows-create-contribute-team-workflow-lib.ts
@@ -235,8 +235,8 @@ const EXPECTATION_KEYS = new Set<ExpectationKey>([
 export const FLOW_CREATE_CONTRIBUTE_TEAM_DATA_WORKFLOW_HELP = `Flow create-contribute-team data workflow
 
 Usage:
-  npm run test:workflows -- --flows:create-contribute-team --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --flows:create-contribute-team --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --flows:create-contribute-team --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --flows:create-contribute-team --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one flow from tests/data-workflows/fixtures/data/flows/005_create_contribute_team.json

--- a/tests/data-workflows/workflows/flows/flows-create-version-update-reference-workflow-lib.ts
+++ b/tests/data-workflows/workflows/flows/flows-create-version-update-reference-workflow-lib.ts
@@ -276,8 +276,8 @@ export type FlowCreateVersionUpdateReferenceDependencies = {
 export const FLOW_CREATE_VERSION_UPDATE_REFERENCE_DATA_WORKFLOW_HELP = `Flow create-version-update-reference data workflow
 
 Usage:
-  npm run test:workflows -- --flows:create-version-update-reference --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --flows:create-version-update-reference --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --flows:create-version-update-reference --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --flows:create-version-update-reference --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one flow from tests/data-workflows/fixtures/data/flows/004_create_version_update_reference.json

--- a/tests/data-workflows/workflows/flows/flows-create-view-copy-workflow-lib.ts
+++ b/tests/data-workflows/workflows/flows/flows-create-view-copy-workflow-lib.ts
@@ -306,8 +306,8 @@ const EXPECTATION_KEYS = new Set<ExpectationKey>([
 export const FLOW_CREATE_VIEW_COPY_DATA_WORKFLOW_HELP = `Flow create-view-copy data workflow
 
 Usage:
-  npm run test:workflows -- --flows:create-view-copy --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --flows:create-view-copy --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --flows:create-view-copy --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --flows:create-view-copy --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one flow from tests/data-workflows/fixtures/data/flows/001_create_view_copy.json

--- a/tests/data-workflows/workflows/flows/flows-create-workflow-lib.ts
+++ b/tests/data-workflows/workflows/flows/flows-create-workflow-lib.ts
@@ -206,8 +206,8 @@ export type RuntimeRecord = {
 export const FLOW_CREATE_DATA_WORKFLOW_HELP = `Flow create data workflow
 
 Usage:
-  npm run test:workflows -- --flows:create --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --flows:create --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie --no-keep-data
+  npm run test:workflows -- --flows:create --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --flows:create --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna --no-keep-data
 
 Flags:
   --role <name>                    Role key from .env.users.local / TEST_USERS_JSON / TEST_<ROLE>_* (defaults to "user")

--- a/tests/data-workflows/workflows/flows/flows-edit-workflow-lib.ts
+++ b/tests/data-workflows/workflows/flows/flows-edit-workflow-lib.ts
@@ -206,8 +206,8 @@ export type FlowEditDependencies = {
 export const FLOW_EDIT_DATA_WORKFLOW_HELP = `Flow edit data workflow
 
 Usage:
-  npm run test:workflows -- --flows:edit --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --flows:edit --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --flows:edit --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --flows:edit --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one flow from tests/data-workflows/fixtures/data/flows/001_create.json

--- a/tests/data-workflows/workflows/full-text-search-shared.ts
+++ b/tests/data-workflows/workflows/full-text-search-shared.ts
@@ -180,7 +180,7 @@ export function buildFullTextSearchHelpText(input: {
   return `${input.title}
 
 Usage:
-  npm run ${input.npmCommand} -- --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
+  npm run ${input.npmCommand} -- --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
   npm run ${input.npmCommand} -- --detail-result --no-keep-data
 
 Flags:

--- a/tests/data-workflows/workflows/lifecyclemodels/lifecyclemodels-all-workflow.ts
+++ b/tests/data-workflows/workflows/lifecyclemodels/lifecyclemodels-all-workflow.ts
@@ -42,7 +42,7 @@ export const LIFECYCLEMODEL_DATA_WORKFLOWS = [
 export const LIFECYCLEMODEL_ALL_DATA_WORKFLOW_HELP = `Lifecycle models data workflow suite
 
 Usage:
-  npm run test:workflows -- --lifecyclemodels:all --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co --supabase-publishable-key <key>
+  npm run test:workflows -- --lifecyclemodels:all --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co --supabase-publishable-key <key>
   npm run test:workflows -- --lifecyclemodels:all --detail-result --no-keep-data
 
 Behavior:

--- a/tests/data-workflows/workflows/lifecyclemodels/lifecyclemodels-workflow-lib.ts
+++ b/tests/data-workflows/workflows/lifecyclemodels/lifecyclemodels-workflow-lib.ts
@@ -384,7 +384,7 @@ export function buildLifeCycleModelSmokeHelp(config: LifeCycleModelWorkflowConfi
   return `${config.helpTitle}
 
 Usage:
-  npm run ${config.command} -- --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co --supabase-publishable-key <key>
+  npm run ${config.command} -- --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co --supabase-publishable-key <key>
   npm run ${config.command} -- --detail-result --no-keep-data
 
 ${workflowText}

--- a/tests/data-workflows/workflows/processes/processes-all-workflow.ts
+++ b/tests/data-workflows/workflows/processes/processes-all-workflow.ts
@@ -44,7 +44,7 @@ export const PROCESS_DATA_WORKFLOWS = [
 export const PROCESS_ALL_DATA_WORKFLOW_HELP = `Processes data workflow suite
 
 Usage:
-  npm run test:workflows -- --processes:all --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co --supabase-publishable-key <key>
+  npm run test:workflows -- --processes:all --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co --supabase-publishable-key <key>
   npm run test:workflows -- --processes:all --detail-result --no-keep-data
 
 Behavior:

--- a/tests/data-workflows/workflows/processes/processes-check-data-runtime-references-workflow-lib.ts
+++ b/tests/data-workflows/workflows/processes/processes-check-data-runtime-references-workflow-lib.ts
@@ -385,8 +385,8 @@ export type ProcessCheckDataRuntimeReferencesDependencies = {
 export const PROCESS_CHECK_DATA_RUNTIME_REFERENCES_DATA_WORKFLOW_HELP = `Process check-data runtime-references data workflow
 
 Usage:
-  npm run test:workflows -- --processes:check-data-runtime-references --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --processes:check-data-runtime-references --role admin --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie --no-keep-data
+  npm run test:workflows -- --processes:check-data-runtime-references --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --processes:check-data-runtime-references --role admin --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna --no-keep-data
 
 Workflow:
   1. Ensure per-account test reference seeds exist

--- a/tests/data-workflows/workflows/processes/processes-check-data-workflow-lib.ts
+++ b/tests/data-workflows/workflows/processes/processes-check-data-workflow-lib.ts
@@ -194,8 +194,8 @@ type LoadedValidationModules = {
 export const PROCESS_CHECK_DATA_WORKFLOW_HELP = `Process check-data data workflow
 
 Usage:
-  npm run test:workflows -- --processes:check-data --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --processes:check-data --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --processes:check-data --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --processes:check-data --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one process from tests/data-workflows/fixtures/data/processes/001_create.json

--- a/tests/data-workflows/workflows/processes/processes-create-contribute-team-workflow-lib.ts
+++ b/tests/data-workflows/workflows/processes/processes-create-contribute-team-workflow-lib.ts
@@ -235,8 +235,8 @@ const EXPECTATION_KEYS = new Set<ExpectationKey>([
 export const PROCESS_CREATE_CONTRIBUTE_TEAM_DATA_WORKFLOW_HELP = `Process create-contribute-team data workflow
 
 Usage:
-  npm run test:workflows -- --processes:create-contribute-team --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --processes:create-contribute-team --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --processes:create-contribute-team --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --processes:create-contribute-team --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one process from tests/data-workflows/fixtures/data/processes/005_create_contribute_team.json

--- a/tests/data-workflows/workflows/processes/processes-create-version-update-reference-workflow-lib.ts
+++ b/tests/data-workflows/workflows/processes/processes-create-version-update-reference-workflow-lib.ts
@@ -276,8 +276,8 @@ export type ProcessCreateVersionUpdateReferenceDependencies = {
 export const PROCESS_CREATE_VERSION_UPDATE_REFERENCE_DATA_WORKFLOW_HELP = `Process create-version-update-reference data workflow
 
 Usage:
-  npm run test:workflows -- --processes:create-version-update-reference --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --processes:create-version-update-reference --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --processes:create-version-update-reference --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --processes:create-version-update-reference --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one process from tests/data-workflows/fixtures/data/processes/004_create_version_update_reference.json

--- a/tests/data-workflows/workflows/processes/processes-create-view-copy-workflow-lib.ts
+++ b/tests/data-workflows/workflows/processes/processes-create-view-copy-workflow-lib.ts
@@ -306,8 +306,8 @@ const EXPECTATION_KEYS = new Set<ExpectationKey>([
 export const PROCESS_CREATE_VIEW_COPY_DATA_WORKFLOW_HELP = `Process create-view-copy data workflow
 
 Usage:
-  npm run test:workflows -- --processes:create-view-copy --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --processes:create-view-copy --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --processes:create-view-copy --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --processes:create-view-copy --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one process from tests/data-workflows/fixtures/data/processes/001_create_view_copy.json

--- a/tests/data-workflows/workflows/processes/processes-create-workflow-lib.ts
+++ b/tests/data-workflows/workflows/processes/processes-create-workflow-lib.ts
@@ -207,8 +207,8 @@ export type RuntimeRecord = {
 export const PROCESS_CREATE_DATA_WORKFLOW_HELP = `Process create data workflow
 
 Usage:
-  npm run test:workflows -- --processes:create --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --processes:create --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie --no-keep-data
+  npm run test:workflows -- --processes:create --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --processes:create --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna --no-keep-data
 
 Flags:
   --role <name>                    Role key from .env.users.local / TEST_USERS_JSON / TEST_<ROLE>_* (defaults to "user")

--- a/tests/data-workflows/workflows/processes/processes-edit-workflow-lib.ts
+++ b/tests/data-workflows/workflows/processes/processes-edit-workflow-lib.ts
@@ -206,8 +206,8 @@ export type ProcessEditDependencies = {
 export const PROCESS_EDIT_DATA_WORKFLOW_HELP = `Process edit data workflow
 
 Usage:
-  npm run test:workflows -- --processes:edit --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --processes:edit --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --processes:edit --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --processes:edit --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one process from tests/data-workflows/fixtures/data/processes/001_create.json

--- a/tests/data-workflows/workflows/processes/processes-full-text-search-workflow-lib.ts
+++ b/tests/data-workflows/workflows/processes/processes-full-text-search-workflow-lib.ts
@@ -164,7 +164,7 @@ export type ProcessFullTextSearchDependencies = {
 export const PROCESS_FULL_TEXT_SEARCH_DATA_WORKFLOW_HELP = `Process full-text-search data workflow
 
 Usage:
-  npm run test:workflows -- --processes:full-text-search --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
+  npm run test:workflows -- --processes:full-text-search --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
   npm run test:workflows -- --processes:full-text-search --detail-result --no-keep-data
 
 Flags:

--- a/tests/data-workflows/workflows/sources/sources-all-workflow.ts
+++ b/tests/data-workflows/workflows/sources/sources-all-workflow.ts
@@ -38,7 +38,7 @@ export const SOURCE_DATA_WORKFLOWS = [
 export const SOURCE_ALL_DATA_WORKFLOW_HELP = `Sources data workflow suite
 
 Usage:
-  npm run test:workflows -- --sources:all --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co --supabase-publishable-key <key>
+  npm run test:workflows -- --sources:all --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co --supabase-publishable-key <key>
   npm run test:workflows -- --sources:all --detail-result --no-keep-data
 
 Behavior:

--- a/tests/data-workflows/workflows/sources/sources-check-data-workflow-lib.ts
+++ b/tests/data-workflows/workflows/sources/sources-check-data-workflow-lib.ts
@@ -194,8 +194,8 @@ type LoadedValidationModules = {
 export const SOURCE_CHECK_DATA_WORKFLOW_HELP = `Source check-data data workflow
 
 Usage:
-  npm run test:workflows -- --sources:check-data --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --sources:check-data --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --sources:check-data --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --sources:check-data --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one source from tests/data-workflows/fixtures/data/sources/001_create.json

--- a/tests/data-workflows/workflows/sources/sources-create-contribute-team-workflow-lib.ts
+++ b/tests/data-workflows/workflows/sources/sources-create-contribute-team-workflow-lib.ts
@@ -235,8 +235,8 @@ const EXPECTATION_KEYS = new Set<ExpectationKey>([
 export const SOURCE_CREATE_CONTRIBUTE_TEAM_DATA_WORKFLOW_HELP = `Source create-contribute-team data workflow
 
 Usage:
-  npm run test:workflows -- --sources:create-contribute-team --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --sources:create-contribute-team --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --sources:create-contribute-team --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --sources:create-contribute-team --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one source from tests/data-workflows/fixtures/data/sources/005_create_contribute_team.json

--- a/tests/data-workflows/workflows/sources/sources-create-version-update-reference-workflow-lib.ts
+++ b/tests/data-workflows/workflows/sources/sources-create-version-update-reference-workflow-lib.ts
@@ -269,8 +269,8 @@ export type SourceCreateVersionUpdateReferenceDependencies = {
 export const SOURCE_CREATE_VERSION_UPDATE_REFERENCE_DATA_WORKFLOW_HELP = `Source create-version-update-reference data workflow
 
 Usage:
-  npm run test:workflows -- --sources:create-version-update-reference --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --sources:create-version-update-reference --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --sources:create-version-update-reference --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --sources:create-version-update-reference --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one source from tests/data-workflows/fixtures/data/sources/004_create_version_update_reference.json

--- a/tests/data-workflows/workflows/sources/sources-create-view-copy-workflow-lib.ts
+++ b/tests/data-workflows/workflows/sources/sources-create-view-copy-workflow-lib.ts
@@ -306,8 +306,8 @@ const EXPECTATION_KEYS = new Set<ExpectationKey>([
 export const SOURCE_CREATE_VIEW_COPY_DATA_WORKFLOW_HELP = `Source create-view-copy data workflow
 
 Usage:
-  npm run test:workflows -- --sources:create-view-copy --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --sources:create-view-copy --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --sources:create-view-copy --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --sources:create-view-copy --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one source from tests/data-workflows/fixtures/data/sources/001_create_view_copy.json

--- a/tests/data-workflows/workflows/sources/sources-create-workflow-lib.ts
+++ b/tests/data-workflows/workflows/sources/sources-create-workflow-lib.ts
@@ -207,8 +207,8 @@ export type RuntimeRecord = {
 export const SOURCE_CREATE_DATA_WORKFLOW_HELP = `Source create data workflow
 
 Usage:
-  npm run test:workflows -- --sources:create --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --sources:create --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie --no-keep-data
+  npm run test:workflows -- --sources:create --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --sources:create --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna --no-keep-data
 
 Flags:
   --role <name>                    Role key from .env.users.local / TEST_USERS_JSON / TEST_<ROLE>_* (defaults to "user")

--- a/tests/data-workflows/workflows/sources/sources-edit-workflow-lib.ts
+++ b/tests/data-workflows/workflows/sources/sources-edit-workflow-lib.ts
@@ -206,8 +206,8 @@ export type SourceEditDependencies = {
 export const SOURCE_EDIT_DATA_WORKFLOW_HELP = `Source edit data workflow
 
 Usage:
-  npm run test:workflows -- --sources:edit --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --sources:edit --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --sources:edit --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --sources:edit --role admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one source from tests/data-workflows/fixtures/data/sources/001_create.json

--- a/tests/data-workflows/workflows/teams/teams-all-workflow.ts
+++ b/tests/data-workflows/workflows/teams/teams-all-workflow.ts
@@ -33,7 +33,7 @@ export const TEAM_DATA_WORKFLOWS = [
 export const TEAM_ALL_DATA_WORKFLOW_HELP = `Teams data workflow suite
 
 Usage:
-  npm run test:workflows -- --teams:all --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co --supabase-publishable-key <key>
+  npm run test:workflows -- --teams:all --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co --supabase-publishable-key <key>
   npm run test:workflows -- --teams:all --detail-result --no-write-runtime
 
 Behavior:

--- a/tests/data-workflows/workflows/teams/teams-create-workflow-lib.ts
+++ b/tests/data-workflows/workflows/teams/teams-create-workflow-lib.ts
@@ -18,8 +18,8 @@ import {
 export const TEAMS_CREATE_DATA_WORKFLOW_HELP = `Teams create data workflow
 
 Usage:
-  npm run test:workflows -- --teams:create --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --teams:create --role teamless-user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --teams:create --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --teams:create --role teamless-user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Flags:
   --role <name>                    Logical role for the creator (defaults to "teamless-user", resolved to "team-owner")

--- a/tests/data-workflows/workflows/teams/teams-edit-workflow-lib.ts
+++ b/tests/data-workflows/workflows/teams/teams-edit-workflow-lib.ts
@@ -22,8 +22,8 @@ import {
 export const TEAMS_EDIT_DATA_WORKFLOW_HELP = `Teams edit data workflow
 
 Usage:
-  npm run test:workflows -- --teams:edit --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --teams:edit --owner-role team-owner --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --teams:edit --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --teams:edit --owner-role team-owner --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Flags:
   --owner-role <name>              Logical owner role (defaults to "team-owner")

--- a/tests/data-workflows/workflows/teams/teams-homepage-rank-workflow-lib.ts
+++ b/tests/data-workflows/workflows/teams/teams-homepage-rank-workflow-lib.ts
@@ -23,8 +23,8 @@ import {
 export const TEAMS_HOMEPAGE_RANK_DATA_WORKFLOW_HELP = `Teams homepage-rank data workflow
 
 Usage:
-  npm run test:workflows -- --teams:homepage-rank --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --teams:homepage-rank --owner-role team-owner --system-role system-admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --teams:homepage-rank --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --teams:homepage-rank --owner-role team-owner --system-role system-admin --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Flags:
   --owner-role <name>              Logical owner role (defaults to "team-owner")

--- a/tests/data-workflows/workflows/teams/teams-invite-accept-workflow-lib.ts
+++ b/tests/data-workflows/workflows/teams/teams-invite-accept-workflow-lib.ts
@@ -26,8 +26,8 @@ import {
 export const TEAMS_INVITE_ACCEPT_DATA_WORKFLOW_HELP = `Teams invite-accept data workflow
 
 Usage:
-  npm run test:workflows -- --teams:invite-accept --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --teams:invite-accept --owner-role team-owner --invitee-role invitee-a --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --teams:invite-accept --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --teams:invite-accept --owner-role team-owner --invitee-role invitee-a --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Flags:
   --owner-role <name>              Logical owner role (defaults to "team-owner")

--- a/tests/data-workflows/workflows/teams/teams-member-role-workflow-lib.ts
+++ b/tests/data-workflows/workflows/teams/teams-member-role-workflow-lib.ts
@@ -24,8 +24,8 @@ import {
 export const TEAMS_MEMBER_ROLE_DATA_WORKFLOW_HELP = `Teams member-role data workflow
 
 Usage:
-  npm run test:workflows -- --teams:member-role --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --teams:member-role --owner-role team-owner --member-role invitee-a --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --teams:member-role --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --teams:member-role --owner-role team-owner --member-role invitee-a --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Flags:
   --owner-role <name>              Logical owner role (defaults to "team-owner")

--- a/tests/data-workflows/workflows/teams/teams-reject-reinvite-workflow-lib.ts
+++ b/tests/data-workflows/workflows/teams/teams-reject-reinvite-workflow-lib.ts
@@ -25,8 +25,8 @@ import {
 export const TEAMS_REJECT_REINVITE_DATA_WORKFLOW_HELP = `Teams reject-reinvite data workflow
 
 Usage:
-  npm run test:workflows -- --teams:reject-reinvite --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --teams:reject-reinvite --owner-role team-owner --invitee-role invitee-b --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --teams:reject-reinvite --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --teams:reject-reinvite --owner-role team-owner --invitee-role invitee-b --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Flags:
   --owner-role <name>              Logical owner role (defaults to "team-owner")

--- a/tests/data-workflows/workflows/unitgroups/unitgroups-all-workflow.ts
+++ b/tests/data-workflows/workflows/unitgroups/unitgroups-all-workflow.ts
@@ -39,7 +39,7 @@ export const UNITGROUP_DATA_WORKFLOWS = [
 export const UNITGROUP_ALL_DATA_WORKFLOW_HELP = `UnitGroups data workflow suite
 
 Usage:
-  npm run test:workflows -- --unitgroups:all --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co --supabase-publishable-key <key>
+  npm run test:workflows -- --unitgroups:all --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co --supabase-publishable-key <key>
   npm run test:workflows -- --unitgroups:all --detail-result --no-keep-data
 
 Behavior:

--- a/tests/data-workflows/workflows/unitgroups/unitgroups-check-data-workflow-lib.ts
+++ b/tests/data-workflows/workflows/unitgroups/unitgroups-check-data-workflow-lib.ts
@@ -194,8 +194,8 @@ type LoadedValidationModules = {
 export const UNITGROUP_CHECK_DATA_WORKFLOW_HELP = `UnitGroup check-data data workflow
 
 Usage:
-  npm run test:workflows -- --unitgroups:check-data --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --unitgroups:check-data --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --unitgroups:check-data --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --unitgroups:check-data --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one unit group from tests/data-workflows/fixtures/data/unitgroups/001_create.json

--- a/tests/data-workflows/workflows/unitgroups/unitgroups-create-contribute-team-workflow-lib.ts
+++ b/tests/data-workflows/workflows/unitgroups/unitgroups-create-contribute-team-workflow-lib.ts
@@ -235,8 +235,8 @@ const EXPECTATION_KEYS = new Set<ExpectationKey>([
 export const UNITGROUP_CREATE_CONTRIBUTE_TEAM_DATA_WORKFLOW_HELP = `UnitGroup create-contribute-team data workflow
 
 Usage:
-  npm run test:workflows -- --unitgroups:create-contribute-team --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --unitgroups:create-contribute-team --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --unitgroups:create-contribute-team --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --unitgroups:create-contribute-team --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one unit group from tests/data-workflows/fixtures/data/unitgroups/005_create_contribute_team.json

--- a/tests/data-workflows/workflows/unitgroups/unitgroups-create-version-update-reference-workflow-lib.ts
+++ b/tests/data-workflows/workflows/unitgroups/unitgroups-create-version-update-reference-workflow-lib.ts
@@ -263,8 +263,8 @@ export type UnitGroupCreateVersionUpdateReferenceDependencies = {
 export const UNITGROUP_CREATE_VERSION_UPDATE_REFERENCE_DATA_WORKFLOW_HELP = `UnitGroup create-version-update-reference data workflow
 
 Usage:
-  npm run test:workflows -- --unitgroups:create-version-update-reference --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --unitgroups:create-version-update-reference --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --unitgroups:create-version-update-reference --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --unitgroups:create-version-update-reference --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one unit group from tests/data-workflows/fixtures/data/unitgroups/004_create_version_update_reference.json

--- a/tests/data-workflows/workflows/unitgroups/unitgroups-create-view-copy-workflow-lib.ts
+++ b/tests/data-workflows/workflows/unitgroups/unitgroups-create-view-copy-workflow-lib.ts
@@ -305,8 +305,8 @@ const EXPECTATION_KEYS = new Set<ExpectationKey>([
 export const UNITGROUP_CREATE_VIEW_COPY_DATA_WORKFLOW_HELP = `UnitGroup create-view-copy data workflow
 
 Usage:
-  npm run test:workflows -- --unitgroups:create-view-copy --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --unitgroups:create-view-copy --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --unitgroups:create-view-copy --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --unitgroups:create-view-copy --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one unit group from tests/data-workflows/fixtures/data/unitgroups/001_create_view_copy.json

--- a/tests/data-workflows/workflows/unitgroups/unitgroups-create-workflow-lib.ts
+++ b/tests/data-workflows/workflows/unitgroups/unitgroups-create-workflow-lib.ts
@@ -207,8 +207,8 @@ export type RuntimeRecord = {
 export const UNITGROUP_CREATE_DATA_WORKFLOW_HELP = `UnitGroup create data workflow
 
 Usage:
-  npm run test:workflows -- --unitgroups:create --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --unitgroups:create --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie --no-keep-data
+  npm run test:workflows -- --unitgroups:create --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --unitgroups:create --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna --no-keep-data
 
 Flags:
   --role <name>                    Role key from .env.users.local / TEST_USERS_JSON / TEST_<ROLE>_* (defaults to "user")

--- a/tests/data-workflows/workflows/unitgroups/unitgroups-edit-workflow-lib.ts
+++ b/tests/data-workflows/workflows/unitgroups/unitgroups-edit-workflow-lib.ts
@@ -206,8 +206,8 @@ export type UnitGroupEditDependencies = {
 export const UNITGROUP_EDIT_DATA_WORKFLOW_HELP = `UnitGroup edit data workflow
 
 Usage:
-  npm run test:workflows -- --unitgroups:edit --frontend-url http://127.0.0.1:8000 --supabase-url https://fotofiyqnuyvgtotswie.supabase.co
-  npm run test:workflows -- --unitgroups:edit --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/fotofiyqnuyvgtotswie
+  npm run test:workflows -- --unitgroups:edit --frontend-url http://127.0.0.1:8000 --supabase-url https://submidrhbtknjxfympna.supabase.co
+  npm run test:workflows -- --unitgroups:edit --role user --frontend-url https://lca.tiangong.earth --supabase-url https://supabase.com/dashboard/project/submidrhbtknjxfympna
 
 Workflow:
   1. Create one unit group from tests/data-workflows/fixtures/data/unitgroups/001_create.json


### PR DESCRIPTION
## 摘要

- 将前端开发环境切换到重建后的持久化 Supabase Dev 项目 `submidrhbtknjxfympna`
- 更新对应 publishable key（未在日志或 PR 中暴露）
- 同步 91 个数据工作流文件中的默认项目 URL、dashboard URL 和项目 ref
- 不改变业务逻辑、生产环境配置或数据库契约

## 验证

- 数据工作流定向测试：46 suites / 334 tests 全部通过
- `lint:js`、Prettier、TypeScript 检查通过
- LCIA cache 与 reference-data 检查通过
- 完整覆盖率门禁运行 408 suites / 5548 tests；407 suites、5545 tests 通过。唯一失败文件为现有 `tests/unit/pages/DataProcessing/index.test.tsx`，其 3 个用例使用已于 `2026-08-05 00:00` 到期的固定签名产物，属于与本次 ref/key 替换无关的日期基线问题；因此覆盖率为 99.98% 而非 100%
- Docpact lint：101 个 changed paths，coverage/freshness 均通过

## 风险与集成

- 仅影响 Git `dev` 的开发环境绑定，不更新 workspace `main` 子模块指针
- Edge Functions 的部署与远程烟测由关联 Edge Issue/PR 独立完成

Closes #768

关联：tiangong-lca/workspace#550