### PR TITLE
chore: prepare v0.0.67 on dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-08-06'
-lastReviewedCommit: 'e9e5e1f26b0cc9ac32975bfb2df29be133355f31'
+lastReviewedAt: "2026-08-06"
+lastReviewedCommit: "9e21c68e29c49a9ed7fc0f8311d52a5c21a4e648"
 lastReviewedNote: 'Reviewed for Issue #778: version-only release automation may record bounded Docpact review evidence, while promotion keeps the merged dev candidate immutable.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-06
-lastReviewedCommit: e9e5e1f26b0cc9ac32975bfb2df29be133355f31
+lastReviewedCommit: 9e21c68e29c49a9ed7fc0f8311d52a5c21a4e648
 lastReviewedNote: 'Reviewed for Issue #778: the two deterministic release commands are the preferred normal PR path; pure version releases may automatically record review-only Docpact evidence, while immutable dev-to-main promotion never mutates the candidate.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-06
-lastReviewedCommit: e9e5e1f26b0cc9ac32975bfb2df29be133355f31
+lastReviewedCommit: 9e21c68e29c49a9ed7fc0f8311d52a5c21a4e648
 lastReviewedNote: 'Reviewed for Issue #778: the two deterministic commands are the preferred normal release-PR flow; version-to-dev may close bounded review-only Docpact evidence, while promotion remains immutable.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-06
-lastReviewedCommit: a944c3ab2825aeb2f496621672cb1a378d7bc970
+lastReviewedCommit: 9e21c68e29c49a9ed7fc0f8311d52a5c21a4e648
 lastReviewedNote: 'Reviewed for Issue #778: bounded version-only Docpact review precedes the unchanged branch-sensitive checked-push and receipt policy.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-06
-lastReviewedCommit: a944c3ab2825aeb2f496621672cb1a378d7bc970
+lastReviewedCommit: 9e21c68e29c49a9ed7fc0f8311d52a5c21a4e648
 lastReviewedNote: 'Reviewed for Issue #778: pure version releases close review-only Docpact evidence under an exact semantic-diff guard; promotion remains exact-candidate validation only.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-06
-lastReviewedCommit: a944c3ab2825aeb2f496621672cb1a378d7bc970
+lastReviewedCommit: 9e21c68e29c49a9ed7fc0f8311d52a5c21a4e648
 lastReviewedNote: 'Reviewed for Issue #778: bounded automatic review adds focused hermetic and real-Docpact proof without changing the broader risk-proportional testing strategy.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-06
-lastReviewedCommit: a944c3ab2825aeb2f496621672cb1a378d7bc970
+lastReviewedCommit: 9e21c68e29c49a9ed7fc0f8311d52a5c21a4e648
 lastReviewedNote: 'Reviewed for Issue #778: automatic release review is closed by bounded fixed-point, semantic-diff, and real-Docpact proof without opening a test backlog.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-06
-lastReviewedCommit: a944c3ab2825aeb2f496621672cb1a378d7bc970
+lastReviewedCommit: 9e21c68e29c49a9ed7fc0f8311d52a5c21a4e648
 lastReviewedNote: 'Reviewed for Issue #778: release orchestration combines hermetic command contracts with a real bounded Docpact fixed-point canary.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-06
-lastReviewedCommit: a944c3ab2825aeb2f496621672cb1a378d7bc970
+lastReviewedCommit: 9e21c68e29c49a9ed7fc0f8311d52a5c21a4e648
 lastReviewedNote: 'Reviewed for Issue #778: automatic-review boundary failures, release drift, and managed-push failures have bounded JSON and local-report recovery paths.'
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.66",
+  "version": "0.0.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.66",
+      "version": "0.0.67",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.66",
+  "version": "0.0.67",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
<!-- tiangong-next-release-automation:v1 issue=778 version=0.0.67 base=9e21c68e29c49a9ed7fc0f8311d52a5c21a4e648 candidate=ddbb730e5333ecb3fd94c7935f103ce299e0ad6a -->

## Branch Contract

- base branch: `dev`
- validated environment: repository-managed dev gate
- back-merge required after merge: No
- root workspace integration expected: after later dev-to-main promotion

## Linked Issue

Refs #778

## Change Facts

- Prepare version `0.0.67` from exact dev base `9e21c68e29c49a9ed7fc0f8311d52a5c21a4e648`.
- Keep package.json and both package-lock root version fields aligned.
- Record Docpact review evidence only after the command proves the candidate has no other semantic change.
- Reviewed paths:
  - `.docpact/config.yaml`
  - `AGENTS.md`
  - `DEV.md`
  - `docs/agents/prepush-gate-policy.md`
  - `docs/agents/repo-validation.md`
  - `docs/agents/test_improvement_plan.md`
  - `docs/agents/test_todo_list.md`
  - `docs/agents/testing-patterns.md`
  - `docs/agents/testing-troubleshooting.md`

## Validation Facts

- Candidate: `ddbb730e5333ecb3fd94c7935f103ce299e0ad6a`
- Docpact automatic-review status: `completed`
- Final push used the repository-managed dev gate; full logs remain local and are not copied into the PR.

## Risks And Follow-Up

- Merge this PR into dev, then run the deterministic dev-to-main promotion command with this PR number.
