### PR TITLE
fix: restore data product manager access

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-07"
-lastReviewedCommit: "24bcbe3f969618dc5ad45961c654111717312a67"
+lastReviewedAt: "2026-08-08"
+lastReviewedCommit: "6e0eacef1d999381e6c6aef8e49001847a3c29b5"
 lastReviewedNote: 'Reviewed for Issues #778 and #780: existing ownership routes cover the merged grouped-review candidate plus automatic qualification evidence, composed-candidate preflight, release orchestration, tests, and governed release docs.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: 0140c2fc2ac0f5388eb1de64fcc6c7fafc9f5fe6
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: ef0329caa888ce93b8b3fa097d3a53908c27a431
 lastReviewedNote: 'Reviewed for Issues #778 and #780: deterministic release preflight and grouped-review delivery remain within the documented dev-to-main, quality-gate, and root-integration boundaries.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - .nvmrc
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: 0140c2fc2ac0f5388eb1de64fcc6c7fafc9f5fe6
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: ef0329caa888ce93b8b3fa097d3a53908c27a431
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged candidate keeps the Node 24, focused-proof, semantic qualification, managed-push, and deterministic release-command workflow.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: 24bcbe3f969618dc5ad45961c654111717312a67
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 6e0eacef1d999381e6c6aef8e49001847a3c29b5
 lastReviewedNote: 'Reviewed for Issues #778 and #780: dual-scope Docpact review and the grouped-review candidate continue through the unchanged checked-push and retry-receipt policy.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - playwright.config.ts
   - config/docs-capture/**
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: 24bcbe3f969618dc5ad45961c654111717312a67
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 6e0eacef1d999381e6c6aef8e49001847a3c29b5
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release automation preserves existing runtime boundaries while grouped-review queue, selection, and dataset views remain database-authority consumers.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: 24bcbe3f969618dc5ad45961c654111717312a67
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 6e0eacef1d999381e6c6aef8e49001847a3c29b5
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged proof matrix covers independent release paths plus the seven-type Root/Reference queue, selection, and dataset-view behavior.'
 related:
   - ../AGENTS.md

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/e2e/**
   - playwright.config.ts
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: 93d8c0e6f48bb05d5516656479eb6856d3043cf5
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 6e0eacef1d999381e6c6aef8e49001847a3c29b5
 lastReviewedNote: 'Reviewed for database-engine Issue #422: Next defaults RPC calls to api, keeps only nine core entities on explicit public access, and consumes the exact reviewed Edge mirror.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - package.json
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: 24bcbe3f969618dc5ad45961c654111717312a67
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 6e0eacef1d999381e6c6aef8e49001847a3c29b5
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release-path and grouped-review coverage extend bounded proof without changing the repository testing strategy.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: 24bcbe3f969618dc5ad45961c654111717312a67
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 6e0eacef1d999381e6c6aef8e49001847a3c29b5
 lastReviewedNote: 'Reviewed for Issues #778 and #780: hermetic release-preflight and grouped-review regression proof leave no new repository-wide test backlog.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -30,8 +30,8 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: 24bcbe3f969618dc5ad45961c654111717312a67
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 6e0eacef1d999381e6c6aef8e49001847a3c29b5
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release proof and grouped-review tests continue to use existing bounded Docpact and service/UI testing patterns.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -27,8 +27,8 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: 24bcbe3f969618dc5ad45961c654111717312a67
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 6e0eacef1d999381e6c6aef8e49001847a3c29b5
 lastReviewedNote: 'Reviewed for Issues #778 and #780: automatic dual-scope release review and focused grouped-review proof require no new recovery exception.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "f14c26a299d9107381c0aaff883dcd88342024471e1dc14dcde8a484e8d3e2df",
-    "auditedInputDigest": "19bfe110bb6c223c7678e774757ac0cd948d37a425cb51babc7e9a1ef3eb54ff"
+    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138",
+    "auditedInputDigest": "a8cc23b311aec26dd4fa9c663216c17859fa6335b99d7c5861ffd159502f305c"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "053ee947311f9da743ed30a26e964e59dc6ad2bca58b557d904de460186f1d22",
+    "dossierDigest": "c4107d15ba13160cb615314e16937107f00ee4a2c477cd4e7dacb5cb536d8b24",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "4ff6643cf9e896782d09714c0922c7541f877a669be5bb636b1507d7c0c16674"
+  "contextDigest": "efc0e45f3219c6a17cc866f0e71c8408908a41eda5d8794db1ce93c66f3b4a06"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "f14c26a299d9107381c0aaff883dcd88342024471e1dc14dcde8a484e8d3e2df"
+    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4ff6643cf9e896782d09714c0922c7541f877a669be5bb636b1507d7c0c16674",
-    "qualityDigest": "27e3a3212f1c44e74ca752772df6144ad91076de64307c5303d2f7c2c3918bdd",
+    "contextDigest": "efc0e45f3219c6a17cc866f0e71c8408908a41eda5d8794db1ce93c66f3b4a06",
+    "qualityDigest": "c24d73ab60c7124617a21fb5e5fb9f1c70a215687fbcb3f08a3aafb718a922ca",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "849d7c034f8dc6aac2a140cc9605b5c0518ac6a909d9bbc15b42687abb0eae60"
+  "activationDigest": "4ded063ed831dd5cc8c81fcd44d9bf8dfdec5de1abe83870a6eb06f2245234e3"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "19bfe110bb6c223c7678e774757ac0cd948d37a425cb51babc7e9a1ef3eb54ff",
+    "auditedInputDigest": "a8cc23b311aec26dd4fa9c663216c17859fa6335b99d7c5861ffd159502f305c",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "f14c26a299d9107381c0aaff883dcd88342024471e1dc14dcde8a484e8d3e2df",
-    "contextDigest": "4ff6643cf9e896782d09714c0922c7541f877a669be5bb636b1507d7c0c16674"
+    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138",
+    "contextDigest": "efc0e45f3219c6a17cc866f0e71c8408908a41eda5d8794db1ce93c66f3b4a06"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "56b3ba55f31103d0e9e8ebb0f3e8d7981bf59bc53f1cb6238aef2827e055645b",
-    "validationDigest": "60fd33cbaae55704aa12b45045ef3999eacdc0d3dfa21cca231807d4c586af50",
+    "digest": "0bd25ff0d53c17fb6c8e283c90519156bf45c0c1b46a9488dd234765399d3ade",
+    "validationDigest": "7afca52ab3f77654c700879cad6e740ce1a059c3258181d8e7a3de41a0f7b48c",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "27e3a3212f1c44e74ca752772df6144ad91076de64307c5303d2f7c2c3918bdd"
+  "qualityDigest": "c24d73ab60c7124617a21fb5e5fb9f1c70a215687fbcb3f08a3aafb718a922ca"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "19bfe110bb6c223c7678e774757ac0cd948d37a425cb51babc7e9a1ef3eb54ff",
+    "auditedInputDigest": "a8cc23b311aec26dd4fa9c663216c17859fa6335b99d7c5861ffd159502f305c",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
-    "dossierDigest": "053ee947311f9da743ed30a26e964e59dc6ad2bca58b557d904de460186f1d22",
+    "dossierDigest": "c4107d15ba13160cb615314e16937107f00ee4a2c477cd4e7dacb5cb536d8b24",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "180d2f23e172c30e6327a5b79d13be982da38410006d8eff1fc67cb5e883f001",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "053ee947311f9da743ed30a26e964e59dc6ad2bca58b557d904de460186f1d22",
+        "dossierDigest": "c4107d15ba13160cb615314e16937107f00ee4a2c477cd4e7dacb5cb536d8b24",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "60fd33cbaae55704aa12b45045ef3999eacdc0d3dfa21cca231807d4c586af50"
+  "validationDigest": "7afca52ab3f77654c700879cad6e740ce1a059c3258181d8e7a3de41a0f7b48c"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "f14c26a299d9107381c0aaff883dcd88342024471e1dc14dcde8a484e8d3e2df",
-    "auditedInputDigest": "19bfe110bb6c223c7678e774757ac0cd948d37a425cb51babc7e9a1ef3eb54ff"
+    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138",
+    "auditedInputDigest": "a8cc23b311aec26dd4fa9c663216c17859fa6335b99d7c5861ffd159502f305c"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "1857c9e56472f13633b9bdef226610013beefaf42e700a9c2db7c8fd273cf5f1",
+    "dossierDigest": "c232466f0b490ad79f9792cb9913d2511c33315082269ee8fd8657ebd00571e2",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "9b248287a0c4b0c00465a9d052c8236f784b6380f44c41791bd81343dfe37d65"
+  "contextDigest": "b30fbac059a5a97c6047bf6a035d9e3d8781437f0a9ddad93815345a1b93b563"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "f14c26a299d9107381c0aaff883dcd88342024471e1dc14dcde8a484e8d3e2df"
+    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "9b248287a0c4b0c00465a9d052c8236f784b6380f44c41791bd81343dfe37d65",
-    "qualityDigest": "628ac74d30ab4a4950fdf25fecae6dcdc98c15d15096c8fde26a67d455ed8a45",
+    "contextDigest": "b30fbac059a5a97c6047bf6a035d9e3d8781437f0a9ddad93815345a1b93b563",
+    "qualityDigest": "796b7d91f73de87ed13518edc1cd186bd13975908d3d81cbd4eefd505d1669b8",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "f08af57ad96d096f55d683dc10c2145065374abd6817bcc6b3767ce32243bab0"
+  "activationDigest": "d438c078aa44d6cac27fe6db49540f436de5143f524ff392e8f0246738b0732c"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "f14c26a299d9107381c0aaff883dcd88342024471e1dc14dcde8a484e8d3e2df",
-    "contextDigest": "9b248287a0c4b0c00465a9d052c8236f784b6380f44c41791bd81343dfe37d65"
+    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138",
+    "contextDigest": "b30fbac059a5a97c6047bf6a035d9e3d8781437f0a9ddad93815345a1b93b563"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "22d757010f6f1003e3b7a4571ad529d4a42c44890067e12ffec79960e3208d58",
-    "validationDigest": "e7586d87b3e4d5f0eeb69099806b5fa8a4ef7cd35729715e3b1e806dbfebb346",
+    "digest": "5a948c60bc0209d30cea065581f541419e7010999d638906e4d5ce2261f0920f",
+    "validationDigest": "cd234fd0bfefccd09e8a585d9a2f5fa68c5917c1c8713c111ed48eaf7f136c16",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "628ac74d30ab4a4950fdf25fecae6dcdc98c15d15096c8fde26a67d455ed8a45"
+  "qualityDigest": "796b7d91f73de87ed13518edc1cd186bd13975908d3d81cbd4eefd505d1669b8"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "19bfe110bb6c223c7678e774757ac0cd948d37a425cb51babc7e9a1ef3eb54ff",
+    "auditedInputDigest": "a8cc23b311aec26dd4fa9c663216c17859fa6335b99d7c5861ffd159502f305c",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
-    "dossierDigest": "1857c9e56472f13633b9bdef226610013beefaf42e700a9c2db7c8fd273cf5f1",
+    "dossierDigest": "c232466f0b490ad79f9792cb9913d2511c33315082269ee8fd8657ebd00571e2",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "180d2f23e172c30e6327a5b79d13be982da38410006d8eff1fc67cb5e883f001",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "1857c9e56472f13633b9bdef226610013beefaf42e700a9c2db7c8fd273cf5f1",
+        "dossierDigest": "c232466f0b490ad79f9792cb9913d2511c33315082269ee8fd8657ebd00571e2",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "e7586d87b3e4d5f0eeb69099806b5fa8a4ef7cd35729715e3b1e806dbfebb346"
+  "validationDigest": "cd234fd0bfefccd09e8a585d9a2f5fa68c5917c1c8713c111ed48eaf7f136c16"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "f14c26a299d9107381c0aaff883dcd88342024471e1dc14dcde8a484e8d3e2df",
-    "auditedInputDigest": "19bfe110bb6c223c7678e774757ac0cd948d37a425cb51babc7e9a1ef3eb54ff"
+    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138",
+    "auditedInputDigest": "a8cc23b311aec26dd4fa9c663216c17859fa6335b99d7c5861ffd159502f305c"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "1ef1dce821075214e7b6f1d425a27781a7a9710d1e82ec967726992e4b47f02c",
+    "dossierDigest": "1b1e218143eb9dbe6c75c4092d87d503e101564709b47e8b2e0bab4a929ee387",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "806dbda9db41b12005250480fd90c76c9f7706917d231a04977562c7a7acb9c2"
+  "contextDigest": "940547c977cdfc330a8258dca1267368c280f8a45b7ee7de24a64e850265a816"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "f14c26a299d9107381c0aaff883dcd88342024471e1dc14dcde8a484e8d3e2df"
+    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "806dbda9db41b12005250480fd90c76c9f7706917d231a04977562c7a7acb9c2",
-    "qualityDigest": "52bb5a4d347c5b87d1698dc6841d038222a27fc8198603e806689391214ce9cd",
+    "contextDigest": "940547c977cdfc330a8258dca1267368c280f8a45b7ee7de24a64e850265a816",
+    "qualityDigest": "13d16da9ef7b5eb35a6446c24def24a94025b61a7aa839df126fa3d895140423",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "df44565b384b9c82d34a3208bf2a8cfc5753c04d8a9f90fdb699eaaf06d71d3f"
+  "activationDigest": "9cbbd7b03d68903fd459b47d39d5d343aeb601cea55f0fd559ad74a34a5babfd"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "f14c26a299d9107381c0aaff883dcd88342024471e1dc14dcde8a484e8d3e2df",
-    "contextDigest": "806dbda9db41b12005250480fd90c76c9f7706917d231a04977562c7a7acb9c2"
+    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138",
+    "contextDigest": "940547c977cdfc330a8258dca1267368c280f8a45b7ee7de24a64e850265a816"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "dc2a0cc7da45a06ef7d732df6c5188f9f0ac8b398083439aa32be1b2dbdbd08e",
-    "validationDigest": "2894d033ffb9e2f5da614b3e9be9506d3687a9efc4ab3f902586b107c8e854fd",
+    "digest": "b2b0cc1e1376aa7166edd0ecf852e21be1b94cd8db595243e826cacb3cb33cea",
+    "validationDigest": "f5f24529bc156b6a5d5b5daec77149d012bffe022c0b699183a8eae9014baf8d",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "52bb5a4d347c5b87d1698dc6841d038222a27fc8198603e806689391214ce9cd"
+  "qualityDigest": "13d16da9ef7b5eb35a6446c24def24a94025b61a7aa839df126fa3d895140423"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "19bfe110bb6c223c7678e774757ac0cd948d37a425cb51babc7e9a1ef3eb54ff",
+    "auditedInputDigest": "a8cc23b311aec26dd4fa9c663216c17859fa6335b99d7c5861ffd159502f305c",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
-    "dossierDigest": "1ef1dce821075214e7b6f1d425a27781a7a9710d1e82ec967726992e4b47f02c",
+    "dossierDigest": "1b1e218143eb9dbe6c75c4092d87d503e101564709b47e8b2e0bab4a929ee387",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "180d2f23e172c30e6327a5b79d13be982da38410006d8eff1fc67cb5e883f001",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "1ef1dce821075214e7b6f1d425a27781a7a9710d1e82ec967726992e4b47f02c",
+        "dossierDigest": "1b1e218143eb9dbe6c75c4092d87d503e101564709b47e8b2e0bab4a929ee387",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "2894d033ffb9e2f5da614b3e9be9506d3687a9efc4ab3f902586b107c8e854fd"
+  "validationDigest": "f5f24529bc156b6a5d5b5daec77149d012bffe022c0b699183a8eae9014baf8d"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "f14c26a299d9107381c0aaff883dcd88342024471e1dc14dcde8a484e8d3e2df",
-    "auditedInputDigest": "19bfe110bb6c223c7678e774757ac0cd948d37a425cb51babc7e9a1ef3eb54ff"
+    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138",
+    "auditedInputDigest": "a8cc23b311aec26dd4fa9c663216c17859fa6335b99d7c5861ffd159502f305c"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "2253cfd2ea4fad2a785de973e64cd94f4f6f67242b874690671192ad565c0b9c",
+    "dossierDigest": "edb857d11880f7044cbbb967598e43c2b96cb644898baff25892769f346f89bb",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "8cbe954fb78ce6701b454d71569e0ef409bccb232281a3335f762cb0eb531a98"
+  "contextDigest": "994242b8c63981b71b3fe3e1261b3d4c546da31c657ba9d1ed762f0beca4b2cb"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "f14c26a299d9107381c0aaff883dcd88342024471e1dc14dcde8a484e8d3e2df"
+    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "8cbe954fb78ce6701b454d71569e0ef409bccb232281a3335f762cb0eb531a98",
-    "qualityDigest": "698db86da64ba7da38c3af333055a66f5049fe1dbe566b48ee4b6b428ec1315f",
+    "contextDigest": "994242b8c63981b71b3fe3e1261b3d4c546da31c657ba9d1ed762f0beca4b2cb",
+    "qualityDigest": "a17d755e7c95c34c44a15a0f091bcfce24af26f89c75c8cebef7a8b37adf6807",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "c24e986193d21acf0e72a2fd924079c16ee68d62ff3b9679c1d7f3641c8d7608"
+  "activationDigest": "5d98450fbce2d325163b76a9eb251fb2118f9b24a8b9feea8087e55f93f06237"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "f14c26a299d9107381c0aaff883dcd88342024471e1dc14dcde8a484e8d3e2df",
-    "contextDigest": "8cbe954fb78ce6701b454d71569e0ef409bccb232281a3335f762cb0eb531a98"
+    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138",
+    "contextDigest": "994242b8c63981b71b3fe3e1261b3d4c546da31c657ba9d1ed762f0beca4b2cb"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "bdbbb52e3287cef0f02d0d499c7133ccae38f52f657a9000913ac50989ad33f1",
-    "validationDigest": "4425f18e776d295e4697defddf270616594960706f05dd4f53f9418373d76b51",
+    "digest": "a29b039826fec3520eb8173f50c61abcddd9bb947c806547ae6a6e09aab735ad",
+    "validationDigest": "bb9bd33e4faadd905215b1dbcfb51ed67b56e18fc0465620027a9ff20d059c26",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "698db86da64ba7da38c3af333055a66f5049fe1dbe566b48ee4b6b428ec1315f"
+  "qualityDigest": "a17d755e7c95c34c44a15a0f091bcfce24af26f89c75c8cebef7a8b37adf6807"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "19bfe110bb6c223c7678e774757ac0cd948d37a425cb51babc7e9a1ef3eb54ff",
+    "auditedInputDigest": "a8cc23b311aec26dd4fa9c663216c17859fa6335b99d7c5861ffd159502f305c",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
-    "dossierDigest": "2253cfd2ea4fad2a785de973e64cd94f4f6f67242b874690671192ad565c0b9c",
+    "dossierDigest": "edb857d11880f7044cbbb967598e43c2b96cb644898baff25892769f346f89bb",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "180d2f23e172c30e6327a5b79d13be982da38410006d8eff1fc67cb5e883f001",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "2253cfd2ea4fad2a785de973e64cd94f4f6f67242b874690671192ad565c0b9c",
+        "dossierDigest": "edb857d11880f7044cbbb967598e43c2b96cb644898baff25892769f346f89bb",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "4425f18e776d295e4697defddf270616594960706f05dd4f53f9418373d76b51"
+  "validationDigest": "bb9bd33e4faadd905215b1dbcfb51ed67b56e18fc0465620027a9ff20d059c26"
 }

--- a/src/services/roles/api.ts
+++ b/src/services/roles/api.ts
@@ -376,7 +376,7 @@ export async function getSystemUserRoleApi() {
     const membership = data?.find(
       (membership: MemberListRow) =>
         membership.team_id === SYSTEM_TEAM_ID &&
-        ['owner', 'admin', 'member'].includes(membership.role),
+        ['owner', 'admin', 'member', 'data_product_manager'].includes(membership.role),
     );
     return membership ? { user_id: membership.user_id, role: membership.role } : null;
   } catch (error) {

--- a/tests/unit/services/roles/api.test.ts
+++ b/tests/unit/services/roles/api.test.ts
@@ -667,6 +667,47 @@ describe('roles api task-4 boundaries', () => {
     consoleSpy.mockRestore();
   });
 
+  it('returns a system data product manager without selecting cross-team or unsupported roles', async () => {
+    supabase.rpc
+      .mockResolvedValueOnce({
+        data: [
+          {
+            user_id: 'manager-user',
+            team_id: SYSTEM_TEAM_ID,
+            role: 'data_product_manager',
+          },
+        ],
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            user_id: 'cross-team-manager',
+            team_id: 'team-id',
+            role: 'data_product_manager',
+          },
+        ],
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            user_id: 'review-user',
+            team_id: SYSTEM_TEAM_ID,
+            role: 'review-member',
+          },
+        ],
+        error: null,
+      });
+
+    await expect(getSystemUserRoleApi()).resolves.toEqual({
+      user_id: 'manager-user',
+      role: 'data_product_manager',
+    });
+    await expect(getSystemUserRoleApi()).resolves.toBeNull();
+    await expect(getSystemUserRoleApi()).resolves.toBeNull();
+  });
+
   it('loads system members via qry_system_get_member_list and falls back on rpc errors', async () => {
     supabase.rpc
       .mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

- Include `data_product_manager` in the system-team role lookup used by the manager route.
- Prove system-team scope while rejecting cross-team and unsupported roles.
- Refresh the canonical locale delivery artifacts required by the changed lookup input; the generator-only diff updates digest fields.

## Tracking

Refs tiangong-lca/database-engine#422.

Do not close #422: it remains the cross-repository master Issue until the remaining exact-SHA validation, promotion, and workspace integration are complete.

## Validation

- `npm run test:ci -- tests/unit/services/roles/api.test.ts --runInBand --no-watchman` (38 tests)
- `npm run test:ci -- tests/unit/i18n/localeDeliveryContracts.test.ts tests/unit/locales.test.ts --runInBand --no-watchman` (30 tests)
- `npm run i18n:locale:artifacts:idempotence`
- `npm run i18n:audit`
- `npm run lint`
- `npm run build`
- `npm run push:checked -- fork codex/issue-422-next-manager-access` followed by the repository-managed `npm run push:retry` after a transport-only failure: 411 suites / 5,613 tests passed; coverage 100% statements, branches, functions, and lines.
- Authenticated persistent Dev Chromium E2E against exact candidate `644267b32e0d05fdf7e1a935e815eaff41ae20a2`: a disposable system-team `data_product_manager` completed password login and rendered `#/data-processing` with the generate, preview, and publish tabs; no application 403 or browser 401/403 occurred.
- Dev cleanup proof: Auth DELETE `200`, `private.roles=0`, `auth.users=0`, Admin readback `404`; browser, local server, and temporary Playwright artifacts were removed.

## Scope and follow-up

This PR is intentionally frontend-only and targets `dev`. The authenticated E2E used only a disposable Dev fixture and did not touch production. After merge, the exact Dev merge SHA must be revalidated before the required `dev -> main` promotion and workspace integration.
