### PR TITLE
chore: bump version to 0.0.66 for LCIA hotfix release

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-08-06'
-lastReviewedCommit: '21a66d230858179097bba98e114f2aca9eefc9da'
-lastReviewedNote: 'Reviewed for Issue #771: the LCIA result-panel state fix remains routed through the existing frontend runtime, testing-gate, and workspace-integration ownership.'
+lastReviewedCommit: 'b7a60b9ee622cf58c02dab1e269dab6c08e7d9e0'
+lastReviewedNote: 'Reviewed for Issue #774: the release-only version bump remains routed through the existing testing-gate, release, and workspace-integration ownership.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-06
-lastReviewedCommit: 21a66d230858179097bba98e114f2aca9eefc9da
-lastReviewedNote: 'Reviewed for Issue #771: separating LCIA query failures from evidence validation remains within existing frontend ownership, production hotfix, quality-gate, and root-integration boundaries.'
+lastReviewedCommit: e1c0fc942613bd8edd14fa64ecf3bc7c742f3be1
+lastReviewedNote: 'Reviewed for Issue #774: the release-only version bump remains within existing frontend ownership, production-hotfix, quality-gate, and root-integration boundaries.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-06
-lastReviewedCommit: 21a66d230858179097bba98e114f2aca9eefc9da
-lastReviewedNote: 'Reviewed for Issue #771: the LCIA result-panel hotfix uses the existing Node 24, focused-test, managed-push, production-hotfix PR, and workspace-integration sequence.'
+lastReviewedCommit: e1c0fc942613bd8edd14fa64ecf3bc7c742f3be1
+lastReviewedNote: 'Reviewed for Issue #774: the release-only version bump uses the existing Node 24, managed-push, production-hotfix PR, release, and workspace-integration sequence.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-06
-lastReviewedCommit: 21a66d230858179097bba98e114f2aca9eefc9da
-lastReviewedNote: 'Reviewed for Issue #771: the focused component regression test does not alter managed-push, protected-branch, release-trigger, or retry-receipt policy.'
+lastReviewedCommit: b7a60b9ee622cf58c02dab1e269dab6c08e7d9e0
+lastReviewedNote: 'Reviewed for Issue #774: the release-only version bump follows the existing managed-push, protected-branch, release-trigger, and retry-receipt policy.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-06
-lastReviewedCommit: 21a66d230858179097bba98e114f2aca9eefc9da
-lastReviewedNote: 'Reviewed for Issue #771: focused Process LCIA result-panel tests cover query/evidence state separation while the existing lint, build, and managed-gate requirements remain accurate.'
+lastReviewedCommit: b7a60b9ee622cf58c02dab1e269dab6c08e7d9e0
+lastReviewedNote: 'Reviewed for Issue #774: the release-only version bump uses the existing release preflight, full gate, and version-driven publication requirements.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-06
-lastReviewedCommit: 21a66d230858179097bba98e114f2aca9eefc9da
-lastReviewedNote: 'Reviewed for Issue #771: query/evidence state separation is covered by the existing component-test strategy and requires no broader testing-strategy change.'
+lastReviewedCommit: b7a60b9ee622cf58c02dab1e269dab6c08e7d9e0
+lastReviewedNote: 'Reviewed for Issue #774: the release-only version bump requires no broader testing-strategy change.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-06
-lastReviewedCommit: 21a66d230858179097bba98e114f2aca9eefc9da
-lastReviewedNote: 'Reviewed for Issue #771: the focused LCIA panel regression suite passes and creates no new repository-wide test backlog item.'
+lastReviewedCommit: b7a60b9ee622cf58c02dab1e269dab6c08e7d9e0
+lastReviewedNote: 'Reviewed for Issue #774: the release-only version bump creates no new repository-wide test backlog item.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-06
-lastReviewedCommit: 21a66d230858179097bba98e114f2aca9eefc9da
-lastReviewedNote: 'Reviewed for Issue #771: the existing mocked-service component pattern cleanly proves that transport failures do not produce evidence-mismatch UI.'
+lastReviewedCommit: b7a60b9ee622cf58c02dab1e269dab6c08e7d9e0
+lastReviewedNote: 'Reviewed for Issue #774: the release-only version bump does not change or add a testing pattern.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-06
-lastReviewedCommit: 21a66d230858179097bba98e114f2aca9eefc9da
-lastReviewedNote: 'Reviewed for Issue #771: the focused serial Jest command and existing gate troubleshooting remain sufficient; no new exception is required.'
+lastReviewedCommit: b7a60b9ee622cf58c02dab1e269dab6c08e7d9e0
+lastReviewedNote: 'Reviewed for Issue #774: existing gate troubleshooting remains sufficient for the release-only version bump; no new exception is required.'
 ---
 
 # Testing Troubleshooting

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.65",
+      "version": "0.0.66",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
Closes #774

## Summary
- Advance package.json and package-lock.json from 0.0.65 to 0.0.66 so the canonical main push enters the normal release path.
- Record the required review of the existing bootstrap, test-gate, and release contracts without changing their behavior.

## Key Decisions
- Use a new patch version instead of manual dispatch or moving the existing v0.0.65 tag.
- Keep the change release-only; the merged LCIA runtime fix remains unchanged.

## Validation
- npm run release:preflight
- npm run docpact:gate
- npm run prepush:gate: 408 suites / 5521 tests passed; 459/459 source files at 100% statements, branches, functions, and lines.
- Managed checked push passed the immutable Docpact and full test gates; bounded push:retry transported exact SHA 80902b758a26054fe176534229cf5deb7d7b5352 after the initial GitHub transport failure.

## Risks / Rollback
- The merge intentionally triggers a production release; rollback is a follow-up patch release, not retagging v0.0.66.

## Follow-ups
- After merge, verify the Build workflow creates v0.0.66 and completes web deployment.
- Back-merge the released main commit to dev and update the root workspace Next pointer.

## Workspace Integration
- Related parent delivery: tiangong-lca/workspace#556. Root integration PR tiangong-lca/workspace#557 remains open and should be updated to the released Next main commit.