### PR TITLE
chore: record v0.0.68 semantic qualification

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-07"
-lastReviewedCommit: "f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc"
+lastReviewedCommit: "56c7bfca9b851dfa83838e72ac26e131ef170d69"
 lastReviewedNote: 'Reviewed for Issue #778: existing ownership rules cover independent candidate and cumulative promotion-range review evidence.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc
+lastReviewedCommit: 56c7bfca9b851dfa83838e72ac26e131ef170d69
 lastReviewedNote: 'Reviewed for Issue #778: release-to-dev independently preflights candidate and cumulative Docpact obligations before immutable promotion.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc
+lastReviewedCommit: 56c7bfca9b851dfa83838e72ac26e131ef170d69
 lastReviewedNote: 'Reviewed for Issue #778: version-to-dev closes bounded candidate and cumulative promotion-range evidence before immutable promotion.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc
+lastReviewedCommit: 56c7bfca9b851dfa83838e72ac26e131ef170d69
 lastReviewedNote: 'Reviewed for Issue #778: independent candidate and cumulative Docpact review precedes the unchanged checked-push policy.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc
+lastReviewedCommit: 56c7bfca9b851dfa83838e72ac26e131ef170d69
 lastReviewedNote: 'Reviewed for Issue #778: release-to-dev checks candidate and cumulative paths independently under exact semantic guards.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc
+lastReviewedCommit: 56c7bfca9b851dfa83838e72ac26e131ef170d69
 lastReviewedNote: 'Reviewed for Issue #778: independent candidate and cumulative path coverage extends bounded proof without changing test strategy.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc
+lastReviewedCommit: 56c7bfca9b851dfa83838e72ac26e131ef170d69
 lastReviewedNote: 'Reviewed for Issue #778: dual-scope release preflight is closed by hermetic regression proof without opening a test backlog.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc
+lastReviewedCommit: 56c7bfca9b851dfa83838e72ac26e131ef170d69
 lastReviewedNote: 'Reviewed for Issue #778: release proof evaluates candidate and cumulative paths independently with bounded Docpact behavior.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: f11fd05c9704ae8621f2fd35f7e3d5fb00f44ffc
+lastReviewedCommit: 56c7bfca9b851dfa83838e72ac26e131ef170d69
 lastReviewedNote: 'Reviewed for Issue #778: dual-scope review is automatic for new releases and immutable candidates retain bounded recovery.'
 ---
 

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "575bf50d21d2055efdbeecae9a671cef9966f82a4f7e1a66cfa6dc1414074c0a"
+    "runResultSha256": "7a0462c4e23efd1062a490cfac8e87ff2edfca650cd54b3717ec6224605783b7"
   },
-  "environmentManifestSha256": "5343ee156c75d52227f7b677c61da90a6affe1abb36b741cecb335e6bf8d4223",
+  "environmentManifestSha256": "f481fda9ebe1cb0d443e4187189828de324cc899aa4aa0bce4397c1d2574bce4",
   "externalRequests": 0,
-  "generatedAt": "2026-08-05T18:39:35.500Z",
+  "generatedAt": "2026-08-06T16:34:50.473Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "92baedb2f9e776cde7fa161531f175652313abadea56073458ad392268767760",
-  "qualifiedCommit": "d36f518ff1c5ebad1262f6dba54fad4d3a183ee1",
-  "qualifiedTree": "b974b76d75793d10293fe6791a8d09dae77b9352",
+  "qualificationInputSha256": "29ab3879145408f2285b22211e7489b83de7d77606ddfbb4322bad0bdda79a81",
+  "qualifiedCommit": "56c7bfca9b851dfa83838e72ac26e131ef170d69",
+  "qualifiedTree": "e85a1d955c28a7fff62f91b7446a6af506a3e0db",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }


### PR DESCRIPTION
## Summary

- records the semantic E2E qualification receipt for the exact merged `dev` candidate `56c7bfca9b851dfa83838e72ac26e131ef170d69`
- records Docpact review evidence required by the governed qualification artifact
- restores the release preflight prerequisite before publishing a new immutable patch candidate

## Validation

- semantic E2E qualification: 60 passed, 24 designed skips, 84 total positions
- browsers: Chromium, Firefox, WebKit
- production safety: 0 external requests, 0 production writes
- `npm run e2e:qualification:check`
- Docpact: 0 active diagnostics; coverage and freshness passed
- checked-push gate: 409 suites / 5567 tests passed; 100% statements, branches, functions, and lines

## Release note

Release PR #785 was merged before this tracked qualification receipt existed. Because release candidates are immutable and promotion must use the exact merged Release PR SHA, this receipt must merge to `dev` first; a new patch Release PR will then be created and promoted.

Refs #778
