### PR TITLE
fix: separate LCIA query failures from evidence trust

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-02"
-lastReviewedCommit: "e0d81988621ef953fcc7b07d1713513cabfc63e8"
-lastReviewedNote: 'Reviewed for Issue #756 after qualifying the current dev candidate: the 60-pass/24-designed-skip, zero-external-request, zero-production-write result preserves the existing routing, testing-gate, release, and workspace-integration boundaries.'
+lastReviewedAt: '2026-08-06'
+lastReviewedCommit: '21a66d230858179097bba98e114f2aca9eefc9da'
+lastReviewedNote: 'Reviewed for Issue #771: the LCIA result-panel state fix remains routed through the existing frontend runtime, testing-gate, and workspace-integration ownership.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,9 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-08-02
-lastReviewedCommit: e0d81988621ef953fcc7b07d1713513cabfc63e8
-lastReviewedNote: 'Reviewed for Issue #756 after qualifying the current dev candidate: the credential-free 60-pass/24-designed-skip receipt does not alter frontend ownership, dev-first branch policy, production-write authorization, validation gates, or root integration ownership.'
+lastReviewedAt: 2026-08-06
+lastReviewedCommit: 21a66d230858179097bba98e114f2aca9eefc9da
+lastReviewedNote: 'Reviewed for Issue #771: separating LCIA query failures from evidence validation remains within existing frontend ownership, production hotfix, quality-gate, and root-integration boundaries.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -28,9 +28,9 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - .nvmrc
-lastReviewedAt: 2026-08-02
-lastReviewedCommit: e0d81988621ef953fcc7b07d1713513cabfc63e8
-lastReviewedNote: 'Reviewed for Issue #756 after qualifying the current dev candidate: the generated credential-free receipt follows the existing clean qualification, normal dev PR, production-preflight, promotion, and workspace-integration sequence.'
+lastReviewedAt: 2026-08-06
+lastReviewedCommit: 21a66d230858179097bba98e114f2aca9eefc9da
+lastReviewedNote: 'Reviewed for Issue #771: the LCIA result-panel hotfix uses the existing Node 24, focused-test, managed-push, production-hotfix PR, and workspace-integration sequence.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/lcia-calculation-evidence.md
+++ b/docs/agents/lcia-calculation-evidence.md
@@ -27,9 +27,9 @@ checkPaths:
   - src/services/processes/api.ts
   - .github/workflows/ci.yml
   - .github/workflows/build.yml
-lastReviewedAt: 2026-07-17
-lastReviewedCommit: cc66ad9a4084063b3fea7659bb4271303a88ba2e
-lastReviewedNote: 'Added the persisted Calculation Bundle and canonical release readback contract for Issue #606 without changing the reviewed static LCIA method bundle.'
+lastReviewedAt: 2026-08-06
+lastReviewedCommit: 21a66d230858179097bba98e114f2aca9eefc9da
+lastReviewedNote: 'Reviewed for Issue #771: distinguish LCIA result transport state from calculation-evidence trust while retaining fail-closed validation after successful responses.'
 ---
 
 # LCIA Method Bundle and Calculation Evidence Contract
@@ -72,6 +72,8 @@ Only `lca.calculation_evidence.v2` can establish service-result completeness. It
 `lcia_factor_coverage` is the single embedded truth source and uses `lcia.method_factor_coverage.matrix.v1`. It must include source, method, factor, and method-identity hashes; `count_unit=exchange_method_pair`; the four key dimensions; global counts; exactly one unique row for each of the 25 reviewed method identities; the same non-empty exchange observation count in every method row; and an evidence artifact when any pair is unmatched, invalid, or unsupported. Every count and derived aggregate must be a non-negative JavaScript safe integer. Global counts must equal the sum of method rows, and the global pair total must equal the per-method pair total times 25. A parallel coverage matrix, a missing identity hash, or any mismatch fails closed. Version 1 evidence remains displayable as legacy evidence but can never be labeled complete.
 
 Frontend inline gap evidence uses `lcia-uncharacterized-jsonl:v1`; Worker v2 evidence must use the external artifact format `lcia-uncharacterized-jsonl:v2`. Raw Worker/S3 artifact URLs are not trusted browser download links. Until Edge provides an authenticated or signed projection, the UI hides the production URL, shows immutable artifact hash/count, and permits downloading the evidence JSON. Explicit development loopback URLs may remain clickable. The UI shows localized complete, incomplete, failure, or source-mismatch notices plus method descriptions and IDs.
+
+Result-query state is not evidence state. A pending or failed Edge query shows only its calculation/query status and must not substitute absent response evidence with static Process evidence or label the transport failure as method-source drift. After a numerical service response succeeds, the returned calculation evidence is still mandatory and is validated fail closed; a successful response without valid evidence remains a genuine trust failure.
 
 ## Private-draft analysis scope
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-08-02
-lastReviewedCommit: e0d81988621ef953fcc7b07d1713513cabfc63e8
-lastReviewedNote: 'Reviewed for Issue #756 after qualifying the current dev candidate: the generated credential-free receipt follows the existing normal dev PR, managed-push, production-authorization, and release-trigger policy.'
+lastReviewedAt: 2026-08-06
+lastReviewedCommit: 21a66d230858179097bba98e114f2aca9eefc9da
+lastReviewedNote: 'Reviewed for Issue #771: the focused component regression test does not alter managed-push, protected-branch, release-trigger, or retry-receipt policy.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,9 +25,9 @@ checkPaths:
   - playwright.config.ts
   - config/docs-capture/**
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-08-01
-lastReviewedCommit: b8b32228f6debd2165512c26fc186801bd3bcfe2
-lastReviewedNote: 'Reviewed for Issue #754: document inline Task Center closure-detail recovery and capability-gated artifact downloads without changing backend or result-package ownership.'
+lastReviewedAt: 2026-08-06
+lastReviewedCommit: 21a66d230858179097bba98e114f2aca9eefc9da
+lastReviewedNote: 'Reviewed for Issue #771: document the separation between LCIA transport state and evidence trust state without changing backend authority.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -81,6 +81,7 @@ Rules:
 - app locale, content language, service-query language, and reference-resource language are separate boundaries. Content reading priorities, backend-query fallbacks, and reference-resource delivery states are declared independently; a native reference overlay exists only after its exact structure/evidence gate passes. Documentation, legal, and public-doc surfaces keep their separately disclosed fallbacks
 - anonymous SPA access is limited to the explicit login/recovery allowlist. Root/Welcome, every other configured application route, case variants, and unmatched paths require the session guard and redirect anonymous users to the canonical login route; authenticated unmatched paths may render the localized 404. Role gates defer missing-session decisions to that global redirect, then enforce their role only after a user exists, so they cannot replace login with an anonymous 403. Localization route/view coverage records this access context but must never broaden it. Authenticated redirects that drive localized query/hash views must preserve their URL state
 - query-, hash-, path-, loading-, empty-, error-, and retry-driven visible states belong to the locale catalog just like the default page view; pages and reusable components must not hide service failures behind a successful empty state
+- LCIA result transport state and calculation-evidence trust state are separate: a failed or pending result query renders its own state and cannot be reinterpreted as missing or mismatched evidence; only a successfully returned numerical result enters the fail-closed evidence validator
 - Contact, FlowProperty, Source, and UnitGroup keyword searches use `src/services/general/hybridSearch.ts` and their four allowlisted Hybrid Edge Functions. UUID-mention and empty-keyword list paths remain on their existing RPCs. The shared service forwards the current user JWT plus query/filter/paging and optional state/team context, returns Team Data as a genuine empty result when no team is selected, and preserves transport/auth/mapping failures as `success: false` instead of presenting them as empty data
 - Process keyword searches use the indexed `search_processes_latest_v2` RPC and pass explicit escaped query terms without app-side field filtering. The `public_plus_owner_draft` calculation picker enables the database-owned strict owner-draft mode for its personal branch, requiring owner `state_code=0` rows with null team/review identity, then merges that result with public state-100 rows. Database migrations own the `extracted_md` lexical source and its PGroonga index
 - computed message IDs must belong to an exact enumerated family that either proves a closed-world producer or implements a localized runtime fallback before an unknown value is formatted; opaque backend diagnostics are not locale keys

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-08-02
-lastReviewedCommit: e0d81988621ef953fcc7b07d1713513cabfc63e8
-lastReviewedNote: 'Reviewed for Issue #756 after qualifying the current dev candidate: 60 browser cases passed, 24 designed cases skipped, all 49 IDs closed, and external requests and production writes stayed zero; the receipt, preflight, and managed-gate flow remains accurate.'
+lastReviewedAt: 2026-08-06
+lastReviewedCommit: 21a66d230858179097bba98e114f2aca9eefc9da
+lastReviewedNote: 'Reviewed for Issue #771: focused Process LCIA result-panel tests cover query/evidence state separation while the existing lint, build, and managed-gate requirements remain accurate.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -69,7 +69,7 @@ npm run prepush:gate
 
 | Change type | Minimum local proof | Stronger proof when risk is higher | Notes |
 | --- | --- | --- | --- |
-| routes, pages, app runtime, shared UI | `npm run lint`; focused `npm run test:ci -- <jest-args>`; `npm run build` | `npm run prepush:gate` | shared UX changes often affect multiple entrypoints |
+| routes, pages, app runtime, shared UI | `npm run lint`; focused `npm run test:ci -- <jest-args>`; `npm run build` | `npm run prepush:gate` | shared UX changes often affect multiple entrypoints; Process LCIA query/evidence state changes include `tests/unit/pages/Processes/Components/processLciaResultsPanel.test.tsx` |
 | services or env selection | `npm run lint`; focused `npm run test:ci -- <jest-args>`; `npm run build` | `npm run prepush:gate` | companion proof may live in another repo if schema or Edge runtime changed |
 | Process keyword search service or LCA picker scope | focused `tests/unit/services/processes/api.test.ts` plus the Process full-text data-workflow unit; `npm run lint`; `npm run build` | smoke against the exact non-production Database revision that exposes `search_processes_latest_v2`; cover public, personal, and `public_plus_owner_draft` scopes | Assert explicit `query_terms`, no direct app-side ILIKE field filter, and `owner_draft_only=true` only for the personal branch of the strict calculation scope. Database owns latest-version, owner/team/review, and `extracted_md` index semantics. |
 | Contact, FlowProperty, Source, or UnitGroup Hybrid Search service/page/picker | `npm run lint`; focused shared-helper, four service, four main-page, four picker, locale-contract, and production-request-guard Jest suites; `npm run build` | final `npm run prepush:gate` through `push:checked`; smoke the exact non-production frontend against matching Database and Edge revisions for `tg`/`co`/`my`/`te` | Keep UUID and empty-keyword paths unchanged; verify state/team forwarding and Team Data without a selected team; auth, transport, malformed-response, and mapping failures must remain `success: false` rather than a successful empty result. New read-only Edge paths require an exact production-request-guard allowlist entry. |

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -26,9 +26,9 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - package.json
-lastReviewedAt: 2026-08-02
-lastReviewedCommit: e0d81988621ef953fcc7b07d1713513cabfc63e8
-lastReviewedNote: 'Reviewed for Issue #756 after qualifying the current dev candidate: the credential-free 60-pass/24-designed-skip, 49-ID result validates the maintained strategy and requires no testing-strategy expansion.'
+lastReviewedAt: 2026-08-06
+lastReviewedCommit: 21a66d230858179097bba98e114f2aca9eefc9da
+lastReviewedNote: 'Reviewed for Issue #771: query/evidence state separation is covered by the existing component-test strategy and requires no broader testing-strategy change.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -28,9 +28,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-02
-lastReviewedCommit: e0d81988621ef953fcc7b07d1713513cabfc63e8
-lastReviewedNote: 'Reviewed for Issue #756 after qualifying the current dev candidate: 60 passes, 24 designed skips, complete 49-ID closure, zero external requests, and zero production writes create no repository-wide coverage backlog item.'
+lastReviewedAt: 2026-08-06
+lastReviewedCommit: 21a66d230858179097bba98e114f2aca9eefc9da
+lastReviewedNote: 'Reviewed for Issue #771: the focused LCIA panel regression suite passes and creates no new repository-wide test backlog item.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -29,9 +29,9 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-02
-lastReviewedCommit: e0d81988621ef953fcc7b07d1713513cabfc63e8
-lastReviewedNote: 'Reviewed for Issue #756 after qualifying the current dev candidate: the credential-free 60-pass/24-designed-skip receipt and complete 49-ID binding validate the existing semantic E2E and managed-gate patterns.'
+lastReviewedAt: 2026-08-06
+lastReviewedCommit: 21a66d230858179097bba98e114f2aca9eefc9da
+lastReviewedNote: 'Reviewed for Issue #771: the existing mocked-service component pattern cleanly proves that transport failures do not produce evidence-mismatch UI.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -26,9 +26,9 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-02
-lastReviewedCommit: e0d81988621ef953fcc7b07d1713513cabfc63e8
-lastReviewedNote: 'Reviewed for Issue #756 after qualifying the current dev candidate: the existing clean-candidate, stale-receipt, Docker, and serial-gate guidance covered the 60-pass/24-designed-skip run without a new exception.'
+lastReviewedAt: 2026-08-06
+lastReviewedCommit: 21a66d230858179097bba98e114f2aca9eefc9da
+lastReviewedNote: 'Reviewed for Issue #771: the focused serial Jest command and existing gate troubleshooting remain sufficient; no new exception is required.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -1043,7 +1043,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
-          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
+          "focusedTestDigest": "8aa00a3dc86fa0851a8dc01ea8e6b367bf58a9908d9c858b04de31cf31e19905",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
+      "rowEvidenceDigest": "262a248a4f3ca5ca87bd2b4428c0997931682e47f34da894cfc32c752d8623e9",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "7bf2f3d0b69aebd09bb1458d733dcd8e0e8983dbb069d7c94b6afb0375f038e7"
+  "contextDigest": "f873c59d7dfbe6a30e3fefcd8a7f2246db77ad9af22703f94ab623711c14ef67"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -1043,7 +1043,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
-          "focusedTestDigest": "8aa00a3dc86fa0851a8dc01ea8e6b367bf58a9908d9c858b04de31cf31e19905",
+          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "262a248a4f3ca5ca87bd2b4428c0997931682e47f34da894cfc32c752d8623e9",
+      "rowEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "f873c59d7dfbe6a30e3fefcd8a7f2246db77ad9af22703f94ab623711c14ef67"
+  "contextDigest": "7bf2f3d0b69aebd09bb1458d733dcd8e0e8983dbb069d7c94b6afb0375f038e7"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb",
-    "auditedInputDigest": "bf1d21a781e4e708227e8a074b85ae03c5ae4435c0740ab76bf3f41edf0af091"
+    "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59",
+    "auditedInputDigest": "6aa6bf11274dc53d74edd5148fa6ea22c902fd9e59b539529562b9fddba99c05"
   },
   "inventory": {
     "sourceMessageCount": 3098,
@@ -47,7 +47,7 @@
     "messageCount": 3098,
     "completeCount": 3098,
     "blockedCount": 0,
-    "dossierDigest": "011cdb89553e700472adfefbe3edba716084133afd2cbff12ef1f3383cd773c4",
+    "dossierDigest": "732873ff7c419b602420c52c0962a6b2a1e587ba86ac5f8d541076d965638c96",
     "catalogDigest": "df0a5502c9d3b710b4506d04cc7a18b39c4d8907f7186c7eb6e58d76fde7361c",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "b24e8fc7ad04520666a8993208606d0ab4be718653297bdef1ca7d19d3561512"
+  "contextDigest": "7bf2f3d0b69aebd09bb1458d733dcd8e0e8983dbb069d7c94b6afb0375f038e7"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb"
+    "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "b24e8fc7ad04520666a8993208606d0ab4be718653297bdef1ca7d19d3561512",
-    "qualityDigest": "19dd07c5147765ea9ede13135e38efe41d822a2b2d8671b32eea48b53fd8c186",
+    "contextDigest": "7bf2f3d0b69aebd09bb1458d733dcd8e0e8983dbb069d7c94b6afb0375f038e7",
+    "qualityDigest": "400586f65d1a1985600017e5e9651bd8f8dd083209911ccbf10e7c6b1797af02",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "c8b66507c3a8e57e81f9e56a9a1e61624f385b06a2c817a757cab17a8c39e7ae",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "5ff7d2331114ee2732b05a23f28ac9b35f3834d5f454724ecc03014fa4f88efc"
+  "activationDigest": "1b83900f9d187f662460c5a1884832cb089951b56354087f24e25205177404f0"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "7bf2f3d0b69aebd09bb1458d733dcd8e0e8983dbb069d7c94b6afb0375f038e7",
-    "qualityDigest": "400586f65d1a1985600017e5e9651bd8f8dd083209911ccbf10e7c6b1797af02",
+    "contextDigest": "f873c59d7dfbe6a30e3fefcd8a7f2246db77ad9af22703f94ab623711c14ef67",
+    "qualityDigest": "2e44c71cbc762fa1235bfa82bb683bfaa5b030f7732e2e101beee44198f3678e",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "c8b66507c3a8e57e81f9e56a9a1e61624f385b06a2c817a757cab17a8c39e7ae",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "1b83900f9d187f662460c5a1884832cb089951b56354087f24e25205177404f0"
+  "activationDigest": "86a6f3f1c8ac254eeb8825f4d43df9801d804991f586d3e208bc640efe403dbe"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "f873c59d7dfbe6a30e3fefcd8a7f2246db77ad9af22703f94ab623711c14ef67",
-    "qualityDigest": "2e44c71cbc762fa1235bfa82bb683bfaa5b030f7732e2e101beee44198f3678e",
+    "contextDigest": "7bf2f3d0b69aebd09bb1458d733dcd8e0e8983dbb069d7c94b6afb0375f038e7",
+    "qualityDigest": "400586f65d1a1985600017e5e9651bd8f8dd083209911ccbf10e7c6b1797af02",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "c8b66507c3a8e57e81f9e56a9a1e61624f385b06a2c817a757cab17a8c39e7ae",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "86a6f3f1c8ac254eeb8825f4d43df9801d804991f586d3e208bc640efe403dbe"
+  "activationDigest": "1b83900f9d187f662460c5a1884832cb089951b56354087f24e25205177404f0"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "bf1d21a781e4e708227e8a074b85ae03c5ae4435c0740ab76bf3f41edf0af091",
+    "auditedInputDigest": "6aa6bf11274dc53d74edd5148fa6ea22c902fd9e59b539529562b9fddba99c05",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59",
-    "contextDigest": "f873c59d7dfbe6a30e3fefcd8a7f2246db77ad9af22703f94ab623711c14ef67"
+    "contextDigest": "7bf2f3d0b69aebd09bb1458d733dcd8e0e8983dbb069d7c94b6afb0375f038e7"
   },
   "catalog": {
     "messageCount": 3098,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "3a9e82b99e6d5bb7e47a108f5955f922e403027d64a1b37b03a5a5aa75342f9e",
-    "validationDigest": "067efb305d58e0a38c79d9b87beddc337f41d0487069a09b4f40c078de3ebce7",
+    "digest": "a206e1dfc42fe175eac9afb4a055ae63a4aee6be925e0235647fa7a45f55e3d9",
+    "validationDigest": "58294940971ce8c7fef5fe22b51af6043d18fc178f627a2cccd515f7a386dd27",
     "laneCount": 1,
     "validatedMessageCount": 3098,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "2e44c71cbc762fa1235bfa82bb683bfaa5b030f7732e2e101beee44198f3678e"
+  "qualityDigest": "400586f65d1a1985600017e5e9651bd8f8dd083209911ccbf10e7c6b1797af02"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb",
-    "contextDigest": "b24e8fc7ad04520666a8993208606d0ab4be718653297bdef1ca7d19d3561512"
+    "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59",
+    "contextDigest": "7bf2f3d0b69aebd09bb1458d733dcd8e0e8983dbb069d7c94b6afb0375f038e7"
   },
   "catalog": {
     "messageCount": 3098,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "bf7c3b67a822a1bb574e76580f89a25783d50e7fd0cbae5d94a2476f4eef4c7f",
-    "validationDigest": "0b3df317260e9a2ad9ff755fe75238c6c80884b9ce303b6e661b738e7da05f96",
+    "digest": "a206e1dfc42fe175eac9afb4a055ae63a4aee6be925e0235647fa7a45f55e3d9",
+    "validationDigest": "58294940971ce8c7fef5fe22b51af6043d18fc178f627a2cccd515f7a386dd27",
     "laneCount": 1,
     "validatedMessageCount": 3098,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "19dd07c5147765ea9ede13135e38efe41d822a2b2d8671b32eea48b53fd8c186"
+  "qualityDigest": "400586f65d1a1985600017e5e9651bd8f8dd083209911ccbf10e7c6b1797af02"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59",
-    "contextDigest": "7bf2f3d0b69aebd09bb1458d733dcd8e0e8983dbb069d7c94b6afb0375f038e7"
+    "contextDigest": "f873c59d7dfbe6a30e3fefcd8a7f2246db77ad9af22703f94ab623711c14ef67"
   },
   "catalog": {
     "messageCount": 3098,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "a206e1dfc42fe175eac9afb4a055ae63a4aee6be925e0235647fa7a45f55e3d9",
-    "validationDigest": "58294940971ce8c7fef5fe22b51af6043d18fc178f627a2cccd515f7a386dd27",
+    "digest": "3a9e82b99e6d5bb7e47a108f5955f922e403027d64a1b37b03a5a5aa75342f9e",
+    "validationDigest": "067efb305d58e0a38c79d9b87beddc337f41d0487069a09b4f40c078de3ebce7",
     "laneCount": 1,
     "validatedMessageCount": 3098,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "400586f65d1a1985600017e5e9651bd8f8dd083209911ccbf10e7c6b1797af02"
+  "qualityDigest": "2e44c71cbc762fa1235bfa82bb683bfaa5b030f7732e2e101beee44198f3678e"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "df0a5502c9d3b710b4506d04cc7a18b39c4d8907f7186c7eb6e58d76fde7361c",
     "dossierDigest": "732873ff7c419b602420c52c0962a6b2a1e587ba86ac5f8d541076d965638c96",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "262a248a4f3ca5ca87bd2b4428c0997931682e47f34da894cfc32c752d8623e9",
+    "routeEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "067efb305d58e0a38c79d9b87beddc337f41d0487069a09b4f40c078de3ebce7"
+  "validationDigest": "58294940971ce8c7fef5fe22b51af6043d18fc178f627a2cccd515f7a386dd27"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "bf1d21a781e4e708227e8a074b85ae03c5ae4435c0740ab76bf3f41edf0af091",
+    "auditedInputDigest": "6aa6bf11274dc53d74edd5148fa6ea22c902fd9e59b539529562b9fddba99c05",
     "validatedMessageCount": 3098,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1374,
     "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
     "catalogDigest": "df0a5502c9d3b710b4506d04cc7a18b39c4d8907f7186c7eb6e58d76fde7361c",
-    "dossierDigest": "011cdb89553e700472adfefbe3edba716084133afd2cbff12ef1f3383cd773c4",
+    "dossierDigest": "732873ff7c419b602420c52c0962a6b2a1e587ba86ac5f8d541076d965638c96",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "5120aa22622b7730b9e96f4cab159adde8950b8353606f00b164af870b82483b",
         "highRiskMessageCount": 1374,
         "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
-        "dossierDigest": "011cdb89553e700472adfefbe3edba716084133afd2cbff12ef1f3383cd773c4",
+        "dossierDigest": "732873ff7c419b602420c52c0962a6b2a1e587ba86ac5f8d541076d965638c96",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "0b3df317260e9a2ad9ff755fe75238c6c80884b9ce303b6e661b738e7da05f96"
+  "validationDigest": "58294940971ce8c7fef5fe22b51af6043d18fc178f627a2cccd515f7a386dd27"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "df0a5502c9d3b710b4506d04cc7a18b39c4d8907f7186c7eb6e58d76fde7361c",
     "dossierDigest": "732873ff7c419b602420c52c0962a6b2a1e587ba86ac5f8d541076d965638c96",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
+    "routeEvidenceDigest": "262a248a4f3ca5ca87bd2b4428c0997931682e47f34da894cfc32c752d8623e9",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "58294940971ce8c7fef5fe22b51af6043d18fc178f627a2cccd515f7a386dd27"
+  "validationDigest": "067efb305d58e0a38c79d9b87beddc337f41d0487069a09b4f40c078de3ebce7"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -1043,7 +1043,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
-          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
+          "focusedTestDigest": "8aa00a3dc86fa0851a8dc01ea8e6b367bf58a9908d9c858b04de31cf31e19905",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
+      "rowEvidenceDigest": "262a248a4f3ca5ca87bd2b4428c0997931682e47f34da894cfc32c752d8623e9",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "5100e44dda452a0f1fbfeb9f4220110df2575fa04154088b4e77dc16d94e32bc"
+  "contextDigest": "5d42b5a313a6230bd3b53a2b39ea42a40eb842eaffe5d4fe83f837716c0286bb"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -1043,7 +1043,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
-          "focusedTestDigest": "8aa00a3dc86fa0851a8dc01ea8e6b367bf58a9908d9c858b04de31cf31e19905",
+          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "262a248a4f3ca5ca87bd2b4428c0997931682e47f34da894cfc32c752d8623e9",
+      "rowEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "5d42b5a313a6230bd3b53a2b39ea42a40eb842eaffe5d4fe83f837716c0286bb"
+  "contextDigest": "5100e44dda452a0f1fbfeb9f4220110df2575fa04154088b4e77dc16d94e32bc"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb",
-    "auditedInputDigest": "bf1d21a781e4e708227e8a074b85ae03c5ae4435c0740ab76bf3f41edf0af091"
+    "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59",
+    "auditedInputDigest": "6aa6bf11274dc53d74edd5148fa6ea22c902fd9e59b539529562b9fddba99c05"
   },
   "inventory": {
     "sourceMessageCount": 3098,
@@ -47,7 +47,7 @@
     "messageCount": 3098,
     "completeCount": 3098,
     "blockedCount": 0,
-    "dossierDigest": "5a216b1988241933c19990a7674ec9c91bb40acbfcbb4451e5cc93eb372d3b90",
+    "dossierDigest": "26c1c5c2f4379cc486c8d13c9dbc30f20a8f299092d80719cd93414e8861b830",
     "catalogDigest": "a3c224f555eb03d69f18241734ed2da7bd391a59956b1df1e99f70a5c9b08014",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "dc9467d95181816dfeffc4ef6125978940936dafcc5722c59b13504784b779b5"
+  "contextDigest": "5100e44dda452a0f1fbfeb9f4220110df2575fa04154088b4e77dc16d94e32bc"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb"
+    "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "dc9467d95181816dfeffc4ef6125978940936dafcc5722c59b13504784b779b5",
-    "qualityDigest": "17d6bc0b243b56cd44c6b84d87316f9389b755707224ca90d61f7deb2be4a908",
+    "contextDigest": "5100e44dda452a0f1fbfeb9f4220110df2575fa04154088b4e77dc16d94e32bc",
+    "qualityDigest": "12e483b48685bfce4e7b4f2612973ad1e7fcac7e34d2a2c0d1ea909623c6018c",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "c8b66507c3a8e57e81f9e56a9a1e61624f385b06a2c817a757cab17a8c39e7ae",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "3027f30d251a4d22a0364940f0434d4581534f3b0c01a101c2e99052bd8350cb"
+  "activationDigest": "efa834459480ac3ffcebac2535fe577132100effe70c0d0e09a8b76dd52c4265"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "5d42b5a313a6230bd3b53a2b39ea42a40eb842eaffe5d4fe83f837716c0286bb",
-    "qualityDigest": "43993a6365c9dd0c338d4fcdad7c91d5105dbbc8b1b4d915edccd4b139608943",
+    "contextDigest": "5100e44dda452a0f1fbfeb9f4220110df2575fa04154088b4e77dc16d94e32bc",
+    "qualityDigest": "12e483b48685bfce4e7b4f2612973ad1e7fcac7e34d2a2c0d1ea909623c6018c",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "c8b66507c3a8e57e81f9e56a9a1e61624f385b06a2c817a757cab17a8c39e7ae",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "ac922a90dffb9d487c15457151ce7798e430bbd61276ac98b69d20dafea20481"
+  "activationDigest": "efa834459480ac3ffcebac2535fe577132100effe70c0d0e09a8b76dd52c4265"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "5100e44dda452a0f1fbfeb9f4220110df2575fa04154088b4e77dc16d94e32bc",
-    "qualityDigest": "12e483b48685bfce4e7b4f2612973ad1e7fcac7e34d2a2c0d1ea909623c6018c",
+    "contextDigest": "5d42b5a313a6230bd3b53a2b39ea42a40eb842eaffe5d4fe83f837716c0286bb",
+    "qualityDigest": "43993a6365c9dd0c338d4fcdad7c91d5105dbbc8b1b4d915edccd4b139608943",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "c8b66507c3a8e57e81f9e56a9a1e61624f385b06a2c817a757cab17a8c39e7ae",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "efa834459480ac3ffcebac2535fe577132100effe70c0d0e09a8b76dd52c4265"
+  "activationDigest": "ac922a90dffb9d487c15457151ce7798e430bbd61276ac98b69d20dafea20481"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59",
-    "contextDigest": "5100e44dda452a0f1fbfeb9f4220110df2575fa04154088b4e77dc16d94e32bc"
+    "contextDigest": "5d42b5a313a6230bd3b53a2b39ea42a40eb842eaffe5d4fe83f837716c0286bb"
   },
   "catalog": {
     "messageCount": 3098,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "0bb99e520a1ce82229c6b09d7718fc8c17b63e6401b37b0fde62c73edbd47a0b",
-    "validationDigest": "772e0a5155ab5b0297afe6a22c4770233628c6d50b2d0b3444541adde2590e4c",
+    "digest": "d6732cf8c53bdabf68f8742f22a0756e569c7fcce0445e844609e6ccabc996bd",
+    "validationDigest": "7ace0c7a3328739fba4f80c164e5ccd78980dedcca91aae9a1f11b61a88af4dd",
     "laneCount": 1,
     "validatedMessageCount": 3098,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "12e483b48685bfce4e7b4f2612973ad1e7fcac7e34d2a2c0d1ea909623c6018c"
+  "qualityDigest": "43993a6365c9dd0c338d4fcdad7c91d5105dbbc8b1b4d915edccd4b139608943"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb",
-    "contextDigest": "dc9467d95181816dfeffc4ef6125978940936dafcc5722c59b13504784b779b5"
+    "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59",
+    "contextDigest": "5100e44dda452a0f1fbfeb9f4220110df2575fa04154088b4e77dc16d94e32bc"
   },
   "catalog": {
     "messageCount": 3098,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "0e761cca58db921f5b9d2792ccf6b7e5b0c9e9ad66416c0b5d1558d6d95e982d",
-    "validationDigest": "e8665d7046c37e27400c06079f83df6dbea377e024315561ad5755915a64b966",
+    "digest": "0bb99e520a1ce82229c6b09d7718fc8c17b63e6401b37b0fde62c73edbd47a0b",
+    "validationDigest": "772e0a5155ab5b0297afe6a22c4770233628c6d50b2d0b3444541adde2590e4c",
     "laneCount": 1,
     "validatedMessageCount": 3098,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "17d6bc0b243b56cd44c6b84d87316f9389b755707224ca90d61f7deb2be4a908"
+  "qualityDigest": "12e483b48685bfce4e7b4f2612973ad1e7fcac7e34d2a2c0d1ea909623c6018c"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59",
-    "contextDigest": "5d42b5a313a6230bd3b53a2b39ea42a40eb842eaffe5d4fe83f837716c0286bb"
+    "contextDigest": "5100e44dda452a0f1fbfeb9f4220110df2575fa04154088b4e77dc16d94e32bc"
   },
   "catalog": {
     "messageCount": 3098,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "d6732cf8c53bdabf68f8742f22a0756e569c7fcce0445e844609e6ccabc996bd",
-    "validationDigest": "7ace0c7a3328739fba4f80c164e5ccd78980dedcca91aae9a1f11b61a88af4dd",
+    "digest": "0bb99e520a1ce82229c6b09d7718fc8c17b63e6401b37b0fde62c73edbd47a0b",
+    "validationDigest": "772e0a5155ab5b0297afe6a22c4770233628c6d50b2d0b3444541adde2590e4c",
     "laneCount": 1,
     "validatedMessageCount": 3098,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "43993a6365c9dd0c338d4fcdad7c91d5105dbbc8b1b4d915edccd4b139608943"
+  "qualityDigest": "12e483b48685bfce4e7b4f2612973ad1e7fcac7e34d2a2c0d1ea909623c6018c"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "a3c224f555eb03d69f18241734ed2da7bd391a59956b1df1e99f70a5c9b08014",
     "dossierDigest": "26c1c5c2f4379cc486c8d13c9dbc30f20a8f299092d80719cd93414e8861b830",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
+    "routeEvidenceDigest": "262a248a4f3ca5ca87bd2b4428c0997931682e47f34da894cfc32c752d8623e9",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "772e0a5155ab5b0297afe6a22c4770233628c6d50b2d0b3444541adde2590e4c"
+  "validationDigest": "7ace0c7a3328739fba4f80c164e5ccd78980dedcca91aae9a1f11b61a88af4dd"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "bf1d21a781e4e708227e8a074b85ae03c5ae4435c0740ab76bf3f41edf0af091",
+    "auditedInputDigest": "6aa6bf11274dc53d74edd5148fa6ea22c902fd9e59b539529562b9fddba99c05",
     "validatedMessageCount": 3098,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1374,
     "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
     "catalogDigest": "a3c224f555eb03d69f18241734ed2da7bd391a59956b1df1e99f70a5c9b08014",
-    "dossierDigest": "5a216b1988241933c19990a7674ec9c91bb40acbfcbb4451e5cc93eb372d3b90",
+    "dossierDigest": "26c1c5c2f4379cc486c8d13c9dbc30f20a8f299092d80719cd93414e8861b830",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "5120aa22622b7730b9e96f4cab159adde8950b8353606f00b164af870b82483b",
         "highRiskMessageCount": 1374,
         "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
-        "dossierDigest": "5a216b1988241933c19990a7674ec9c91bb40acbfcbb4451e5cc93eb372d3b90",
+        "dossierDigest": "26c1c5c2f4379cc486c8d13c9dbc30f20a8f299092d80719cd93414e8861b830",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "e8665d7046c37e27400c06079f83df6dbea377e024315561ad5755915a64b966"
+  "validationDigest": "772e0a5155ab5b0297afe6a22c4770233628c6d50b2d0b3444541adde2590e4c"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "a3c224f555eb03d69f18241734ed2da7bd391a59956b1df1e99f70a5c9b08014",
     "dossierDigest": "26c1c5c2f4379cc486c8d13c9dbc30f20a8f299092d80719cd93414e8861b830",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "262a248a4f3ca5ca87bd2b4428c0997931682e47f34da894cfc32c752d8623e9",
+    "routeEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "7ace0c7a3328739fba4f80c164e5ccd78980dedcca91aae9a1f11b61a88af4dd"
+  "validationDigest": "772e0a5155ab5b0297afe6a22c4770233628c6d50b2d0b3444541adde2590e4c"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb",
-    "auditedInputDigest": "bf1d21a781e4e708227e8a074b85ae03c5ae4435c0740ab76bf3f41edf0af091"
+    "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59",
+    "auditedInputDigest": "6aa6bf11274dc53d74edd5148fa6ea22c902fd9e59b539529562b9fddba99c05"
   },
   "inventory": {
     "sourceMessageCount": 3098,
@@ -47,7 +47,7 @@
     "messageCount": 3098,
     "completeCount": 3098,
     "blockedCount": 0,
-    "dossierDigest": "65a1fcc5f1ba97ab505830d262709aa986c695318ff75e8ff54c4163cd8d1e4a",
+    "dossierDigest": "a6301fb3b1ff3000bd63cd625e7da24009dfd4197f92ba945f5c0ad548173afb",
     "catalogDigest": "58420e05cff95c7300d1f8b3dc9f1132c53b067e4b864f195c3f5a5296b81cd0",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "62e2c96b82c4a2fc565764a7ecf3bdf7d58da4b1de7d2a6f90107ff71fc923f7"
+  "contextDigest": "4a3d1709b16027d8245922120cf3bd867c4ca8d9b021e9166f912ec167070b4b"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -1043,7 +1043,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
-          "focusedTestDigest": "8aa00a3dc86fa0851a8dc01ea8e6b367bf58a9908d9c858b04de31cf31e19905",
+          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "262a248a4f3ca5ca87bd2b4428c0997931682e47f34da894cfc32c752d8623e9",
+      "rowEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "5bb5f70e46873181fe8846bf6d3f565bcc1e51f1c96ee1ab630ab5d2d8468b05"
+  "contextDigest": "4a3d1709b16027d8245922120cf3bd867c4ca8d9b021e9166f912ec167070b4b"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -1043,7 +1043,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
-          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
+          "focusedTestDigest": "8aa00a3dc86fa0851a8dc01ea8e6b367bf58a9908d9c858b04de31cf31e19905",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
+      "rowEvidenceDigest": "262a248a4f3ca5ca87bd2b4428c0997931682e47f34da894cfc32c752d8623e9",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "4a3d1709b16027d8245922120cf3bd867c4ca8d9b021e9166f912ec167070b4b"
+  "contextDigest": "5bb5f70e46873181fe8846bf6d3f565bcc1e51f1c96ee1ab630ab5d2d8468b05"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4a3d1709b16027d8245922120cf3bd867c4ca8d9b021e9166f912ec167070b4b",
-    "qualityDigest": "edb919d3aa9bff9edd23a9b389e9f1e9ad886c205bce935c03ce3d82018f6d3e",
+    "contextDigest": "5bb5f70e46873181fe8846bf6d3f565bcc1e51f1c96ee1ab630ab5d2d8468b05",
+    "qualityDigest": "8fb21baa5e8b40d7f1a8c06cecbb350c850dbfe06e909cb4548a04f6b0613f3a",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "c8b66507c3a8e57e81f9e56a9a1e61624f385b06a2c817a757cab17a8c39e7ae",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "99035c1545f543b45dfbc9ee4c29f526f5d9a8ad55b1721928fe89d822e8b825"
+  "activationDigest": "8ce1d3472e16f1ef4e220f71db786ac21f57fbf1041a5fd70c2d0c1f84fbe2d8"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "5bb5f70e46873181fe8846bf6d3f565bcc1e51f1c96ee1ab630ab5d2d8468b05",
-    "qualityDigest": "8fb21baa5e8b40d7f1a8c06cecbb350c850dbfe06e909cb4548a04f6b0613f3a",
+    "contextDigest": "4a3d1709b16027d8245922120cf3bd867c4ca8d9b021e9166f912ec167070b4b",
+    "qualityDigest": "edb919d3aa9bff9edd23a9b389e9f1e9ad886c205bce935c03ce3d82018f6d3e",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "c8b66507c3a8e57e81f9e56a9a1e61624f385b06a2c817a757cab17a8c39e7ae",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "8ce1d3472e16f1ef4e220f71db786ac21f57fbf1041a5fd70c2d0c1f84fbe2d8"
+  "activationDigest": "99035c1545f543b45dfbc9ee4c29f526f5d9a8ad55b1721928fe89d822e8b825"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb"
+    "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "62e2c96b82c4a2fc565764a7ecf3bdf7d58da4b1de7d2a6f90107ff71fc923f7",
-    "qualityDigest": "e86fe8fbb2ed22ee42dbf4a2051f68f5012f2985af966294d406f9079a1330d0",
+    "contextDigest": "4a3d1709b16027d8245922120cf3bd867c4ca8d9b021e9166f912ec167070b4b",
+    "qualityDigest": "edb919d3aa9bff9edd23a9b389e9f1e9ad886c205bce935c03ce3d82018f6d3e",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "c8b66507c3a8e57e81f9e56a9a1e61624f385b06a2c817a757cab17a8c39e7ae",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "3beae2ddc420e01947b2b119866564363754ddccd68ade5ad34b77ec00fef8b5"
+  "activationDigest": "99035c1545f543b45dfbc9ee4c29f526f5d9a8ad55b1721928fe89d822e8b825"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb",
-    "contextDigest": "62e2c96b82c4a2fc565764a7ecf3bdf7d58da4b1de7d2a6f90107ff71fc923f7"
+    "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59",
+    "contextDigest": "4a3d1709b16027d8245922120cf3bd867c4ca8d9b021e9166f912ec167070b4b"
   },
   "catalog": {
     "messageCount": 3098,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "162aa9c9802d319261844fa83f5aa583e41240e70d4891178de23b2026553a19",
-    "validationDigest": "728e12502e9386c509a057bae12de81b9a1a3f2d60fe7d750655928612b38113",
+    "digest": "315185200af082d3f4b2b32245e33c76095e6025851cdd988a70c0d34c89773b",
+    "validationDigest": "ce2cb6a17000c7ded73bedc270b2c3d03d065b8ea1243a09030e0b532b453f3b",
     "laneCount": 1,
     "validatedMessageCount": 3098,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "e86fe8fbb2ed22ee42dbf4a2051f68f5012f2985af966294d406f9079a1330d0"
+  "qualityDigest": "edb919d3aa9bff9edd23a9b389e9f1e9ad886c205bce935c03ce3d82018f6d3e"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59",
-    "contextDigest": "4a3d1709b16027d8245922120cf3bd867c4ca8d9b021e9166f912ec167070b4b"
+    "contextDigest": "5bb5f70e46873181fe8846bf6d3f565bcc1e51f1c96ee1ab630ab5d2d8468b05"
   },
   "catalog": {
     "messageCount": 3098,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "315185200af082d3f4b2b32245e33c76095e6025851cdd988a70c0d34c89773b",
-    "validationDigest": "ce2cb6a17000c7ded73bedc270b2c3d03d065b8ea1243a09030e0b532b453f3b",
+    "digest": "8c45619600aec0837d34039ac63975dc5961a184accc842fc6c93f2b194f4d58",
+    "validationDigest": "ebe7a6cb57b60ec154ce20a750e60d1934f3a1cfdb372221c522b2e9787d73db",
     "laneCount": 1,
     "validatedMessageCount": 3098,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "edb919d3aa9bff9edd23a9b389e9f1e9ad886c205bce935c03ce3d82018f6d3e"
+  "qualityDigest": "8fb21baa5e8b40d7f1a8c06cecbb350c850dbfe06e909cb4548a04f6b0613f3a"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59",
-    "contextDigest": "5bb5f70e46873181fe8846bf6d3f565bcc1e51f1c96ee1ab630ab5d2d8468b05"
+    "contextDigest": "4a3d1709b16027d8245922120cf3bd867c4ca8d9b021e9166f912ec167070b4b"
   },
   "catalog": {
     "messageCount": 3098,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "8c45619600aec0837d34039ac63975dc5961a184accc842fc6c93f2b194f4d58",
-    "validationDigest": "ebe7a6cb57b60ec154ce20a750e60d1934f3a1cfdb372221c522b2e9787d73db",
+    "digest": "315185200af082d3f4b2b32245e33c76095e6025851cdd988a70c0d34c89773b",
+    "validationDigest": "ce2cb6a17000c7ded73bedc270b2c3d03d065b8ea1243a09030e0b532b453f3b",
     "laneCount": 1,
     "validatedMessageCount": 3098,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "8fb21baa5e8b40d7f1a8c06cecbb350c850dbfe06e909cb4548a04f6b0613f3a"
+  "qualityDigest": "edb919d3aa9bff9edd23a9b389e9f1e9ad886c205bce935c03ce3d82018f6d3e"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "58420e05cff95c7300d1f8b3dc9f1132c53b067e4b864f195c3f5a5296b81cd0",
     "dossierDigest": "a6301fb3b1ff3000bd63cd625e7da24009dfd4197f92ba945f5c0ad548173afb",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
+    "routeEvidenceDigest": "262a248a4f3ca5ca87bd2b4428c0997931682e47f34da894cfc32c752d8623e9",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "ce2cb6a17000c7ded73bedc270b2c3d03d065b8ea1243a09030e0b532b453f3b"
+  "validationDigest": "ebe7a6cb57b60ec154ce20a750e60d1934f3a1cfdb372221c522b2e9787d73db"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "bf1d21a781e4e708227e8a074b85ae03c5ae4435c0740ab76bf3f41edf0af091",
+    "auditedInputDigest": "6aa6bf11274dc53d74edd5148fa6ea22c902fd9e59b539529562b9fddba99c05",
     "validatedMessageCount": 3098,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1374,
     "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
     "catalogDigest": "58420e05cff95c7300d1f8b3dc9f1132c53b067e4b864f195c3f5a5296b81cd0",
-    "dossierDigest": "65a1fcc5f1ba97ab505830d262709aa986c695318ff75e8ff54c4163cd8d1e4a",
+    "dossierDigest": "a6301fb3b1ff3000bd63cd625e7da24009dfd4197f92ba945f5c0ad548173afb",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "5120aa22622b7730b9e96f4cab159adde8950b8353606f00b164af870b82483b",
         "highRiskMessageCount": 1374,
         "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
-        "dossierDigest": "65a1fcc5f1ba97ab505830d262709aa986c695318ff75e8ff54c4163cd8d1e4a",
+        "dossierDigest": "a6301fb3b1ff3000bd63cd625e7da24009dfd4197f92ba945f5c0ad548173afb",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "728e12502e9386c509a057bae12de81b9a1a3f2d60fe7d750655928612b38113"
+  "validationDigest": "ce2cb6a17000c7ded73bedc270b2c3d03d065b8ea1243a09030e0b532b453f3b"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "58420e05cff95c7300d1f8b3dc9f1132c53b067e4b864f195c3f5a5296b81cd0",
     "dossierDigest": "a6301fb3b1ff3000bd63cd625e7da24009dfd4197f92ba945f5c0ad548173afb",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "262a248a4f3ca5ca87bd2b4428c0997931682e47f34da894cfc32c752d8623e9",
+    "routeEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "ebe7a6cb57b60ec154ce20a750e60d1934f3a1cfdb372221c522b2e9787d73db"
+  "validationDigest": "ce2cb6a17000c7ded73bedc270b2c3d03d065b8ea1243a09030e0b532b453f3b"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -1043,7 +1043,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
-          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
+          "focusedTestDigest": "8aa00a3dc86fa0851a8dc01ea8e6b367bf58a9908d9c858b04de31cf31e19905",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
+      "rowEvidenceDigest": "262a248a4f3ca5ca87bd2b4428c0997931682e47f34da894cfc32c752d8623e9",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "e1f45a2a60d1682595690a90470db91ff6a332784090fb018d7d3b3d1aac16f0"
+  "contextDigest": "064131f10410cc392e359580cd834c2c34c7007d7f10ca6e6654339813f0eecf"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb",
-    "auditedInputDigest": "bf1d21a781e4e708227e8a074b85ae03c5ae4435c0740ab76bf3f41edf0af091"
+    "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59",
+    "auditedInputDigest": "6aa6bf11274dc53d74edd5148fa6ea22c902fd9e59b539529562b9fddba99c05"
   },
   "inventory": {
     "sourceMessageCount": 3098,
@@ -47,7 +47,7 @@
     "messageCount": 3098,
     "completeCount": 3098,
     "blockedCount": 0,
-    "dossierDigest": "07514073fdf7d9342d4f32f1984ba5d6e76bc2d44f145d5463f0fedea2beee72",
+    "dossierDigest": "cf0ec6854837186433be9cd4ee64f3d63f2a18bb8732cda273e422beaa3c318c",
     "catalogDigest": "fc8ca32e41215b0ee38ba57c2f414c679fea664f5711119f714e20c481cc2f73",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "eaa32bfd01f8408cf6010f09a930d15c0199e175f6ef40b1fa52cdf7fe555735"
+  "contextDigest": "e1f45a2a60d1682595690a90470db91ff6a332784090fb018d7d3b3d1aac16f0"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -1043,7 +1043,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
-          "focusedTestDigest": "8aa00a3dc86fa0851a8dc01ea8e6b367bf58a9908d9c858b04de31cf31e19905",
+          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "262a248a4f3ca5ca87bd2b4428c0997931682e47f34da894cfc32c752d8623e9",
+      "rowEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "064131f10410cc392e359580cd834c2c34c7007d7f10ca6e6654339813f0eecf"
+  "contextDigest": "e1f45a2a60d1682595690a90470db91ff6a332784090fb018d7d3b3d1aac16f0"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb"
+    "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "eaa32bfd01f8408cf6010f09a930d15c0199e175f6ef40b1fa52cdf7fe555735",
-    "qualityDigest": "5f23cb5d169ffb3cb6a908412bc4886ef8208d12c0c2b7a3dba8e99cf933dfdd",
+    "contextDigest": "e1f45a2a60d1682595690a90470db91ff6a332784090fb018d7d3b3d1aac16f0",
+    "qualityDigest": "d4b9ff33501b184957608868052c7b13c58a8f771a5960b869170331906443ae",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "c8b66507c3a8e57e81f9e56a9a1e61624f385b06a2c817a757cab17a8c39e7ae",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "02987bcc17c2db21d4873c3d7ca2fbd3616aef23a373a070e317ef2fa8325a42"
+  "activationDigest": "99d712265021c05f6c9b956002231b339aabd15dfad20d165f277f171c22640c"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "064131f10410cc392e359580cd834c2c34c7007d7f10ca6e6654339813f0eecf",
-    "qualityDigest": "465db02f377cc1e8e812fa3f77729b414ea5a3de7479f06e899d7eb3017f9ebd",
+    "contextDigest": "e1f45a2a60d1682595690a90470db91ff6a332784090fb018d7d3b3d1aac16f0",
+    "qualityDigest": "d4b9ff33501b184957608868052c7b13c58a8f771a5960b869170331906443ae",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "c8b66507c3a8e57e81f9e56a9a1e61624f385b06a2c817a757cab17a8c39e7ae",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "50f4f8ffb03aa7ac9d4bcb24536c1fae55006b89afd0a879772e229d020ef2e4"
+  "activationDigest": "99d712265021c05f6c9b956002231b339aabd15dfad20d165f277f171c22640c"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "e1f45a2a60d1682595690a90470db91ff6a332784090fb018d7d3b3d1aac16f0",
-    "qualityDigest": "d4b9ff33501b184957608868052c7b13c58a8f771a5960b869170331906443ae",
+    "contextDigest": "064131f10410cc392e359580cd834c2c34c7007d7f10ca6e6654339813f0eecf",
+    "qualityDigest": "465db02f377cc1e8e812fa3f77729b414ea5a3de7479f06e899d7eb3017f9ebd",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "c8b66507c3a8e57e81f9e56a9a1e61624f385b06a2c817a757cab17a8c39e7ae",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "99d712265021c05f6c9b956002231b339aabd15dfad20d165f277f171c22640c"
+  "activationDigest": "50f4f8ffb03aa7ac9d4bcb24536c1fae55006b89afd0a879772e229d020ef2e4"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59",
-    "contextDigest": "064131f10410cc392e359580cd834c2c34c7007d7f10ca6e6654339813f0eecf"
+    "contextDigest": "e1f45a2a60d1682595690a90470db91ff6a332784090fb018d7d3b3d1aac16f0"
   },
   "catalog": {
     "messageCount": 3098,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "804a7a32a1386d33fedfe633ff40003075d3c928b7ff8ad5ce58566543f171c4",
-    "validationDigest": "5208dfe680b3aaa99eb0e83bf006aaabd25994b96520a9ac20790960cdc878e8",
+    "digest": "bc6cbf0a894ce35904863dda2ae83e13285ba73fb3e3673453ce3a8f7864ef1f",
+    "validationDigest": "884c53e3f6a2dd1ce9cc63612cb7e98102357748ace3100c8475da2f8515418d",
     "laneCount": 1,
     "validatedMessageCount": 3098,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "465db02f377cc1e8e812fa3f77729b414ea5a3de7479f06e899d7eb3017f9ebd"
+  "qualityDigest": "d4b9ff33501b184957608868052c7b13c58a8f771a5960b869170331906443ae"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "68f2e9cf0d96854cbe126a0a3ae9cfd00380a571435484493b9b7c65885f3fcb",
-    "contextDigest": "eaa32bfd01f8408cf6010f09a930d15c0199e175f6ef40b1fa52cdf7fe555735"
+    "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59",
+    "contextDigest": "e1f45a2a60d1682595690a90470db91ff6a332784090fb018d7d3b3d1aac16f0"
   },
   "catalog": {
     "messageCount": 3098,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "a37ac71eb1ab5cc70f8ed38bca5129d4538de5dbf34f3edca6a804032cf5cd20",
-    "validationDigest": "45cb432c01f7cc87a1920a7070fc8622f1c74dc9439adf576524caa9848c5921",
+    "digest": "bc6cbf0a894ce35904863dda2ae83e13285ba73fb3e3673453ce3a8f7864ef1f",
+    "validationDigest": "884c53e3f6a2dd1ce9cc63612cb7e98102357748ace3100c8475da2f8515418d",
     "laneCount": 1,
     "validatedMessageCount": 3098,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "5f23cb5d169ffb3cb6a908412bc4886ef8208d12c0c2b7a3dba8e99cf933dfdd"
+  "qualityDigest": "d4b9ff33501b184957608868052c7b13c58a8f771a5960b869170331906443ae"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "990f5bceb4d172a3c090d5ae688c0029195e9154225b529591582ec4cc319e59",
-    "contextDigest": "e1f45a2a60d1682595690a90470db91ff6a332784090fb018d7d3b3d1aac16f0"
+    "contextDigest": "064131f10410cc392e359580cd834c2c34c7007d7f10ca6e6654339813f0eecf"
   },
   "catalog": {
     "messageCount": 3098,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "bc6cbf0a894ce35904863dda2ae83e13285ba73fb3e3673453ce3a8f7864ef1f",
-    "validationDigest": "884c53e3f6a2dd1ce9cc63612cb7e98102357748ace3100c8475da2f8515418d",
+    "digest": "804a7a32a1386d33fedfe633ff40003075d3c928b7ff8ad5ce58566543f171c4",
+    "validationDigest": "5208dfe680b3aaa99eb0e83bf006aaabd25994b96520a9ac20790960cdc878e8",
     "laneCount": 1,
     "validatedMessageCount": 3098,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "d4b9ff33501b184957608868052c7b13c58a8f771a5960b869170331906443ae"
+  "qualityDigest": "465db02f377cc1e8e812fa3f77729b414ea5a3de7479f06e899d7eb3017f9ebd"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "bf1d21a781e4e708227e8a074b85ae03c5ae4435c0740ab76bf3f41edf0af091",
+    "auditedInputDigest": "6aa6bf11274dc53d74edd5148fa6ea22c902fd9e59b539529562b9fddba99c05",
     "validatedMessageCount": 3098,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1374,
     "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
     "catalogDigest": "fc8ca32e41215b0ee38ba57c2f414c679fea664f5711119f714e20c481cc2f73",
-    "dossierDigest": "07514073fdf7d9342d4f32f1984ba5d6e76bc2d44f145d5463f0fedea2beee72",
+    "dossierDigest": "cf0ec6854837186433be9cd4ee64f3d63f2a18bb8732cda273e422beaa3c318c",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "5120aa22622b7730b9e96f4cab159adde8950b8353606f00b164af870b82483b",
         "highRiskMessageCount": 1374,
         "highRiskMessageDigest": "44ed6dfa08749dad9601d7f0b0068f2d912b6e000f4c633f3e4da8ed444084fb",
-        "dossierDigest": "07514073fdf7d9342d4f32f1984ba5d6e76bc2d44f145d5463f0fedea2beee72",
+        "dossierDigest": "cf0ec6854837186433be9cd4ee64f3d63f2a18bb8732cda273e422beaa3c318c",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "45cb432c01f7cc87a1920a7070fc8622f1c74dc9439adf576524caa9848c5921"
+  "validationDigest": "884c53e3f6a2dd1ce9cc63612cb7e98102357748ace3100c8475da2f8515418d"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "fc8ca32e41215b0ee38ba57c2f414c679fea664f5711119f714e20c481cc2f73",
     "dossierDigest": "cf0ec6854837186433be9cd4ee64f3d63f2a18bb8732cda273e422beaa3c318c",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
+    "routeEvidenceDigest": "262a248a4f3ca5ca87bd2b4428c0997931682e47f34da894cfc32c752d8623e9",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "884c53e3f6a2dd1ce9cc63612cb7e98102357748ace3100c8475da2f8515418d"
+  "validationDigest": "5208dfe680b3aaa99eb0e83bf006aaabd25994b96520a9ac20790960cdc878e8"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "fc8ca32e41215b0ee38ba57c2f414c679fea664f5711119f714e20c481cc2f73",
     "dossierDigest": "cf0ec6854837186433be9cd4ee64f3d63f2a18bb8732cda273e422beaa3c318c",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "262a248a4f3ca5ca87bd2b4428c0997931682e47f34da894cfc32c752d8623e9",
+    "routeEvidenceDigest": "6039a8a44e9a963168013d01cdc3db834fd859111b20b9a872771d17c061e391",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "5208dfe680b3aaa99eb0e83bf006aaabd25994b96520a9ac20790960cdc878e8"
+  "validationDigest": "884c53e3f6a2dd1ce9cc63612cb7e98102357748ace3100c8475da2f8515418d"
 }

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "0cbff1b7ff691ea297e06944d3a7e3cd5a94e438eb1f58dcf750c16b7fe234ff"
+    "runResultSha256": "575bf50d21d2055efdbeecae9a671cef9966f82a4f7e1a66cfa6dc1414074c0a"
   },
-  "environmentManifestSha256": "2ae5a43d4f61bd398b184a4ab55b6c99765fb2dd4a40ac1f6afa6ce000b30dc6",
+  "environmentManifestSha256": "5343ee156c75d52227f7b677c61da90a6affe1abb36b741cecb335e6bf8d4223",
   "externalRequests": 0,
-  "generatedAt": "2026-08-02T02:27:16.070Z",
+  "generatedAt": "2026-08-05T18:39:35.500Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "68d4e1c2a933d7dda65bd7af985a5d3cd769e70a311c9cce3c6affb582bbaa97",
-  "qualifiedCommit": "e0d81988621ef953fcc7b07d1713513cabfc63e8",
-  "qualifiedTree": "36d73f1f9561bb8c3c74923462267166adcc5b47",
+  "qualificationInputSha256": "92baedb2f9e776cde7fa161531f175652313abadea56073458ad392268767760",
+  "qualifiedCommit": "d36f518ff1c5ebad1262f6dba54fad4d3a183ee1",
+  "qualifiedTree": "b974b76d75793d10293fe6791a8d09dae77b9352",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }

--- a/src/pages/Processes/Components/processLciaResultsPanel.tsx
+++ b/src/pages/Processes/Components/processLciaResultsPanel.tsx
@@ -570,11 +570,11 @@ const ProcessLciaResultsPanel: FC<Props> = ({
           )}
         </Space>
       )}
-      {!shouldUsePublishedPackage && (
-        <LcaCalculationEvidenceNotice
-          staticEvidence={solverLciaMeta ? undefined : baseCalculationEvidence}
-          calculationEvidence={solverLciaMeta?.calculationEvidence}
-        />
+      {!shouldUsePublishedPackage && !canQuerySolver && (
+        <LcaCalculationEvidenceNotice staticEvidence={baseCalculationEvidence} />
+      )}
+      {!shouldUsePublishedPackage && canQuerySolver && solverLciaMeta && (
+        <LcaCalculationEvidenceNotice calculationEvidence={solverLciaMeta.calculationEvidence} />
       )}
       <LcaProfileSummary
         rows={rows}

--- a/tests/setupTests.jsx
+++ b/tests/setupTests.jsx
@@ -120,13 +120,22 @@ const shouldFailOnActWarning =
 
 const actWarningRecords = [];
 let actWarningsThisTest = 0;
+let dataProcessingDateNowSpy;
 
 beforeEach(() => {
   actWarningsThisTest = 0;
+  const testPath = global.expect?.getState?.().testPath;
+  if (testPath?.endsWith('/tests/unit/pages/DataProcessing/index.test.tsx')) {
+    dataProcessingDateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(Date.parse('2026-08-04T00:00:00Z'));
+  }
 });
 
 afterEach(() => {
   cleanup();
+  dataProcessingDateNowSpy?.mockRestore();
+  dataProcessingDateNowSpy = undefined;
   jest.useRealTimers();
 
   if (!shouldFailOnActWarning || actWarningsThisTest === 0) {

--- a/tests/unit/pages/DataProcessing/index.test.tsx
+++ b/tests/unit/pages/DataProcessing/index.test.tsx
@@ -39,7 +39,7 @@ function contractArtifacts(states: [TestArtifactState, TestArtifactState] = ['re
               mediaType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
               size: 1024,
               checksumSha256: 'a'.repeat(64),
-              artifactExpiresAt: '2026-08-05T00:00:00Z',
+              artifactExpiresAt: '2099-08-05T00:00:00Z',
             }
           : {
               filename: 'closure-complete-manifest.json',
@@ -47,7 +47,7 @@ function contractArtifacts(states: [TestArtifactState, TestArtifactState] = ['re
               mediaType: 'application/vnd.tiangong.scope-closure-manifest+json',
               size: 2048,
               checksumSha256: 'b'.repeat(64),
-              artifactExpiresAt: '2026-08-05T00:00:00Z',
+              artifactExpiresAt: '2099-08-05T00:00:00Z',
             };
       return state === 'ready'
         ? { ...fixture, ...readyMetadata, artifactState: state }
@@ -2288,7 +2288,7 @@ describe('DataProcessing page', () => {
 
     const report = screen.getByTestId('closure-artifact-closure_report_xlsx');
     const manifest = screen.getByTestId('closure-artifact-closure_issue_manifest');
-    expect(within(report).getByText(/Available until: 2026-08-05 00:00/)).toBeInTheDocument();
+    expect(within(report).getByText(/Available until: 2099-08-05 00:00/)).toBeInTheDocument();
     expect(within(report).getByText('closure-issues.xlsx')).toBeInTheDocument();
     expect(within(report).getByText(/xlsx.*1\.0 KB/)).toBeInTheDocument();
     expect(within(report).getByText('a'.repeat(64))).toBeInTheDocument();
@@ -2610,7 +2610,7 @@ describe('DataProcessing page', () => {
 
   it('expires ready artifacts at the client deadline without another network request', async () => {
     jest.useFakeTimers();
-    jest.setSystemTime(Date.parse('2026-08-04T23:59:59Z'));
+    jest.setSystemTime(Date.parse('2099-08-04T23:59:59Z'));
     mockGetClosureCheck.mockReset().mockResolvedValue({
       data: closureSummary(['ready', 'ready']),
       error: null,
@@ -2874,7 +2874,7 @@ describe('DataProcessing page', () => {
 
     expect(screen.getByText('closure-issues.xlsx')).toBeInTheDocument();
     expect(screen.getByText('closure-complete-manifest.json')).toBeInTheDocument();
-    expect(screen.getAllByText(/Available until: 2026-08-05 00:00/)).toHaveLength(2);
+    expect(screen.getAllByText(/Available until: 2099-08-05 00:00/)).toHaveLength(2);
 
     fireEvent.click(screen.getByRole('button', { name: 'Download machine result manifest' }));
     expect(

--- a/tests/unit/pages/DataProcessing/index.test.tsx
+++ b/tests/unit/pages/DataProcessing/index.test.tsx
@@ -39,7 +39,7 @@ function contractArtifacts(states: [TestArtifactState, TestArtifactState] = ['re
               mediaType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
               size: 1024,
               checksumSha256: 'a'.repeat(64),
-              artifactExpiresAt: '2099-08-05T00:00:00Z',
+              artifactExpiresAt: '2026-08-05T00:00:00Z',
             }
           : {
               filename: 'closure-complete-manifest.json',
@@ -47,7 +47,7 @@ function contractArtifacts(states: [TestArtifactState, TestArtifactState] = ['re
               mediaType: 'application/vnd.tiangong.scope-closure-manifest+json',
               size: 2048,
               checksumSha256: 'b'.repeat(64),
-              artifactExpiresAt: '2099-08-05T00:00:00Z',
+              artifactExpiresAt: '2026-08-05T00:00:00Z',
             };
       return state === 'ready'
         ? { ...fixture, ...readyMetadata, artifactState: state }
@@ -2288,7 +2288,7 @@ describe('DataProcessing page', () => {
 
     const report = screen.getByTestId('closure-artifact-closure_report_xlsx');
     const manifest = screen.getByTestId('closure-artifact-closure_issue_manifest');
-    expect(within(report).getByText(/Available until: 2099-08-05 00:00/)).toBeInTheDocument();
+    expect(within(report).getByText(/Available until: 2026-08-05 00:00/)).toBeInTheDocument();
     expect(within(report).getByText('closure-issues.xlsx')).toBeInTheDocument();
     expect(within(report).getByText(/xlsx.*1\.0 KB/)).toBeInTheDocument();
     expect(within(report).getByText('a'.repeat(64))).toBeInTheDocument();
@@ -2610,7 +2610,7 @@ describe('DataProcessing page', () => {
 
   it('expires ready artifacts at the client deadline without another network request', async () => {
     jest.useFakeTimers();
-    jest.setSystemTime(Date.parse('2099-08-04T23:59:59Z'));
+    jest.setSystemTime(Date.parse('2026-08-04T23:59:59Z'));
     mockGetClosureCheck.mockReset().mockResolvedValue({
       data: closureSummary(['ready', 'ready']),
       error: null,
@@ -2874,7 +2874,7 @@ describe('DataProcessing page', () => {
 
     expect(screen.getByText('closure-issues.xlsx')).toBeInTheDocument();
     expect(screen.getByText('closure-complete-manifest.json')).toBeInTheDocument();
-    expect(screen.getAllByText(/Available until: 2099-08-05 00:00/)).toHaveLength(2);
+    expect(screen.getAllByText(/Available until: 2026-08-05 00:00/)).toHaveLength(2);
 
     fireEvent.click(screen.getByRole('button', { name: 'Download machine result manifest' }));
     expect(

--- a/tests/unit/pages/Processes/Components/processLciaResultsPanel.test.tsx
+++ b/tests/unit/pages/Processes/Components/processLciaResultsPanel.test.tsx
@@ -9,6 +9,7 @@ const mockQueryLcaResults = jest.fn();
 const mockIsLcaFunctionInvokeError = jest.fn();
 const mockGetPublishedLciaResultPackage = jest.fn();
 const mockUseLocation = jest.fn();
+const mockLcaCalculationEvidenceNotice = jest.fn();
 
 const toText = (node: any): string => {
   if (node === null || node === undefined) return '';
@@ -78,7 +79,10 @@ jest.mock('@/pages/Processes/Components/lcaProfileSummary', () => ({
 
 jest.mock('@/pages/Processes/Components/lcaCalculationEvidenceNotice', () => ({
   __esModule: true,
-  default: () => <div data-testid='lcia-evidence-notice' />,
+  default: (props: any) => {
+    mockLcaCalculationEvidenceNotice(props);
+    return <div data-testid='lcia-evidence-notice' />;
+  },
 }));
 
 jest.mock('@ant-design/pro-components', () => ({
@@ -551,6 +555,70 @@ describe('ProcessLciaResultsPanel', () => {
 
     expect(mockQueryLcaResults).toHaveBeenCalledTimes(1);
     jest.useRealTimers();
+  });
+
+  it('does not turn a solver query failure into a calculation-evidence mismatch', async () => {
+    mockQueryLcaResults.mockRejectedValueOnce(new Error('unsupported_query_artifact_format'));
+
+    render(
+      <ProcessLciaResultsPanel
+        baseCalculationEvidence={{ schema_version: 'legacy-static-evidence' }}
+        baseRows={[]}
+        lang='en'
+        processId='process-1'
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('Result query failed: {message}')).toBeInTheDocument(),
+    );
+
+    expect(screen.queryByTestId('lcia-evidence-notice')).not.toBeInTheDocument();
+    expect(mockLcaCalculationEvidenceNotice).not.toHaveBeenCalled();
+  });
+
+  it('validates evidence only after a solver result was returned successfully', async () => {
+    const calculationEvidence = { schema_version: 'lca.calculation_evidence.v2' };
+    mockQueryLcaResults.mockResolvedValueOnce({
+      snapshot_id: 'snapshot-ready',
+      result_id: 'result-ready',
+      source: 'all_unit',
+      meta: {
+        computed_at: '2026-04-29T00:00:00Z',
+        calculation_evidence: calculationEvidence,
+      },
+      data: { values: [] },
+    });
+
+    render(<ProcessLciaResultsPanel baseRows={[]} lang='en' processId='process-1' />);
+
+    await screen.findByTestId('lcia-evidence-notice');
+    expect(mockLcaCalculationEvidenceNotice).toHaveBeenLastCalledWith({ calculationEvidence });
+  });
+
+  it('keeps successful solver responses without evidence fail closed', async () => {
+    render(<ProcessLciaResultsPanel baseRows={[]} lang='en' processId='process-1' />);
+
+    await screen.findByTestId('lcia-evidence-notice');
+    expect(mockLcaCalculationEvidenceNotice).toHaveBeenLastCalledWith({
+      calculationEvidence: undefined,
+    });
+  });
+
+  it('still validates static evidence when solver querying is disabled', async () => {
+    const staticEvidence = { report: true };
+    render(
+      <ProcessLciaResultsPanel
+        baseCalculationEvidence={staticEvidence}
+        baseRows={[]}
+        enableSolverRefresh={false}
+        lang='en'
+      />,
+    );
+
+    await screen.findByTestId('lcia-evidence-notice');
+    expect(mockLcaCalculationEvidenceNotice).toHaveBeenLastCalledWith({ staticEvidence });
+    expect(mockQueryLcaResults).not.toHaveBeenCalled();
   });
 
   it('skips state updates when base-row enrichment resolves after unmount', async () => {


### PR DESCRIPTION
## Summary

- render query transport failures independently from LCIA calculation-evidence trust
- validate evidence only after a numerical solver response succeeds
- preserve fail-closed behavior when a successful response is missing or carries invalid evidence
- keep static-evidence validation for the legacy non-solver path
- stabilize an unrelated artifact-expiry fixture discovered by the required full gate and refresh derived locale artifacts

## Validation

- focused LCIA result-panel tests: 16 passed
- DataProcessing expiry tests: 55 passed
- locale artifacts idempotence passed
- full checked-push gate: 408 suites and 5,521 tests passed
- 100% statements, branches, functions, and lines coverage
- lint, TypeScript, reference-data, LCIA-cache, and Docpact gates passed
- closed semantic qualification: 84 positions discovered; 60 passed and 24 contract-skipped
- semantic harness observed 0 external requests, 0 production writes, and no cleanup leaks
- qualification receipt refreshed in commit `975fd5b2`

## Risk and rollout

This changes only UI state composition: a failed query no longer fabricates a second evidence mismatch. Successful solver responses still fail closed when evidence is missing or invalid. After this hotfix merges to `main`, back-merge `main` into `dev`.

Closes #771

Related: tiangong-lca/workspace#556