### PR TITLE
chore: prepare v0.0.68 on dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-08-06'
-lastReviewedCommit: '269ea042df47fbdca5cda5128d0fe56aa6b2dea6'
+lastReviewedAt: "2026-08-07"
+lastReviewedCommit: "f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc"
 lastReviewedNote: 'Reviewed for Issue #778: existing ownership rules cover independent candidate and cumulative promotion-range review evidence.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 269ea042df47fbdca5cda5128d0fe56aa6b2dea6
+lastReviewedAt: 2026-08-07
+lastReviewedCommit: f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc
 lastReviewedNote: 'Reviewed for Issue #778: release-to-dev independently preflights candidate and cumulative Docpact obligations before immutable promotion.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - .nvmrc
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 269ea042df47fbdca5cda5128d0fe56aa6b2dea6
+lastReviewedAt: 2026-08-07
+lastReviewedCommit: f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc
 lastReviewedNote: 'Reviewed for Issue #778: version-to-dev closes bounded candidate and cumulative promotion-range evidence before immutable promotion.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 269ea042df47fbdca5cda5128d0fe56aa6b2dea6
+lastReviewedAt: 2026-08-07
+lastReviewedCommit: f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc
 lastReviewedNote: 'Reviewed for Issue #778: independent candidate and cumulative Docpact review precedes the unchanged checked-push policy.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 269ea042df47fbdca5cda5128d0fe56aa6b2dea6
+lastReviewedAt: 2026-08-07
+lastReviewedCommit: f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc
 lastReviewedNote: 'Reviewed for Issue #778: release-to-dev checks candidate and cumulative paths independently under exact semantic guards.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - package.json
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 269ea042df47fbdca5cda5128d0fe56aa6b2dea6
+lastReviewedAt: 2026-08-07
+lastReviewedCommit: f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc
 lastReviewedNote: 'Reviewed for Issue #778: independent candidate and cumulative path coverage extends bounded proof without changing test strategy.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 269ea042df47fbdca5cda5128d0fe56aa6b2dea6
+lastReviewedAt: 2026-08-07
+lastReviewedCommit: f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc
 lastReviewedNote: 'Reviewed for Issue #778: dual-scope release preflight is closed by hermetic regression proof without opening a test backlog.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -30,8 +30,8 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 269ea042df47fbdca5cda5128d0fe56aa6b2dea6
+lastReviewedAt: 2026-08-07
+lastReviewedCommit: f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc
 lastReviewedNote: 'Reviewed for Issue #778: release proof evaluates candidate and cumulative paths independently with bounded Docpact behavior.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -27,8 +27,8 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 269ea042df47fbdca5cda5128d0fe56aa6b2dea6
+lastReviewedAt: 2026-08-07
+lastReviewedCommit: f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc
 lastReviewedNote: 'Reviewed for Issue #778: dual-scope review is automatic for new releases and immutable candidates retain bounded recovery.'
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.67",
+  "version": "0.0.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.67",
+      "version": "0.0.68",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.67",
+  "version": "0.0.68",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
<!-- tiangong-next-release-automation:v1 issue=778 version=0.0.68 base=f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc candidate=254c3eaa8ee180344820cefa95847721e53a0fdd -->

## Branch Contract

- base branch: `dev`
- validated environment: repository-managed dev gate
- back-merge required after merge: No
- root workspace integration expected: after later dev-to-main promotion

## Linked Issue

Refs #778

## Change Facts

- Prepare version `0.0.68` from exact dev base `f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc`.
- Keep package.json and both package-lock root version fields aligned.
- Record Docpact review evidence only after the command proves the candidate has no other semantic change.
- Reviewed paths:
  - `.docpact/config.yaml`
  - `AGENTS.md`
  - `DEV.md`
  - `docs/agents/prepush-gate-policy.md`
  - `docs/agents/repo-validation.md`
  - `docs/agents/test_improvement_plan.md`
  - `docs/agents/test_todo_list.md`
  - `docs/agents/testing-patterns.md`
  - `docs/agents/testing-troubleshooting.md`

## Validation Facts

- Candidate: `254c3eaa8ee180344820cefa95847721e53a0fdd`
- Main baseline: `8dba6c8944f8c3acb1b4047529130f6216a75228`
- Docpact automatic-review status: `previously_completed`
- Docpact checked the complete main-to-candidate promotion range before the dev PR was created.
- Final push used the repository-managed dev gate; full logs remain local and are not copied into the PR.

## Risks And Follow-Up

- Merge this PR into dev, then run the deterministic dev-to-main promotion command with this PR number.
