### PR TITLE
fix: restore role-gated management actions

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "d0f78f65e6a6a22b0f3a8fe4fa599dec60ef3eb5"
+lastReviewedCommit: "7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b"
 lastReviewedNote: 'Reviewed for Issues #778 and #780: existing ownership routes cover the merged grouped-review candidate plus automatic qualification evidence, composed-candidate preflight, release orchestration, tests, and governed release docs.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "6e0eacef1d999381e6c6aef8e49001847a3c29b5"
+lastReviewedCommit: "2019fbcdd819df198f811c7c1d14a41531d96571"
 lastReviewedNote: 'Reviewed for Issues #778 and #780: existing ownership routes cover the merged grouped-review candidate plus automatic qualification evidence, composed-candidate preflight, release orchestration, tests, and governed release docs.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b"
+lastReviewedCommit: "7906c03926d9d4b6f6b7eba8057f32b6520ed460"
 lastReviewedNote: 'Reviewed for Issues #778 and #780: existing ownership routes cover the merged grouped-review candidate plus automatic qualification evidence, composed-candidate preflight, release orchestration, tests, and governed release docs.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "ed9eaac485add16eb924120764fd821d98355f9a"
+lastReviewedCommit: "c3a40654a3272f988d844fc21faedd818233853c"
 lastReviewedNote: 'Reviewed for Issues #778 and #780: existing ownership routes cover the merged grouped-review candidate plus automatic qualification evidence, composed-candidate preflight, release orchestration, tests, and governed release docs.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "c3a40654a3272f988d844fc21faedd818233853c"
+lastReviewedCommit: "d0f78f65e6a6a22b0f3a8fe4fa599dec60ef3eb5"
 lastReviewedNote: 'Reviewed for Issues #778 and #780: existing ownership routes cover the merged grouped-review candidate plus automatic qualification evidence, composed-candidate preflight, release orchestration, tests, and governed release docs.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "2019fbcdd819df198f811c7c1d14a41531d96571"
+lastReviewedCommit: "ed9eaac485add16eb924120764fd821d98355f9a"
 lastReviewedNote: 'Reviewed for Issues #778 and #780: existing ownership routes cover the merged grouped-review candidate plus automatic qualification evidence, composed-candidate preflight, release orchestration, tests, and governed release docs.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "7906c03926d9d4b6f6b7eba8057f32b6520ed460"
+lastReviewedCommit: "f26b54d064f8f408982a169a0ddda0381395826d"
 lastReviewedNote: 'Reviewed for Issues #778 and #780: existing ownership routes cover the merged grouped-review candidate plus automatic qualification evidence, composed-candidate preflight, release orchestration, tests, and governed release docs.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 2019fbcdd819df198f811c7c1d14a41531d96571
+lastReviewedCommit: ed9eaac485add16eb924120764fd821d98355f9a
 lastReviewedNote: 'Reviewed for Issues #778 and #780: deterministic release preflight and grouped-review delivery remain within the documented dev-to-main, quality-gate, and root-integration boundaries.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b
+lastReviewedCommit: 7906c03926d9d4b6f6b7eba8057f32b6520ed460
 lastReviewedNote: 'Reviewed for Issues #778 and #780: deterministic release preflight and grouped-review delivery remain within the documented dev-to-main, quality-gate, and root-integration boundaries.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: ed9eaac485add16eb924120764fd821d98355f9a
+lastReviewedCommit: c3a40654a3272f988d844fc21faedd818233853c
 lastReviewedNote: 'Reviewed for Issues #778 and #780: deterministic release preflight and grouped-review delivery remain within the documented dev-to-main, quality-gate, and root-integration boundaries.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 7906c03926d9d4b6f6b7eba8057f32b6520ed460
+lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
 lastReviewedNote: 'Reviewed for Issues #778 and #780: deterministic release preflight and grouped-review delivery remain within the documented dev-to-main, quality-gate, and root-integration boundaries.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: d0f78f65e6a6a22b0f3a8fe4fa599dec60ef3eb5
+lastReviewedCommit: 7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b
 lastReviewedNote: 'Reviewed for Issues #778 and #780: deterministic release preflight and grouped-review delivery remain within the documented dev-to-main, quality-gate, and root-integration boundaries.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: ef0329caa888ce93b8b3fa097d3a53908c27a431
+lastReviewedCommit: 2019fbcdd819df198f811c7c1d14a41531d96571
 lastReviewedNote: 'Reviewed for Issues #778 and #780: deterministic release preflight and grouped-review delivery remain within the documented dev-to-main, quality-gate, and root-integration boundaries.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: c3a40654a3272f988d844fc21faedd818233853c
+lastReviewedCommit: d0f78f65e6a6a22b0f3a8fe4fa599dec60ef3eb5
 lastReviewedNote: 'Reviewed for Issues #778 and #780: deterministic release preflight and grouped-review delivery remain within the documented dev-to-main, quality-gate, and root-integration boundaries.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b
+lastReviewedCommit: 7906c03926d9d4b6f6b7eba8057f32b6520ed460
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged candidate keeps the Node 24, focused-proof, semantic qualification, managed-push, and deterministic release-command workflow.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: c3a40654a3272f988d844fc21faedd818233853c
+lastReviewedCommit: d0f78f65e6a6a22b0f3a8fe4fa599dec60ef3eb5
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged candidate keeps the Node 24, focused-proof, semantic qualification, managed-push, and deterministic release-command workflow.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: ed9eaac485add16eb924120764fd821d98355f9a
+lastReviewedCommit: c3a40654a3272f988d844fc21faedd818233853c
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged candidate keeps the Node 24, focused-proof, semantic qualification, managed-push, and deterministic release-command workflow.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: d0f78f65e6a6a22b0f3a8fe4fa599dec60ef3eb5
+lastReviewedCommit: 7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged candidate keeps the Node 24, focused-proof, semantic qualification, managed-push, and deterministic release-command workflow.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 2019fbcdd819df198f811c7c1d14a41531d96571
+lastReviewedCommit: ed9eaac485add16eb924120764fd821d98355f9a
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged candidate keeps the Node 24, focused-proof, semantic qualification, managed-push, and deterministic release-command workflow.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 7906c03926d9d4b6f6b7eba8057f32b6520ed460
+lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged candidate keeps the Node 24, focused-proof, semantic qualification, managed-push, and deterministic release-command workflow.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: ef0329caa888ce93b8b3fa097d3a53908c27a431
+lastReviewedCommit: 2019fbcdd819df198f811c7c1d14a41531d96571
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged candidate keeps the Node 24, focused-proof, semantic qualification, managed-push, and deterministic release-command workflow.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 7906c03926d9d4b6f6b7eba8057f32b6520ed460
+lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
 lastReviewedNote: 'Reviewed for Issues #778 and #780: dual-scope Docpact review and the grouped-review candidate continue through the unchanged checked-push and retry-receipt policy.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: d0f78f65e6a6a22b0f3a8fe4fa599dec60ef3eb5
+lastReviewedCommit: 7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b
 lastReviewedNote: 'Reviewed for Issues #778 and #780: dual-scope Docpact review and the grouped-review candidate continue through the unchanged checked-push and retry-receipt policy.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 6e0eacef1d999381e6c6aef8e49001847a3c29b5
+lastReviewedCommit: 2019fbcdd819df198f811c7c1d14a41531d96571
 lastReviewedNote: 'Reviewed for Issues #778 and #780: dual-scope Docpact review and the grouped-review candidate continue through the unchanged checked-push and retry-receipt policy.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b
+lastReviewedCommit: 7906c03926d9d4b6f6b7eba8057f32b6520ed460
 lastReviewedNote: 'Reviewed for Issues #778 and #780: dual-scope Docpact review and the grouped-review candidate continue through the unchanged checked-push and retry-receipt policy.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: ed9eaac485add16eb924120764fd821d98355f9a
+lastReviewedCommit: c3a40654a3272f988d844fc21faedd818233853c
 lastReviewedNote: 'Reviewed for Issues #778 and #780: dual-scope Docpact review and the grouped-review candidate continue through the unchanged checked-push and retry-receipt policy.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: c3a40654a3272f988d844fc21faedd818233853c
+lastReviewedCommit: d0f78f65e6a6a22b0f3a8fe4fa599dec60ef3eb5
 lastReviewedNote: 'Reviewed for Issues #778 and #780: dual-scope Docpact review and the grouped-review candidate continue through the unchanged checked-push and retry-receipt policy.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 2019fbcdd819df198f811c7c1d14a41531d96571
+lastReviewedCommit: ed9eaac485add16eb924120764fd821d98355f9a
 lastReviewedNote: 'Reviewed for Issues #778 and #780: dual-scope Docpact review and the grouped-review candidate continue through the unchanged checked-push and retry-receipt policy.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b
+lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release automation preserves existing runtime boundaries while grouped-review queue, selection, and dataset views remain database-authority consumers.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 2019fbcdd819df198f811c7c1d14a41531d96571
+lastReviewedCommit: c3a40654a3272f988d844fc21faedd818233853c
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release automation preserves existing runtime boundaries while grouped-review queue, selection, and dataset views remain database-authority consumers.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 6e0eacef1d999381e6c6aef8e49001847a3c29b5
+lastReviewedCommit: 2019fbcdd819df198f811c7c1d14a41531d96571
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release automation preserves existing runtime boundaries while grouped-review queue, selection, and dataset views remain database-authority consumers.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: c3a40654a3272f988d844fc21faedd818233853c
+lastReviewedCommit: 7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release automation preserves existing runtime boundaries while grouped-review queue, selection, and dataset views remain database-authority consumers.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 2019fbcdd819df198f811c7c1d14a41531d96571
+lastReviewedCommit: ed9eaac485add16eb924120764fd821d98355f9a
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged proof matrix covers independent release paths plus the seven-type Root/Reference queue, selection, and dataset-view behavior.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b
+lastReviewedCommit: 7906c03926d9d4b6f6b7eba8057f32b6520ed460
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged proof matrix covers independent release paths plus the seven-type Root/Reference queue, selection, and dataset-view behavior.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: c3a40654a3272f988d844fc21faedd818233853c
+lastReviewedCommit: d0f78f65e6a6a22b0f3a8fe4fa599dec60ef3eb5
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged proof matrix covers independent release paths plus the seven-type Root/Reference queue, selection, and dataset-view behavior.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: d0f78f65e6a6a22b0f3a8fe4fa599dec60ef3eb5
+lastReviewedCommit: 7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged proof matrix covers independent release paths plus the seven-type Root/Reference queue, selection, and dataset-view behavior.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: ed9eaac485add16eb924120764fd821d98355f9a
+lastReviewedCommit: c3a40654a3272f988d844fc21faedd818233853c
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged proof matrix covers independent release paths plus the seven-type Root/Reference queue, selection, and dataset-view behavior.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 6e0eacef1d999381e6c6aef8e49001847a3c29b5
+lastReviewedCommit: 2019fbcdd819df198f811c7c1d14a41531d96571
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged proof matrix covers independent release paths plus the seven-type Root/Reference queue, selection, and dataset-view behavior.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 7906c03926d9d4b6f6b7eba8057f32b6520ed460
+lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged proof matrix covers independent release paths plus the seven-type Root/Reference queue, selection, and dataset-view behavior.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: d0f78f65e6a6a22b0f3a8fe4fa599dec60ef3eb5
+lastReviewedCommit: 7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release-path and grouped-review coverage extend bounded proof without changing the repository testing strategy.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: ed9eaac485add16eb924120764fd821d98355f9a
+lastReviewedCommit: c3a40654a3272f988d844fc21faedd818233853c
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release-path and grouped-review coverage extend bounded proof without changing the repository testing strategy.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 7906c03926d9d4b6f6b7eba8057f32b6520ed460
+lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release-path and grouped-review coverage extend bounded proof without changing the repository testing strategy.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 6e0eacef1d999381e6c6aef8e49001847a3c29b5
+lastReviewedCommit: 2019fbcdd819df198f811c7c1d14a41531d96571
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release-path and grouped-review coverage extend bounded proof without changing the repository testing strategy.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: c3a40654a3272f988d844fc21faedd818233853c
+lastReviewedCommit: d0f78f65e6a6a22b0f3a8fe4fa599dec60ef3eb5
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release-path and grouped-review coverage extend bounded proof without changing the repository testing strategy.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b
+lastReviewedCommit: 7906c03926d9d4b6f6b7eba8057f32b6520ed460
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release-path and grouped-review coverage extend bounded proof without changing the repository testing strategy.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 2019fbcdd819df198f811c7c1d14a41531d96571
+lastReviewedCommit: ed9eaac485add16eb924120764fd821d98355f9a
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release-path and grouped-review coverage extend bounded proof without changing the repository testing strategy.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: ed9eaac485add16eb924120764fd821d98355f9a
+lastReviewedCommit: c3a40654a3272f988d844fc21faedd818233853c
 lastReviewedNote: 'Reviewed for Issues #778 and #780: hermetic release-preflight and grouped-review regression proof leave no new repository-wide test backlog.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b
+lastReviewedCommit: 7906c03926d9d4b6f6b7eba8057f32b6520ed460
 lastReviewedNote: 'Reviewed for Issues #778 and #780: hermetic release-preflight and grouped-review regression proof leave no new repository-wide test backlog.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: d0f78f65e6a6a22b0f3a8fe4fa599dec60ef3eb5
+lastReviewedCommit: 7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b
 lastReviewedNote: 'Reviewed for Issues #778 and #780: hermetic release-preflight and grouped-review regression proof leave no new repository-wide test backlog.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 2019fbcdd819df198f811c7c1d14a41531d96571
+lastReviewedCommit: ed9eaac485add16eb924120764fd821d98355f9a
 lastReviewedNote: 'Reviewed for Issues #778 and #780: hermetic release-preflight and grouped-review regression proof leave no new repository-wide test backlog.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: c3a40654a3272f988d844fc21faedd818233853c
+lastReviewedCommit: d0f78f65e6a6a22b0f3a8fe4fa599dec60ef3eb5
 lastReviewedNote: 'Reviewed for Issues #778 and #780: hermetic release-preflight and grouped-review regression proof leave no new repository-wide test backlog.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 7906c03926d9d4b6f6b7eba8057f32b6520ed460
+lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
 lastReviewedNote: 'Reviewed for Issues #778 and #780: hermetic release-preflight and grouped-review regression proof leave no new repository-wide test backlog.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 6e0eacef1d999381e6c6aef8e49001847a3c29b5
+lastReviewedCommit: 2019fbcdd819df198f811c7c1d14a41531d96571
 lastReviewedNote: 'Reviewed for Issues #778 and #780: hermetic release-preflight and grouped-review regression proof leave no new repository-wide test backlog.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: c3a40654a3272f988d844fc21faedd818233853c
+lastReviewedCommit: d0f78f65e6a6a22b0f3a8fe4fa599dec60ef3eb5
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release proof and grouped-review tests continue to use existing bounded Docpact and service/UI testing patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: ed9eaac485add16eb924120764fd821d98355f9a
+lastReviewedCommit: c3a40654a3272f988d844fc21faedd818233853c
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release proof and grouped-review tests continue to use existing bounded Docpact and service/UI testing patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b
+lastReviewedCommit: 7906c03926d9d4b6f6b7eba8057f32b6520ed460
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release proof and grouped-review tests continue to use existing bounded Docpact and service/UI testing patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 6e0eacef1d999381e6c6aef8e49001847a3c29b5
+lastReviewedCommit: 2019fbcdd819df198f811c7c1d14a41531d96571
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release proof and grouped-review tests continue to use existing bounded Docpact and service/UI testing patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: d0f78f65e6a6a22b0f3a8fe4fa599dec60ef3eb5
+lastReviewedCommit: 7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release proof and grouped-review tests continue to use existing bounded Docpact and service/UI testing patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 2019fbcdd819df198f811c7c1d14a41531d96571
+lastReviewedCommit: ed9eaac485add16eb924120764fd821d98355f9a
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release proof and grouped-review tests continue to use existing bounded Docpact and service/UI testing patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 7906c03926d9d4b6f6b7eba8057f32b6520ed460
+lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release proof and grouped-review tests continue to use existing bounded Docpact and service/UI testing patterns.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 6e0eacef1d999381e6c6aef8e49001847a3c29b5
+lastReviewedCommit: 2019fbcdd819df198f811c7c1d14a41531d96571
 lastReviewedNote: 'Reviewed for Issues #778 and #780: automatic dual-scope release review and focused grouped-review proof require no new recovery exception.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 2019fbcdd819df198f811c7c1d14a41531d96571
+lastReviewedCommit: ed9eaac485add16eb924120764fd821d98355f9a
 lastReviewedNote: 'Reviewed for Issues #778 and #780: automatic dual-scope release review and focused grouped-review proof require no new recovery exception.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: c3a40654a3272f988d844fc21faedd818233853c
+lastReviewedCommit: d0f78f65e6a6a22b0f3a8fe4fa599dec60ef3eb5
 lastReviewedNote: 'Reviewed for Issues #778 and #780: automatic dual-scope release review and focused grouped-review proof require no new recovery exception.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 7906c03926d9d4b6f6b7eba8057f32b6520ed460
+lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
 lastReviewedNote: 'Reviewed for Issues #778 and #780: automatic dual-scope release review and focused grouped-review proof require no new recovery exception.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b
+lastReviewedCommit: 7906c03926d9d4b6f6b7eba8057f32b6520ed460
 lastReviewedNote: 'Reviewed for Issues #778 and #780: automatic dual-scope release review and focused grouped-review proof require no new recovery exception.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: d0f78f65e6a6a22b0f3a8fe4fa599dec60ef3eb5
+lastReviewedCommit: 7a53d181cfb9d53d875bf241ca6ac8d6fb39b78b
 lastReviewedNote: 'Reviewed for Issues #778 and #780: automatic dual-scope release review and focused grouped-review proof require no new recovery exception.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: ed9eaac485add16eb924120764fd821d98355f9a
+lastReviewedCommit: c3a40654a3272f988d844fc21faedd818233853c
 lastReviewedNote: 'Reviewed for Issues #778 and #780: automatic dual-scope release review and focused grouped-review proof require no new recovery exception.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7",
-    "auditedInputDigest": "0845c55abaa41c4a11a597c9204fed58c4ec6a768f1c0a9be039eb08d9f925c1"
+    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33",
+    "auditedInputDigest": "8705763d8afecd25cd301172a83f1b6197b8df2a2970191cc5817e19f02e4c0a"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "db5a419a87c3f2acc7c51e76b004460103014386ef4676b86d5898460e3b925a",
+    "dossierDigest": "9d3d0fa4af7772a322b55f5ff0f6a08246c7fb5e9cb2a6aca3d05ab3fb7fc588",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "cfed36e5b6b1a95d318b33e71139cef0020f930775793f82bf3e3dc3f8fb8194",
+      "sourceEvidenceDigest": "be6177218f6995df000c8d3beeb6ce38f5475ef3204eb606e78485c1c018e5cb",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -754,8 +754,8 @@
           "route": "/tgdata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "4d3dc66593fb0d8c3d5985f9d0e63a3fb530eefa833a501139861475118197c7",
-          "focusedTestDigest": "8e30d1b73ff8a8e3ebcc2071597e233c69e885059eaca6a01a81f79a269e6a9d",
+          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
+          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -772,8 +772,8 @@
           "route": "/codata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "4d3dc66593fb0d8c3d5985f9d0e63a3fb530eefa833a501139861475118197c7",
-          "focusedTestDigest": "8e30d1b73ff8a8e3ebcc2071597e233c69e885059eaca6a01a81f79a269e6a9d",
+          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
+          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -790,8 +790,8 @@
           "route": "/mydata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "4d3dc66593fb0d8c3d5985f9d0e63a3fb530eefa833a501139861475118197c7",
-          "focusedTestDigest": "8e30d1b73ff8a8e3ebcc2071597e233c69e885059eaca6a01a81f79a269e6a9d",
+          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
+          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -808,8 +808,8 @@
           "route": "/tedata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "4d3dc66593fb0d8c3d5985f9d0e63a3fb530eefa833a501139861475118197c7",
-          "focusedTestDigest": "8e30d1b73ff8a8e3ebcc2071597e233c69e885059eaca6a01a81f79a269e6a9d",
+          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
+          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -826,8 +826,8 @@
           "route": "/tgdata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "151ce983c9018c935164670133c71385c6671dd94c44f8ce9cf29fa053c72fc8",
-          "focusedTestDigest": "777519ff310e3a8d1c078730e2947495dca55a38142f0d9c6bf34990c8ae81ae",
+          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
+          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -844,8 +844,8 @@
           "route": "/codata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "151ce983c9018c935164670133c71385c6671dd94c44f8ce9cf29fa053c72fc8",
-          "focusedTestDigest": "777519ff310e3a8d1c078730e2947495dca55a38142f0d9c6bf34990c8ae81ae",
+          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
+          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -862,8 +862,8 @@
           "route": "/mydata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "151ce983c9018c935164670133c71385c6671dd94c44f8ce9cf29fa053c72fc8",
-          "focusedTestDigest": "777519ff310e3a8d1c078730e2947495dca55a38142f0d9c6bf34990c8ae81ae",
+          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
+          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -880,8 +880,8 @@
           "route": "/tedata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "151ce983c9018c935164670133c71385c6671dd94c44f8ce9cf29fa053c72fc8",
-          "focusedTestDigest": "777519ff310e3a8d1c078730e2947495dca55a38142f0d9c6bf34990c8ae81ae",
+          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
+          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "180d2f23e172c30e6327a5b79d13be982da38410006d8eff1fc67cb5e883f001",
+      "rowEvidenceDigest": "ea46ee411d510f3a80157de004d0cd7137cd36a7d42155b1c1643d93d2775d11",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "cfb6ae9ba5f59234c51bc9441d3831236a2e91febcba838d3b9a67ebdb3e5649"
+  "contextDigest": "ec27fdac64b26e591167bcbc9fdc117d639b431bcdf87e8b90c62276bfe6e66c"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138",
-    "auditedInputDigest": "a8cc23b311aec26dd4fa9c663216c17859fa6335b99d7c5861ffd159502f305c"
+    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7",
+    "auditedInputDigest": "0845c55abaa41c4a11a597c9204fed58c4ec6a768f1c0a9be039eb08d9f925c1"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "c4107d15ba13160cb615314e16937107f00ee4a2c477cd4e7dacb5cb536d8b24",
+    "dossierDigest": "db5a419a87c3f2acc7c51e76b004460103014386ef4676b86d5898460e3b925a",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "efc0e45f3219c6a17cc866f0e71c8408908a41eda5d8794db1ce93c66f3b4a06"
+  "contextDigest": "cfb6ae9ba5f59234c51bc9441d3831236a2e91febcba838d3b9a67ebdb3e5649"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5",
-    "auditedInputDigest": "cd7190e34b6d974b460e0c9612fa0188417339ee9b417f95e01f25abe6bc3a64"
+    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
+    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "50546b32dac10d197c65c0f051ea494abff737807af90649d07ea9ca465a1595",
+    "dossierDigest": "49092b48ae9b16af90a49415fec0c1bb70a634b9bab628c3f91ef7fb2968a315",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "f5cc80c9dd4a11954e893d3ef404ba4e0b160eb5153d2a269ca8e1ad0ebac2e1",
+      "sourceEvidenceDigest": "1faf9a4b23b3ecc7cfa2ef06327e573ad77959c3b2f06a597991cde88fb43f32",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -826,7 +826,7 @@
           "route": "/tgdata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "sourceDigest": "57818d138116fff5daf60206eeb2f5e62781eb8429b53977e32571e31406a3cc",
           "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
@@ -844,7 +844,7 @@
           "route": "/codata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "sourceDigest": "57818d138116fff5daf60206eeb2f5e62781eb8429b53977e32571e31406a3cc",
           "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
@@ -862,7 +862,7 @@
           "route": "/mydata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "sourceDigest": "57818d138116fff5daf60206eeb2f5e62781eb8429b53977e32571e31406a3cc",
           "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
@@ -880,7 +880,7 @@
           "route": "/tedata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "sourceDigest": "57818d138116fff5daf60206eeb2f5e62781eb8429b53977e32571e31406a3cc",
           "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "da4acf775da34bc3a803f05c5dc5ab1aecb0b7b83e91e65acc4d45c5e595f5bf",
+      "rowEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "8aae1e0a319e8c3e732952c4d7435ada0d7ca0a111fb0ee539f2a0e5001026ab"
+  "contextDigest": "069c773023e8841822696fcbe0dc127610503fbb0bce76d8495d883d1164b0e4"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33",
-    "auditedInputDigest": "8705763d8afecd25cd301172a83f1b6197b8df2a2970191cc5817e19f02e4c0a"
+    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5",
+    "auditedInputDigest": "cd7190e34b6d974b460e0c9612fa0188417339ee9b417f95e01f25abe6bc3a64"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "9d3d0fa4af7772a322b55f5ff0f6a08246c7fb5e9cb2a6aca3d05ab3fb7fc588",
+    "dossierDigest": "50546b32dac10d197c65c0f051ea494abff737807af90649d07ea9ca465a1595",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "be6177218f6995df000c8d3beeb6ce38f5475ef3204eb606e78485c1c018e5cb",
+      "sourceEvidenceDigest": "f5cc80c9dd4a11954e893d3ef404ba4e0b160eb5153d2a269ca8e1ad0ebac2e1",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -754,8 +754,8 @@
           "route": "/tgdata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
-          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
+          "sourceDigest": "bdefd8b299520d940bcc9279e97264f0c60c908a73d19dc3abd561d474e78388",
+          "focusedTestDigest": "b0e9a957a1b05f35d2490ab6fe579a74a180a9b6b12e52a87b00eabaf08bacf7",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -772,8 +772,8 @@
           "route": "/codata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
-          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
+          "sourceDigest": "bdefd8b299520d940bcc9279e97264f0c60c908a73d19dc3abd561d474e78388",
+          "focusedTestDigest": "b0e9a957a1b05f35d2490ab6fe579a74a180a9b6b12e52a87b00eabaf08bacf7",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -790,8 +790,8 @@
           "route": "/mydata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
-          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
+          "sourceDigest": "bdefd8b299520d940bcc9279e97264f0c60c908a73d19dc3abd561d474e78388",
+          "focusedTestDigest": "b0e9a957a1b05f35d2490ab6fe579a74a180a9b6b12e52a87b00eabaf08bacf7",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -808,8 +808,8 @@
           "route": "/tedata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
-          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
+          "sourceDigest": "bdefd8b299520d940bcc9279e97264f0c60c908a73d19dc3abd561d474e78388",
+          "focusedTestDigest": "b0e9a957a1b05f35d2490ab6fe579a74a180a9b6b12e52a87b00eabaf08bacf7",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -826,8 +826,8 @@
           "route": "/tgdata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
-          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
+          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -844,8 +844,8 @@
           "route": "/codata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
-          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
+          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -862,8 +862,8 @@
           "route": "/mydata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
-          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
+          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -880,8 +880,8 @@
           "route": "/tedata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
-          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
+          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "ea46ee411d510f3a80157de004d0cd7137cd36a7d42155b1c1643d93d2775d11",
+      "rowEvidenceDigest": "da4acf775da34bc3a803f05c5dc5ab1aecb0b7b83e91e65acc4d45c5e595f5bf",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "ec27fdac64b26e591167bcbc9fdc117d639b431bcdf87e8b90c62276bfe6e66c"
+  "contextDigest": "8aae1e0a319e8c3e732952c4d7435ada0d7ca0a111fb0ee539f2a0e5001026ab"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138"
+    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "efc0e45f3219c6a17cc866f0e71c8408908a41eda5d8794db1ce93c66f3b4a06",
-    "qualityDigest": "c24d73ab60c7124617a21fb5e5fb9f1c70a215687fbcb3f08a3aafb718a922ca",
+    "contextDigest": "cfb6ae9ba5f59234c51bc9441d3831236a2e91febcba838d3b9a67ebdb3e5649",
+    "qualityDigest": "d34e68f447e0d8808c2d6030332e12ff6239f7bda3f645678ad938a1b9e32808",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "4ded063ed831dd5cc8c81fcd44d9bf8dfdec5de1abe83870a6eb06f2245234e3"
+  "activationDigest": "afe395642eef2e2c233b941c68401b567874c531f3ca41e13aa2c75f99768f6f"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33"
+    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "ec27fdac64b26e591167bcbc9fdc117d639b431bcdf87e8b90c62276bfe6e66c",
-    "qualityDigest": "8e340cc1479f15dbdb1089d1efe9aa5c98d21e1680afadfe2eea69271a59a7ad",
+    "contextDigest": "8aae1e0a319e8c3e732952c4d7435ada0d7ca0a111fb0ee539f2a0e5001026ab",
+    "qualityDigest": "34e7abc67da76efc5b85a56712711bf7eb418456b79fca43e4538a33f0f5ed8f",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "26faf2b7296c542aa97beff712703e1c8c10d4a12bbf3869d91c645d84b50085"
+  "activationDigest": "feb31b2387521e34954151858ce4023496738090a9be6c7e86d3ca5d4ec1390b"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5"
+    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "8aae1e0a319e8c3e732952c4d7435ada0d7ca0a111fb0ee539f2a0e5001026ab",
-    "qualityDigest": "34e7abc67da76efc5b85a56712711bf7eb418456b79fca43e4538a33f0f5ed8f",
+    "contextDigest": "069c773023e8841822696fcbe0dc127610503fbb0bce76d8495d883d1164b0e4",
+    "qualityDigest": "52fc2b4d6ed512e70cdd02b5447e82bba2076840ee3a55fbe1b30c2e839f66ba",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "feb31b2387521e34954151858ce4023496738090a9be6c7e86d3ca5d4ec1390b"
+  "activationDigest": "7d3072d1e777d5cf48c557b17441b34d812ae271d880a1bb3a24bba570bd530b"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7"
+    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "cfb6ae9ba5f59234c51bc9441d3831236a2e91febcba838d3b9a67ebdb3e5649",
-    "qualityDigest": "d34e68f447e0d8808c2d6030332e12ff6239f7bda3f645678ad938a1b9e32808",
+    "contextDigest": "ec27fdac64b26e591167bcbc9fdc117d639b431bcdf87e8b90c62276bfe6e66c",
+    "qualityDigest": "8e340cc1479f15dbdb1089d1efe9aa5c98d21e1680afadfe2eea69271a59a7ad",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "afe395642eef2e2c233b941c68401b567874c531f3ca41e13aa2c75f99768f6f"
+  "activationDigest": "26faf2b7296c542aa97beff712703e1c8c10d4a12bbf3869d91c645d84b50085"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "cd7190e34b6d974b460e0c9612fa0188417339ee9b417f95e01f25abe6bc3a64",
+    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "0845c55abaa41c4a11a597c9204fed58c4ec6a768f1c0a9be039eb08d9f925c1",
+    "auditedInputDigest": "8705763d8afecd25cd301172a83f1b6197b8df2a2970191cc5817e19f02e4c0a",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -29379,7 +29379,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 366,
+          "line": 373,
           "column": 15,
           "symbol": "TableList",
           "defaultMessage": "Flow Properties",
@@ -29394,7 +29394,7 @@
           "locations": [
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 366,
+              "line": 373,
               "column": 15,
               "kind": "FormattedMessage"
             }
@@ -29853,7 +29853,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 352,
+          "line": 358,
           "column": 15,
           "symbol": "TableList",
           "defaultMessage": "Unit Groups",
@@ -29868,7 +29868,7 @@
           "locations": [
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 352,
+              "line": 358,
               "column": 15,
               "kind": "FormattedMessage"
             }
@@ -85204,7 +85204,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 209,
+          "line": 211,
           "column": 9,
           "symbol": "flowpropertiesColumns",
           "defaultMessage": "Reference unit",
@@ -85315,7 +85315,7 @@
             },
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 209,
+              "line": 211,
               "column": 9,
               "kind": "FormattedMessage"
             },
@@ -85443,7 +85443,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 381,
+          "line": 388,
           "column": 17,
           "symbol": "TableList",
           "defaultMessage": "Need to add or supplement flow properties? Contact an administrator.",
@@ -85458,7 +85458,7 @@
           "locations": [
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 381,
+              "line": 388,
               "column": 17,
               "kind": "FormattedMessage"
             }
@@ -217921,7 +217921,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 334,
+          "line": 341,
           "column": 28,
           "symbol": "TableList",
           "defaultMessage": null,
@@ -218137,7 +218137,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 320,
+          "line": 326,
           "column": 28,
           "symbol": "TableList",
           "defaultMessage": null,
@@ -218565,7 +218565,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 349,
+          "line": 356,
           "column": 17,
           "symbol": "TableList",
           "defaultMessage": "Reference Lookup",
@@ -218610,7 +218610,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 335,
+          "line": 341,
           "column": 17,
           "symbol": "TableList",
           "defaultMessage": "Reference Lookup",
@@ -218631,7 +218631,7 @@
             },
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 349,
+              "line": 356,
               "column": 17,
               "kind": "FormattedMessage"
             },
@@ -218661,7 +218661,7 @@
             },
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 335,
+              "line": 341,
               "column": 17,
               "kind": "FormattedMessage"
             }
@@ -218738,7 +218738,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 334,
+          "line": 341,
           "column": 28,
           "symbol": "TableList",
           "defaultMessage": null,
@@ -218783,7 +218783,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 320,
+          "line": 326,
           "column": 28,
           "symbol": "TableList",
           "defaultMessage": null,
@@ -229325,7 +229325,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 197,
+          "line": 199,
           "column": 9,
           "symbol": "flowpropertiesColumns",
           "defaultMessage": "Classification",
@@ -229433,7 +229433,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 201,
+          "line": 203,
           "column": 9,
           "symbol": "unitGroupColumns",
           "defaultMessage": "Classification",
@@ -229466,7 +229466,7 @@
             },
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 197,
+              "line": 199,
               "column": 9,
               "kind": "FormattedMessage"
             },
@@ -229538,7 +229538,7 @@
             },
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 201,
+              "line": 203,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -229849,7 +229849,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 183,
+          "line": 185,
           "column": 14,
           "symbol": "flowpropertiesColumns",
           "defaultMessage": "Index",
@@ -230092,7 +230092,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 170,
+          "line": 172,
           "column": 9,
           "symbol": "unitGroupColumns",
           "defaultMessage": "Index",
@@ -230125,7 +230125,7 @@
             },
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 183,
+              "line": 185,
               "column": 14,
               "kind": "FormattedMessage"
             },
@@ -230287,7 +230287,7 @@
             },
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 170,
+              "line": 172,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -230489,7 +230489,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 189,
+          "line": 191,
           "column": 14,
           "symbol": "flowpropertiesColumns",
           "defaultMessage": "Name",
@@ -230660,7 +230660,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 177,
+          "line": 179,
           "column": 9,
           "symbol": "unitGroupColumns",
           "defaultMessage": "Name",
@@ -230699,7 +230699,7 @@
             },
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 189,
+              "line": 191,
               "column": 14,
               "kind": "FormattedMessage"
             },
@@ -230813,7 +230813,7 @@
             },
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 177,
+              "line": 179,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -230917,7 +230917,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 295,
+          "line": 297,
           "column": 14,
           "symbol": "flowpropertiesColumns",
           "defaultMessage": "Actions",
@@ -231133,7 +231133,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 281,
+          "line": 283,
           "column": 9,
           "symbol": "unitGroupColumns",
           "defaultMessage": "Actions",
@@ -231172,7 +231172,7 @@
             },
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 295,
+              "line": 297,
               "column": 14,
               "kind": "FormattedMessage"
             },
@@ -231316,7 +231316,7 @@
             },
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 281,
+              "line": 283,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -231402,7 +231402,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 285,
+          "line": 287,
           "column": 14,
           "symbol": "flowpropertiesColumns",
           "defaultMessage": "Updated at",
@@ -231474,7 +231474,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 266,
+          "line": 268,
           "column": 9,
           "symbol": "unitGroupColumns",
           "defaultMessage": "Updated at",
@@ -231501,7 +231501,7 @@
             },
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 285,
+              "line": 287,
               "column": 14,
               "kind": "FormattedMessage"
             },
@@ -231549,7 +231549,7 @@
             },
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 266,
+              "line": 268,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -231653,7 +231653,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 234,
+          "line": 236,
           "column": 14,
           "symbol": "flowpropertiesColumns",
           "defaultMessage": "Version",
@@ -231842,7 +231842,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 215,
+          "line": 217,
           "column": 14,
           "symbol": "unitGroupColumns",
           "defaultMessage": "Version",
@@ -231881,7 +231881,7 @@
             },
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 234,
+              "line": 236,
               "column": 14,
               "kind": "FormattedMessage"
             },
@@ -232007,7 +232007,7 @@
             },
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 215,
+              "line": 217,
               "column": 14,
               "kind": "FormattedMessage"
             }
@@ -238948,7 +238948,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 367,
+          "line": 373,
           "column": 17,
           "symbol": "TableList",
           "defaultMessage": "Need to add or supplement unit groups? Contact an administrator.",
@@ -238963,7 +238963,7 @@
           "locations": [
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 367,
+              "line": 373,
               "column": 17,
               "kind": "FormattedMessage"
             }
@@ -239657,7 +239657,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 186,
+          "line": 188,
           "column": 9,
           "symbol": "unitGroupColumns",
           "defaultMessage": "Quantitative reference",
@@ -239714,7 +239714,7 @@
             },
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 186,
+              "line": 188,
               "column": 9,
               "kind": "FormattedMessage"
             }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "a8cc23b311aec26dd4fa9c663216c17859fa6335b99d7c5861ffd159502f305c",
+    "auditedInputDigest": "0845c55abaa41c4a11a597c9204fed58c4ec6a768f1c0a9be039eb08d9f925c1",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -11884,7 +11884,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/components/RightContent/AvatarDropdown.tsx",
-          "line": 278,
+          "line": 290,
           "column": 16,
           "symbol": "AvatarDropdown",
           "defaultMessage": "All Teams",
@@ -11911,7 +11911,7 @@
             },
             {
               "path": "src/components/RightContent/AvatarDropdown.tsx",
-              "line": 278,
+              "line": 290,
               "column": 16,
               "kind": "FormattedMessage"
             }
@@ -23694,7 +23694,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/components/RightContent/AvatarDropdown.tsx",
-          "line": 261,
+          "line": 273,
           "column": 14,
           "symbol": "menuItems",
           "defaultMessage": "Logout",
@@ -23709,7 +23709,7 @@
           "locations": [
             {
               "path": "src/components/RightContent/AvatarDropdown.tsx",
-              "line": 261,
+              "line": 273,
               "column": 14,
               "kind": "FormattedMessage"
             }
@@ -23895,7 +23895,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/components/RightContent/AvatarDropdown.tsx",
-          "line": 235,
+          "line": 245,
           "column": 14,
           "symbol": "menuItems",
           "defaultMessage": "Account Profile",
@@ -23919,7 +23919,7 @@
           "locations": [
             {
               "path": "src/components/RightContent/AvatarDropdown.tsx",
-              "line": 235,
+              "line": 245,
               "column": 14,
               "kind": "FormattedMessage"
             },
@@ -23993,7 +23993,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/components/RightContent/AvatarDropdown.tsx",
-          "line": 252,
+          "line": 264,
           "column": 14,
           "symbol": "menuItems",
           "defaultMessage": "Review Management",
@@ -24008,7 +24008,7 @@
           "locations": [
             {
               "path": "src/components/RightContent/AvatarDropdown.tsx",
-              "line": 252,
+              "line": 264,
               "column": 14,
               "kind": "FormattedMessage"
             }
@@ -24135,7 +24135,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/components/RightContent/AvatarDropdown.tsx",
-          "line": 240,
+          "line": 250,
           "column": 14,
           "symbol": "menuItems",
           "defaultMessage": "My Team",
@@ -24168,7 +24168,7 @@
           "locations": [
             {
               "path": "src/components/RightContent/AvatarDropdown.tsx",
-              "line": 240,
+              "line": 250,
               "column": 14,
               "kind": "FormattedMessage"
             },
@@ -27048,7 +27048,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/components/RightContent/AvatarDropdown.tsx",
-          "line": 245,
+          "line": 255,
           "column": 14,
           "symbol": "menuItems",
           "defaultMessage": "System Management",
@@ -27081,7 +27081,7 @@
           "locations": [
             {
               "path": "src/components/RightContent/AvatarDropdown.tsx",
-              "line": 245,
+              "line": 255,
               "column": 14,
               "kind": "FormattedMessage"
             },
@@ -256074,7 +256074,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/RightContent/AvatarDropdown.tsx",
-          "line": 133,
+          "line": 143,
           "column": 22,
           "symbol": "onMenuClick",
           "defaultMessage": "You can create a team or join an existing team.",
@@ -256089,7 +256089,7 @@
           "locations": [
             {
               "path": "src/components/RightContent/AvatarDropdown.tsx",
-              "line": 133,
+              "line": 143,
               "column": 22,
               "kind": "formatMessage"
             }
@@ -256157,7 +256157,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/RightContent/AvatarDropdown.tsx",
-          "line": 172,
+          "line": 182,
           "column": 20,
           "symbol": "onMenuClick",
           "defaultMessage": "Create Team",
@@ -256172,7 +256172,7 @@
           "locations": [
             {
               "path": "src/components/RightContent/AvatarDropdown.tsx",
-              "line": 172,
+              "line": 182,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -256240,7 +256240,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/RightContent/AvatarDropdown.tsx",
-          "line": 147,
+          "line": 157,
           "column": 20,
           "symbol": "onMenuClick",
           "defaultMessage": "Join Team",
@@ -256255,7 +256255,7 @@
           "locations": [
             {
               "path": "src/components/RightContent/AvatarDropdown.tsx",
-              "line": 147,
+              "line": 157,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -256323,7 +256323,7 @@
         {
           "kind": "formatMessage",
           "path": "src/components/RightContent/AvatarDropdown.tsx",
-          "line": 129,
+          "line": 139,
           "column": 20,
           "symbol": "onMenuClick",
           "defaultMessage": "You are not in any team",
@@ -256338,7 +256338,7 @@
           "locations": [
             {
               "path": "src/components/RightContent/AvatarDropdown.tsx",
-              "line": 129,
+              "line": 139,
               "column": 20,
               "kind": "formatMessage"
             }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "8705763d8afecd25cd301172a83f1b6197b8df2a2970191cc5817e19f02e4c0a",
+    "auditedInputDigest": "cd7190e34b6d974b460e0c9612fa0188417339ee9b417f95e01f25abe6bc3a64",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -29379,7 +29379,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 373,
+          "line": 392,
           "column": 15,
           "symbol": "TableList",
           "defaultMessage": "Flow Properties",
@@ -29394,7 +29394,7 @@
           "locations": [
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 373,
+              "line": 392,
               "column": 15,
               "kind": "FormattedMessage"
             }
@@ -29853,7 +29853,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 358,
+          "line": 372,
           "column": 15,
           "symbol": "TableList",
           "defaultMessage": "Unit Groups",
@@ -29868,7 +29868,7 @@
           "locations": [
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 358,
+              "line": 372,
               "column": 15,
               "kind": "FormattedMessage"
             }
@@ -85204,7 +85204,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 211,
+          "line": 228,
           "column": 9,
           "symbol": "flowpropertiesColumns",
           "defaultMessage": "Reference unit",
@@ -85315,7 +85315,7 @@
             },
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 211,
+              "line": 228,
               "column": 9,
               "kind": "FormattedMessage"
             },
@@ -85443,7 +85443,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 388,
+          "line": 407,
           "column": 17,
           "symbol": "TableList",
           "defaultMessage": "Need to add or supplement flow properties? Contact an administrator.",
@@ -85458,7 +85458,7 @@
           "locations": [
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 388,
+              "line": 407,
               "column": 17,
               "kind": "FormattedMessage"
             }
@@ -217921,7 +217921,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 341,
+          "line": 360,
           "column": 28,
           "symbol": "TableList",
           "defaultMessage": null,
@@ -218137,7 +218137,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 326,
+          "line": 340,
           "column": 28,
           "symbol": "TableList",
           "defaultMessage": null,
@@ -218565,7 +218565,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 356,
+          "line": 375,
           "column": 17,
           "symbol": "TableList",
           "defaultMessage": "Reference Lookup",
@@ -218610,7 +218610,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 341,
+          "line": 355,
           "column": 17,
           "symbol": "TableList",
           "defaultMessage": "Reference Lookup",
@@ -218631,7 +218631,7 @@
             },
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 356,
+              "line": 375,
               "column": 17,
               "kind": "FormattedMessage"
             },
@@ -218661,7 +218661,7 @@
             },
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 341,
+              "line": 355,
               "column": 17,
               "kind": "FormattedMessage"
             }
@@ -218738,7 +218738,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 341,
+          "line": 360,
           "column": 28,
           "symbol": "TableList",
           "defaultMessage": null,
@@ -218783,7 +218783,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 326,
+          "line": 340,
           "column": 28,
           "symbol": "TableList",
           "defaultMessage": null,
@@ -229325,7 +229325,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 199,
+          "line": 216,
           "column": 9,
           "symbol": "flowpropertiesColumns",
           "defaultMessage": "Classification",
@@ -229433,7 +229433,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 203,
+          "line": 215,
           "column": 9,
           "symbol": "unitGroupColumns",
           "defaultMessage": "Classification",
@@ -229466,7 +229466,7 @@
             },
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 199,
+              "line": 216,
               "column": 9,
               "kind": "FormattedMessage"
             },
@@ -229538,7 +229538,7 @@
             },
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 203,
+              "line": 215,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -229849,7 +229849,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 185,
+          "line": 202,
           "column": 14,
           "symbol": "flowpropertiesColumns",
           "defaultMessage": "Index",
@@ -230092,7 +230092,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 172,
+          "line": 184,
           "column": 9,
           "symbol": "unitGroupColumns",
           "defaultMessage": "Index",
@@ -230125,7 +230125,7 @@
             },
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 185,
+              "line": 202,
               "column": 14,
               "kind": "FormattedMessage"
             },
@@ -230287,7 +230287,7 @@
             },
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 172,
+              "line": 184,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -230489,7 +230489,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 191,
+          "line": 208,
           "column": 14,
           "symbol": "flowpropertiesColumns",
           "defaultMessage": "Name",
@@ -230660,7 +230660,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 179,
+          "line": 191,
           "column": 9,
           "symbol": "unitGroupColumns",
           "defaultMessage": "Name",
@@ -230699,7 +230699,7 @@
             },
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 191,
+              "line": 208,
               "column": 14,
               "kind": "FormattedMessage"
             },
@@ -230813,7 +230813,7 @@
             },
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 179,
+              "line": 191,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -230917,7 +230917,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 297,
+          "line": 316,
           "column": 14,
           "symbol": "flowpropertiesColumns",
           "defaultMessage": "Actions",
@@ -231133,7 +231133,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 283,
+          "line": 297,
           "column": 9,
           "symbol": "unitGroupColumns",
           "defaultMessage": "Actions",
@@ -231172,7 +231172,7 @@
             },
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 297,
+              "line": 316,
               "column": 14,
               "kind": "FormattedMessage"
             },
@@ -231316,7 +231316,7 @@
             },
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 283,
+              "line": 297,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -231402,7 +231402,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 287,
+          "line": 306,
           "column": 14,
           "symbol": "flowpropertiesColumns",
           "defaultMessage": "Updated at",
@@ -231474,7 +231474,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 268,
+          "line": 282,
           "column": 9,
           "symbol": "unitGroupColumns",
           "defaultMessage": "Updated at",
@@ -231501,7 +231501,7 @@
             },
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 287,
+              "line": 306,
               "column": 14,
               "kind": "FormattedMessage"
             },
@@ -231549,7 +231549,7 @@
             },
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 268,
+              "line": 282,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -231653,7 +231653,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/index.tsx",
-          "line": 236,
+          "line": 253,
           "column": 14,
           "symbol": "flowpropertiesColumns",
           "defaultMessage": "Version",
@@ -231842,7 +231842,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 217,
+          "line": 229,
           "column": 14,
           "symbol": "unitGroupColumns",
           "defaultMessage": "Version",
@@ -231881,7 +231881,7 @@
             },
             {
               "path": "src/pages/Flowproperties/index.tsx",
-              "line": 236,
+              "line": 253,
               "column": 14,
               "kind": "FormattedMessage"
             },
@@ -232007,7 +232007,7 @@
             },
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 217,
+              "line": 229,
               "column": 14,
               "kind": "FormattedMessage"
             }
@@ -238948,7 +238948,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 373,
+          "line": 387,
           "column": 17,
           "symbol": "TableList",
           "defaultMessage": "Need to add or supplement unit groups? Contact an administrator.",
@@ -238963,7 +238963,7 @@
           "locations": [
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 373,
+              "line": 387,
               "column": 17,
               "kind": "FormattedMessage"
             }
@@ -239657,7 +239657,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/index.tsx",
-          "line": 188,
+          "line": 200,
           "column": 9,
           "symbol": "unitGroupColumns",
           "defaultMessage": "Quantitative reference",
@@ -239714,7 +239714,7 @@
             },
             {
               "path": "src/pages/Unitgroups/index.tsx",
-              "line": 188,
+              "line": 200,
               "column": 9,
               "kind": "FormattedMessage"
             }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5",
-    "contextDigest": "8aae1e0a319e8c3e732952c4d7435ada0d7ca0a111fb0ee539f2a0e5001026ab"
+    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
+    "contextDigest": "069c773023e8841822696fcbe0dc127610503fbb0bce76d8495d883d1164b0e4"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "9e0eacb8c6f25bd11fc3fff0ef49a96dc65d2d41958fc4fa609ffaeee35304ab",
-    "validationDigest": "659c39e8d42175fdd62f9296d2d1fe5d18ebc3e16a94d27f8a67d6057da5277d",
+    "digest": "8c18fcdf4966a771a5aac60fe00c952b743bfd34bd27c0bad368a77046376707",
+    "validationDigest": "6629a38843a1654a0efc533a3cfb4a8465166dcbc60d194eaa7229426e5717df",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "34e7abc67da76efc5b85a56712711bf7eb418456b79fca43e4538a33f0f5ed8f"
+  "qualityDigest": "52fc2b4d6ed512e70cdd02b5447e82bba2076840ee3a55fbe1b30c2e839f66ba"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33",
-    "contextDigest": "ec27fdac64b26e591167bcbc9fdc117d639b431bcdf87e8b90c62276bfe6e66c"
+    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5",
+    "contextDigest": "8aae1e0a319e8c3e732952c4d7435ada0d7ca0a111fb0ee539f2a0e5001026ab"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "ccf421c51fecfe32f3e92980041521499e87056fc27b94f0b89df48c48e47c62",
-    "validationDigest": "84f64175c90f3c2f192b780e07f826dc459149430059fce6a5b9d9ee7df9a4aa",
+    "digest": "9e0eacb8c6f25bd11fc3fff0ef49a96dc65d2d41958fc4fa609ffaeee35304ab",
+    "validationDigest": "659c39e8d42175fdd62f9296d2d1fe5d18ebc3e16a94d27f8a67d6057da5277d",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "8e340cc1479f15dbdb1089d1efe9aa5c98d21e1680afadfe2eea69271a59a7ad"
+  "qualityDigest": "34e7abc67da76efc5b85a56712711bf7eb418456b79fca43e4538a33f0f5ed8f"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7",
-    "contextDigest": "cfb6ae9ba5f59234c51bc9441d3831236a2e91febcba838d3b9a67ebdb3e5649"
+    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33",
+    "contextDigest": "ec27fdac64b26e591167bcbc9fdc117d639b431bcdf87e8b90c62276bfe6e66c"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "8b76610681c2f54af634908ca3743fd7b657d13becadde1d94cb06a0aeb4b9f1",
-    "validationDigest": "b566b24d04b156d803b784144735b0a01f65c71d3611102c70c9a889c44b7d70",
+    "digest": "ccf421c51fecfe32f3e92980041521499e87056fc27b94f0b89df48c48e47c62",
+    "validationDigest": "84f64175c90f3c2f192b780e07f826dc459149430059fce6a5b9d9ee7df9a4aa",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "d34e68f447e0d8808c2d6030332e12ff6239f7bda3f645678ad938a1b9e32808"
+  "qualityDigest": "8e340cc1479f15dbdb1089d1efe9aa5c98d21e1680afadfe2eea69271a59a7ad"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138",
-    "contextDigest": "efc0e45f3219c6a17cc866f0e71c8408908a41eda5d8794db1ce93c66f3b4a06"
+    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7",
+    "contextDigest": "cfb6ae9ba5f59234c51bc9441d3831236a2e91febcba838d3b9a67ebdb3e5649"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "0bd25ff0d53c17fb6c8e283c90519156bf45c0c1b46a9488dd234765399d3ade",
-    "validationDigest": "7afca52ab3f77654c700879cad6e740ce1a059c3258181d8e7a3de41a0f7b48c",
+    "digest": "8b76610681c2f54af634908ca3743fd7b657d13becadde1d94cb06a0aeb4b9f1",
+    "validationDigest": "b566b24d04b156d803b784144735b0a01f65c71d3611102c70c9a889c44b7d70",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "c24d73ab60c7124617a21fb5e5fb9f1c70a215687fbcb3f08a3aafb718a922ca"
+  "qualityDigest": "d34e68f447e0d8808c2d6030332e12ff6239f7bda3f645678ad938a1b9e32808"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "a8cc23b311aec26dd4fa9c663216c17859fa6335b99d7c5861ffd159502f305c",
+    "auditedInputDigest": "0845c55abaa41c4a11a597c9204fed58c4ec6a768f1c0a9be039eb08d9f925c1",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
-    "dossierDigest": "c4107d15ba13160cb615314e16937107f00ee4a2c477cd4e7dacb5cb536d8b24",
+    "dossierDigest": "db5a419a87c3f2acc7c51e76b004460103014386ef4676b86d5898460e3b925a",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "180d2f23e172c30e6327a5b79d13be982da38410006d8eff1fc67cb5e883f001",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "c4107d15ba13160cb615314e16937107f00ee4a2c477cd4e7dacb5cb536d8b24",
+        "dossierDigest": "db5a419a87c3f2acc7c51e76b004460103014386ef4676b86d5898460e3b925a",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "7afca52ab3f77654c700879cad6e740ce1a059c3258181d8e7a3de41a0f7b48c"
+  "validationDigest": "b566b24d04b156d803b784144735b0a01f65c71d3611102c70c9a889c44b7d70"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "8705763d8afecd25cd301172a83f1b6197b8df2a2970191cc5817e19f02e4c0a",
+    "auditedInputDigest": "cd7190e34b6d974b460e0c9612fa0188417339ee9b417f95e01f25abe6bc3a64",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
-    "dossierDigest": "9d3d0fa4af7772a322b55f5ff0f6a08246c7fb5e9cb2a6aca3d05ab3fb7fc588",
+    "dossierDigest": "50546b32dac10d197c65c0f051ea494abff737807af90649d07ea9ca465a1595",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "ea46ee411d510f3a80157de004d0cd7137cd36a7d42155b1c1643d93d2775d11",
+    "routeEvidenceDigest": "da4acf775da34bc3a803f05c5dc5ab1aecb0b7b83e91e65acc4d45c5e595f5bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "9d3d0fa4af7772a322b55f5ff0f6a08246c7fb5e9cb2a6aca3d05ab3fb7fc588",
+        "dossierDigest": "50546b32dac10d197c65c0f051ea494abff737807af90649d07ea9ca465a1595",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "84f64175c90f3c2f192b780e07f826dc459149430059fce6a5b9d9ee7df9a4aa"
+  "validationDigest": "659c39e8d42175fdd62f9296d2d1fe5d18ebc3e16a94d27f8a67d6057da5277d"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "0845c55abaa41c4a11a597c9204fed58c4ec6a768f1c0a9be039eb08d9f925c1",
+    "auditedInputDigest": "8705763d8afecd25cd301172a83f1b6197b8df2a2970191cc5817e19f02e4c0a",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
-    "dossierDigest": "db5a419a87c3f2acc7c51e76b004460103014386ef4676b86d5898460e3b925a",
+    "dossierDigest": "9d3d0fa4af7772a322b55f5ff0f6a08246c7fb5e9cb2a6aca3d05ab3fb7fc588",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "180d2f23e172c30e6327a5b79d13be982da38410006d8eff1fc67cb5e883f001",
+    "routeEvidenceDigest": "ea46ee411d510f3a80157de004d0cd7137cd36a7d42155b1c1643d93d2775d11",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "db5a419a87c3f2acc7c51e76b004460103014386ef4676b86d5898460e3b925a",
+        "dossierDigest": "9d3d0fa4af7772a322b55f5ff0f6a08246c7fb5e9cb2a6aca3d05ab3fb7fc588",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "b566b24d04b156d803b784144735b0a01f65c71d3611102c70c9a889c44b7d70"
+  "validationDigest": "84f64175c90f3c2f192b780e07f826dc459149430059fce6a5b9d9ee7df9a4aa"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "cd7190e34b6d974b460e0c9612fa0188417339ee9b417f95e01f25abe6bc3a64",
+    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
-    "dossierDigest": "50546b32dac10d197c65c0f051ea494abff737807af90649d07ea9ca465a1595",
+    "dossierDigest": "49092b48ae9b16af90a49415fec0c1bb70a634b9bab628c3f91ef7fb2968a315",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "da4acf775da34bc3a803f05c5dc5ab1aecb0b7b83e91e65acc4d45c5e595f5bf",
+    "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "50546b32dac10d197c65c0f051ea494abff737807af90649d07ea9ca465a1595",
+        "dossierDigest": "49092b48ae9b16af90a49415fec0c1bb70a634b9bab628c3f91ef7fb2968a315",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "659c39e8d42175fdd62f9296d2d1fe5d18ebc3e16a94d27f8a67d6057da5277d"
+  "validationDigest": "6629a38843a1654a0efc533a3cfb4a8465166dcbc60d194eaa7229426e5717df"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7",
-    "auditedInputDigest": "0845c55abaa41c4a11a597c9204fed58c4ec6a768f1c0a9be039eb08d9f925c1"
+    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33",
+    "auditedInputDigest": "8705763d8afecd25cd301172a83f1b6197b8df2a2970191cc5817e19f02e4c0a"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "b5eb23edb9ca3b6e5e25f747ca9b96550960371535bf8c0091404b7d76e616ad",
+    "dossierDigest": "9896d17f4910fca406d49fe2ba9d2d4522c44b3dfa3222ec83f566f3470035ac",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "cfed36e5b6b1a95d318b33e71139cef0020f930775793f82bf3e3dc3f8fb8194",
+      "sourceEvidenceDigest": "be6177218f6995df000c8d3beeb6ce38f5475ef3204eb606e78485c1c018e5cb",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -754,8 +754,8 @@
           "route": "/tgdata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "4d3dc66593fb0d8c3d5985f9d0e63a3fb530eefa833a501139861475118197c7",
-          "focusedTestDigest": "8e30d1b73ff8a8e3ebcc2071597e233c69e885059eaca6a01a81f79a269e6a9d",
+          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
+          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -772,8 +772,8 @@
           "route": "/codata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "4d3dc66593fb0d8c3d5985f9d0e63a3fb530eefa833a501139861475118197c7",
-          "focusedTestDigest": "8e30d1b73ff8a8e3ebcc2071597e233c69e885059eaca6a01a81f79a269e6a9d",
+          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
+          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -790,8 +790,8 @@
           "route": "/mydata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "4d3dc66593fb0d8c3d5985f9d0e63a3fb530eefa833a501139861475118197c7",
-          "focusedTestDigest": "8e30d1b73ff8a8e3ebcc2071597e233c69e885059eaca6a01a81f79a269e6a9d",
+          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
+          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -808,8 +808,8 @@
           "route": "/tedata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "4d3dc66593fb0d8c3d5985f9d0e63a3fb530eefa833a501139861475118197c7",
-          "focusedTestDigest": "8e30d1b73ff8a8e3ebcc2071597e233c69e885059eaca6a01a81f79a269e6a9d",
+          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
+          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -826,8 +826,8 @@
           "route": "/tgdata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "151ce983c9018c935164670133c71385c6671dd94c44f8ce9cf29fa053c72fc8",
-          "focusedTestDigest": "777519ff310e3a8d1c078730e2947495dca55a38142f0d9c6bf34990c8ae81ae",
+          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
+          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -844,8 +844,8 @@
           "route": "/codata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "151ce983c9018c935164670133c71385c6671dd94c44f8ce9cf29fa053c72fc8",
-          "focusedTestDigest": "777519ff310e3a8d1c078730e2947495dca55a38142f0d9c6bf34990c8ae81ae",
+          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
+          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -862,8 +862,8 @@
           "route": "/mydata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "151ce983c9018c935164670133c71385c6671dd94c44f8ce9cf29fa053c72fc8",
-          "focusedTestDigest": "777519ff310e3a8d1c078730e2947495dca55a38142f0d9c6bf34990c8ae81ae",
+          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
+          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -880,8 +880,8 @@
           "route": "/tedata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "151ce983c9018c935164670133c71385c6671dd94c44f8ce9cf29fa053c72fc8",
-          "focusedTestDigest": "777519ff310e3a8d1c078730e2947495dca55a38142f0d9c6bf34990c8ae81ae",
+          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
+          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "180d2f23e172c30e6327a5b79d13be982da38410006d8eff1fc67cb5e883f001",
+      "rowEvidenceDigest": "ea46ee411d510f3a80157de004d0cd7137cd36a7d42155b1c1643d93d2775d11",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "db50c14613105409846378ea3626caa8cf6d232fc5b4e987007da981f4d11b96"
+  "contextDigest": "dd478e9b14f2e5d05414b7a4b9922051a83b2ffeae443a4ed56abcb5348e2bcb"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5",
-    "auditedInputDigest": "cd7190e34b6d974b460e0c9612fa0188417339ee9b417f95e01f25abe6bc3a64"
+    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
+    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "c1085b371c5f58bf58b2769b64566658827f189cb0e0abb795f141d6ccd5f5c1",
+    "dossierDigest": "637555d5e12222d2e311dde8e39b081ebbab2fe8dd7206344d7890d98ef49dbb",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "f5cc80c9dd4a11954e893d3ef404ba4e0b160eb5153d2a269ca8e1ad0ebac2e1",
+      "sourceEvidenceDigest": "1faf9a4b23b3ecc7cfa2ef06327e573ad77959c3b2f06a597991cde88fb43f32",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -826,7 +826,7 @@
           "route": "/tgdata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "sourceDigest": "57818d138116fff5daf60206eeb2f5e62781eb8429b53977e32571e31406a3cc",
           "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
@@ -844,7 +844,7 @@
           "route": "/codata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "sourceDigest": "57818d138116fff5daf60206eeb2f5e62781eb8429b53977e32571e31406a3cc",
           "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
@@ -862,7 +862,7 @@
           "route": "/mydata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "sourceDigest": "57818d138116fff5daf60206eeb2f5e62781eb8429b53977e32571e31406a3cc",
           "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
@@ -880,7 +880,7 @@
           "route": "/tedata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "sourceDigest": "57818d138116fff5daf60206eeb2f5e62781eb8429b53977e32571e31406a3cc",
           "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "da4acf775da34bc3a803f05c5dc5ab1aecb0b7b83e91e65acc4d45c5e595f5bf",
+      "rowEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "7194bf97b4de44bb69b8892f71dffc06c3f03b117106b5062e4f683f6741ab12"
+  "contextDigest": "4d34fd93f20a467e99721a8dde665890a6a304acb2f14bc3f86f7acab69257a8"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138",
-    "auditedInputDigest": "a8cc23b311aec26dd4fa9c663216c17859fa6335b99d7c5861ffd159502f305c"
+    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7",
+    "auditedInputDigest": "0845c55abaa41c4a11a597c9204fed58c4ec6a768f1c0a9be039eb08d9f925c1"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "c232466f0b490ad79f9792cb9913d2511c33315082269ee8fd8657ebd00571e2",
+    "dossierDigest": "b5eb23edb9ca3b6e5e25f747ca9b96550960371535bf8c0091404b7d76e616ad",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "b30fbac059a5a97c6047bf6a035d9e3d8781437f0a9ddad93815345a1b93b563"
+  "contextDigest": "db50c14613105409846378ea3626caa8cf6d232fc5b4e987007da981f4d11b96"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33",
-    "auditedInputDigest": "8705763d8afecd25cd301172a83f1b6197b8df2a2970191cc5817e19f02e4c0a"
+    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5",
+    "auditedInputDigest": "cd7190e34b6d974b460e0c9612fa0188417339ee9b417f95e01f25abe6bc3a64"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "9896d17f4910fca406d49fe2ba9d2d4522c44b3dfa3222ec83f566f3470035ac",
+    "dossierDigest": "c1085b371c5f58bf58b2769b64566658827f189cb0e0abb795f141d6ccd5f5c1",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "be6177218f6995df000c8d3beeb6ce38f5475ef3204eb606e78485c1c018e5cb",
+      "sourceEvidenceDigest": "f5cc80c9dd4a11954e893d3ef404ba4e0b160eb5153d2a269ca8e1ad0ebac2e1",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -754,8 +754,8 @@
           "route": "/tgdata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
-          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
+          "sourceDigest": "bdefd8b299520d940bcc9279e97264f0c60c908a73d19dc3abd561d474e78388",
+          "focusedTestDigest": "b0e9a957a1b05f35d2490ab6fe579a74a180a9b6b12e52a87b00eabaf08bacf7",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -772,8 +772,8 @@
           "route": "/codata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
-          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
+          "sourceDigest": "bdefd8b299520d940bcc9279e97264f0c60c908a73d19dc3abd561d474e78388",
+          "focusedTestDigest": "b0e9a957a1b05f35d2490ab6fe579a74a180a9b6b12e52a87b00eabaf08bacf7",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -790,8 +790,8 @@
           "route": "/mydata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
-          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
+          "sourceDigest": "bdefd8b299520d940bcc9279e97264f0c60c908a73d19dc3abd561d474e78388",
+          "focusedTestDigest": "b0e9a957a1b05f35d2490ab6fe579a74a180a9b6b12e52a87b00eabaf08bacf7",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -808,8 +808,8 @@
           "route": "/tedata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
-          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
+          "sourceDigest": "bdefd8b299520d940bcc9279e97264f0c60c908a73d19dc3abd561d474e78388",
+          "focusedTestDigest": "b0e9a957a1b05f35d2490ab6fe579a74a180a9b6b12e52a87b00eabaf08bacf7",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -826,8 +826,8 @@
           "route": "/tgdata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
-          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
+          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -844,8 +844,8 @@
           "route": "/codata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
-          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
+          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -862,8 +862,8 @@
           "route": "/mydata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
-          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
+          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -880,8 +880,8 @@
           "route": "/tedata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
-          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
+          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "ea46ee411d510f3a80157de004d0cd7137cd36a7d42155b1c1643d93d2775d11",
+      "rowEvidenceDigest": "da4acf775da34bc3a803f05c5dc5ab1aecb0b7b83e91e65acc4d45c5e595f5bf",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "dd478e9b14f2e5d05414b7a4b9922051a83b2ffeae443a4ed56abcb5348e2bcb"
+  "contextDigest": "7194bf97b4de44bb69b8892f71dffc06c3f03b117106b5062e4f683f6741ab12"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5"
+    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "7194bf97b4de44bb69b8892f71dffc06c3f03b117106b5062e4f683f6741ab12",
-    "qualityDigest": "d2e2d9426deabd38497addd77cf533f784f62cbab6051bcbf5600019d6c06bce",
+    "contextDigest": "4d34fd93f20a467e99721a8dde665890a6a304acb2f14bc3f86f7acab69257a8",
+    "qualityDigest": "e9b5dc488b81d5a9c476ab68a4f36c20bb72ddd7f048e109ec398046450385e7",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "bd79cd06ebcd88ae7a18adef17baec30ebe9f6228951fcff72bd6cb6fc151e32"
+  "activationDigest": "0a74a0042d321a1823c2cab2908e6bfc2840a4730399df20224ae4010dfa2bcc"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138"
+    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "b30fbac059a5a97c6047bf6a035d9e3d8781437f0a9ddad93815345a1b93b563",
-    "qualityDigest": "796b7d91f73de87ed13518edc1cd186bd13975908d3d81cbd4eefd505d1669b8",
+    "contextDigest": "db50c14613105409846378ea3626caa8cf6d232fc5b4e987007da981f4d11b96",
+    "qualityDigest": "78ca73de33af53ece9bbbaf8a1c980e2dc611ed97f4c8deaf3a99e0b43e4897b",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "d438c078aa44d6cac27fe6db49540f436de5143f524ff392e8f0246738b0732c"
+  "activationDigest": "356722e9bd9b1b82baa93fdd7b4dcc61e39b42bb34fd362a478ac74857464daa"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33"
+    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "dd478e9b14f2e5d05414b7a4b9922051a83b2ffeae443a4ed56abcb5348e2bcb",
-    "qualityDigest": "a1621427bcb42e501da34f71954e8a51083ef51604f0e05854356f282b955db6",
+    "contextDigest": "7194bf97b4de44bb69b8892f71dffc06c3f03b117106b5062e4f683f6741ab12",
+    "qualityDigest": "d2e2d9426deabd38497addd77cf533f784f62cbab6051bcbf5600019d6c06bce",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "e5de0c4b496ff063dca38c5de5e3340f3732b3d0a23331938fef5c496f53d0d8"
+  "activationDigest": "bd79cd06ebcd88ae7a18adef17baec30ebe9f6228951fcff72bd6cb6fc151e32"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7"
+    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "db50c14613105409846378ea3626caa8cf6d232fc5b4e987007da981f4d11b96",
-    "qualityDigest": "78ca73de33af53ece9bbbaf8a1c980e2dc611ed97f4c8deaf3a99e0b43e4897b",
+    "contextDigest": "dd478e9b14f2e5d05414b7a4b9922051a83b2ffeae443a4ed56abcb5348e2bcb",
+    "qualityDigest": "a1621427bcb42e501da34f71954e8a51083ef51604f0e05854356f282b955db6",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "356722e9bd9b1b82baa93fdd7b4dcc61e39b42bb34fd362a478ac74857464daa"
+  "activationDigest": "e5de0c4b496ff063dca38c5de5e3340f3732b3d0a23331938fef5c496f53d0d8"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33",
-    "contextDigest": "dd478e9b14f2e5d05414b7a4b9922051a83b2ffeae443a4ed56abcb5348e2bcb"
+    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5",
+    "contextDigest": "7194bf97b4de44bb69b8892f71dffc06c3f03b117106b5062e4f683f6741ab12"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "23ef0fc18fd685554bfd8bd77c9496ea73bb0edb3d3b3d872802430d9770341a",
-    "validationDigest": "8998fe1ddf6d48c6b96603d62a0f78bec55b48bd922929f544dc9da493f8e4c9",
+    "digest": "93614533080c7717df2d9eb780447503cee60be1320ed5453a8e1bf45b38685a",
+    "validationDigest": "21432a0508dbff36a9c805edd61d146752c4382b3b2820c4e314a9fe5781021d",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "a1621427bcb42e501da34f71954e8a51083ef51604f0e05854356f282b955db6"
+  "qualityDigest": "d2e2d9426deabd38497addd77cf533f784f62cbab6051bcbf5600019d6c06bce"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5",
-    "contextDigest": "7194bf97b4de44bb69b8892f71dffc06c3f03b117106b5062e4f683f6741ab12"
+    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
+    "contextDigest": "4d34fd93f20a467e99721a8dde665890a6a304acb2f14bc3f86f7acab69257a8"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "93614533080c7717df2d9eb780447503cee60be1320ed5453a8e1bf45b38685a",
-    "validationDigest": "21432a0508dbff36a9c805edd61d146752c4382b3b2820c4e314a9fe5781021d",
+    "digest": "096800de4db14e86c059c872889e330963389032b9d644895bdfe12cc5bf5664",
+    "validationDigest": "2de8d9f884455beb28590b14ea5ed52947d1bf0756b964a2737e301fe4ffbdac",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "d2e2d9426deabd38497addd77cf533f784f62cbab6051bcbf5600019d6c06bce"
+  "qualityDigest": "e9b5dc488b81d5a9c476ab68a4f36c20bb72ddd7f048e109ec398046450385e7"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138",
-    "contextDigest": "b30fbac059a5a97c6047bf6a035d9e3d8781437f0a9ddad93815345a1b93b563"
+    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7",
+    "contextDigest": "db50c14613105409846378ea3626caa8cf6d232fc5b4e987007da981f4d11b96"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "5a948c60bc0209d30cea065581f541419e7010999d638906e4d5ce2261f0920f",
-    "validationDigest": "cd234fd0bfefccd09e8a585d9a2f5fa68c5917c1c8713c111ed48eaf7f136c16",
+    "digest": "aecf5690070afd317d70fba7ac1ee9e71c23a761e90dabf9df73070d35242732",
+    "validationDigest": "66035d2835562a5177220dbed0ab8f4364a6ebb3adcd2c33543430bdbd538ee5",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "796b7d91f73de87ed13518edc1cd186bd13975908d3d81cbd4eefd505d1669b8"
+  "qualityDigest": "78ca73de33af53ece9bbbaf8a1c980e2dc611ed97f4c8deaf3a99e0b43e4897b"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7",
-    "contextDigest": "db50c14613105409846378ea3626caa8cf6d232fc5b4e987007da981f4d11b96"
+    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33",
+    "contextDigest": "dd478e9b14f2e5d05414b7a4b9922051a83b2ffeae443a4ed56abcb5348e2bcb"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "aecf5690070afd317d70fba7ac1ee9e71c23a761e90dabf9df73070d35242732",
-    "validationDigest": "66035d2835562a5177220dbed0ab8f4364a6ebb3adcd2c33543430bdbd538ee5",
+    "digest": "23ef0fc18fd685554bfd8bd77c9496ea73bb0edb3d3b3d872802430d9770341a",
+    "validationDigest": "8998fe1ddf6d48c6b96603d62a0f78bec55b48bd922929f544dc9da493f8e4c9",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "78ca73de33af53ece9bbbaf8a1c980e2dc611ed97f4c8deaf3a99e0b43e4897b"
+  "qualityDigest": "a1621427bcb42e501da34f71954e8a51083ef51604f0e05854356f282b955db6"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "cd7190e34b6d974b460e0c9612fa0188417339ee9b417f95e01f25abe6bc3a64",
+    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
-    "dossierDigest": "c1085b371c5f58bf58b2769b64566658827f189cb0e0abb795f141d6ccd5f5c1",
+    "dossierDigest": "637555d5e12222d2e311dde8e39b081ebbab2fe8dd7206344d7890d98ef49dbb",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "da4acf775da34bc3a803f05c5dc5ab1aecb0b7b83e91e65acc4d45c5e595f5bf",
+    "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "c1085b371c5f58bf58b2769b64566658827f189cb0e0abb795f141d6ccd5f5c1",
+        "dossierDigest": "637555d5e12222d2e311dde8e39b081ebbab2fe8dd7206344d7890d98ef49dbb",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "21432a0508dbff36a9c805edd61d146752c4382b3b2820c4e314a9fe5781021d"
+  "validationDigest": "2de8d9f884455beb28590b14ea5ed52947d1bf0756b964a2737e301fe4ffbdac"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "8705763d8afecd25cd301172a83f1b6197b8df2a2970191cc5817e19f02e4c0a",
+    "auditedInputDigest": "cd7190e34b6d974b460e0c9612fa0188417339ee9b417f95e01f25abe6bc3a64",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
-    "dossierDigest": "9896d17f4910fca406d49fe2ba9d2d4522c44b3dfa3222ec83f566f3470035ac",
+    "dossierDigest": "c1085b371c5f58bf58b2769b64566658827f189cb0e0abb795f141d6ccd5f5c1",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "ea46ee411d510f3a80157de004d0cd7137cd36a7d42155b1c1643d93d2775d11",
+    "routeEvidenceDigest": "da4acf775da34bc3a803f05c5dc5ab1aecb0b7b83e91e65acc4d45c5e595f5bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "9896d17f4910fca406d49fe2ba9d2d4522c44b3dfa3222ec83f566f3470035ac",
+        "dossierDigest": "c1085b371c5f58bf58b2769b64566658827f189cb0e0abb795f141d6ccd5f5c1",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "8998fe1ddf6d48c6b96603d62a0f78bec55b48bd922929f544dc9da493f8e4c9"
+  "validationDigest": "21432a0508dbff36a9c805edd61d146752c4382b3b2820c4e314a9fe5781021d"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "a8cc23b311aec26dd4fa9c663216c17859fa6335b99d7c5861ffd159502f305c",
+    "auditedInputDigest": "0845c55abaa41c4a11a597c9204fed58c4ec6a768f1c0a9be039eb08d9f925c1",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
-    "dossierDigest": "c232466f0b490ad79f9792cb9913d2511c33315082269ee8fd8657ebd00571e2",
+    "dossierDigest": "b5eb23edb9ca3b6e5e25f747ca9b96550960371535bf8c0091404b7d76e616ad",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "180d2f23e172c30e6327a5b79d13be982da38410006d8eff1fc67cb5e883f001",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "c232466f0b490ad79f9792cb9913d2511c33315082269ee8fd8657ebd00571e2",
+        "dossierDigest": "b5eb23edb9ca3b6e5e25f747ca9b96550960371535bf8c0091404b7d76e616ad",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "cd234fd0bfefccd09e8a585d9a2f5fa68c5917c1c8713c111ed48eaf7f136c16"
+  "validationDigest": "66035d2835562a5177220dbed0ab8f4364a6ebb3adcd2c33543430bdbd538ee5"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "0845c55abaa41c4a11a597c9204fed58c4ec6a768f1c0a9be039eb08d9f925c1",
+    "auditedInputDigest": "8705763d8afecd25cd301172a83f1b6197b8df2a2970191cc5817e19f02e4c0a",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
-    "dossierDigest": "b5eb23edb9ca3b6e5e25f747ca9b96550960371535bf8c0091404b7d76e616ad",
+    "dossierDigest": "9896d17f4910fca406d49fe2ba9d2d4522c44b3dfa3222ec83f566f3470035ac",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "180d2f23e172c30e6327a5b79d13be982da38410006d8eff1fc67cb5e883f001",
+    "routeEvidenceDigest": "ea46ee411d510f3a80157de004d0cd7137cd36a7d42155b1c1643d93d2775d11",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "b5eb23edb9ca3b6e5e25f747ca9b96550960371535bf8c0091404b7d76e616ad",
+        "dossierDigest": "9896d17f4910fca406d49fe2ba9d2d4522c44b3dfa3222ec83f566f3470035ac",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "66035d2835562a5177220dbed0ab8f4364a6ebb3adcd2c33543430bdbd538ee5"
+  "validationDigest": "8998fe1ddf6d48c6b96603d62a0f78bec55b48bd922929f544dc9da493f8e4c9"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7",
-    "auditedInputDigest": "0845c55abaa41c4a11a597c9204fed58c4ec6a768f1c0a9be039eb08d9f925c1"
+    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33",
+    "auditedInputDigest": "8705763d8afecd25cd301172a83f1b6197b8df2a2970191cc5817e19f02e4c0a"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "918e463b32839f936281b280003962c0ceb9a6a1e36ab3625e7ad6170522a38c",
+    "dossierDigest": "ef61f07b2adb96e9eaef8d029324581a142d5a541acd8d6a2aae5e98db390777",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "cfed36e5b6b1a95d318b33e71139cef0020f930775793f82bf3e3dc3f8fb8194",
+      "sourceEvidenceDigest": "be6177218f6995df000c8d3beeb6ce38f5475ef3204eb606e78485c1c018e5cb",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -754,8 +754,8 @@
           "route": "/tgdata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "4d3dc66593fb0d8c3d5985f9d0e63a3fb530eefa833a501139861475118197c7",
-          "focusedTestDigest": "8e30d1b73ff8a8e3ebcc2071597e233c69e885059eaca6a01a81f79a269e6a9d",
+          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
+          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -772,8 +772,8 @@
           "route": "/codata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "4d3dc66593fb0d8c3d5985f9d0e63a3fb530eefa833a501139861475118197c7",
-          "focusedTestDigest": "8e30d1b73ff8a8e3ebcc2071597e233c69e885059eaca6a01a81f79a269e6a9d",
+          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
+          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -790,8 +790,8 @@
           "route": "/mydata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "4d3dc66593fb0d8c3d5985f9d0e63a3fb530eefa833a501139861475118197c7",
-          "focusedTestDigest": "8e30d1b73ff8a8e3ebcc2071597e233c69e885059eaca6a01a81f79a269e6a9d",
+          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
+          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -808,8 +808,8 @@
           "route": "/tedata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "4d3dc66593fb0d8c3d5985f9d0e63a3fb530eefa833a501139861475118197c7",
-          "focusedTestDigest": "8e30d1b73ff8a8e3ebcc2071597e233c69e885059eaca6a01a81f79a269e6a9d",
+          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
+          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -826,8 +826,8 @@
           "route": "/tgdata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "151ce983c9018c935164670133c71385c6671dd94c44f8ce9cf29fa053c72fc8",
-          "focusedTestDigest": "777519ff310e3a8d1c078730e2947495dca55a38142f0d9c6bf34990c8ae81ae",
+          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
+          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -844,8 +844,8 @@
           "route": "/codata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "151ce983c9018c935164670133c71385c6671dd94c44f8ce9cf29fa053c72fc8",
-          "focusedTestDigest": "777519ff310e3a8d1c078730e2947495dca55a38142f0d9c6bf34990c8ae81ae",
+          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
+          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -862,8 +862,8 @@
           "route": "/mydata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "151ce983c9018c935164670133c71385c6671dd94c44f8ce9cf29fa053c72fc8",
-          "focusedTestDigest": "777519ff310e3a8d1c078730e2947495dca55a38142f0d9c6bf34990c8ae81ae",
+          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
+          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -880,8 +880,8 @@
           "route": "/tedata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "151ce983c9018c935164670133c71385c6671dd94c44f8ce9cf29fa053c72fc8",
-          "focusedTestDigest": "777519ff310e3a8d1c078730e2947495dca55a38142f0d9c6bf34990c8ae81ae",
+          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
+          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "180d2f23e172c30e6327a5b79d13be982da38410006d8eff1fc67cb5e883f001",
+      "rowEvidenceDigest": "ea46ee411d510f3a80157de004d0cd7137cd36a7d42155b1c1643d93d2775d11",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "b8772e2671335d2babf2d2365e43d539adb7bf741a856334ccec9edba351576e"
+  "contextDigest": "5822c293b83d78a716a32d76c4efde4ff195916a1bfac98c24f877a45d9f6efe"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138",
-    "auditedInputDigest": "a8cc23b311aec26dd4fa9c663216c17859fa6335b99d7c5861ffd159502f305c"
+    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7",
+    "auditedInputDigest": "0845c55abaa41c4a11a597c9204fed58c4ec6a768f1c0a9be039eb08d9f925c1"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "1b1e218143eb9dbe6c75c4092d87d503e101564709b47e8b2e0bab4a929ee387",
+    "dossierDigest": "918e463b32839f936281b280003962c0ceb9a6a1e36ab3625e7ad6170522a38c",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "940547c977cdfc330a8258dca1267368c280f8a45b7ee7de24a64e850265a816"
+  "contextDigest": "b8772e2671335d2babf2d2365e43d539adb7bf741a856334ccec9edba351576e"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33",
-    "auditedInputDigest": "8705763d8afecd25cd301172a83f1b6197b8df2a2970191cc5817e19f02e4c0a"
+    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5",
+    "auditedInputDigest": "cd7190e34b6d974b460e0c9612fa0188417339ee9b417f95e01f25abe6bc3a64"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "ef61f07b2adb96e9eaef8d029324581a142d5a541acd8d6a2aae5e98db390777",
+    "dossierDigest": "adff8c41aaa88defec417ba5b5ae2aaa6df8076134fd21b6ab6e919b91482f12",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "be6177218f6995df000c8d3beeb6ce38f5475ef3204eb606e78485c1c018e5cb",
+      "sourceEvidenceDigest": "f5cc80c9dd4a11954e893d3ef404ba4e0b160eb5153d2a269ca8e1ad0ebac2e1",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -754,8 +754,8 @@
           "route": "/tgdata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
-          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
+          "sourceDigest": "bdefd8b299520d940bcc9279e97264f0c60c908a73d19dc3abd561d474e78388",
+          "focusedTestDigest": "b0e9a957a1b05f35d2490ab6fe579a74a180a9b6b12e52a87b00eabaf08bacf7",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -772,8 +772,8 @@
           "route": "/codata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
-          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
+          "sourceDigest": "bdefd8b299520d940bcc9279e97264f0c60c908a73d19dc3abd561d474e78388",
+          "focusedTestDigest": "b0e9a957a1b05f35d2490ab6fe579a74a180a9b6b12e52a87b00eabaf08bacf7",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -790,8 +790,8 @@
           "route": "/mydata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
-          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
+          "sourceDigest": "bdefd8b299520d940bcc9279e97264f0c60c908a73d19dc3abd561d474e78388",
+          "focusedTestDigest": "b0e9a957a1b05f35d2490ab6fe579a74a180a9b6b12e52a87b00eabaf08bacf7",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -808,8 +808,8 @@
           "route": "/tedata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
-          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
+          "sourceDigest": "bdefd8b299520d940bcc9279e97264f0c60c908a73d19dc3abd561d474e78388",
+          "focusedTestDigest": "b0e9a957a1b05f35d2490ab6fe579a74a180a9b6b12e52a87b00eabaf08bacf7",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -826,8 +826,8 @@
           "route": "/tgdata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
-          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
+          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -844,8 +844,8 @@
           "route": "/codata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
-          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
+          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -862,8 +862,8 @@
           "route": "/mydata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
-          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
+          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -880,8 +880,8 @@
           "route": "/tedata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
-          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
+          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "ea46ee411d510f3a80157de004d0cd7137cd36a7d42155b1c1643d93d2775d11",
+      "rowEvidenceDigest": "da4acf775da34bc3a803f05c5dc5ab1aecb0b7b83e91e65acc4d45c5e595f5bf",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "5822c293b83d78a716a32d76c4efde4ff195916a1bfac98c24f877a45d9f6efe"
+  "contextDigest": "9f70576d7df58bd93aa69d58199865464a480b22af1a724b5bee23445a0a5d13"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5",
-    "auditedInputDigest": "cd7190e34b6d974b460e0c9612fa0188417339ee9b417f95e01f25abe6bc3a64"
+    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
+    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "adff8c41aaa88defec417ba5b5ae2aaa6df8076134fd21b6ab6e919b91482f12",
+    "dossierDigest": "087c774b56add49d807f6ca751bd0e3a51b709751dcf52b64052d9be48a59ae4",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "f5cc80c9dd4a11954e893d3ef404ba4e0b160eb5153d2a269ca8e1ad0ebac2e1",
+      "sourceEvidenceDigest": "1faf9a4b23b3ecc7cfa2ef06327e573ad77959c3b2f06a597991cde88fb43f32",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -826,7 +826,7 @@
           "route": "/tgdata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "sourceDigest": "57818d138116fff5daf60206eeb2f5e62781eb8429b53977e32571e31406a3cc",
           "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
@@ -844,7 +844,7 @@
           "route": "/codata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "sourceDigest": "57818d138116fff5daf60206eeb2f5e62781eb8429b53977e32571e31406a3cc",
           "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
@@ -862,7 +862,7 @@
           "route": "/mydata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "sourceDigest": "57818d138116fff5daf60206eeb2f5e62781eb8429b53977e32571e31406a3cc",
           "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
@@ -880,7 +880,7 @@
           "route": "/tedata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "sourceDigest": "57818d138116fff5daf60206eeb2f5e62781eb8429b53977e32571e31406a3cc",
           "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "da4acf775da34bc3a803f05c5dc5ab1aecb0b7b83e91e65acc4d45c5e595f5bf",
+      "rowEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "9f70576d7df58bd93aa69d58199865464a480b22af1a724b5bee23445a0a5d13"
+  "contextDigest": "6c33d01e8a3a80f6af1a33209a7578c297f71d92ee1e334e545fa6b461aaf983"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33"
+    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "5822c293b83d78a716a32d76c4efde4ff195916a1bfac98c24f877a45d9f6efe",
-    "qualityDigest": "00a27aca93334508533015741a1e874e9267c8ea66eec38932bcc437b52546eb",
+    "contextDigest": "9f70576d7df58bd93aa69d58199865464a480b22af1a724b5bee23445a0a5d13",
+    "qualityDigest": "9f2dd110dc3f94ce13a62d42d5300af1eb87af89bc5b328602d6675fc9ce6b5f",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "03d80eac59d4b1dfa44aed305271374cd25fd9d613b3b9d048df0615db797772"
+  "activationDigest": "e6623329ce16350d62b538fa8c74ea5bcf8066b2268887ba959002585ea58463"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7"
+    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "b8772e2671335d2babf2d2365e43d539adb7bf741a856334ccec9edba351576e",
-    "qualityDigest": "eb533c4e4aa04c29092691135b7b300d3b68506f739e16e1a4e45ad99c04de24",
+    "contextDigest": "5822c293b83d78a716a32d76c4efde4ff195916a1bfac98c24f877a45d9f6efe",
+    "qualityDigest": "00a27aca93334508533015741a1e874e9267c8ea66eec38932bcc437b52546eb",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "01bc744fcfeee422c9c3d3c79a81ced165c269cd69190bb28ff293b3566c6b76"
+  "activationDigest": "03d80eac59d4b1dfa44aed305271374cd25fd9d613b3b9d048df0615db797772"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138"
+    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "940547c977cdfc330a8258dca1267368c280f8a45b7ee7de24a64e850265a816",
-    "qualityDigest": "13d16da9ef7b5eb35a6446c24def24a94025b61a7aa839df126fa3d895140423",
+    "contextDigest": "b8772e2671335d2babf2d2365e43d539adb7bf741a856334ccec9edba351576e",
+    "qualityDigest": "eb533c4e4aa04c29092691135b7b300d3b68506f739e16e1a4e45ad99c04de24",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "9cbbd7b03d68903fd459b47d39d5d343aeb601cea55f0fd559ad74a34a5babfd"
+  "activationDigest": "01bc744fcfeee422c9c3d3c79a81ced165c269cd69190bb28ff293b3566c6b76"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5"
+    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "9f70576d7df58bd93aa69d58199865464a480b22af1a724b5bee23445a0a5d13",
-    "qualityDigest": "9f2dd110dc3f94ce13a62d42d5300af1eb87af89bc5b328602d6675fc9ce6b5f",
+    "contextDigest": "6c33d01e8a3a80f6af1a33209a7578c297f71d92ee1e334e545fa6b461aaf983",
+    "qualityDigest": "ea979a83edb576da0dc8b19ffbf4034466a5cdde4a592ef587a6569b899cd5e2",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "e6623329ce16350d62b538fa8c74ea5bcf8066b2268887ba959002585ea58463"
+  "activationDigest": "2419aed98b5010bc97f2cce28bbcdd51508161febb64d4d94fba17980e788539"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138",
-    "contextDigest": "940547c977cdfc330a8258dca1267368c280f8a45b7ee7de24a64e850265a816"
+    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7",
+    "contextDigest": "b8772e2671335d2babf2d2365e43d539adb7bf741a856334ccec9edba351576e"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "b2b0cc1e1376aa7166edd0ecf852e21be1b94cd8db595243e826cacb3cb33cea",
-    "validationDigest": "f5f24529bc156b6a5d5b5daec77149d012bffe022c0b699183a8eae9014baf8d",
+    "digest": "796fdd51f9496ac771a2615bd028f66d1504ae4cc6339d05eca7173c1a402c76",
+    "validationDigest": "c582c20a9972ffbeca7dc12c45193862936f92c0fe815fed15801a946a400990",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "13d16da9ef7b5eb35a6446c24def24a94025b61a7aa839df126fa3d895140423"
+  "qualityDigest": "eb533c4e4aa04c29092691135b7b300d3b68506f739e16e1a4e45ad99c04de24"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5",
-    "contextDigest": "9f70576d7df58bd93aa69d58199865464a480b22af1a724b5bee23445a0a5d13"
+    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
+    "contextDigest": "6c33d01e8a3a80f6af1a33209a7578c297f71d92ee1e334e545fa6b461aaf983"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "57dd98b9749917c49793c0e153232828af8ac5003cf3f60ee218b7b416805a3b",
-    "validationDigest": "5c4965cef7a6ed53f1bb4dab87f53c42c74e8b858cb071cf554214733165d926",
+    "digest": "150f9639e6d99212f74fd1ddffff8fc6bf05bedb6449fafeb8f95cf1f2c9e9a8",
+    "validationDigest": "b9a8c413ff931e29f27be45d22cea95dfda0c069d57df70667405938078a3960",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "9f2dd110dc3f94ce13a62d42d5300af1eb87af89bc5b328602d6675fc9ce6b5f"
+  "qualityDigest": "ea979a83edb576da0dc8b19ffbf4034466a5cdde4a592ef587a6569b899cd5e2"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33",
-    "contextDigest": "5822c293b83d78a716a32d76c4efde4ff195916a1bfac98c24f877a45d9f6efe"
+    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5",
+    "contextDigest": "9f70576d7df58bd93aa69d58199865464a480b22af1a724b5bee23445a0a5d13"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "16b05bb0d2a9d2bd3d225b23305774515b3b0744ee10e110c81edd16ff739ff5",
-    "validationDigest": "2fe0a8ca046d2fbcc743b32d174594a695b7089ec0b439420b369deabe4a91ed",
+    "digest": "57dd98b9749917c49793c0e153232828af8ac5003cf3f60ee218b7b416805a3b",
+    "validationDigest": "5c4965cef7a6ed53f1bb4dab87f53c42c74e8b858cb071cf554214733165d926",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "00a27aca93334508533015741a1e874e9267c8ea66eec38932bcc437b52546eb"
+  "qualityDigest": "9f2dd110dc3f94ce13a62d42d5300af1eb87af89bc5b328602d6675fc9ce6b5f"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7",
-    "contextDigest": "b8772e2671335d2babf2d2365e43d539adb7bf741a856334ccec9edba351576e"
+    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33",
+    "contextDigest": "5822c293b83d78a716a32d76c4efde4ff195916a1bfac98c24f877a45d9f6efe"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "796fdd51f9496ac771a2615bd028f66d1504ae4cc6339d05eca7173c1a402c76",
-    "validationDigest": "c582c20a9972ffbeca7dc12c45193862936f92c0fe815fed15801a946a400990",
+    "digest": "16b05bb0d2a9d2bd3d225b23305774515b3b0744ee10e110c81edd16ff739ff5",
+    "validationDigest": "2fe0a8ca046d2fbcc743b32d174594a695b7089ec0b439420b369deabe4a91ed",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "eb533c4e4aa04c29092691135b7b300d3b68506f739e16e1a4e45ad99c04de24"
+  "qualityDigest": "00a27aca93334508533015741a1e874e9267c8ea66eec38932bcc437b52546eb"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "8705763d8afecd25cd301172a83f1b6197b8df2a2970191cc5817e19f02e4c0a",
+    "auditedInputDigest": "cd7190e34b6d974b460e0c9612fa0188417339ee9b417f95e01f25abe6bc3a64",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
-    "dossierDigest": "ef61f07b2adb96e9eaef8d029324581a142d5a541acd8d6a2aae5e98db390777",
+    "dossierDigest": "adff8c41aaa88defec417ba5b5ae2aaa6df8076134fd21b6ab6e919b91482f12",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "ea46ee411d510f3a80157de004d0cd7137cd36a7d42155b1c1643d93d2775d11",
+    "routeEvidenceDigest": "da4acf775da34bc3a803f05c5dc5ab1aecb0b7b83e91e65acc4d45c5e595f5bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "ef61f07b2adb96e9eaef8d029324581a142d5a541acd8d6a2aae5e98db390777",
+        "dossierDigest": "adff8c41aaa88defec417ba5b5ae2aaa6df8076134fd21b6ab6e919b91482f12",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "2fe0a8ca046d2fbcc743b32d174594a695b7089ec0b439420b369deabe4a91ed"
+  "validationDigest": "5c4965cef7a6ed53f1bb4dab87f53c42c74e8b858cb071cf554214733165d926"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "a8cc23b311aec26dd4fa9c663216c17859fa6335b99d7c5861ffd159502f305c",
+    "auditedInputDigest": "0845c55abaa41c4a11a597c9204fed58c4ec6a768f1c0a9be039eb08d9f925c1",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
-    "dossierDigest": "1b1e218143eb9dbe6c75c4092d87d503e101564709b47e8b2e0bab4a929ee387",
+    "dossierDigest": "918e463b32839f936281b280003962c0ceb9a6a1e36ab3625e7ad6170522a38c",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "180d2f23e172c30e6327a5b79d13be982da38410006d8eff1fc67cb5e883f001",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "1b1e218143eb9dbe6c75c4092d87d503e101564709b47e8b2e0bab4a929ee387",
+        "dossierDigest": "918e463b32839f936281b280003962c0ceb9a6a1e36ab3625e7ad6170522a38c",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "f5f24529bc156b6a5d5b5daec77149d012bffe022c0b699183a8eae9014baf8d"
+  "validationDigest": "c582c20a9972ffbeca7dc12c45193862936f92c0fe815fed15801a946a400990"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "cd7190e34b6d974b460e0c9612fa0188417339ee9b417f95e01f25abe6bc3a64",
+    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
-    "dossierDigest": "adff8c41aaa88defec417ba5b5ae2aaa6df8076134fd21b6ab6e919b91482f12",
+    "dossierDigest": "087c774b56add49d807f6ca751bd0e3a51b709751dcf52b64052d9be48a59ae4",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "da4acf775da34bc3a803f05c5dc5ab1aecb0b7b83e91e65acc4d45c5e595f5bf",
+    "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "adff8c41aaa88defec417ba5b5ae2aaa6df8076134fd21b6ab6e919b91482f12",
+        "dossierDigest": "087c774b56add49d807f6ca751bd0e3a51b709751dcf52b64052d9be48a59ae4",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "5c4965cef7a6ed53f1bb4dab87f53c42c74e8b858cb071cf554214733165d926"
+  "validationDigest": "b9a8c413ff931e29f27be45d22cea95dfda0c069d57df70667405938078a3960"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "0845c55abaa41c4a11a597c9204fed58c4ec6a768f1c0a9be039eb08d9f925c1",
+    "auditedInputDigest": "8705763d8afecd25cd301172a83f1b6197b8df2a2970191cc5817e19f02e4c0a",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
-    "dossierDigest": "918e463b32839f936281b280003962c0ceb9a6a1e36ab3625e7ad6170522a38c",
+    "dossierDigest": "ef61f07b2adb96e9eaef8d029324581a142d5a541acd8d6a2aae5e98db390777",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "180d2f23e172c30e6327a5b79d13be982da38410006d8eff1fc67cb5e883f001",
+    "routeEvidenceDigest": "ea46ee411d510f3a80157de004d0cd7137cd36a7d42155b1c1643d93d2775d11",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "918e463b32839f936281b280003962c0ceb9a6a1e36ab3625e7ad6170522a38c",
+        "dossierDigest": "ef61f07b2adb96e9eaef8d029324581a142d5a541acd8d6a2aae5e98db390777",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "c582c20a9972ffbeca7dc12c45193862936f92c0fe815fed15801a946a400990"
+  "validationDigest": "2fe0a8ca046d2fbcc743b32d174594a695b7089ec0b439420b369deabe4a91ed"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138",
-    "auditedInputDigest": "a8cc23b311aec26dd4fa9c663216c17859fa6335b99d7c5861ffd159502f305c"
+    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7",
+    "auditedInputDigest": "0845c55abaa41c4a11a597c9204fed58c4ec6a768f1c0a9be039eb08d9f925c1"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "edb857d11880f7044cbbb967598e43c2b96cb644898baff25892769f346f89bb",
+    "dossierDigest": "dc055afc46a48f2d0ef159a02a37b02afe0b865a4bf48f5dddb9e31a148b16c9",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "994242b8c63981b71b3fe3e1261b3d4c546da31c657ba9d1ed762f0beca4b2cb"
+  "contextDigest": "daf457e8c6ba4611f3d6aad3d73cccdd42794d262753eb10fbc51ce110ed948c"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7",
-    "auditedInputDigest": "0845c55abaa41c4a11a597c9204fed58c4ec6a768f1c0a9be039eb08d9f925c1"
+    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33",
+    "auditedInputDigest": "8705763d8afecd25cd301172a83f1b6197b8df2a2970191cc5817e19f02e4c0a"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "dc055afc46a48f2d0ef159a02a37b02afe0b865a4bf48f5dddb9e31a148b16c9",
+    "dossierDigest": "2b873e765c846f6af2cf25dfb1d71c3fe4cfa7ca2d9a6d28d463c4417b2ebb90",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "cfed36e5b6b1a95d318b33e71139cef0020f930775793f82bf3e3dc3f8fb8194",
+      "sourceEvidenceDigest": "be6177218f6995df000c8d3beeb6ce38f5475ef3204eb606e78485c1c018e5cb",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -754,8 +754,8 @@
           "route": "/tgdata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "4d3dc66593fb0d8c3d5985f9d0e63a3fb530eefa833a501139861475118197c7",
-          "focusedTestDigest": "8e30d1b73ff8a8e3ebcc2071597e233c69e885059eaca6a01a81f79a269e6a9d",
+          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
+          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -772,8 +772,8 @@
           "route": "/codata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "4d3dc66593fb0d8c3d5985f9d0e63a3fb530eefa833a501139861475118197c7",
-          "focusedTestDigest": "8e30d1b73ff8a8e3ebcc2071597e233c69e885059eaca6a01a81f79a269e6a9d",
+          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
+          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -790,8 +790,8 @@
           "route": "/mydata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "4d3dc66593fb0d8c3d5985f9d0e63a3fb530eefa833a501139861475118197c7",
-          "focusedTestDigest": "8e30d1b73ff8a8e3ebcc2071597e233c69e885059eaca6a01a81f79a269e6a9d",
+          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
+          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -808,8 +808,8 @@
           "route": "/tedata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "4d3dc66593fb0d8c3d5985f9d0e63a3fb530eefa833a501139861475118197c7",
-          "focusedTestDigest": "8e30d1b73ff8a8e3ebcc2071597e233c69e885059eaca6a01a81f79a269e6a9d",
+          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
+          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -826,8 +826,8 @@
           "route": "/tgdata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "151ce983c9018c935164670133c71385c6671dd94c44f8ce9cf29fa053c72fc8",
-          "focusedTestDigest": "777519ff310e3a8d1c078730e2947495dca55a38142f0d9c6bf34990c8ae81ae",
+          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
+          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -844,8 +844,8 @@
           "route": "/codata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "151ce983c9018c935164670133c71385c6671dd94c44f8ce9cf29fa053c72fc8",
-          "focusedTestDigest": "777519ff310e3a8d1c078730e2947495dca55a38142f0d9c6bf34990c8ae81ae",
+          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
+          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -862,8 +862,8 @@
           "route": "/mydata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "151ce983c9018c935164670133c71385c6671dd94c44f8ce9cf29fa053c72fc8",
-          "focusedTestDigest": "777519ff310e3a8d1c078730e2947495dca55a38142f0d9c6bf34990c8ae81ae",
+          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
+          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -880,8 +880,8 @@
           "route": "/tedata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "151ce983c9018c935164670133c71385c6671dd94c44f8ce9cf29fa053c72fc8",
-          "focusedTestDigest": "777519ff310e3a8d1c078730e2947495dca55a38142f0d9c6bf34990c8ae81ae",
+          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
+          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "180d2f23e172c30e6327a5b79d13be982da38410006d8eff1fc67cb5e883f001",
+      "rowEvidenceDigest": "ea46ee411d510f3a80157de004d0cd7137cd36a7d42155b1c1643d93d2775d11",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "daf457e8c6ba4611f3d6aad3d73cccdd42794d262753eb10fbc51ce110ed948c"
+  "contextDigest": "6f4b3109dfdb408941f32f56a7c508c747b1fbd6e164b446b57413b33d598a51"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33",
-    "auditedInputDigest": "8705763d8afecd25cd301172a83f1b6197b8df2a2970191cc5817e19f02e4c0a"
+    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5",
+    "auditedInputDigest": "cd7190e34b6d974b460e0c9612fa0188417339ee9b417f95e01f25abe6bc3a64"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "2b873e765c846f6af2cf25dfb1d71c3fe4cfa7ca2d9a6d28d463c4417b2ebb90",
+    "dossierDigest": "08cc0b524cafda9b7923c7c63ad64af08ed62b135bbe0ff808f5fe51bc5057e0",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "be6177218f6995df000c8d3beeb6ce38f5475ef3204eb606e78485c1c018e5cb",
+      "sourceEvidenceDigest": "f5cc80c9dd4a11954e893d3ef404ba4e0b160eb5153d2a269ca8e1ad0ebac2e1",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -754,8 +754,8 @@
           "route": "/tgdata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
-          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
+          "sourceDigest": "bdefd8b299520d940bcc9279e97264f0c60c908a73d19dc3abd561d474e78388",
+          "focusedTestDigest": "b0e9a957a1b05f35d2490ab6fe579a74a180a9b6b12e52a87b00eabaf08bacf7",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -772,8 +772,8 @@
           "route": "/codata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
-          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
+          "sourceDigest": "bdefd8b299520d940bcc9279e97264f0c60c908a73d19dc3abd561d474e78388",
+          "focusedTestDigest": "b0e9a957a1b05f35d2490ab6fe579a74a180a9b6b12e52a87b00eabaf08bacf7",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -790,8 +790,8 @@
           "route": "/mydata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
-          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
+          "sourceDigest": "bdefd8b299520d940bcc9279e97264f0c60c908a73d19dc3abd561d474e78388",
+          "focusedTestDigest": "b0e9a957a1b05f35d2490ab6fe579a74a180a9b6b12e52a87b00eabaf08bacf7",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -808,8 +808,8 @@
           "route": "/tedata/flowproperties",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "5260b2182d99cd6520997accd06f48bdb6684995da02a1b51fa71d93639e340c",
-          "focusedTestDigest": "5887595a3a8aeb6398e3869fffa54110a817d17b39471f4cb14e4850ce1630ce",
+          "sourceDigest": "bdefd8b299520d940bcc9279e97264f0c60c908a73d19dc3abd561d474e78388",
+          "focusedTestDigest": "b0e9a957a1b05f35d2490ab6fe579a74a180a9b6b12e52a87b00eabaf08bacf7",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "e1d241d9e1d7dcaf920bf8f6059135864f2e11561f9463a01ee21481bd168fdf",
           "derivedMessageCount": 12,
@@ -826,8 +826,8 @@
           "route": "/tgdata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
-          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
+          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -844,8 +844,8 @@
           "route": "/codata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
-          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
+          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -862,8 +862,8 @@
           "route": "/mydata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
-          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
+          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -880,8 +880,8 @@
           "route": "/tedata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "eebf21dd52bf162728e807e914a8415ba6735692bdee4225c7d2ac4dee8ccc61",
-          "focusedTestDigest": "ee46ae00bea61e378c7a601efb81389c067bb5648a39f41ae785d88ca93c3b1f",
+          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
           "derivedMessageCount": 12,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "ea46ee411d510f3a80157de004d0cd7137cd36a7d42155b1c1643d93d2775d11",
+      "rowEvidenceDigest": "da4acf775da34bc3a803f05c5dc5ab1aecb0b7b83e91e65acc4d45c5e595f5bf",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "6f4b3109dfdb408941f32f56a7c508c747b1fbd6e164b446b57413b33d598a51"
+  "contextDigest": "8a61c6468cf2b9877795e7bf68347e6e97787efe38d7f2b43eb77cad41b8f65d"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5",
-    "auditedInputDigest": "cd7190e34b6d974b460e0c9612fa0188417339ee9b417f95e01f25abe6bc3a64"
+    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
+    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "08cc0b524cafda9b7923c7c63ad64af08ed62b135bbe0ff808f5fe51bc5057e0",
+    "dossierDigest": "d7de591ef47e06efcf5144b93de90e2d631f2bf17614db603e6d6d10aa3c14e5",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "f5cc80c9dd4a11954e893d3ef404ba4e0b160eb5153d2a269ca8e1ad0ebac2e1",
+      "sourceEvidenceDigest": "1faf9a4b23b3ecc7cfa2ef06327e573ad77959c3b2f06a597991cde88fb43f32",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -826,7 +826,7 @@
           "route": "/tgdata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "sourceDigest": "57818d138116fff5daf60206eeb2f5e62781eb8429b53977e32571e31406a3cc",
           "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
@@ -844,7 +844,7 @@
           "route": "/codata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "sourceDigest": "57818d138116fff5daf60206eeb2f5e62781eb8429b53977e32571e31406a3cc",
           "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
@@ -862,7 +862,7 @@
           "route": "/mydata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "sourceDigest": "57818d138116fff5daf60206eeb2f5e62781eb8429b53977e32571e31406a3cc",
           "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
@@ -880,7 +880,7 @@
           "route": "/tedata/unitgroups",
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "20411519ebb76aedc707c87454fd195d766147cd23ce603d2e0bd17b26a8da67",
+          "sourceDigest": "57818d138116fff5daf60206eeb2f5e62781eb8429b53977e32571e31406a3cc",
           "focusedTestDigest": "a7ebcc5b8a1f7ce3430d7cc4fdfacc59a5323b8c92b656a72155e0c49c172a65",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "614085f9d3c4a14cae9bc69f4539d94a6bc83e15ece84c1f8b9432df5bb46c32",
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "da4acf775da34bc3a803f05c5dc5ab1aecb0b7b83e91e65acc4d45c5e595f5bf",
+      "rowEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "8a61c6468cf2b9877795e7bf68347e6e97787efe38d7f2b43eb77cad41b8f65d"
+  "contextDigest": "4d94171760a8b4e83cebd57e0a914c0f50b1f94b9ad853dba7ff61d0248eaf7e"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33"
+    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "6f4b3109dfdb408941f32f56a7c508c747b1fbd6e164b446b57413b33d598a51",
-    "qualityDigest": "2c825e4671207112ed48a49ae6d3eeea777a89246fc257b0c913f0896ca86a1b",
+    "contextDigest": "8a61c6468cf2b9877795e7bf68347e6e97787efe38d7f2b43eb77cad41b8f65d",
+    "qualityDigest": "02d6ad0b8852b4d76e48e3040875bb6b83ec6bca8fc489f885817eb38b542ef7",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "f4b90d4edb711055f02c94898e0258d9d56510c8e393a6163ffe849bb7953360"
+  "activationDigest": "51463debc596b8d3d26413e58ccec1f54fb8723bc106114d06f0cf35630eb355"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5"
+    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "8a61c6468cf2b9877795e7bf68347e6e97787efe38d7f2b43eb77cad41b8f65d",
-    "qualityDigest": "02d6ad0b8852b4d76e48e3040875bb6b83ec6bca8fc489f885817eb38b542ef7",
+    "contextDigest": "4d94171760a8b4e83cebd57e0a914c0f50b1f94b9ad853dba7ff61d0248eaf7e",
+    "qualityDigest": "650ff946876e9a5ea7db6334c35e48a36df0b335a9a537b94b7abe6c982a47df",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "51463debc596b8d3d26413e58ccec1f54fb8723bc106114d06f0cf35630eb355"
+  "activationDigest": "4b91c787f01ecce57cb772270bc4edc3ecb1d30931b2c236b2daeebdd3c0432e"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7"
+    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "daf457e8c6ba4611f3d6aad3d73cccdd42794d262753eb10fbc51ce110ed948c",
-    "qualityDigest": "447fb72edc989169311d76a83d4e40c3f2d6fabb8253697e18ee9c5c0bd730ba",
+    "contextDigest": "6f4b3109dfdb408941f32f56a7c508c747b1fbd6e164b446b57413b33d598a51",
+    "qualityDigest": "2c825e4671207112ed48a49ae6d3eeea777a89246fc257b0c913f0896ca86a1b",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "a35b931418b3271a5c53a99997b02fa5fff38f8a2351f82d3920fd0289a34e5e"
+  "activationDigest": "f4b90d4edb711055f02c94898e0258d9d56510c8e393a6163ffe849bb7953360"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138"
+    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "994242b8c63981b71b3fe3e1261b3d4c546da31c657ba9d1ed762f0beca4b2cb",
-    "qualityDigest": "a17d755e7c95c34c44a15a0f091bcfce24af26f89c75c8cebef7a8b37adf6807",
+    "contextDigest": "daf457e8c6ba4611f3d6aad3d73cccdd42794d262753eb10fbc51ce110ed948c",
+    "qualityDigest": "447fb72edc989169311d76a83d4e40c3f2d6fabb8253697e18ee9c5c0bd730ba",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "5d98450fbce2d325163b76a9eb251fb2118f9b24a8b9feea8087e55f93f06237"
+  "activationDigest": "a35b931418b3271a5c53a99997b02fa5fff38f8a2351f82d3920fd0289a34e5e"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7",
-    "contextDigest": "daf457e8c6ba4611f3d6aad3d73cccdd42794d262753eb10fbc51ce110ed948c"
+    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33",
+    "contextDigest": "6f4b3109dfdb408941f32f56a7c508c747b1fbd6e164b446b57413b33d598a51"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "b3c610453bd7567b06880001b0698daa4e5be96631add0416df2f334328e48bc",
-    "validationDigest": "6a4cceb95ce4b9ebb0fd3fc0f732b3e41adc2fe777fe69e024bd16a1d679e628",
+    "digest": "fbcaa4e1f9afe3e2a021fe393c7bcbfc4da1339752f367e128beb81ad2181708",
+    "validationDigest": "b051e30170f51fab04da2219557dcd6ce17e6c8b37a6c3576ce7e687097695b1",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "447fb72edc989169311d76a83d4e40c3f2d6fabb8253697e18ee9c5c0bd730ba"
+  "qualityDigest": "2c825e4671207112ed48a49ae6d3eeea777a89246fc257b0c913f0896ca86a1b"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "188371d6d5079148403a822ecf5d0cb956a08193ccd83daed5cff67e45bacf33",
-    "contextDigest": "6f4b3109dfdb408941f32f56a7c508c747b1fbd6e164b446b57413b33d598a51"
+    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5",
+    "contextDigest": "8a61c6468cf2b9877795e7bf68347e6e97787efe38d7f2b43eb77cad41b8f65d"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "fbcaa4e1f9afe3e2a021fe393c7bcbfc4da1339752f367e128beb81ad2181708",
-    "validationDigest": "b051e30170f51fab04da2219557dcd6ce17e6c8b37a6c3576ce7e687097695b1",
+    "digest": "db57409bd708c0ad2bfcd6de57c1cd1cc380a06237b63c9d5b042be5f9e96b59",
+    "validationDigest": "efd33718eb428e7725881d13a776b12954849d9fa3cb53a5ff9cc8a99a6697b0",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "2c825e4671207112ed48a49ae6d3eeea777a89246fc257b0c913f0896ca86a1b"
+  "qualityDigest": "02d6ad0b8852b4d76e48e3040875bb6b83ec6bca8fc489f885817eb38b542ef7"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "746d58dbf9c58f1c5e3a23f58b9e0afa2cf8578a05d9ebc05ac4000f547027b5",
-    "contextDigest": "8a61c6468cf2b9877795e7bf68347e6e97787efe38d7f2b43eb77cad41b8f65d"
+    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
+    "contextDigest": "4d94171760a8b4e83cebd57e0a914c0f50b1f94b9ad853dba7ff61d0248eaf7e"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "db57409bd708c0ad2bfcd6de57c1cd1cc380a06237b63c9d5b042be5f9e96b59",
-    "validationDigest": "efd33718eb428e7725881d13a776b12954849d9fa3cb53a5ff9cc8a99a6697b0",
+    "digest": "86fb1b0f23ad09baf8857accc396db1de41a3824dbbd5a428c2cfce0c446cbfd",
+    "validationDigest": "8e9acac9897fab2ef2395f91e6d1555aa241b0d3ebb1a51d8d4491225c9dfa9a",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "02d6ad0b8852b4d76e48e3040875bb6b83ec6bca8fc489f885817eb38b542ef7"
+  "qualityDigest": "650ff946876e9a5ea7db6334c35e48a36df0b335a9a537b94b7abe6c982a47df"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "8c5065cd57222e6f3e5550503ee93958f63747a0fb2aefb6ff2147e513cd8138",
-    "contextDigest": "994242b8c63981b71b3fe3e1261b3d4c546da31c657ba9d1ed762f0beca4b2cb"
+    "sourceManifestDigest": "15abd94b377fdf87a36de7718d09c5c974445586361f32314a8f92255b3abdf7",
+    "contextDigest": "daf457e8c6ba4611f3d6aad3d73cccdd42794d262753eb10fbc51ce110ed948c"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "a29b039826fec3520eb8173f50c61abcddd9bb947c806547ae6a6e09aab735ad",
-    "validationDigest": "bb9bd33e4faadd905215b1dbcfb51ed67b56e18fc0465620027a9ff20d059c26",
+    "digest": "b3c610453bd7567b06880001b0698daa4e5be96631add0416df2f334328e48bc",
+    "validationDigest": "6a4cceb95ce4b9ebb0fd3fc0f732b3e41adc2fe777fe69e024bd16a1d679e628",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "a17d755e7c95c34c44a15a0f091bcfce24af26f89c75c8cebef7a8b37adf6807"
+  "qualityDigest": "447fb72edc989169311d76a83d4e40c3f2d6fabb8253697e18ee9c5c0bd730ba"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "0845c55abaa41c4a11a597c9204fed58c4ec6a768f1c0a9be039eb08d9f925c1",
+    "auditedInputDigest": "8705763d8afecd25cd301172a83f1b6197b8df2a2970191cc5817e19f02e4c0a",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
-    "dossierDigest": "dc055afc46a48f2d0ef159a02a37b02afe0b865a4bf48f5dddb9e31a148b16c9",
+    "dossierDigest": "2b873e765c846f6af2cf25dfb1d71c3fe4cfa7ca2d9a6d28d463c4417b2ebb90",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "180d2f23e172c30e6327a5b79d13be982da38410006d8eff1fc67cb5e883f001",
+    "routeEvidenceDigest": "ea46ee411d510f3a80157de004d0cd7137cd36a7d42155b1c1643d93d2775d11",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "dc055afc46a48f2d0ef159a02a37b02afe0b865a4bf48f5dddb9e31a148b16c9",
+        "dossierDigest": "2b873e765c846f6af2cf25dfb1d71c3fe4cfa7ca2d9a6d28d463c4417b2ebb90",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "6a4cceb95ce4b9ebb0fd3fc0f732b3e41adc2fe777fe69e024bd16a1d679e628"
+  "validationDigest": "b051e30170f51fab04da2219557dcd6ce17e6c8b37a6c3576ce7e687097695b1"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "8705763d8afecd25cd301172a83f1b6197b8df2a2970191cc5817e19f02e4c0a",
+    "auditedInputDigest": "cd7190e34b6d974b460e0c9612fa0188417339ee9b417f95e01f25abe6bc3a64",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
-    "dossierDigest": "2b873e765c846f6af2cf25dfb1d71c3fe4cfa7ca2d9a6d28d463c4417b2ebb90",
+    "dossierDigest": "08cc0b524cafda9b7923c7c63ad64af08ed62b135bbe0ff808f5fe51bc5057e0",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "ea46ee411d510f3a80157de004d0cd7137cd36a7d42155b1c1643d93d2775d11",
+    "routeEvidenceDigest": "da4acf775da34bc3a803f05c5dc5ab1aecb0b7b83e91e65acc4d45c5e595f5bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "2b873e765c846f6af2cf25dfb1d71c3fe4cfa7ca2d9a6d28d463c4417b2ebb90",
+        "dossierDigest": "08cc0b524cafda9b7923c7c63ad64af08ed62b135bbe0ff808f5fe51bc5057e0",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "b051e30170f51fab04da2219557dcd6ce17e6c8b37a6c3576ce7e687097695b1"
+  "validationDigest": "efd33718eb428e7725881d13a776b12954849d9fa3cb53a5ff9cc8a99a6697b0"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "cd7190e34b6d974b460e0c9612fa0188417339ee9b417f95e01f25abe6bc3a64",
+    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
-    "dossierDigest": "08cc0b524cafda9b7923c7c63ad64af08ed62b135bbe0ff808f5fe51bc5057e0",
+    "dossierDigest": "d7de591ef47e06efcf5144b93de90e2d631f2bf17614db603e6d6d10aa3c14e5",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "da4acf775da34bc3a803f05c5dc5ab1aecb0b7b83e91e65acc4d45c5e595f5bf",
+    "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "08cc0b524cafda9b7923c7c63ad64af08ed62b135bbe0ff808f5fe51bc5057e0",
+        "dossierDigest": "d7de591ef47e06efcf5144b93de90e2d631f2bf17614db603e6d6d10aa3c14e5",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "efd33718eb428e7725881d13a776b12954849d9fa3cb53a5ff9cc8a99a6697b0"
+  "validationDigest": "8e9acac9897fab2ef2395f91e6d1555aa241b0d3ebb1a51d8d4491225c9dfa9a"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "a8cc23b311aec26dd4fa9c663216c17859fa6335b99d7c5861ffd159502f305c",
+    "auditedInputDigest": "0845c55abaa41c4a11a597c9204fed58c4ec6a768f1c0a9be039eb08d9f925c1",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
-    "dossierDigest": "edb857d11880f7044cbbb967598e43c2b96cb644898baff25892769f346f89bb",
+    "dossierDigest": "dc055afc46a48f2d0ef159a02a37b02afe0b865a4bf48f5dddb9e31a148b16c9",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "180d2f23e172c30e6327a5b79d13be982da38410006d8eff1fc67cb5e883f001",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "edb857d11880f7044cbbb967598e43c2b96cb644898baff25892769f346f89bb",
+        "dossierDigest": "dc055afc46a48f2d0ef159a02a37b02afe0b865a4bf48f5dddb9e31a148b16c9",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "bb9bd33e4faadd905215b1dbcfb51ed67b56e18fc0465620027a9ff20d059c26"
+  "validationDigest": "6a4cceb95ce4b9ebb0fd3fc0f732b3e41adc2fe777fe69e024bd16a1d679e628"
 }

--- a/src/components/RightContent/AvatarDropdown.tsx
+++ b/src/components/RightContent/AvatarDropdown.tsx
@@ -1,4 +1,3 @@
-import { getSystemUserRoleApi } from '@/services/roles/api';
 import {
   AuditOutlined,
   LogoutOutlined,
@@ -10,7 +9,7 @@ import { history, useIntl, useLocation, useModel } from '@umijs/max';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { logout } from '@/services/auth';
-import { getUserRoles } from '@/services/roles/api';
+import { getReviewUserRoleApi, getSystemUserRoleApi, getUserRoles } from '@/services/roles/api';
 import { Button, Modal, Spin, theme } from 'antd';
 import type { MenuInfo } from 'rc-menu/lib/interface';
 import { flushSync } from 'react-dom';
@@ -50,7 +49,14 @@ export const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({ children }) =
   const [isLoadingHovered, setIsLoadingHovered] = useState(false);
   // const [isUserInTeam, setIsUserInTeam] = useState(false);
   const [showAllTeamsModal, setShowAllTeamsModal] = useState(false);
-  const [userData, setUserData] = useState<{ user_id: string; role: string } | null>(null);
+  const [systemUserData, setSystemUserData] = useState<{
+    user_id: string;
+    role: string;
+  } | null>(null);
+  const [reviewUserData, setReviewUserData] = useState<{
+    user_id: string;
+    role: string;
+  } | null>(null);
 
   const getUserRole = async () => {
     const { data } = await getUserRoles();
@@ -64,14 +70,18 @@ export const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({ children }) =
     }
   };
 
-  const getSystemUserRole = async () => {
-    const userData = await getSystemUserRoleApi();
-    setUserData(userData);
+  const getMenuUserRoles = async () => {
+    const [systemUserData, reviewUserData] = await Promise.all([
+      getSystemUserRoleApi(),
+      getReviewUserRoleApi(),
+    ]);
+    setSystemUserData(systemUserData);
+    setReviewUserData(reviewUserData);
   };
 
   useEffect(() => {
     // getUserRole();
-    getSystemUserRole();
+    getMenuUserRoles();
   }, []);
   /**
    * Logout and save the current URL
@@ -244,13 +254,15 @@ export const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({ children }) =
       icon: <SettingOutlined />,
       label: <FormattedMessage id='menu.manageSystem' defaultMessage='System Management' />,
       hidden:
-        userData?.role !== 'admin' && userData?.role !== 'owner' && userData?.role !== 'member',
+        systemUserData?.role !== 'admin' &&
+        systemUserData?.role !== 'owner' &&
+        systemUserData?.role !== 'member',
     },
     {
       key: 'review',
       icon: <AuditOutlined />,
       label: <FormattedMessage id='menu.account.review' defaultMessage='Review Management' />,
-      hidden: userData?.role !== 'review-admin' && userData?.role !== 'review-member',
+      hidden: reviewUserData?.role !== 'review-admin' && reviewUserData?.role !== 'review-member',
     },
     {
       type: 'divider' as const,

--- a/src/pages/Flowproperties/index.tsx
+++ b/src/pages/Flowproperties/index.tsx
@@ -14,7 +14,13 @@ import {
   DEFAULT_BROWSER_APP_LOCALE,
   normalizeRuntimeLocale,
 } from '@/services/general/runtimeLocale';
-import { getDataSource, getLang, getLangText, getUnitData } from '@/services/general/util';
+import {
+  getDataSource,
+  getLang,
+  getLangText,
+  getUnitData,
+  isDataUnderReview,
+} from '@/services/general/util';
 import { getRoleByUserId } from '@/services/roles/api';
 import { TeamTable } from '@/services/teams/data';
 import { InfoCircleOutlined } from '@ant-design/icons';
@@ -57,6 +63,7 @@ import {
 } from '../Utils/referenceLookup';
 import ReferenceLookupHelpIcon from '../Utils/ReferenceLookupHelpIcon';
 import FlowpropertiesCreate from './Components/create';
+import FlowpropertiesEdit from './Components/edit';
 import FlowpropertyView from './Components/view';
 
 const { Search } = Input;
@@ -146,6 +153,16 @@ const TableList: FC = () => {
             id={row.id}
             version={row.version}
           />
+          {isSystemAdmin && (
+            <FlowpropertiesEdit
+              disabled={isDataUnderReview(row.stateCode)}
+              id={row.id}
+              version={row.version}
+              buttonType='icon'
+              actionRef={listActionRef}
+              lang={lang}
+            />
+          )}
         </ResponsiveDataListActions>,
       ];
     }
@@ -276,7 +293,9 @@ const TableList: FC = () => {
               operationRender={(versionRow, { actionRef: allVersionsActionRef }) =>
                 renderFlowpropertyActions(versionRow as FlowpropertyTable, allVersionsActionRef)
               }
-              operationColumnWidth={isMobileDataList ? 88 : dataSource === 'my' ? 104 : 184}
+              operationColumnWidth={
+                isMobileDataList ? 88 : dataSource === 'my' ? (isSystemAdmin ? 144 : 104) : 184
+              }
             ></AllVersionsList>
           </Space>
         );
@@ -292,7 +311,7 @@ const TableList: FC = () => {
     },
     {
       ...dataListActionColumn<FlowpropertyTable>(
-        isMobileDataList ? 72 : dataSource === 'my' ? 104 : 152,
+        isMobileDataList ? 72 : dataSource === 'my' ? (isSystemAdmin ? 144 : 104) : 152,
       ),
       title: <FormattedMessage id='pages.table.title.option' defaultMessage='Actions' />,
       dataIndex: 'option',

--- a/src/pages/Flowproperties/index.tsx
+++ b/src/pages/Flowproperties/index.tsx
@@ -3,7 +3,7 @@ import {
   getFlowpropertyTableAll,
   getFlowpropertyTableUuidMentionSearch,
 } from '@/services/flowproperties/api';
-import { FlowpropertyTable } from '@/services/flowproperties/data';
+import { FlowpropertyImportData, FlowpropertyTable } from '@/services/flowproperties/data';
 import { attachStateCodesToRows } from '@/services/general/api';
 import {
   guardLocaleMaterializedTableRequest,
@@ -30,6 +30,7 @@ import { SearchProps } from 'antd/es/input/Search';
 // import ReferenceUnit from '../Unitgroups/Components/Unit/reference';
 import { toSuperscript } from '@/components/AlignedNumber';
 import ExportData from '@/components/ExportData';
+import ImportData from '@/components/ImportData';
 import {
   DATA_LIST_COLUMN_RESPONSIVE,
   ResponsiveDataListActions,
@@ -64,6 +65,7 @@ const TableList: FC = () => {
   const [keyWord, setKeyWord] = useState<string>('');
   const [, setStateCode] = useState<string | number>('all');
   const [team, setTeam] = useState<TeamTable | null>(null);
+  const [importData, setImportData] = useState<FlowpropertyImportData | null>(null);
   const [referenceLookup, setReferenceLookup] = useState<boolean>(false);
   const [isSystemAdmin, setIsSystemAdmin] = useState<boolean>(false);
   const [viewDrawerVisible, setViewDrawerVisible] = useState<boolean>(false);
@@ -86,7 +88,7 @@ const TableList: FC = () => {
   const currentAppLocaleRef = useRef(appLocale);
   const tableRequestEpochRef = useRef(0);
   syncLocaleMaterializedTableRequestEpochs(currentAppLocaleRef, appLocale, [tableRequestEpochRef]);
-  const shouldShowFlowpropertyTip = dataSource === 'my' || dataSource === 'te';
+  const shouldShowFlowpropertyTip = (dataSource === 'my' && !isSystemAdmin) || dataSource === 'te';
 
   const actionRef = useRef<ActionType>();
   const keyWordRef = useRef<string>('');
@@ -319,6 +321,11 @@ const TableList: FC = () => {
     }
     actionRef.current?.reload();
   };
+
+  const handleImportData = (jsonData: FlowpropertyImportData) => {
+    setImportData(jsonData);
+  };
+
   return (
     <PageContainer
       header={{
@@ -407,6 +414,15 @@ const TableList: FC = () => {
                   actionRef.current?.reload();
                 }}
               />,
+              <FlowpropertiesCreate
+                disabled={!isSystemAdmin}
+                importData={importData}
+                onClose={() => setImportData(null)}
+                lang={lang}
+                key={0}
+                actionRef={actionRef}
+              />,
+              <ImportData disabled={!isSystemAdmin} onJsonData={handleImportData} key={1} />,
             ];
           }
           return [];

--- a/src/pages/Unitgroups/index.tsx
+++ b/src/pages/Unitgroups/index.tsx
@@ -148,7 +148,7 @@ const TableList: FC = () => {
               buttonType='icon'
               lang={lang}
               actionRef={listActionRef}
-              setViewDrawerVisible={() => {}}
+              setViewDrawerVisible={setViewDrawerVisible}
             />
           )}
         </ResponsiveDataListActions>,

--- a/src/pages/Unitgroups/index.tsx
+++ b/src/pages/Unitgroups/index.tsx
@@ -1,6 +1,7 @@
 import { toSuperscript } from '@/components/AlignedNumber';
 import AllVersionsList from '@/components/AllVersions';
 import ExportData from '@/components/ExportData';
+import ImportData from '@/components/ImportData';
 import {
   DATA_LIST_COLUMN_RESPONSIVE,
   ResponsiveDataListActions,
@@ -35,7 +36,7 @@ import {
   getUnitGroupTableUuidMentionSearch,
   unitgroup_hybrid_search,
 } from '@/services/unitgroups/api';
-import { UnitGroupTable } from '@/services/unitgroups/data';
+import { UnitGroupImportItem, UnitGroupTable } from '@/services/unitgroups/data';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { ActionType, PageContainer, ProColumns, ProTable } from '@ant-design/pro-components';
 import { Card, Checkbox, Col, Input, Row, Space, theme } from 'antd';
@@ -62,6 +63,7 @@ const TableList: FC = () => {
   const [keyWord, setKeyWord] = useState<string>('');
   const [, setStateCode] = useState<string | number>('all');
   const [team, setTeam] = useState<TeamTable | null>(null);
+  const [importData, setImportData] = useState<UnitGroupImportItem[] | null>(null);
   const [referenceLookup, setReferenceLookup] = useState<boolean>(false);
   const [isSystemAdmin, setIsSystemAdmin] = useState<boolean>(false);
   const [viewDrawerVisible, setViewDrawerVisible] = useState<boolean>(false);
@@ -84,7 +86,7 @@ const TableList: FC = () => {
   const currentAppLocaleRef = useRef(appLocale);
   const tableRequestEpochRef = useRef(0);
   syncLocaleMaterializedTableRequestEpochs(currentAppLocaleRef, appLocale, [tableRequestEpochRef]);
-  const shouldShowUnitGroupTip = dataSource === 'my' || dataSource === 'te';
+  const shouldShowUnitGroupTip = (dataSource === 'my' && !isSystemAdmin) || dataSource === 'te';
 
   const actionRef = useRef<ActionType>();
   const keyWordRef = useRef<string>('');
@@ -305,6 +307,10 @@ const TableList: FC = () => {
     actionRef.current?.reload();
   };
 
+  const handleImportData = (jsonData: UnitGroupImportItem[]) => {
+    setImportData(jsonData);
+  };
+
   return (
     <PageContainer
       header={{
@@ -393,6 +399,15 @@ const TableList: FC = () => {
                   actionRef.current?.reload();
                 }}
               />,
+              <UnitGroupCreate
+                disabled={!isSystemAdmin}
+                importData={importData}
+                onClose={() => setImportData(null)}
+                lang={lang}
+                key={0}
+                actionRef={actionRef}
+              />,
+              <ImportData disabled={!isSystemAdmin} onJsonData={handleImportData} key={1} />,
             ];
           }
           return [];

--- a/src/pages/Unitgroups/index.tsx
+++ b/src/pages/Unitgroups/index.tsx
@@ -27,7 +27,7 @@ import {
   DEFAULT_BROWSER_APP_LOCALE,
   normalizeRuntimeLocale,
 } from '@/services/general/runtimeLocale';
-import { getDataSource, getLang, getLangText } from '@/services/general/util';
+import { getDataSource, getLang, getLangText, isDataUnderReview } from '@/services/general/util';
 import { getRoleByUserId } from '@/services/roles/api';
 import { getTeamById } from '@/services/teams/api';
 import { TeamTable } from '@/services/teams/data';
@@ -55,6 +55,7 @@ import {
 } from '../Utils/referenceLookup';
 import ReferenceLookupHelpIcon from '../Utils/ReferenceLookupHelpIcon';
 import UnitGroupCreate from './Components/create';
+import UnitGroupEdit from './Components/edit';
 import UnitGroupView from './Components/view';
 
 const { Search } = Input;
@@ -139,6 +140,17 @@ const TableList: FC = () => {
             version={row.version}
             buttonType={'icon'}
           />
+          {isSystemAdmin && (
+            <UnitGroupEdit
+              disabled={isDataUnderReview(row.stateCode)}
+              id={row.id}
+              version={row.version}
+              buttonType='icon'
+              lang={lang}
+              actionRef={listActionRef}
+              setViewDrawerVisible={() => {}}
+            />
+          )}
         </ResponsiveDataListActions>,
       ];
     }
@@ -256,7 +268,9 @@ const TableList: FC = () => {
               operationRender={(versionRow, { actionRef: allVersionsActionRef }) =>
                 renderUnitGroupActions(versionRow as UnitGroupTable, allVersionsActionRef)
               }
-              operationColumnWidth={isMobileDataList ? 88 : dataSource === 'my' ? 104 : 184}
+              operationColumnWidth={
+                isMobileDataList ? 88 : dataSource === 'my' ? (isSystemAdmin ? 144 : 104) : 184
+              }
             ></AllVersionsList>
           </Space>
         );
@@ -277,7 +291,7 @@ const TableList: FC = () => {
     },
     {
       ...dataListActionColumn<UnitGroupTable>(
-        isMobileDataList ? 72 : dataSource === 'my' ? 104 : 152,
+        isMobileDataList ? 72 : dataSource === 'my' ? (isSystemAdmin ? 144 : 104) : 152,
       ),
       title: (
         <FormattedMessage id='pages.table.title.option' defaultMessage='Actions'></FormattedMessage>

--- a/tests/integration/flowproperties/FlowpropertiesWorkflow.integration.test.tsx
+++ b/tests/integration/flowproperties/FlowpropertiesWorkflow.integration.test.tsx
@@ -4,7 +4,7 @@
  *
  * Journey:
  * 1. Owner opens My Data / Flow Properties list (ProTable request -> getFlowpropertyTableAll).
- * 2. System admins can create/import while existing My Data rows remain read-only.
+ * 2. System admins can create/import/edit while destructive My Data actions remain closed.
  * 3. Open-data users land on /tgdata flow properties and only see the read-only source matrix.
  *
  * Services mocked:
@@ -298,9 +298,10 @@ jest.mock('@/pages/Flowproperties/Components/edit', () => {
   const { updateFlowproperties } = jest.requireMock('@/services/flowproperties/api');
   return {
     __esModule: true,
-    default: ({ id, version, actionRef }: any) => (
+    default: ({ id, version, disabled, actionRef }: any) => (
       <button
         type='button'
+        disabled={disabled}
         onClick={async () => {
           await updateFlowproperties(id, version, { updated: true });
           message.success?.('Saved successfully!');
@@ -384,7 +385,7 @@ describe('Flowproperties workflow integration', () => {
     });
   };
 
-  it('lets system admins create and import while rows remain read-only', async () => {
+  it('lets system admins create, import, and edit while destructive actions remain closed', async () => {
     await renderFlowproperties();
     const user = userEvent.setup();
 
@@ -396,10 +397,15 @@ describe('Flowproperties workflow integration', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'import' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /contribute/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /edit fp-1/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /edit fp-1/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /delete fp-1/i })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'view fp-1:1.0.0' })).toBeInTheDocument();
     expect(screen.getByText('export')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /edit fp-1/i }));
+    await waitFor(() =>
+      expect(mockUpdateFlowproperties).toHaveBeenCalledWith('fp-1', '1.0.0', { updated: true }),
+    );
 
     await user.selectOptions(screen.getByRole('combobox'), '100');
 

--- a/tests/integration/flowproperties/FlowpropertiesWorkflow.integration.test.tsx
+++ b/tests/integration/flowproperties/FlowpropertiesWorkflow.integration.test.tsx
@@ -1,10 +1,10 @@
 /**
- * Flowproperties read-only workflow integration test.
+ * Flowproperties role-gated workflow integration test.
  * Covers page at: src/pages/Flowproperties/index.tsx
  *
  * Journey:
  * 1. Owner opens My Data / Flow Properties list (ProTable request -> getFlowpropertyTableAll).
- * 2. My Data shows existing rows without create/edit/delete controls.
+ * 2. System admins can create/import while existing My Data rows remain read-only.
  * 3. Open-data users land on /tgdata flow properties and only see the read-only source matrix.
  *
  * Services mocked:
@@ -384,7 +384,7 @@ describe('Flowproperties workflow integration', () => {
     });
   };
 
-  it('renders my-data flow properties read-only while preserving filters', async () => {
+  it('lets system admins create and import while rows remain read-only', async () => {
     await renderFlowproperties();
     const user = userEvent.setup();
 
@@ -392,9 +392,9 @@ describe('Flowproperties workflow integration', () => {
     expect(await screen.findByText('Water mass')).toBeInTheDocument();
 
     expect(
-      within(screen.getByTestId('pro-table-toolbar')).queryByRole('button', { name: /create/i }),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'import' })).not.toBeInTheDocument();
+      within(screen.getByTestId('pro-table-toolbar')).getByRole('button', { name: /create/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'import' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /contribute/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /edit fp-1/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /delete fp-1/i })).not.toBeInTheDocument();

--- a/tests/integration/unitgroups/UnitgroupsWorkflow.integration.test.tsx
+++ b/tests/integration/unitgroups/UnitgroupsWorkflow.integration.test.tsx
@@ -3,7 +3,7 @@
  * Covers src/pages/Unitgroups/index.tsx with focus on:
  * - Initial table load via getUnitGroupTableAll.
  * - Search behaviour delegating to unitgroup_hybrid_search.
- * - System admins can create/import while existing My Data rows remain read-only.
+ * - System admins can create/import/edit while destructive My Data actions remain closed.
  * - Open-data users land on /tgdata unit groups and only see the read-only source matrix.
  *
  * Service mocks:
@@ -379,7 +379,7 @@ describe('Unitgroups Workflow Integration', () => {
     });
   });
 
-  it('lets system admins create and import while rows remain read-only', async () => {
+  it('lets system admins create, import, and edit while destructive actions remain closed', async () => {
     const user = userEvent.setup();
 
     renderWithProviders(<UnitgroupsPage />);
@@ -416,7 +416,7 @@ describe('Unitgroups Workflow Integration', () => {
     const dataRow = screen.getByText('Heat units').closest('tr') as HTMLElement;
     expect(within(dataRow).getByRole('button', { name: 'view' })).toBeInTheDocument();
     expect(screen.getByText('export')).toBeInTheDocument();
-    expect(within(dataRow).queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+    expect(within(dataRow).getByRole('button', { name: /edit/i })).toBeInTheDocument();
     expect(within(dataRow).queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
 
     await user.selectOptions(screen.getByLabelText('state-filter'), '100');

--- a/tests/integration/unitgroups/UnitgroupsWorkflow.integration.test.tsx
+++ b/tests/integration/unitgroups/UnitgroupsWorkflow.integration.test.tsx
@@ -1,9 +1,9 @@
 /**
- * Unitgroups read-only workflow integration test.
+ * Unitgroups role-gated workflow integration test.
  * Covers src/pages/Unitgroups/index.tsx with focus on:
  * - Initial table load via getUnitGroupTableAll.
  * - Search behaviour delegating to unitgroup_hybrid_search.
- * - My Data unit groups expose existing rows without create/edit/delete controls.
+ * - System admins can create/import while existing My Data rows remain read-only.
  * - Open-data users land on /tgdata unit groups and only see the read-only source matrix.
  *
  * Service mocks:
@@ -379,7 +379,7 @@ describe('Unitgroups Workflow Integration', () => {
     });
   });
 
-  it('renders my-data unit groups read-only while preserving search and filters', async () => {
+  it('lets system admins create and import while rows remain read-only', async () => {
     const user = userEvent.setup();
 
     renderWithProviders(<UnitgroupsPage />);
@@ -409,8 +409,8 @@ describe('Unitgroups Workflow Integration', () => {
     });
 
     const toolbar = screen.getByTestId('pro-table-toolbar');
-    expect(within(toolbar).queryByRole('button', { name: /create/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'import' })).not.toBeInTheDocument();
+    expect(within(toolbar).getByRole('button', { name: /create/i })).toBeInTheDocument();
+    expect(within(toolbar).getByRole('button', { name: 'import' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /contribute/i })).not.toBeInTheDocument();
 
     const dataRow = screen.getByText('Heat units').closest('tr') as HTMLElement;

--- a/tests/unit/components/AvatarDropdown.test.tsx
+++ b/tests/unit/components/AvatarDropdown.test.tsx
@@ -191,6 +191,7 @@ const setupModuleMocks = () => {
       __esModule: true,
       getUserRoles: jest.fn(),
       getSystemUserRoleApi: jest.fn(),
+      getReviewUserRoleApi: jest.fn(),
     }),
     { virtual: true },
   );
@@ -218,8 +219,15 @@ const { AvatarDropdown, AvatarName } =
 
 const { logout: mockedLogout } = require('@/services/auth') as { logout: jest.Mock };
 
-const { getUserRoles: mockedGetUserRoles, getSystemUserRoleApi: mockedGetSystemUserRoleApi } =
-  require('@/services/roles/api') as { getUserRoles: jest.Mock; getSystemUserRoleApi: jest.Mock };
+const {
+  getUserRoles: mockedGetUserRoles,
+  getSystemUserRoleApi: mockedGetSystemUserRoleApi,
+  getReviewUserRoleApi: mockedGetReviewUserRoleApi,
+} = require('@/services/roles/api') as {
+  getUserRoles: jest.Mock;
+  getSystemUserRoleApi: jest.Mock;
+  getReviewUserRoleApi: jest.Mock;
+};
 
 describe('AvatarDropdown', () => {
   beforeEach(() => {
@@ -234,6 +242,7 @@ describe('AvatarDropdown', () => {
     mockedLogout.mockResolvedValue(undefined);
     mockedGetUserRoles.mockResolvedValue({ data: [{ role: 'member' }] });
     mockedGetSystemUserRoleApi.mockResolvedValue({ role: 'admin' });
+    mockedGetReviewUserRoleApi.mockResolvedValue(null);
     window.history.pushState({}, '', '/');
   });
 
@@ -253,6 +262,7 @@ describe('AvatarDropdown', () => {
 
     await waitFor(() => {
       expect(mockedGetSystemUserRoleApi).toHaveBeenCalled();
+      expect(mockedGetReviewUserRoleApi).toHaveBeenCalled();
     });
   });
 
@@ -276,6 +286,7 @@ describe('AvatarDropdown', () => {
     expect(screen.getByRole('status', { name: /loading user menu/i })).toBeInTheDocument();
     await waitFor(() => {
       expect(mockedGetSystemUserRoleApi).toHaveBeenCalled();
+      expect(mockedGetReviewUserRoleApi).toHaveBeenCalled();
     });
   });
 
@@ -312,6 +323,7 @@ describe('AvatarDropdown', () => {
 
     await user.click(screen.getByRole('button', { name: 'System Management' }));
     expect(mockHistoryPush).toHaveBeenCalledWith('/manageSystem');
+    expect(screen.queryByRole('button', { name: 'Review Management' })).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Logout' }));
 
@@ -334,7 +346,35 @@ describe('AvatarDropdown', () => {
     });
   });
 
-  it('shows review navigation when user has review role while hiding system settings', async () => {
+  it.each(['review-admin', 'review-member'])(
+    'shows review navigation for %s while hiding system management without a system role',
+    async (role) => {
+      const setInitialState = jest.fn();
+      mockUseModel.mockImplementation((model: string) => {
+        if (model === '@@initialState') {
+          return { initialState: { currentUser: { name: 'Riley' } }, setInitialState };
+        }
+        return {};
+      });
+
+      mockedGetSystemUserRoleApi.mockResolvedValue(null);
+      mockedGetReviewUserRoleApi.mockResolvedValue({ role });
+
+      const user = userEvent.setup();
+
+      render(<AvatarDropdown>avatar</AvatarDropdown>);
+
+      expect(await screen.findByRole('button', { name: 'Account Profile' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'System Management' })).not.toBeInTheDocument();
+
+      const reviewButton = await screen.findByRole('button', { name: 'Review Management' });
+      await user.click(reviewButton);
+
+      expect(mockHistoryPush).toHaveBeenCalledWith('/review');
+    },
+  );
+
+  it('shows system and review navigation when both roles are assigned', async () => {
     const setInitialState = jest.fn();
     mockUseModel.mockImplementation((model: string) => {
       if (model === '@@initialState') {
@@ -343,19 +383,31 @@ describe('AvatarDropdown', () => {
       return {};
     });
 
-    mockedGetSystemUserRoleApi.mockResolvedValue({ role: 'review-member' });
+    mockedGetReviewUserRoleApi.mockResolvedValue({ role: 'review-admin' });
 
-    const user = userEvent.setup();
+    render(<AvatarDropdown>avatar</AvatarDropdown>);
+
+    expect(await screen.findByRole('button', { name: 'System Management' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Review Management' })).toBeInTheDocument();
+  });
+
+  it('hides privileged navigation when neither role lookup finds a membership', async () => {
+    const setInitialState = jest.fn();
+    mockUseModel.mockImplementation((model: string) => {
+      if (model === '@@initialState') {
+        return { initialState: { currentUser: { name: 'Jordan' } }, setInitialState };
+      }
+      return {};
+    });
+
+    mockedGetSystemUserRoleApi.mockResolvedValue(null);
+    mockedGetReviewUserRoleApi.mockResolvedValue(null);
 
     render(<AvatarDropdown>avatar</AvatarDropdown>);
 
     expect(await screen.findByRole('button', { name: 'Account Profile' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'System Settings' })).not.toBeInTheDocument();
-
-    const reviewButton = await screen.findByRole('button', { name: 'Review Management' });
-    await user.click(reviewButton);
-
-    expect(mockHistoryPush).toHaveBeenCalledWith('/review');
+    expect(screen.queryByRole('button', { name: 'System Management' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Review Management' })).not.toBeInTheDocument();
   });
 
   it('opens the team selection modal when the user is not part of a team', async () => {

--- a/tests/unit/pages/Flowproperties/index.test.tsx
+++ b/tests/unit/pages/Flowproperties/index.test.tsx
@@ -36,6 +36,7 @@ const mockGetRoleByUserId = jest.fn();
 const mockGetTeamById = jest.fn();
 const mockGetUnitData = jest.fn();
 const mockDatasetUuidMentionSearch = jest.fn();
+const mockIsDataUnderReview = jest.fn((stateCode: number | undefined) => stateCode === 20);
 const mockMessage = {
   success: jest.fn(),
   error: jest.fn(),
@@ -65,7 +66,7 @@ jest.mock('@/services/general/util', () => ({
   getLang: (...args: any[]) => mockGetLang(...args),
   getLangText: (...args: any[]) => mockGetLangText(...args),
   getUnitData: (...args: any[]) => mockGetUnitData(...args),
-  isDataUnderReview: () => false,
+  isDataUnderReview: (...args: any[]) => mockIsDataUnderReview(...args),
 }));
 
 jest.mock('@/services/teams/api', () => ({
@@ -198,9 +199,9 @@ jest.mock('@/pages/Flowproperties/Components/delete', () => ({
 
 jest.mock('@/pages/Flowproperties/Components/edit', () => ({
   __esModule: true,
-  default: ({ id, version, autoOpen, onDrawerClose }: any) => (
+  default: ({ id, version, disabled, autoOpen, onDrawerClose }: any) => (
     <div data-testid='flowproperty-edit'>
-      {JSON.stringify({ id, version, autoOpen })}
+      {JSON.stringify({ id, version, disabled, autoOpen })}
       <button type='button' onClick={() => onDrawerClose?.()}>
         flowproperty-edit-close
       </button>
@@ -474,7 +475,7 @@ describe('FlowpropertiesPage', () => {
     expect(screen.getByTestId('export-data')).toHaveTextContent('flowproperties:fp-1:01.00.000');
   });
 
-  it('allows system admins to create and import while keeping existing rows read-only', async () => {
+  it('allows system admins to create, import, and edit while keeping other row actions closed', async () => {
     renderWithProviders(<FlowpropertiesPage />);
 
     await waitFor(() => expect(mockGetTeamById).toHaveBeenCalledWith('team-1'));
@@ -502,7 +503,8 @@ describe('FlowpropertiesPage', () => {
     expect(screen.getByText('sup:kg')).toBeInTheDocument();
     expect(screen.getByTestId('flowproperty-view')).toHaveTextContent('fp-1:01.00.000');
     expect(screen.queryByTestId('flowproperty-delete')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('flowproperty-edit')).not.toBeInTheDocument();
+    expect(await screen.findByTestId('flowproperty-edit')).toHaveTextContent('"id":"fp-1"');
+    expect(screen.getByTestId('flowproperty-edit')).toHaveTextContent('"disabled":false');
     expect(screen.getByTestId('flowproperty-create')).toHaveTextContent('"disabled":false');
     expect(screen.getByTestId('flowproperty-create')).toHaveTextContent('"importCount":0');
     expect(screen.queryByRole('button', { name: /contribute-action/i })).not.toBeInTheDocument();
@@ -518,7 +520,26 @@ describe('FlowpropertiesPage', () => {
     expect(screen.getByTestId('flowproperty-create')).toHaveTextContent('"importCount":0');
   });
 
-  it('keeps admin create and import controls available on mobile', async () => {
+  it('keeps system-admin editing disabled while a flow property is under review', async () => {
+    mockGetFlowpropertyTableAll.mockResolvedValue({
+      data: [
+        {
+          id: 'fp-review',
+          version: '01.00.000',
+          name: 'Under-review flow property',
+          stateCode: 20,
+        },
+      ],
+      success: true,
+    });
+
+    renderWithProviders(<FlowpropertiesPage />);
+
+    expect(await screen.findByTestId('flowproperty-edit')).toHaveTextContent('"disabled":true');
+    expect(mockIsDataUnderReview).toHaveBeenCalledWith(20);
+  });
+
+  it('keeps admin create, import, and edit controls available on mobile', async () => {
     mockBreakpointScreens = { md: false };
 
     renderWithProviders(<FlowpropertiesPage />);
@@ -528,6 +549,7 @@ describe('FlowpropertiesPage', () => {
     expect(screen.getByRole('button', { name: /table-filter/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /import-data/i })).not.toBeDisabled();
     expect(screen.getByTestId('flowproperty-create')).toHaveTextContent('"disabled":false');
+    expect(await screen.findByTestId('flowproperty-edit')).toHaveTextContent('"disabled":false');
   });
 
   it('reloads the table with the selected state filter', async () => {

--- a/tests/unit/pages/Flowproperties/index.test.tsx
+++ b/tests/unit/pages/Flowproperties/index.test.tsx
@@ -465,8 +465,8 @@ describe('FlowpropertiesPage', () => {
     expect(screen.getByRole('button', { name: /search/i })).not.toBeDisabled();
     expect(screen.getByText(/contact an administrator/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /table-filter/i })).not.toBeDisabled();
-    expect(screen.queryByRole('button', { name: /import-data/i })).not.toBeInTheDocument();
-    expect(screen.queryByTestId('flowproperty-create')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /import-data/i })).toBeDisabled();
+    expect(screen.getByTestId('flowproperty-create')).toHaveTextContent('"disabled":true');
     expect(screen.queryByTestId('flowproperty-delete')).not.toBeInTheDocument();
     expect(screen.queryByTestId('flowproperty-edit')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /contribute-action/i })).not.toBeInTheDocument();
@@ -474,7 +474,7 @@ describe('FlowpropertiesPage', () => {
     expect(screen.getByTestId('export-data')).toHaveTextContent('flowproperties:fp-1:01.00.000');
   });
 
-  it('loads the default table with read-only my-data actions', async () => {
+  it('allows system admins to create and import while keeping existing rows read-only', async () => {
     renderWithProviders(<FlowpropertiesPage />);
 
     await waitFor(() => expect(mockGetTeamById).toHaveBeenCalledWith('team-1'));
@@ -503,16 +503,22 @@ describe('FlowpropertiesPage', () => {
     expect(screen.getByTestId('flowproperty-view')).toHaveTextContent('fp-1:01.00.000');
     expect(screen.queryByTestId('flowproperty-delete')).not.toBeInTheDocument();
     expect(screen.queryByTestId('flowproperty-edit')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('flowproperty-create')).not.toBeInTheDocument();
+    expect(screen.getByTestId('flowproperty-create')).toHaveTextContent('"disabled":false');
+    expect(screen.getByTestId('flowproperty-create')).toHaveTextContent('"importCount":0');
     expect(screen.queryByRole('button', { name: /contribute-action/i })).not.toBeInTheDocument();
     expect(screen.getByTestId('table-dropdown')).toBeInTheDocument();
     expect(screen.getByTestId('export-data')).toHaveTextContent('flowproperties:fp-1:01.00.000');
     expect(screen.getByRole('checkbox', { name: 'Reference Lookup' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /import-data/i })).not.toBeDisabled();
+    expect(screen.queryByText(/contact an administrator/i)).not.toBeInTheDocument();
 
-    expect(screen.queryByRole('button', { name: /import-data/i })).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /import-data/i }));
+    expect(screen.getByTestId('flowproperty-create')).toHaveTextContent('"importCount":1');
+    await userEvent.click(screen.getByRole('button', { name: /flowproperty-create-close/i }));
+    expect(screen.getByTestId('flowproperty-create')).toHaveTextContent('"importCount":0');
   });
 
-  it('uses compact mobile controls for my data rows without import actions', async () => {
+  it('keeps admin create and import controls available on mobile', async () => {
     mockBreakpointScreens = { md: false };
 
     renderWithProviders(<FlowpropertiesPage />);
@@ -520,7 +526,8 @@ describe('FlowpropertiesPage', () => {
     await waitFor(() => expect(mockGetFlowpropertyTableAll).toHaveBeenCalled());
     expect(await screen.findByTestId('flowproperty-view')).toHaveTextContent('fp-1:01.00.000');
     expect(screen.getByRole('button', { name: /table-filter/i })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /import-data/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /import-data/i })).not.toBeDisabled();
+    expect(screen.getByTestId('flowproperty-create')).toHaveTextContent('"disabled":false');
   });
 
   it('reloads the table with the selected state filter', async () => {
@@ -573,7 +580,7 @@ describe('FlowpropertiesPage', () => {
   });
 
   it('uses non-my option branches without my-data write controls', async () => {
-    const { rerender } = renderWithProviders(<FlowpropertiesPage />);
+    const { unmount } = renderWithProviders(<FlowpropertiesPage />);
 
     await waitFor(() => expect(mockGetFlowpropertyTableAll).toHaveBeenCalled());
     await screen.findByTestId('flowproperty-view');
@@ -586,7 +593,8 @@ describe('FlowpropertiesPage', () => {
       search: '',
     };
 
-    rerender(<FlowpropertiesPage />);
+    unmount();
+    renderWithProviders(<FlowpropertiesPage />);
 
     await waitFor(() =>
       expect(mockGetFlowpropertyTableAll).toHaveBeenLastCalledWith(

--- a/tests/unit/pages/Unitgroups/index.test.tsx
+++ b/tests/unit/pages/Unitgroups/index.test.tsx
@@ -176,15 +176,22 @@ jest.mock('@/pages/Unitgroups/Components/create', () => ({
   __esModule: true,
   default: (props: any) => {
     mockUnitGroupCreateCalls.push(props);
-    const { actionType = 'create', importData, newVersion, disabled } = props;
+    const { actionType = 'create', importData, newVersion, disabled, onClose } = props;
     return (
-      <div data-testid='unitgroup-create'>
-        {JSON.stringify({
-          actionType,
-          importCount: importData?.length ?? 0,
-          newVersion,
-          disabled: !!disabled,
-        })}
+      <div>
+        <div data-testid='unitgroup-create'>
+          {JSON.stringify({
+            actionType,
+            importCount: importData?.length ?? 0,
+            newVersion,
+            disabled: !!disabled,
+          })}
+        </div>
+        {onClose ? (
+          <button type='button' onClick={() => onClose()}>
+            unitgroup-create-close
+          </button>
+        ) : null}
       </div>
     );
   },
@@ -487,8 +494,8 @@ describe('UnitgroupsPage', () => {
     expect(screen.getByRole('button', { name: /search/i })).not.toBeDisabled();
     expect(screen.getByText(/contact an administrator/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /table-filter/i })).not.toBeDisabled();
-    expect(screen.queryByRole('button', { name: /import-data/i })).not.toBeInTheDocument();
-    expect(screen.queryByTestId('unitgroup-create')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /import-data/i })).toBeDisabled();
+    expect(screen.getByTestId('unitgroup-create')).toHaveTextContent('"disabled":true');
     expect(screen.queryByTestId('unitgroup-edit')).not.toBeInTheDocument();
     expect(screen.queryByTestId('unitgroup-delete')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /contribute-action/i })).not.toBeInTheDocument();
@@ -497,7 +504,7 @@ describe('UnitgroupsPage', () => {
     expect(mockAllVersionsOperationWidths).toContain(104);
   });
 
-  it('loads admin my data read-only and supports pgroonga search', async () => {
+  it('allows system admins to create and import while keeping existing rows read-only', async () => {
     mockGetRoleByUserId.mockResolvedValue([
       {
         team_id: '00000000-0000-0000-0000-000000000000',
@@ -524,9 +531,17 @@ describe('UnitgroupsPage', () => {
     );
     expect(screen.queryByTestId('unitgroup-edit')).not.toBeInTheDocument();
     expect(screen.queryByTestId('unitgroup-delete')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('unitgroup-create')).not.toBeInTheDocument();
+    expect(screen.getByTestId('unitgroup-create')).toHaveTextContent('"disabled":false');
+    expect(screen.getByTestId('unitgroup-create')).toHaveTextContent('"importCount":0');
+    expect(screen.getByRole('button', { name: /import-data/i })).not.toBeDisabled();
     expect(screen.queryByRole('button', { name: /contribute-action/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/contact an administrator/i)).not.toBeInTheDocument();
     expect(mockAllVersionsOperationWidths).toContain(104);
+
+    await userEvent.click(screen.getByRole('button', { name: /import-data/i }));
+    expect(screen.getByTestId('unitgroup-create')).toHaveTextContent('"importCount":1');
+    await userEvent.click(screen.getByRole('button', { name: /unitgroup-create-close/i }));
+    expect(screen.getByTestId('unitgroup-create')).toHaveTextContent('"importCount":0');
 
     await userEvent.click(screen.getByRole('button', { name: /table-filter/i }));
     await waitFor(() =>
@@ -630,7 +645,7 @@ describe('UnitgroupsPage', () => {
     );
   });
 
-  it('uses compact mobile controls for my data rows without import actions', async () => {
+  it('keeps admin create and import controls available on mobile', async () => {
     mockBreakpointScreens = { md: false };
     mockGetRoleByUserId.mockResolvedValue([
       {
@@ -643,7 +658,8 @@ describe('UnitgroupsPage', () => {
 
     await waitFor(() => expect(mockGetUnitGroupTableAll).toHaveBeenCalled());
     expect(screen.getByRole('button', { name: /table-filter/i })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /import-data/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /import-data/i })).not.toBeDisabled();
+    expect(screen.getByTestId('unitgroup-create')).toHaveTextContent('"disabled":false');
     await waitFor(() => expect(mockAllVersionsOperationWidths).toContain(88));
   });
 
@@ -699,7 +715,7 @@ describe('UnitgroupsPage', () => {
     expect(mockContributeSource).not.toHaveBeenCalled();
   });
 
-  it('reloads when the state filter changes without import or create actions', async () => {
+  it('reloads when the state filter changes with admin create and import actions', async () => {
     mockGetRoleByUserId.mockResolvedValue([
       {
         team_id: '00000000-0000-0000-0000-000000000000',
@@ -713,8 +729,8 @@ describe('UnitgroupsPage', () => {
       expect(screen.getByRole('button', { name: /table-filter/i })).toBeInTheDocument(),
     );
 
-    expect(screen.queryByRole('button', { name: /import-data/i })).not.toBeInTheDocument();
-    expect(screen.queryByTestId('unitgroup-create')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /import-data/i })).not.toBeDisabled();
+    expect(screen.getByTestId('unitgroup-create')).toHaveTextContent('"disabled":false');
 
     await userEvent.click(screen.getByRole('button', { name: /table-filter/i }));
     await waitFor(() =>

--- a/tests/unit/pages/Unitgroups/index.test.tsx
+++ b/tests/unit/pages/Unitgroups/index.test.tsx
@@ -35,6 +35,7 @@ const mockGetUnitGroupTableAll = jest.fn();
 const mockGetUnitGroupTablePgroongaSearch = jest.fn();
 const mockGetUnitGroupTableUuidMentionSearch = jest.fn();
 const mockDatasetUuidMentionSearch = jest.fn();
+const mockIsDataUnderReview = jest.fn((stateCode: number | undefined) => stateCode === 20);
 
 jest.mock('umi', () => ({
   __esModule: true,
@@ -57,7 +58,7 @@ jest.mock('@/services/general/util', () => ({
   getDataSource: (...args: any[]) => mockGetDataSource(...args),
   getLang: (...args: any[]) => mockGetLang(...args),
   getLangText: (...args: any[]) => mockGetLangText(...args),
-  isDataUnderReview: () => false,
+  isDataUnderReview: (...args: any[]) => mockIsDataUnderReview(...args),
 }));
 
 jest.mock('@/services/roles/api', () => ({
@@ -209,7 +210,11 @@ jest.mock('@/pages/Unitgroups/Components/edit', () => ({
   __esModule: true,
   default: (props: any) => {
     mockUnitGroupEditCalls.push(props);
-    return <div data-testid='unitgroup-edit'>{`edit:${props.id}`}</div>;
+    return (
+      <div data-testid='unitgroup-edit'>
+        {JSON.stringify({ id: props.id, version: props.version, disabled: props.disabled })}
+      </div>
+    );
   },
 }));
 
@@ -504,7 +509,7 @@ describe('UnitgroupsPage', () => {
     expect(mockAllVersionsOperationWidths).toContain(104);
   });
 
-  it('allows system admins to create and import while keeping existing rows read-only', async () => {
+  it('allows system admins to create, import, and edit while keeping other row actions closed', async () => {
     mockGetRoleByUserId.mockResolvedValue([
       {
         team_id: '00000000-0000-0000-0000-000000000000',
@@ -529,14 +534,15 @@ describe('UnitgroupsPage', () => {
     await waitFor(() =>
       expect(screen.getByTestId('unitgroup-view')).toHaveTextContent('view:ug-1'),
     );
-    expect(screen.queryByTestId('unitgroup-edit')).not.toBeInTheDocument();
+    expect(await screen.findByTestId('unitgroup-edit')).toHaveTextContent('"id":"ug-1"');
+    expect(screen.getByTestId('unitgroup-edit')).toHaveTextContent('"disabled":false');
     expect(screen.queryByTestId('unitgroup-delete')).not.toBeInTheDocument();
     expect(screen.getByTestId('unitgroup-create')).toHaveTextContent('"disabled":false');
     expect(screen.getByTestId('unitgroup-create')).toHaveTextContent('"importCount":0');
     expect(screen.getByRole('button', { name: /import-data/i })).not.toBeDisabled();
     expect(screen.queryByRole('button', { name: /contribute-action/i })).not.toBeInTheDocument();
     expect(screen.queryByText(/contact an administrator/i)).not.toBeInTheDocument();
-    expect(mockAllVersionsOperationWidths).toContain(104);
+    expect(mockAllVersionsOperationWidths).toContain(144);
 
     await userEvent.click(screen.getByRole('button', { name: /import-data/i }));
     expect(screen.getByTestId('unitgroup-create')).toHaveTextContent('"importCount":1');
@@ -567,6 +573,31 @@ describe('UnitgroupsPage', () => {
         'team-1',
       ),
     );
+  });
+
+  it('keeps system-admin editing disabled while a unit group is under review', async () => {
+    mockGetRoleByUserId.mockResolvedValue([
+      {
+        team_id: '00000000-0000-0000-0000-000000000000',
+        role: 'admin',
+      },
+    ]);
+    mockGetUnitGroupTableAll.mockResolvedValue({
+      data: [
+        {
+          id: 'ug-review',
+          version: '1.0.0',
+          name: 'Under-review units',
+          stateCode: 20,
+        },
+      ],
+      success: true,
+    });
+
+    renderWithProviders(<UnitgroupsPage />);
+
+    expect(await screen.findByTestId('unitgroup-edit')).toHaveTextContent('"disabled":true');
+    expect(mockIsDataUnderReview).toHaveBeenCalledWith(20);
   });
 
   it('uses the main table for reference lookup and clears rows for incomplete UUIDs', async () => {
@@ -645,7 +676,7 @@ describe('UnitgroupsPage', () => {
     );
   });
 
-  it('keeps admin create and import controls available on mobile', async () => {
+  it('keeps admin create, import, and edit controls available on mobile', async () => {
     mockBreakpointScreens = { md: false };
     mockGetRoleByUserId.mockResolvedValue([
       {
@@ -660,6 +691,7 @@ describe('UnitgroupsPage', () => {
     expect(screen.getByRole('button', { name: /table-filter/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /import-data/i })).not.toBeDisabled();
     expect(screen.getByTestId('unitgroup-create')).toHaveTextContent('"disabled":false');
+    expect(await screen.findByTestId('unitgroup-edit')).toHaveTextContent('"disabled":false');
     await waitFor(() => expect(mockAllVersionsOperationWidths).toContain(88));
   });
 

--- a/tests/unit/pages/underReviewListEdit.test.tsx
+++ b/tests/unit/pages/underReviewListEdit.test.tsx
@@ -383,7 +383,7 @@ describe('under review list actions', () => {
     );
   });
 
-  it('does not render unit group edit and delete buttons for rows under review', async () => {
+  it('disables system-admin unit group editing and keeps delete closed for rows under review', async () => {
     mockLocation = {
       pathname: '/mydata/unitgroups',
       search: '?tid=team-1',
@@ -418,7 +418,7 @@ describe('under review list actions', () => {
         ]),
       ),
     );
-    expect(screen.queryByTestId('unitgroup-edit')).not.toBeInTheDocument();
+    expect(screen.getByTestId('unitgroup-edit')).toBeDisabled();
     expect(screen.queryByTestId('unitgroup-delete')).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
Closes #790

## Summary
- Load system-management and review-management roles through their independent role APIs.
- Show 审核管理 to review-admin and review-member accounts while preserving existing 系统管理 visibility.
- Restore Unit Group and Flow Property create/import/edit controls for system-team `admin` users on My Data.
- Keep non-admin users read-only and preserve the existing under-review edit guard.

## Key Decisions
- Keep system and review authorization in separate component state so one role namespace cannot mask the other.
- Gate reference-data create/import/edit controls on the existing system-team `admin` role; do not extend them to owner, member, review roles, or ordinary team admins.
- Reuse the existing edit drawers and their update, validation, and submit-review workflows.
- Do not restore delete, contribute, copy, or create-version actions for existing reference-data rows.
- Refresh canonical locale proof artifacts when changed page sources shift audited message locations.

## Validation
- Unit Group / Flow Property focused page and workflow proof: 4 suites, 26 tests passed.
- Under-review list-action contract: 5 tests passed.
- Unit Group page coverage proof: 2 suites, 15 tests passed with 100% statements, branches, functions, and lines.
- Locale delivery contract: 18 tests passed; generated artifacts are idempotent.
- Lint, TypeScript, production build, and Docpact passed.
- Managed pre-push gate: 411 suites, 5618 tests passed; 460/460 tracked source files reached 100/100/100/100 coverage.

## Risks / Rollback
- The permission expansion is intentionally limited to system-team `admin` on My Data, with the existing under-review edit guard retained.

## Follow-ups
- Review and CI remain before merge into `dev`.

## Workspace Integration
- Workspace integration remains Pending; root `main` can advance only after this change is promoted to child `main` under the branch policy.