### PR TITLE
fix: 统一审核操作与确认按钮主题样式

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "59e505a28d2c599a3c2c0d06dc71551292ee8d3a"
+lastReviewedCommit: "83315614691354d2a3fc82beb33b6939e6f61c35"
 lastReviewedNote: 'Reviewed for Issues #778 and #780: existing ownership routes cover the merged grouped-review candidate plus automatic qualification evidence, composed-candidate preflight, release orchestration, tests, and governed release docs.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "83315614691354d2a3fc82beb33b6939e6f61c35"
+lastReviewedAt: "2026-08-09"
+lastReviewedCommit: "b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3"
 lastReviewedNote: 'Reviewed for Issues #778 and #780: existing ownership routes cover the merged grouped-review candidate plus automatic qualification evidence, composed-candidate preflight, release orchestration, tests, and governed release docs.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-09"
-lastReviewedCommit: "b184f74e4989088f83d371e0e0d9eb2bcd857cb4"
+lastReviewedCommit: "be18e70370533dce97086185378a3e5bf2602a18"
 lastReviewedNote: 'Reviewed for Issues #778 and #780: existing ownership routes cover the merged grouped-review candidate plus automatic qualification evidence, composed-candidate preflight, release orchestration, tests, and governed release docs.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "f26b54d064f8f408982a169a0ddda0381395826d"
+lastReviewedCommit: "59e505a28d2c599a3c2c0d06dc71551292ee8d3a"
 lastReviewedNote: 'Reviewed for Issues #778 and #780: existing ownership routes cover the merged grouped-review candidate plus automatic qualification evidence, composed-candidate preflight, release orchestration, tests, and governed release docs.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-09"
-lastReviewedCommit: "b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3"
+lastReviewedCommit: "b184f74e4989088f83d371e0e0d9eb2bcd857cb4"
 lastReviewedNote: 'Reviewed for Issues #778 and #780: existing ownership routes cover the merged grouped-review candidate plus automatic qualification evidence, composed-candidate preflight, release orchestration, tests, and governed release docs.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 83315614691354d2a3fc82beb33b6939e6f61c35
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
 lastReviewedNote: 'Reviewed for Issues #778 and #780: deterministic release preflight and grouped-review delivery remain within the documented dev-to-main, quality-gate, and root-integration boundaries.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
+lastReviewedCommit: 83315614691354d2a3fc82beb33b6939e6f61c35
 lastReviewedNote: 'Reviewed for Issues #778 and #780: deterministic release preflight and grouped-review delivery remain within the documented dev-to-main, quality-gate, and root-integration boundaries.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b184f74e4989088f83d371e0e0d9eb2bcd857cb4
+lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
 lastReviewedNote: 'Reviewed for Issues #778 and #780: deterministic release preflight and grouped-review delivery remain within the documented dev-to-main, quality-gate, and root-integration boundaries.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
+lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
 lastReviewedNote: 'Reviewed for Issues #778 and #780: deterministic release preflight and grouped-review delivery remain within the documented dev-to-main, quality-gate, and root-integration boundaries.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
+lastReviewedCommit: b184f74e4989088f83d371e0e0d9eb2bcd857cb4
 lastReviewedNote: 'Reviewed for Issues #778 and #780: deterministic release preflight and grouped-review delivery remain within the documented dev-to-main, quality-gate, and root-integration boundaries.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b184f74e4989088f83d371e0e0d9eb2bcd857cb4
+lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged candidate keeps the Node 24, focused-proof, semantic qualification, managed-push, and deterministic release-command workflow.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
+lastReviewedCommit: 83315614691354d2a3fc82beb33b6939e6f61c35
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged candidate keeps the Node 24, focused-proof, semantic qualification, managed-push, and deterministic release-command workflow.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
+lastReviewedCommit: b184f74e4989088f83d371e0e0d9eb2bcd857cb4
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged candidate keeps the Node 24, focused-proof, semantic qualification, managed-push, and deterministic release-command workflow.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - .nvmrc
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 83315614691354d2a3fc82beb33b6939e6f61c35
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged candidate keeps the Node 24, focused-proof, semantic qualification, managed-push, and deterministic release-command workflow.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
+lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged candidate keeps the Node 24, focused-proof, semantic qualification, managed-push, and deterministic release-command workflow.'
 ---
 

--- a/docs/agents/data_audit_instruction.md
+++ b/docs/agents/data_audit_instruction.md
@@ -18,8 +18,8 @@ checkPaths:
   - docs/agents/data_audit_instruction.md
   - src/pages/Review/**
   - src/pages/ManageSystem/**
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
 lastReviewedNote: 'Reviewed for Issues #745 and #780: retain Root-only/current-tab queue semantics and record the seven-type read-only dataset drawers available from readable Root and Reference rows.'
 ---
 

--- a/docs/agents/data_audit_instruction.md
+++ b/docs/agents/data_audit_instruction.md
@@ -19,7 +19,7 @@ checkPaths:
   - src/pages/Review/**
   - src/pages/ManageSystem/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
+lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
 lastReviewedNote: 'Reviewed for Issues #745 and #780: retain Root-only/current-tab queue semantics and record the seven-type read-only dataset drawers available from readable Root and Reference rows.'
 ---
 

--- a/docs/agents/data_audit_instruction.md
+++ b/docs/agents/data_audit_instruction.md
@@ -18,8 +18,8 @@ checkPaths:
   - docs/agents/data_audit_instruction.md
   - src/pages/Review/**
   - src/pages/ManageSystem/**
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 115cc3eaf0d09657c7d6a91acd7b5128f5e639eb
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
 lastReviewedNote: 'Reviewed for Issues #745 and #780: retain Root-only/current-tab queue semantics and record the seven-type read-only dataset drawers available from readable Root and Reference rows.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
+lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
 lastReviewedNote: 'Reviewed for Issues #778 and #780: dual-scope Docpact review and the grouped-review candidate continue through the unchanged checked-push and retry-receipt policy.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
+lastReviewedCommit: b184f74e4989088f83d371e0e0d9eb2bcd857cb4
 lastReviewedNote: 'Reviewed for Issues #778 and #780: dual-scope Docpact review and the grouped-review candidate continue through the unchanged checked-push and retry-receipt policy.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
+lastReviewedCommit: 83315614691354d2a3fc82beb33b6939e6f61c35
 lastReviewedNote: 'Reviewed for Issues #778 and #780: dual-scope Docpact review and the grouped-review candidate continue through the unchanged checked-push and retry-receipt policy.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 83315614691354d2a3fc82beb33b6939e6f61c35
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
 lastReviewedNote: 'Reviewed for Issues #778 and #780: dual-scope Docpact review and the grouped-review candidate continue through the unchanged checked-push and retry-receipt policy.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b184f74e4989088f83d371e0e0d9eb2bcd857cb4
+lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
 lastReviewedNote: 'Reviewed for Issues #778 and #780: dual-scope Docpact review and the grouped-review candidate continue through the unchanged checked-push and retry-receipt policy.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
+lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release automation preserves existing runtime boundaries while grouped-review queue, selection, and dataset views remain database-authority consumers.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
+lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release automation preserves existing runtime boundaries while grouped-review queue, selection, and dataset views remain database-authority consumers.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - playwright.config.ts
   - config/docs-capture/**
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release automation preserves existing runtime boundaries while grouped-review queue, selection, and dataset views remain database-authority consumers.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
+lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged proof matrix covers independent release paths plus the seven-type Root/Reference queue, selection, and dataset-view behavior.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
+lastReviewedCommit: 83315614691354d2a3fc82beb33b6939e6f61c35
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged proof matrix covers independent release paths plus the seven-type Root/Reference queue, selection, and dataset-view behavior.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 83315614691354d2a3fc82beb33b6939e6f61c35
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged proof matrix covers independent release paths plus the seven-type Root/Reference queue, selection, and dataset-view behavior.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b184f74e4989088f83d371e0e0d9eb2bcd857cb4
+lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged proof matrix covers independent release paths plus the seven-type Root/Reference queue, selection, and dataset-view behavior.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
+lastReviewedCommit: b184f74e4989088f83d371e0e0d9eb2bcd857cb4
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged proof matrix covers independent release paths plus the seven-type Root/Reference queue, selection, and dataset-view behavior.'
 related:
   - ../AGENTS.md

--- a/docs/agents/team_management.md
+++ b/docs/agents/team_management.md
@@ -19,8 +19,8 @@ checkPaths:
   - src/pages/Teams/**
   - src/pages/Review/**
   - src/pages/ManageSystem/**
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 115cc3eaf0d09657c7d6a91acd7b5128f5e639eb
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
 lastReviewedNote: 'Reviewed for Issues #745 and #780: grouped-review view drawers do not change team roles or review authority; membership still constrains only already-authorized dataset visibility.'
 ---
 

--- a/docs/agents/team_management.md
+++ b/docs/agents/team_management.md
@@ -20,7 +20,7 @@ checkPaths:
   - src/pages/Review/**
   - src/pages/ManageSystem/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
+lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
 lastReviewedNote: 'Reviewed for Issues #745 and #780: grouped-review view drawers do not change team roles or review authority; membership still constrains only already-authorized dataset visibility.'
 ---
 

--- a/docs/agents/team_management.md
+++ b/docs/agents/team_management.md
@@ -19,8 +19,8 @@ checkPaths:
   - src/pages/Teams/**
   - src/pages/Review/**
   - src/pages/ManageSystem/**
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
 lastReviewedNote: 'Reviewed for Issues #745 and #780: grouped-review view drawers do not change team roles or review authority; membership still constrains only already-authorized dataset visibility.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
+lastReviewedCommit: b184f74e4989088f83d371e0e0d9eb2bcd857cb4
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release-path and grouped-review coverage extend bounded proof without changing the repository testing strategy.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b184f74e4989088f83d371e0e0d9eb2bcd857cb4
+lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release-path and grouped-review coverage extend bounded proof without changing the repository testing strategy.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
+lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release-path and grouped-review coverage extend bounded proof without changing the repository testing strategy.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - package.json
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 83315614691354d2a3fc82beb33b6939e6f61c35
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release-path and grouped-review coverage extend bounded proof without changing the repository testing strategy.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
+lastReviewedCommit: 83315614691354d2a3fc82beb33b6939e6f61c35
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release-path and grouped-review coverage extend bounded proof without changing the repository testing strategy.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b184f74e4989088f83d371e0e0d9eb2bcd857cb4
+lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
 lastReviewedNote: 'Reviewed for Issues #778 and #780: hermetic release-preflight and grouped-review regression proof leave no new repository-wide test backlog.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 83315614691354d2a3fc82beb33b6939e6f61c35
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
 lastReviewedNote: 'Reviewed for Issues #778 and #780: hermetic release-preflight and grouped-review regression proof leave no new repository-wide test backlog.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
+lastReviewedCommit: 83315614691354d2a3fc82beb33b6939e6f61c35
 lastReviewedNote: 'Reviewed for Issues #778 and #780: hermetic release-preflight and grouped-review regression proof leave no new repository-wide test backlog.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
+lastReviewedCommit: b184f74e4989088f83d371e0e0d9eb2bcd857cb4
 lastReviewedNote: 'Reviewed for Issues #778 and #780: hermetic release-preflight and grouped-review regression proof leave no new repository-wide test backlog.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
+lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
 lastReviewedNote: 'Reviewed for Issues #778 and #780: hermetic release-preflight and grouped-review regression proof leave no new repository-wide test backlog.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
+lastReviewedCommit: 83315614691354d2a3fc82beb33b6939e6f61c35
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release proof and grouped-review tests continue to use existing bounded Docpact and service/UI testing patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b184f74e4989088f83d371e0e0d9eb2bcd857cb4
+lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release proof and grouped-review tests continue to use existing bounded Docpact and service/UI testing patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
+lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release proof and grouped-review tests continue to use existing bounded Docpact and service/UI testing patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -30,8 +30,8 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 83315614691354d2a3fc82beb33b6939e6f61c35
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release proof and grouped-review tests continue to use existing bounded Docpact and service/UI testing patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
+lastReviewedCommit: b184f74e4989088f83d371e0e0d9eb2bcd857cb4
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release proof and grouped-review tests continue to use existing bounded Docpact and service/UI testing patterns.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
+lastReviewedCommit: b184f74e4989088f83d371e0e0d9eb2bcd857cb4
 lastReviewedNote: 'Reviewed for Issues #778 and #780: automatic dual-scope release review and focused grouped-review proof require no new recovery exception.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -27,8 +27,8 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 83315614691354d2a3fc82beb33b6939e6f61c35
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: b1c1cfedc6bfaeeaaddaee0564e0c0c04d5212e3
 lastReviewedNote: 'Reviewed for Issues #778 and #780: automatic dual-scope release review and focused grouped-review proof require no new recovery exception.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
+lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
 lastReviewedNote: 'Reviewed for Issues #778 and #780: automatic dual-scope release review and focused grouped-review proof require no new recovery exception.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 59e505a28d2c599a3c2c0d06dc71551292ee8d3a
+lastReviewedCommit: 83315614691354d2a3fc82beb33b6939e6f61c35
 lastReviewedNote: 'Reviewed for Issues #778 and #780: automatic dual-scope release review and focused grouped-review proof require no new recovery exception.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: b184f74e4989088f83d371e0e0d9eb2bcd857cb4
+lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
 lastReviewedNote: 'Reviewed for Issues #778 and #780: automatic dual-scope release review and focused grouped-review proof require no new recovery exception.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
-    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858"
+    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d",
+    "auditedInputDigest": "af06c25c24de9a489f0868882b6141fbc6d25f9b2145de908298eac4238a448a"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "49092b48ae9b16af90a49415fec0c1bb70a634b9bab628c3f91ef7fb2968a315",
+    "dossierDigest": "b5f0e5f4dfd3e4cc985061cc575d6fe20c1581fb1a8a2b4af565fa86d21ce643",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "069c773023e8841822696fcbe0dc127610503fbb0bce76d8495d883d1164b0e4"
+  "contextDigest": "19067a7e9b62981339ad806200e687d210a65caa0730362ce0c5b7e9bdeb3496"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e",
-    "auditedInputDigest": "45fed751734a5f45d6e9a394d8cc34c4f1b362ae87a704bf360cfed276839edb"
+    "sourceManifestDigest": "5b14926f3c266cbdeda840d39e3f28824c7c0b7a231b68ba7eda3cab4a0c0dc6",
+    "auditedInputDigest": "34776090965e8adc231707122e565992b8331b9c54b5a97242cccb9c91974fcb"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "7c103771586e43fb97ffb8b136c0c6ffa460add6bc35797fa1067aedc0755f55",
+    "dossierDigest": "16c5e07ab81d824109fe87df9822d8b13487f8b28e50d7862e8deb15796c2391",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "ebc9fe88ac047120e309e53f54dd948a3f6e23116b218ed3cc83a0cc767a45eb"
+  "contextDigest": "75d8b5eddb44bd449e97eb55ee6c83f7ad2029ec8a2f4b898a8d7786299202ce"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d",
-    "auditedInputDigest": "af06c25c24de9a489f0868882b6141fbc6d25f9b2145de908298eac4238a448a"
+    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e",
+    "auditedInputDigest": "45fed751734a5f45d6e9a394d8cc34c4f1b362ae87a704bf360cfed276839edb"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "b5f0e5f4dfd3e4cc985061cc575d6fe20c1581fb1a8a2b4af565fa86d21ce643",
+    "dossierDigest": "7c103771586e43fb97ffb8b136c0c6ffa460add6bc35797fa1067aedc0755f55",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "19067a7e9b62981339ad806200e687d210a65caa0730362ce0c5b7e9bdeb3496"
+  "contextDigest": "ebc9fe88ac047120e309e53f54dd948a3f6e23116b218ed3cc83a0cc767a45eb"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d"
+    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "19067a7e9b62981339ad806200e687d210a65caa0730362ce0c5b7e9bdeb3496",
-    "qualityDigest": "f7ea668f957f8fb89674ce4e9eace078ea027dd3e1604159044803f8716a2545",
+    "contextDigest": "ebc9fe88ac047120e309e53f54dd948a3f6e23116b218ed3cc83a0cc767a45eb",
+    "qualityDigest": "f1bbddd375be66824be8e915f3dc119b75a17199719ff54763f71d6435bce147",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "8ab3fe086dd15c48408aaedca3ffb5f02c3ccb4cd260bd7158bd8c90b9374414"
+  "activationDigest": "67fd6c49660b03946eaa0f5ecc894a44f72879aeee9d39cca9307c9b1ce1a7a8"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9"
+    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "069c773023e8841822696fcbe0dc127610503fbb0bce76d8495d883d1164b0e4",
-    "qualityDigest": "52fc2b4d6ed512e70cdd02b5447e82bba2076840ee3a55fbe1b30c2e839f66ba",
+    "contextDigest": "19067a7e9b62981339ad806200e687d210a65caa0730362ce0c5b7e9bdeb3496",
+    "qualityDigest": "f7ea668f957f8fb89674ce4e9eace078ea027dd3e1604159044803f8716a2545",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "7d3072d1e777d5cf48c557b17441b34d812ae271d880a1bb3a24bba570bd530b"
+  "activationDigest": "8ab3fe086dd15c48408aaedca3ffb5f02c3ccb4cd260bd7158bd8c90b9374414"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e"
+    "sourceManifestDigest": "5b14926f3c266cbdeda840d39e3f28824c7c0b7a231b68ba7eda3cab4a0c0dc6"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "ebc9fe88ac047120e309e53f54dd948a3f6e23116b218ed3cc83a0cc767a45eb",
-    "qualityDigest": "f1bbddd375be66824be8e915f3dc119b75a17199719ff54763f71d6435bce147",
+    "contextDigest": "75d8b5eddb44bd449e97eb55ee6c83f7ad2029ec8a2f4b898a8d7786299202ce",
+    "qualityDigest": "abb8b85e1da1d57f80f9e84d4e1c199ab44080e07fb9724b2b0cf107a97b7ce0",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "67fd6c49660b03946eaa0f5ecc894a44f72879aeee9d39cca9307c9b1ce1a7a8"
+  "activationDigest": "0df89958da0815102f637d64e9e80b7831040f27dc2d3861425b9c2e73acbec7"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "45fed751734a5f45d6e9a394d8cc34c4f1b362ae87a704bf360cfed276839edb",
+    "auditedInputDigest": "34776090965e8adc231707122e565992b8331b9c54b5a97242cccb9c91974fcb",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -16316,8 +16316,8 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-          "line": 137,
-          "column": 20,
+          "line": 143,
+          "column": 22,
           "symbol": "SimpleReviewActions",
           "defaultMessage": "Reject Review",
           "defaultMessageExpression": null
@@ -16337,8 +16337,8 @@
             },
             {
               "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-              "line": 137,
-              "column": 20,
+              "line": 143,
+              "column": 22,
               "kind": "formatMessage"
             }
           ]
@@ -16414,8 +16414,8 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-          "line": 148,
-          "column": 24,
+          "line": 154,
+          "column": 26,
           "symbol": "SimpleReviewActions",
           "defaultMessage": "Reject Reason",
           "defaultMessageExpression": null
@@ -16435,8 +16435,8 @@
             },
             {
               "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-              "line": 148,
-              "column": 24,
+              "line": 154,
+              "column": 26,
               "kind": "formatMessage"
             }
           ]
@@ -213619,8 +213619,8 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-          "line": 89,
-          "column": 16,
+          "line": 92,
+          "column": 18,
           "symbol": "SimpleReviewActions",
           "defaultMessage": "Approve",
           "defaultMessageExpression": null
@@ -213634,8 +213634,8 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-              "line": 89,
-              "column": 16,
+              "line": 92,
+              "column": 18,
               "kind": "formatMessage"
             }
           ]
@@ -213702,8 +213702,8 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-          "line": 101,
-          "column": 22,
+          "line": 104,
+          "column": 24,
           "symbol": "SimpleReviewActions",
           "defaultMessage": "Confirm approval?",
           "defaultMessageExpression": null
@@ -213717,8 +213717,8 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-              "line": 101,
-              "column": 22,
+              "line": 104,
+              "column": 24,
               "kind": "formatMessage"
             }
           ]
@@ -213785,7 +213785,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-          "line": 41,
+          "line": 42,
           "column": 9,
           "symbol": "approve",
           "defaultMessage": "Review approved.",
@@ -213800,7 +213800,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-              "line": 41,
+              "line": 42,
               "column": 9,
               "kind": "formatMessage"
             }
@@ -213868,7 +213868,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-          "line": 49,
+          "line": 50,
           "column": 9,
           "symbol": "approve",
           "defaultMessage": "Unable to submit the review decision.",
@@ -213877,7 +213877,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-          "line": 76,
+          "line": 77,
           "column": 9,
           "symbol": "rejectAsReviewer",
           "defaultMessage": "Unable to submit the review decision.",
@@ -213892,13 +213892,13 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-              "line": 49,
+              "line": 50,
               "column": 9,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-              "line": 76,
+              "line": 77,
               "column": 9,
               "kind": "formatMessage"
             }
@@ -213966,8 +213966,8 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-          "line": 122,
-          "column": 20,
+          "line": 128,
+          "column": 22,
           "symbol": "SimpleReviewActions",
           "defaultMessage": "Reject",
           "defaultMessageExpression": null
@@ -213981,8 +213981,8 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-              "line": 122,
-              "column": 20,
+              "line": 128,
+              "column": 22,
               "kind": "formatMessage"
             }
           ]
@@ -214049,7 +214049,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-          "line": 66,
+          "line": 67,
           "column": 9,
           "symbol": "rejectAsReviewer",
           "defaultMessage": "Review rejection submitted.",
@@ -214064,7 +214064,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-              "line": 66,
+              "line": 67,
               "column": 9,
               "kind": "formatMessage"
             }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858",
+    "auditedInputDigest": "af06c25c24de9a489f0868882b6141fbc6d25f9b2145de908298eac4238a448a",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -16316,7 +16316,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-          "line": 138,
+          "line": 137,
           "column": 20,
           "symbol": "SimpleReviewActions",
           "defaultMessage": "Reject Review",
@@ -16337,7 +16337,7 @@
             },
             {
               "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-              "line": 138,
+              "line": 137,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -16414,7 +16414,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-          "line": 149,
+          "line": 148,
           "column": 24,
           "symbol": "SimpleReviewActions",
           "defaultMessage": "Reject Reason",
@@ -16435,7 +16435,7 @@
             },
             {
               "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-              "line": 149,
+              "line": 148,
               "column": 24,
               "kind": "formatMessage"
             }
@@ -213702,7 +213702,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-          "line": 102,
+          "line": 101,
           "column": 22,
           "symbol": "SimpleReviewActions",
           "defaultMessage": "Confirm approval?",
@@ -213717,7 +213717,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-              "line": 102,
+              "line": 101,
               "column": 22,
               "kind": "formatMessage"
             }
@@ -213966,7 +213966,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-          "line": 123,
+          "line": 122,
           "column": 20,
           "symbol": "SimpleReviewActions",
           "defaultMessage": "Reject",
@@ -213981,7 +213981,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/SimpleReviewActions.tsx",
-              "line": 123,
+              "line": 122,
               "column": 20,
               "kind": "formatMessage"
             }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "af06c25c24de9a489f0868882b6141fbc6d25f9b2145de908298eac4238a448a",
+    "auditedInputDigest": "45fed751734a5f45d6e9a394d8cc34c4f1b362ae87a704bf360cfed276839edb",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
-    "contextDigest": "069c773023e8841822696fcbe0dc127610503fbb0bce76d8495d883d1164b0e4"
+    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d",
+    "contextDigest": "19067a7e9b62981339ad806200e687d210a65caa0730362ce0c5b7e9bdeb3496"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "8c18fcdf4966a771a5aac60fe00c952b743bfd34bd27c0bad368a77046376707",
-    "validationDigest": "6629a38843a1654a0efc533a3cfb4a8465166dcbc60d194eaa7229426e5717df",
+    "digest": "e5fad5843e31e8b10ac0d9d1a6f6a23551c635fff4f0435173f338836bf60969",
+    "validationDigest": "6a328b6cb2ef78f179d50ce4e999911da5fd4fbbf36cece9eb952caaa5ce3442",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "52fc2b4d6ed512e70cdd02b5447e82bba2076840ee3a55fbe1b30c2e839f66ba"
+  "qualityDigest": "f7ea668f957f8fb89674ce4e9eace078ea027dd3e1604159044803f8716a2545"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e",
-    "contextDigest": "ebc9fe88ac047120e309e53f54dd948a3f6e23116b218ed3cc83a0cc767a45eb"
+    "sourceManifestDigest": "5b14926f3c266cbdeda840d39e3f28824c7c0b7a231b68ba7eda3cab4a0c0dc6",
+    "contextDigest": "75d8b5eddb44bd449e97eb55ee6c83f7ad2029ec8a2f4b898a8d7786299202ce"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "fa33d31a49425b1b1205c3f843b0e1b2fa61da3dcb18133ccb90717e1c868f00",
-    "validationDigest": "0aa6b8f51281ea01d74cc2e17c85e44d9e6c9596c266e2d6f4e24fd1cffcb54d",
+    "digest": "28a25146969094501ae03845918334f2e30d72804d695de15685c6dc0758a6a6",
+    "validationDigest": "abef6bbe30c78a3bb576e3a8af30dccac1af6234a2c29a577438f70e497fa4d0",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "f1bbddd375be66824be8e915f3dc119b75a17199719ff54763f71d6435bce147"
+  "qualityDigest": "abb8b85e1da1d57f80f9e84d4e1c199ab44080e07fb9724b2b0cf107a97b7ce0"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d",
-    "contextDigest": "19067a7e9b62981339ad806200e687d210a65caa0730362ce0c5b7e9bdeb3496"
+    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e",
+    "contextDigest": "ebc9fe88ac047120e309e53f54dd948a3f6e23116b218ed3cc83a0cc767a45eb"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "e5fad5843e31e8b10ac0d9d1a6f6a23551c635fff4f0435173f338836bf60969",
-    "validationDigest": "6a328b6cb2ef78f179d50ce4e999911da5fd4fbbf36cece9eb952caaa5ce3442",
+    "digest": "fa33d31a49425b1b1205c3f843b0e1b2fa61da3dcb18133ccb90717e1c868f00",
+    "validationDigest": "0aa6b8f51281ea01d74cc2e17c85e44d9e6c9596c266e2d6f4e24fd1cffcb54d",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "f7ea668f957f8fb89674ce4e9eace078ea027dd3e1604159044803f8716a2545"
+  "qualityDigest": "f1bbddd375be66824be8e915f3dc119b75a17199719ff54763f71d6435bce147"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "45fed751734a5f45d6e9a394d8cc34c4f1b362ae87a704bf360cfed276839edb",
+    "auditedInputDigest": "34776090965e8adc231707122e565992b8331b9c54b5a97242cccb9c91974fcb",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
-    "dossierDigest": "7c103771586e43fb97ffb8b136c0c6ffa460add6bc35797fa1067aedc0755f55",
+    "dossierDigest": "16c5e07ab81d824109fe87df9822d8b13487f8b28e50d7862e8deb15796c2391",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "7c103771586e43fb97ffb8b136c0c6ffa460add6bc35797fa1067aedc0755f55",
+        "dossierDigest": "16c5e07ab81d824109fe87df9822d8b13487f8b28e50d7862e8deb15796c2391",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "0aa6b8f51281ea01d74cc2e17c85e44d9e6c9596c266e2d6f4e24fd1cffcb54d"
+  "validationDigest": "abef6bbe30c78a3bb576e3a8af30dccac1af6234a2c29a577438f70e497fa4d0"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858",
+    "auditedInputDigest": "af06c25c24de9a489f0868882b6141fbc6d25f9b2145de908298eac4238a448a",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
-    "dossierDigest": "49092b48ae9b16af90a49415fec0c1bb70a634b9bab628c3f91ef7fb2968a315",
+    "dossierDigest": "b5f0e5f4dfd3e4cc985061cc575d6fe20c1581fb1a8a2b4af565fa86d21ce643",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "49092b48ae9b16af90a49415fec0c1bb70a634b9bab628c3f91ef7fb2968a315",
+        "dossierDigest": "b5f0e5f4dfd3e4cc985061cc575d6fe20c1581fb1a8a2b4af565fa86d21ce643",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "6629a38843a1654a0efc533a3cfb4a8465166dcbc60d194eaa7229426e5717df"
+  "validationDigest": "6a328b6cb2ef78f179d50ce4e999911da5fd4fbbf36cece9eb952caaa5ce3442"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "af06c25c24de9a489f0868882b6141fbc6d25f9b2145de908298eac4238a448a",
+    "auditedInputDigest": "45fed751734a5f45d6e9a394d8cc34c4f1b362ae87a704bf360cfed276839edb",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
-    "dossierDigest": "b5f0e5f4dfd3e4cc985061cc575d6fe20c1581fb1a8a2b4af565fa86d21ce643",
+    "dossierDigest": "7c103771586e43fb97ffb8b136c0c6ffa460add6bc35797fa1067aedc0755f55",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "b5f0e5f4dfd3e4cc985061cc575d6fe20c1581fb1a8a2b4af565fa86d21ce643",
+        "dossierDigest": "7c103771586e43fb97ffb8b136c0c6ffa460add6bc35797fa1067aedc0755f55",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "6a328b6cb2ef78f179d50ce4e999911da5fd4fbbf36cece9eb952caaa5ce3442"
+  "validationDigest": "0aa6b8f51281ea01d74cc2e17c85e44d9e6c9596c266e2d6f4e24fd1cffcb54d"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e",
-    "auditedInputDigest": "45fed751734a5f45d6e9a394d8cc34c4f1b362ae87a704bf360cfed276839edb"
+    "sourceManifestDigest": "5b14926f3c266cbdeda840d39e3f28824c7c0b7a231b68ba7eda3cab4a0c0dc6",
+    "auditedInputDigest": "34776090965e8adc231707122e565992b8331b9c54b5a97242cccb9c91974fcb"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "0cf50cb1e81cea796470e98dd6d4cf4ce40bea7089f9d654090b521ad72af07c",
+    "dossierDigest": "d1617c83e3bfebcedf75a0b69d50b36855626658c94f22ef7a9600b1d99e18c8",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "fbb33f01926f2ef924cb0aa77d527e6df001c243ed31f8e3f15d007e7280d997"
+  "contextDigest": "f8610e12fbfbe9b700961c7ddc010880d81ecc24661066f7097dd10871a91375"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
-    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858"
+    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d",
+    "auditedInputDigest": "af06c25c24de9a489f0868882b6141fbc6d25f9b2145de908298eac4238a448a"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "637555d5e12222d2e311dde8e39b081ebbab2fe8dd7206344d7890d98ef49dbb",
+    "dossierDigest": "cf594926a738fe2bdb07d882aa72d3b313160943fe9173000ca66c10f691091f",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "4d34fd93f20a467e99721a8dde665890a6a304acb2f14bc3f86f7acab69257a8"
+  "contextDigest": "6149e021260c34c21304f729d6ac84491abb1e4a751340628c33f07dc2dc4c8a"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d",
-    "auditedInputDigest": "af06c25c24de9a489f0868882b6141fbc6d25f9b2145de908298eac4238a448a"
+    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e",
+    "auditedInputDigest": "45fed751734a5f45d6e9a394d8cc34c4f1b362ae87a704bf360cfed276839edb"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "cf594926a738fe2bdb07d882aa72d3b313160943fe9173000ca66c10f691091f",
+    "dossierDigest": "0cf50cb1e81cea796470e98dd6d4cf4ce40bea7089f9d654090b521ad72af07c",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "6149e021260c34c21304f729d6ac84491abb1e4a751340628c33f07dc2dc4c8a"
+  "contextDigest": "fbb33f01926f2ef924cb0aa77d527e6df001c243ed31f8e3f15d007e7280d997"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9"
+    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4d34fd93f20a467e99721a8dde665890a6a304acb2f14bc3f86f7acab69257a8",
-    "qualityDigest": "e9b5dc488b81d5a9c476ab68a4f36c20bb72ddd7f048e109ec398046450385e7",
+    "contextDigest": "6149e021260c34c21304f729d6ac84491abb1e4a751340628c33f07dc2dc4c8a",
+    "qualityDigest": "138d226f30edf243e7b5c777c33b5fcaed0c79a742ff5ec81975abf5c6ea8255",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "0a74a0042d321a1823c2cab2908e6bfc2840a4730399df20224ae4010dfa2bcc"
+  "activationDigest": "bf8298a3806d6f043b86d2aea4f2794d187a61987836636aa2a5314fcec07ceb"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e"
+    "sourceManifestDigest": "5b14926f3c266cbdeda840d39e3f28824c7c0b7a231b68ba7eda3cab4a0c0dc6"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "fbb33f01926f2ef924cb0aa77d527e6df001c243ed31f8e3f15d007e7280d997",
-    "qualityDigest": "9ad5bc88f50386bb1d5ddc1bdfd89da1aa9b71a2ebe13c3feaba88b89807e5a7",
+    "contextDigest": "f8610e12fbfbe9b700961c7ddc010880d81ecc24661066f7097dd10871a91375",
+    "qualityDigest": "f47ad7b695b77d9dedc10d49fc08a151c6ab15c67eb4113e8a564c64319b51a6",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "51bbd2cbd32906487bb0eb9b4b0e147ddbc16a22184199471578492209b96d39"
+  "activationDigest": "ba689e6573d6d73c31a48ae38f40b4343fc6b0131b9de21e19ce6db7b8cc4254"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d"
+    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "6149e021260c34c21304f729d6ac84491abb1e4a751340628c33f07dc2dc4c8a",
-    "qualityDigest": "138d226f30edf243e7b5c777c33b5fcaed0c79a742ff5ec81975abf5c6ea8255",
+    "contextDigest": "fbb33f01926f2ef924cb0aa77d527e6df001c243ed31f8e3f15d007e7280d997",
+    "qualityDigest": "9ad5bc88f50386bb1d5ddc1bdfd89da1aa9b71a2ebe13c3feaba88b89807e5a7",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "bf8298a3806d6f043b86d2aea4f2794d187a61987836636aa2a5314fcec07ceb"
+  "activationDigest": "51bbd2cbd32906487bb0eb9b4b0e147ddbc16a22184199471578492209b96d39"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d",
-    "contextDigest": "6149e021260c34c21304f729d6ac84491abb1e4a751340628c33f07dc2dc4c8a"
+    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e",
+    "contextDigest": "fbb33f01926f2ef924cb0aa77d527e6df001c243ed31f8e3f15d007e7280d997"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "94d20739008286e6d1778f861299890e2727033166947ea0bcbad2ec72c0cb4a",
-    "validationDigest": "d1fd59288ba24e367763c14d9cc41c18e811bdc6a9f66e41e530b5b7af54a828",
+    "digest": "803a3f139f3ee3ee8e4184dfe6ea4a24b736d4b6c15c0b2a242e84a6c5383b51",
+    "validationDigest": "751929ba1230ade55211abcc243db257df9203cd367f99af76ba7f0e17b0e14c",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "138d226f30edf243e7b5c777c33b5fcaed0c79a742ff5ec81975abf5c6ea8255"
+  "qualityDigest": "9ad5bc88f50386bb1d5ddc1bdfd89da1aa9b71a2ebe13c3feaba88b89807e5a7"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e",
-    "contextDigest": "fbb33f01926f2ef924cb0aa77d527e6df001c243ed31f8e3f15d007e7280d997"
+    "sourceManifestDigest": "5b14926f3c266cbdeda840d39e3f28824c7c0b7a231b68ba7eda3cab4a0c0dc6",
+    "contextDigest": "f8610e12fbfbe9b700961c7ddc010880d81ecc24661066f7097dd10871a91375"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "803a3f139f3ee3ee8e4184dfe6ea4a24b736d4b6c15c0b2a242e84a6c5383b51",
-    "validationDigest": "751929ba1230ade55211abcc243db257df9203cd367f99af76ba7f0e17b0e14c",
+    "digest": "111722016f5d515692598124e570c307b53c723efee0b7c43ed45e8e77b12274",
+    "validationDigest": "1b8eb793fd2c52ca7f19b3e405ee22648e06fa2f215f344fa0aa5e64ed9c0b9a",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "9ad5bc88f50386bb1d5ddc1bdfd89da1aa9b71a2ebe13c3feaba88b89807e5a7"
+  "qualityDigest": "f47ad7b695b77d9dedc10d49fc08a151c6ab15c67eb4113e8a564c64319b51a6"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
-    "contextDigest": "4d34fd93f20a467e99721a8dde665890a6a304acb2f14bc3f86f7acab69257a8"
+    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d",
+    "contextDigest": "6149e021260c34c21304f729d6ac84491abb1e4a751340628c33f07dc2dc4c8a"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "096800de4db14e86c059c872889e330963389032b9d644895bdfe12cc5bf5664",
-    "validationDigest": "2de8d9f884455beb28590b14ea5ed52947d1bf0756b964a2737e301fe4ffbdac",
+    "digest": "94d20739008286e6d1778f861299890e2727033166947ea0bcbad2ec72c0cb4a",
+    "validationDigest": "d1fd59288ba24e367763c14d9cc41c18e811bdc6a9f66e41e530b5b7af54a828",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "e9b5dc488b81d5a9c476ab68a4f36c20bb72ddd7f048e109ec398046450385e7"
+  "qualityDigest": "138d226f30edf243e7b5c777c33b5fcaed0c79a742ff5ec81975abf5c6ea8255"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "af06c25c24de9a489f0868882b6141fbc6d25f9b2145de908298eac4238a448a",
+    "auditedInputDigest": "45fed751734a5f45d6e9a394d8cc34c4f1b362ae87a704bf360cfed276839edb",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
-    "dossierDigest": "cf594926a738fe2bdb07d882aa72d3b313160943fe9173000ca66c10f691091f",
+    "dossierDigest": "0cf50cb1e81cea796470e98dd6d4cf4ce40bea7089f9d654090b521ad72af07c",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "cf594926a738fe2bdb07d882aa72d3b313160943fe9173000ca66c10f691091f",
+        "dossierDigest": "0cf50cb1e81cea796470e98dd6d4cf4ce40bea7089f9d654090b521ad72af07c",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "d1fd59288ba24e367763c14d9cc41c18e811bdc6a9f66e41e530b5b7af54a828"
+  "validationDigest": "751929ba1230ade55211abcc243db257df9203cd367f99af76ba7f0e17b0e14c"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858",
+    "auditedInputDigest": "af06c25c24de9a489f0868882b6141fbc6d25f9b2145de908298eac4238a448a",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
-    "dossierDigest": "637555d5e12222d2e311dde8e39b081ebbab2fe8dd7206344d7890d98ef49dbb",
+    "dossierDigest": "cf594926a738fe2bdb07d882aa72d3b313160943fe9173000ca66c10f691091f",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "637555d5e12222d2e311dde8e39b081ebbab2fe8dd7206344d7890d98ef49dbb",
+        "dossierDigest": "cf594926a738fe2bdb07d882aa72d3b313160943fe9173000ca66c10f691091f",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "2de8d9f884455beb28590b14ea5ed52947d1bf0756b964a2737e301fe4ffbdac"
+  "validationDigest": "d1fd59288ba24e367763c14d9cc41c18e811bdc6a9f66e41e530b5b7af54a828"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "45fed751734a5f45d6e9a394d8cc34c4f1b362ae87a704bf360cfed276839edb",
+    "auditedInputDigest": "34776090965e8adc231707122e565992b8331b9c54b5a97242cccb9c91974fcb",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
-    "dossierDigest": "0cf50cb1e81cea796470e98dd6d4cf4ce40bea7089f9d654090b521ad72af07c",
+    "dossierDigest": "d1617c83e3bfebcedf75a0b69d50b36855626658c94f22ef7a9600b1d99e18c8",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "0cf50cb1e81cea796470e98dd6d4cf4ce40bea7089f9d654090b521ad72af07c",
+        "dossierDigest": "d1617c83e3bfebcedf75a0b69d50b36855626658c94f22ef7a9600b1d99e18c8",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "751929ba1230ade55211abcc243db257df9203cd367f99af76ba7f0e17b0e14c"
+  "validationDigest": "1b8eb793fd2c52ca7f19b3e405ee22648e06fa2f215f344fa0aa5e64ed9c0b9a"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
-    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858"
+    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d",
+    "auditedInputDigest": "af06c25c24de9a489f0868882b6141fbc6d25f9b2145de908298eac4238a448a"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "087c774b56add49d807f6ca751bd0e3a51b709751dcf52b64052d9be48a59ae4",
+    "dossierDigest": "b90dca56241520dd034dad02c8f5edd33a71ea7cffed6d58ae9c842a883d7710",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "6c33d01e8a3a80f6af1a33209a7578c297f71d92ee1e334e545fa6b461aaf983"
+  "contextDigest": "dafa84b7a16ccf33598f2372c08f7a27f66c565e0cfdd63d5c77a2dd9fa06b1b"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d",
-    "auditedInputDigest": "af06c25c24de9a489f0868882b6141fbc6d25f9b2145de908298eac4238a448a"
+    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e",
+    "auditedInputDigest": "45fed751734a5f45d6e9a394d8cc34c4f1b362ae87a704bf360cfed276839edb"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "b90dca56241520dd034dad02c8f5edd33a71ea7cffed6d58ae9c842a883d7710",
+    "dossierDigest": "150eab488acca7617d73ea35908a70c64bb0741e0b5126ee1cc019723716ba1f",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "dafa84b7a16ccf33598f2372c08f7a27f66c565e0cfdd63d5c77a2dd9fa06b1b"
+  "contextDigest": "3aa420620b43ca3e55567c90f3512e36854ec25f0bbbb312709039dfdf2cbbd6"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e",
-    "auditedInputDigest": "45fed751734a5f45d6e9a394d8cc34c4f1b362ae87a704bf360cfed276839edb"
+    "sourceManifestDigest": "5b14926f3c266cbdeda840d39e3f28824c7c0b7a231b68ba7eda3cab4a0c0dc6",
+    "auditedInputDigest": "34776090965e8adc231707122e565992b8331b9c54b5a97242cccb9c91974fcb"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "150eab488acca7617d73ea35908a70c64bb0741e0b5126ee1cc019723716ba1f",
+    "dossierDigest": "0816f98dd2ee6f38e16db690cdf8145126ed5a6f93a5f97a83851288f3c0a4b1",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "3aa420620b43ca3e55567c90f3512e36854ec25f0bbbb312709039dfdf2cbbd6"
+  "contextDigest": "38ecd22993ea79127f37fa7bc1dd9232fab6a5ab8865c4950055feca4b2b1654"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e"
+    "sourceManifestDigest": "5b14926f3c266cbdeda840d39e3f28824c7c0b7a231b68ba7eda3cab4a0c0dc6"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "3aa420620b43ca3e55567c90f3512e36854ec25f0bbbb312709039dfdf2cbbd6",
-    "qualityDigest": "f96c6298bd90f60fd25fd675b42bdcce5b6fde3f1cf8f45d274ee46509741b8c",
+    "contextDigest": "38ecd22993ea79127f37fa7bc1dd9232fab6a5ab8865c4950055feca4b2b1654",
+    "qualityDigest": "e152e4d2a9d5472b1ff512fece874fcef062581ee4f8299c1d2b2e4c9739294c",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "c7282b99a3b5f794d8a1b38868349ef31cbeb6ec8dc0a25231781e5cf2b42f77"
+  "activationDigest": "97e834c6d82cae8b6152e741164748cbf7f2ca7d02da53818b05f57f4026aa27"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9"
+    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "6c33d01e8a3a80f6af1a33209a7578c297f71d92ee1e334e545fa6b461aaf983",
-    "qualityDigest": "ea979a83edb576da0dc8b19ffbf4034466a5cdde4a592ef587a6569b899cd5e2",
+    "contextDigest": "dafa84b7a16ccf33598f2372c08f7a27f66c565e0cfdd63d5c77a2dd9fa06b1b",
+    "qualityDigest": "f855991c0d9ee21d213336291edebe35923b621d7f04bdf8720754092cd230ca",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "2419aed98b5010bc97f2cce28bbcdd51508161febb64d4d94fba17980e788539"
+  "activationDigest": "53981aa30c27c17e972800b2cafc3daf7a1e55b9ba54d4c6b825d6c8c8786f00"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d"
+    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "dafa84b7a16ccf33598f2372c08f7a27f66c565e0cfdd63d5c77a2dd9fa06b1b",
-    "qualityDigest": "f855991c0d9ee21d213336291edebe35923b621d7f04bdf8720754092cd230ca",
+    "contextDigest": "3aa420620b43ca3e55567c90f3512e36854ec25f0bbbb312709039dfdf2cbbd6",
+    "qualityDigest": "f96c6298bd90f60fd25fd675b42bdcce5b6fde3f1cf8f45d274ee46509741b8c",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "53981aa30c27c17e972800b2cafc3daf7a1e55b9ba54d4c6b825d6c8c8786f00"
+  "activationDigest": "c7282b99a3b5f794d8a1b38868349ef31cbeb6ec8dc0a25231781e5cf2b42f77"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e",
-    "contextDigest": "3aa420620b43ca3e55567c90f3512e36854ec25f0bbbb312709039dfdf2cbbd6"
+    "sourceManifestDigest": "5b14926f3c266cbdeda840d39e3f28824c7c0b7a231b68ba7eda3cab4a0c0dc6",
+    "contextDigest": "38ecd22993ea79127f37fa7bc1dd9232fab6a5ab8865c4950055feca4b2b1654"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "a866a3c7ebf3e78682f36d74e64492a20cd835f58de79e9b21d5dbf499a55f92",
-    "validationDigest": "58673a92b74509bc633e4ab3e1137787970fa94de98b4fe2bb67c9ad81d212b8",
+    "digest": "d7e5e75e6f86efb06b36b50061023abd079288d91d996d0731d6e54aec05041f",
+    "validationDigest": "f34abaf2e2e4b0a5ed43520c9ef9fa49d5e997d7ed65744fa187cd59cca58bb4",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "f96c6298bd90f60fd25fd675b42bdcce5b6fde3f1cf8f45d274ee46509741b8c"
+  "qualityDigest": "e152e4d2a9d5472b1ff512fece874fcef062581ee4f8299c1d2b2e4c9739294c"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d",
-    "contextDigest": "dafa84b7a16ccf33598f2372c08f7a27f66c565e0cfdd63d5c77a2dd9fa06b1b"
+    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e",
+    "contextDigest": "3aa420620b43ca3e55567c90f3512e36854ec25f0bbbb312709039dfdf2cbbd6"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "b32cc88a3d359da5f26de63cee5a34d6929ef7b277910fb1a3b95225de5fae09",
-    "validationDigest": "8ab29c4e61399f56795b9d3007938882121d873965e7442ffe692e374b62b11e",
+    "digest": "a866a3c7ebf3e78682f36d74e64492a20cd835f58de79e9b21d5dbf499a55f92",
+    "validationDigest": "58673a92b74509bc633e4ab3e1137787970fa94de98b4fe2bb67c9ad81d212b8",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "f855991c0d9ee21d213336291edebe35923b621d7f04bdf8720754092cd230ca"
+  "qualityDigest": "f96c6298bd90f60fd25fd675b42bdcce5b6fde3f1cf8f45d274ee46509741b8c"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
-    "contextDigest": "6c33d01e8a3a80f6af1a33209a7578c297f71d92ee1e334e545fa6b461aaf983"
+    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d",
+    "contextDigest": "dafa84b7a16ccf33598f2372c08f7a27f66c565e0cfdd63d5c77a2dd9fa06b1b"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "150f9639e6d99212f74fd1ddffff8fc6bf05bedb6449fafeb8f95cf1f2c9e9a8",
-    "validationDigest": "b9a8c413ff931e29f27be45d22cea95dfda0c069d57df70667405938078a3960",
+    "digest": "b32cc88a3d359da5f26de63cee5a34d6929ef7b277910fb1a3b95225de5fae09",
+    "validationDigest": "8ab29c4e61399f56795b9d3007938882121d873965e7442ffe692e374b62b11e",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "ea979a83edb576da0dc8b19ffbf4034466a5cdde4a592ef587a6569b899cd5e2"
+  "qualityDigest": "f855991c0d9ee21d213336291edebe35923b621d7f04bdf8720754092cd230ca"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "45fed751734a5f45d6e9a394d8cc34c4f1b362ae87a704bf360cfed276839edb",
+    "auditedInputDigest": "34776090965e8adc231707122e565992b8331b9c54b5a97242cccb9c91974fcb",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
-    "dossierDigest": "150eab488acca7617d73ea35908a70c64bb0741e0b5126ee1cc019723716ba1f",
+    "dossierDigest": "0816f98dd2ee6f38e16db690cdf8145126ed5a6f93a5f97a83851288f3c0a4b1",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "150eab488acca7617d73ea35908a70c64bb0741e0b5126ee1cc019723716ba1f",
+        "dossierDigest": "0816f98dd2ee6f38e16db690cdf8145126ed5a6f93a5f97a83851288f3c0a4b1",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "58673a92b74509bc633e4ab3e1137787970fa94de98b4fe2bb67c9ad81d212b8"
+  "validationDigest": "f34abaf2e2e4b0a5ed43520c9ef9fa49d5e997d7ed65744fa187cd59cca58bb4"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858",
+    "auditedInputDigest": "af06c25c24de9a489f0868882b6141fbc6d25f9b2145de908298eac4238a448a",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
-    "dossierDigest": "087c774b56add49d807f6ca751bd0e3a51b709751dcf52b64052d9be48a59ae4",
+    "dossierDigest": "b90dca56241520dd034dad02c8f5edd33a71ea7cffed6d58ae9c842a883d7710",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "087c774b56add49d807f6ca751bd0e3a51b709751dcf52b64052d9be48a59ae4",
+        "dossierDigest": "b90dca56241520dd034dad02c8f5edd33a71ea7cffed6d58ae9c842a883d7710",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "b9a8c413ff931e29f27be45d22cea95dfda0c069d57df70667405938078a3960"
+  "validationDigest": "8ab29c4e61399f56795b9d3007938882121d873965e7442ffe692e374b62b11e"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "af06c25c24de9a489f0868882b6141fbc6d25f9b2145de908298eac4238a448a",
+    "auditedInputDigest": "45fed751734a5f45d6e9a394d8cc34c4f1b362ae87a704bf360cfed276839edb",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
-    "dossierDigest": "b90dca56241520dd034dad02c8f5edd33a71ea7cffed6d58ae9c842a883d7710",
+    "dossierDigest": "150eab488acca7617d73ea35908a70c64bb0741e0b5126ee1cc019723716ba1f",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "b90dca56241520dd034dad02c8f5edd33a71ea7cffed6d58ae9c842a883d7710",
+        "dossierDigest": "150eab488acca7617d73ea35908a70c64bb0741e0b5126ee1cc019723716ba1f",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "8ab29c4e61399f56795b9d3007938882121d873965e7442ffe692e374b62b11e"
+  "validationDigest": "58673a92b74509bc633e4ab3e1137787970fa94de98b4fe2bb67c9ad81d212b8"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e",
-    "auditedInputDigest": "45fed751734a5f45d6e9a394d8cc34c4f1b362ae87a704bf360cfed276839edb"
+    "sourceManifestDigest": "5b14926f3c266cbdeda840d39e3f28824c7c0b7a231b68ba7eda3cab4a0c0dc6",
+    "auditedInputDigest": "34776090965e8adc231707122e565992b8331b9c54b5a97242cccb9c91974fcb"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "2b67ad649edd9110ceca645ca00a321b74178da049b58efb0e9d5972f3704044",
+    "dossierDigest": "a3cfec8d62205345a2af4aa6339ece6751845109710ec6563d8fe65538405f48",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "3d8da29331be7185ae8a364ede7dc0f7226b2093bf6a47926163bd39529c5645"
+  "contextDigest": "da3456fc1b6abed5ce40e6d5aaf62e1a1f946024b7c32fde032028e44f11a2e8"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d",
-    "auditedInputDigest": "af06c25c24de9a489f0868882b6141fbc6d25f9b2145de908298eac4238a448a"
+    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e",
+    "auditedInputDigest": "45fed751734a5f45d6e9a394d8cc34c4f1b362ae87a704bf360cfed276839edb"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "cff631d9e684bf1068d3bd242dcfac472da42569857f30269fbf6c1e37484355",
+    "dossierDigest": "2b67ad649edd9110ceca645ca00a321b74178da049b58efb0e9d5972f3704044",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "69f81c50a5cbe33c371ceaf9acfb5e337187e570c6e0aa9e85492064ecd9bd8d"
+  "contextDigest": "3d8da29331be7185ae8a364ede7dc0f7226b2093bf6a47926163bd39529c5645"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
-    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858"
+    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d",
+    "auditedInputDigest": "af06c25c24de9a489f0868882b6141fbc6d25f9b2145de908298eac4238a448a"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "d7de591ef47e06efcf5144b93de90e2d631f2bf17614db603e6d6d10aa3c14e5",
+    "dossierDigest": "cff631d9e684bf1068d3bd242dcfac472da42569857f30269fbf6c1e37484355",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "4d94171760a8b4e83cebd57e0a914c0f50b1f94b9ad853dba7ff61d0248eaf7e"
+  "contextDigest": "69f81c50a5cbe33c371ceaf9acfb5e337187e570c6e0aa9e85492064ecd9bd8d"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d"
+    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "69f81c50a5cbe33c371ceaf9acfb5e337187e570c6e0aa9e85492064ecd9bd8d",
-    "qualityDigest": "90cc560c14db990d6f508b2e237e20528caa0a748a331da784858af1b4f3b1b3",
+    "contextDigest": "3d8da29331be7185ae8a364ede7dc0f7226b2093bf6a47926163bd39529c5645",
+    "qualityDigest": "eef11ba57096cfa3dbbf0378f0fed70205b491171bff977667c3794db413fe6e",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "ec320b0624dffda01cb18c6aa3331d7b1dd5170a2db376f06911ced81a40d716"
+  "activationDigest": "f55320f1bab27011bbb169e3da875141077f008141b1d876530f321f1ab16429"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9"
+    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4d94171760a8b4e83cebd57e0a914c0f50b1f94b9ad853dba7ff61d0248eaf7e",
-    "qualityDigest": "650ff946876e9a5ea7db6334c35e48a36df0b335a9a537b94b7abe6c982a47df",
+    "contextDigest": "69f81c50a5cbe33c371ceaf9acfb5e337187e570c6e0aa9e85492064ecd9bd8d",
+    "qualityDigest": "90cc560c14db990d6f508b2e237e20528caa0a748a331da784858af1b4f3b1b3",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "4b91c787f01ecce57cb772270bc4edc3ecb1d30931b2c236b2daeebdd3c0432e"
+  "activationDigest": "ec320b0624dffda01cb18c6aa3331d7b1dd5170a2db376f06911ced81a40d716"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e"
+    "sourceManifestDigest": "5b14926f3c266cbdeda840d39e3f28824c7c0b7a231b68ba7eda3cab4a0c0dc6"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "3d8da29331be7185ae8a364ede7dc0f7226b2093bf6a47926163bd39529c5645",
-    "qualityDigest": "eef11ba57096cfa3dbbf0378f0fed70205b491171bff977667c3794db413fe6e",
+    "contextDigest": "da3456fc1b6abed5ce40e6d5aaf62e1a1f946024b7c32fde032028e44f11a2e8",
+    "qualityDigest": "85bfc8de9af86800e86c4b5e66bd22419a65770953c5b2d92424337d4fcd72b9",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "f55320f1bab27011bbb169e3da875141077f008141b1d876530f321f1ab16429"
+  "activationDigest": "5431adf8aeb09e3763204aa025c8be348a04bfff85aa83a6e60a96a02c5f6b25"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d",
-    "contextDigest": "69f81c50a5cbe33c371ceaf9acfb5e337187e570c6e0aa9e85492064ecd9bd8d"
+    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e",
+    "contextDigest": "3d8da29331be7185ae8a364ede7dc0f7226b2093bf6a47926163bd39529c5645"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "f17808701373c4dd119439fcfe75144b313c1a449087d52909bd5a32669692c4",
-    "validationDigest": "8ea4ad2476f9dcff6627d15ba58cb7943ef64ffab448f39294b498dfa3744b1c",
+    "digest": "ec520350681037bfc39af73949e046d5a85711f7806f620842218c185d4eed0b",
+    "validationDigest": "8667893a3c4e6195770389e4a3109eac97586c3fe121df797064f26eeee37b34",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "90cc560c14db990d6f508b2e237e20528caa0a748a331da784858af1b4f3b1b3"
+  "qualityDigest": "eef11ba57096cfa3dbbf0378f0fed70205b491171bff977667c3794db413fe6e"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
-    "contextDigest": "4d94171760a8b4e83cebd57e0a914c0f50b1f94b9ad853dba7ff61d0248eaf7e"
+    "sourceManifestDigest": "f59133cd2e3f2d06305aae4e38a11c30a8614d3fe18fcb854ee8e9330f7a3e1d",
+    "contextDigest": "69f81c50a5cbe33c371ceaf9acfb5e337187e570c6e0aa9e85492064ecd9bd8d"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "86fb1b0f23ad09baf8857accc396db1de41a3824dbbd5a428c2cfce0c446cbfd",
-    "validationDigest": "8e9acac9897fab2ef2395f91e6d1555aa241b0d3ebb1a51d8d4491225c9dfa9a",
+    "digest": "f17808701373c4dd119439fcfe75144b313c1a449087d52909bd5a32669692c4",
+    "validationDigest": "8ea4ad2476f9dcff6627d15ba58cb7943ef64ffab448f39294b498dfa3744b1c",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "650ff946876e9a5ea7db6334c35e48a36df0b335a9a537b94b7abe6c982a47df"
+  "qualityDigest": "90cc560c14db990d6f508b2e237e20528caa0a748a331da784858af1b4f3b1b3"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "39dd9b74ef54362f382452d59b91cbda440b3da53e2fa8a926240c23e280404e",
-    "contextDigest": "3d8da29331be7185ae8a364ede7dc0f7226b2093bf6a47926163bd39529c5645"
+    "sourceManifestDigest": "5b14926f3c266cbdeda840d39e3f28824c7c0b7a231b68ba7eda3cab4a0c0dc6",
+    "contextDigest": "da3456fc1b6abed5ce40e6d5aaf62e1a1f946024b7c32fde032028e44f11a2e8"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "ec520350681037bfc39af73949e046d5a85711f7806f620842218c185d4eed0b",
-    "validationDigest": "8667893a3c4e6195770389e4a3109eac97586c3fe121df797064f26eeee37b34",
+    "digest": "2a84d2263837da4cbbbed633073b2cd93ddc5787b405b2ca54c7502a93057163",
+    "validationDigest": "f911fc9e260c52e90c0f1d09b10676fcf27db11f38b66b524676b2f0f49619e2",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "eef11ba57096cfa3dbbf0378f0fed70205b491171bff977667c3794db413fe6e"
+  "qualityDigest": "85bfc8de9af86800e86c4b5e66bd22419a65770953c5b2d92424337d4fcd72b9"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "af06c25c24de9a489f0868882b6141fbc6d25f9b2145de908298eac4238a448a",
+    "auditedInputDigest": "45fed751734a5f45d6e9a394d8cc34c4f1b362ae87a704bf360cfed276839edb",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
-    "dossierDigest": "cff631d9e684bf1068d3bd242dcfac472da42569857f30269fbf6c1e37484355",
+    "dossierDigest": "2b67ad649edd9110ceca645ca00a321b74178da049b58efb0e9d5972f3704044",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "cff631d9e684bf1068d3bd242dcfac472da42569857f30269fbf6c1e37484355",
+        "dossierDigest": "2b67ad649edd9110ceca645ca00a321b74178da049b58efb0e9d5972f3704044",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "8ea4ad2476f9dcff6627d15ba58cb7943ef64ffab448f39294b498dfa3744b1c"
+  "validationDigest": "8667893a3c4e6195770389e4a3109eac97586c3fe121df797064f26eeee37b34"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858",
+    "auditedInputDigest": "af06c25c24de9a489f0868882b6141fbc6d25f9b2145de908298eac4238a448a",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
-    "dossierDigest": "d7de591ef47e06efcf5144b93de90e2d631f2bf17614db603e6d6d10aa3c14e5",
+    "dossierDigest": "cff631d9e684bf1068d3bd242dcfac472da42569857f30269fbf6c1e37484355",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "d7de591ef47e06efcf5144b93de90e2d631f2bf17614db603e6d6d10aa3c14e5",
+        "dossierDigest": "cff631d9e684bf1068d3bd242dcfac472da42569857f30269fbf6c1e37484355",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "8e9acac9897fab2ef2395f91e6d1555aa241b0d3ebb1a51d8d4491225c9dfa9a"
+  "validationDigest": "8ea4ad2476f9dcff6627d15ba58cb7943ef64ffab448f39294b498dfa3744b1c"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "45fed751734a5f45d6e9a394d8cc34c4f1b362ae87a704bf360cfed276839edb",
+    "auditedInputDigest": "34776090965e8adc231707122e565992b8331b9c54b5a97242cccb9c91974fcb",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
-    "dossierDigest": "2b67ad649edd9110ceca645ca00a321b74178da049b58efb0e9d5972f3704044",
+    "dossierDigest": "a3cfec8d62205345a2af4aa6339ece6751845109710ec6563d8fe65538405f48",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "2b67ad649edd9110ceca645ca00a321b74178da049b58efb0e9d5972f3704044",
+        "dossierDigest": "a3cfec8d62205345a2af4aa6339ece6751845109710ec6563d8fe65538405f48",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "8667893a3c4e6195770389e4a3109eac97586c3fe121df797064f26eeee37b34"
+  "validationDigest": "f911fc9e260c52e90c0f1d09b10676fcf27db11f38b66b524676b2f0f49619e2"
 }

--- a/src/pages/Review/Components/SimpleReviewActions.tsx
+++ b/src/pages/Review/Components/SimpleReviewActions.tsx
@@ -24,6 +24,7 @@ const SimpleReviewActions = ({
 }: SimpleReviewActionsProps) => {
   const intl = useIntl();
   const [form] = Form.useForm<{ reason: string }>();
+  const [modal, modalContextHolder] = Modal.useModal();
   const [rejectOpen, setRejectOpen] = useState(false);
   const [loading, setLoading] = useState(false);
 
@@ -84,80 +85,86 @@ const SimpleReviewActions = ({
   };
 
   return (
-    <Space>
-      <Tooltip
-        title={intl.formatMessage({
-          id: 'pages.review.simpleDecision.approve',
-          defaultMessage: 'Approve',
-        })}
-      >
-        <Button
-          size='small'
-          shape='circle'
-          icon={<SafetyCertificateOutlined />}
-          loading={loading}
-          onClick={() =>
-            Modal.confirm({
-              title: intl.formatMessage({
-                id: 'pages.review.simpleDecision.approveConfirm',
-                defaultMessage: 'Confirm approval?',
-              }),
-              onOk: approve,
-            })
-          }
-        />
-      </Tooltip>
-      {role === 'admin' ? (
-        <RejectReview
-          reviewId={reviewId}
-          dataId=''
-          dataVersion=''
-          isModel={targetTable === 'lifecyclemodels'}
-          targetTable={targetTable}
-          actionRef={actionRef}
-        />
-      ) : (
-        <>
-          <Tooltip
-            title={intl.formatMessage({
-              id: 'pages.review.simpleDecision.reject',
-              defaultMessage: 'Reject',
-            })}
-          >
-            <Button
-              size='small'
-              shape='circle'
-              type='default'
-              icon={<FileExcelOutlined />}
-              onClick={() => setRejectOpen(true)}
-            />
-          </Tooltip>
-          <Modal
-            open={rejectOpen}
-            title={intl.formatMessage({
-              id: 'component.rejectReview.modal.title',
-              defaultMessage: 'Reject Review',
-            })}
-            confirmLoading={loading}
-            onCancel={() => setRejectOpen(false)}
-            onOk={rejectAsReviewer}
-          >
-            <Form form={form} layout='vertical'>
-              <Form.Item
-                name='reason'
-                label={intl.formatMessage({
-                  id: 'component.rejectReview.reason.label',
-                  defaultMessage: 'Reject Reason',
-                })}
-                rules={[{ required: true, whitespace: true }]}
-              >
-                <Input.TextArea rows={4} maxLength={1000} showCount />
-              </Form.Item>
-            </Form>
-          </Modal>
-        </>
-      )}
-    </Space>
+    <>
+      {modalContextHolder}
+      <Space>
+        <Tooltip
+          title={intl.formatMessage({
+            id: 'pages.review.simpleDecision.approve',
+            defaultMessage: 'Approve',
+          })}
+        >
+          <Button
+            size='small'
+            shape='circle'
+            icon={<SafetyCertificateOutlined />}
+            loading={loading}
+            onClick={() =>
+              modal.confirm({
+                title: intl.formatMessage({
+                  id: 'pages.review.simpleDecision.approveConfirm',
+                  defaultMessage: 'Confirm approval?',
+                }),
+                okButtonProps: {
+                  type: 'primary',
+                },
+                onOk: approve,
+              })
+            }
+          />
+        </Tooltip>
+        {role === 'admin' ? (
+          <RejectReview
+            reviewId={reviewId}
+            dataId=''
+            dataVersion=''
+            isModel={targetTable === 'lifecyclemodels'}
+            targetTable={targetTable}
+            actionRef={actionRef}
+          />
+        ) : (
+          <>
+            <Tooltip
+              title={intl.formatMessage({
+                id: 'pages.review.simpleDecision.reject',
+                defaultMessage: 'Reject',
+              })}
+            >
+              <Button
+                size='small'
+                shape='circle'
+                type='default'
+                icon={<FileExcelOutlined />}
+                onClick={() => setRejectOpen(true)}
+              />
+            </Tooltip>
+            <Modal
+              open={rejectOpen}
+              title={intl.formatMessage({
+                id: 'component.rejectReview.modal.title',
+                defaultMessage: 'Reject Review',
+              })}
+              confirmLoading={loading}
+              onCancel={() => setRejectOpen(false)}
+              onOk={rejectAsReviewer}
+            >
+              <Form form={form} layout='vertical'>
+                <Form.Item
+                  name='reason'
+                  label={intl.formatMessage({
+                    id: 'component.rejectReview.reason.label',
+                    defaultMessage: 'Reject Reason',
+                  })}
+                  rules={[{ required: true, whitespace: true }]}
+                >
+                  <Input.TextArea rows={4} maxLength={1000} showCount />
+                </Form.Item>
+              </Form>
+            </Modal>
+          </>
+        )}
+      </Space>
+    </>
   );
 };
 

--- a/src/pages/Review/Components/SimpleReviewActions.tsx
+++ b/src/pages/Review/Components/SimpleReviewActions.tsx
@@ -3,7 +3,7 @@ import {
   submitSimpleReviewDecision,
   type ReviewSubmitDatasetTable,
 } from '@/services/reviews/api';
-import { CloseOutlined, SafetyCertificateOutlined } from '@ant-design/icons';
+import { FileExcelOutlined, SafetyCertificateOutlined } from '@ant-design/icons';
 import { useIntl } from '@umijs/max';
 import { Button, Form, Input, message, Modal, Space, Tooltip } from 'antd';
 import { useState } from 'react';
@@ -127,8 +127,8 @@ const SimpleReviewActions = ({
             <Button
               size='small'
               shape='circle'
-              danger
-              icon={<CloseOutlined />}
+              type='default'
+              icon={<FileExcelOutlined />}
               onClick={() => setRejectOpen(true)}
             />
           </Tooltip>

--- a/src/pages/Review/Components/SimpleReviewActions.tsx
+++ b/src/pages/Review/Components/SimpleReviewActions.tsx
@@ -3,7 +3,7 @@ import {
   submitSimpleReviewDecision,
   type ReviewSubmitDatasetTable,
 } from '@/services/reviews/api';
-import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
+import { CloseOutlined, SafetyCertificateOutlined } from '@ant-design/icons';
 import { useIntl } from '@umijs/max';
 import { Button, Form, Input, message, Modal, Space, Tooltip } from 'antd';
 import { useState } from 'react';
@@ -94,8 +94,7 @@ const SimpleReviewActions = ({
         <Button
           size='small'
           shape='circle'
-          type='primary'
-          icon={<CheckOutlined />}
+          icon={<SafetyCertificateOutlined />}
           loading={loading}
           onClick={() =>
             Modal.confirm({

--- a/tests/unit/pages/Review/SimpleReviewActions.test.tsx
+++ b/tests/unit/pages/Review/SimpleReviewActions.test.tsx
@@ -15,8 +15,8 @@ jest.mock('@/services/reviews/api', () => ({
 }));
 
 jest.mock('@ant-design/icons', () => ({
-  CheckOutlined: () => <span>approve-icon</span>,
   CloseOutlined: () => <span>reject-icon</span>,
+  SafetyCertificateOutlined: () => <span>approve-icon</span>,
 }));
 
 jest.mock('@umijs/max', () => ({
@@ -90,6 +90,9 @@ jest.mock('antd', () => {
     Button: ({
       icon,
       onClick,
+      shape,
+      size,
+      type,
     }: {
       icon?: import('react').ReactNode;
       onClick?: () => void;
@@ -99,7 +102,13 @@ jest.mock('antd', () => {
       type?: string;
       danger?: boolean;
     }) => (
-      <button type='button' onClick={onClick}>
+      <button
+        type='button'
+        data-button-shape={shape}
+        data-button-size={size}
+        data-button-type={type ?? 'default'}
+        onClick={onClick}
+      >
         {icon}
       </button>
     ),
@@ -146,7 +155,11 @@ describe('SimpleReviewActions', () => {
       />,
     );
 
-    fireEvent.click(screen.getByText('approve-icon'));
+    const approveButton = screen.getByText('approve-icon').closest('button');
+    expect(approveButton).toHaveAttribute('data-button-shape', 'circle');
+    expect(approveButton).toHaveAttribute('data-button-size', 'small');
+    expect(approveButton).toHaveAttribute('data-button-type', 'default');
+    fireEvent.click(approveButton!);
 
     await waitFor(() =>
       expect(approveReviewApiMock).toHaveBeenCalledWith('review-id', 'lifecyclemodels'),

--- a/tests/unit/pages/Review/SimpleReviewActions.test.tsx
+++ b/tests/unit/pages/Review/SimpleReviewActions.test.tsx
@@ -15,7 +15,7 @@ jest.mock('@/services/reviews/api', () => ({
 }));
 
 jest.mock('@ant-design/icons', () => ({
-  CloseOutlined: () => <span>reject-icon</span>,
+  FileExcelOutlined: () => <span>reject-icon</span>,
   SafetyCertificateOutlined: () => <span>approve-icon</span>,
 }));
 
@@ -93,6 +93,7 @@ jest.mock('antd', () => {
       shape,
       size,
       type,
+      danger,
     }: {
       icon?: import('react').ReactNode;
       onClick?: () => void;
@@ -107,6 +108,7 @@ jest.mock('antd', () => {
         data-button-shape={shape}
         data-button-size={size}
         data-button-type={type ?? 'default'}
+        data-button-danger={danger ? 'true' : 'false'}
         onClick={onClick}
       >
         {icon}
@@ -232,7 +234,12 @@ describe('SimpleReviewActions', () => {
       />,
     );
 
-    fireEvent.click(screen.getByText('reject-icon'));
+    const rejectButton = screen.getByText('reject-icon').closest('button');
+    expect(rejectButton).toHaveAttribute('data-button-shape', 'circle');
+    expect(rejectButton).toHaveAttribute('data-button-size', 'small');
+    expect(rejectButton).toHaveAttribute('data-button-type', 'default');
+    expect(rejectButton).toHaveAttribute('data-button-danger', 'false');
+    fireEvent.click(rejectButton!);
     fireEvent.click(screen.getByRole('button', { name: 'cancel-rejection' }));
     fireEvent.click(screen.getByText('reject-icon'));
     fireEvent.click(screen.getByRole('button', { name: 'confirm-rejection' }));

--- a/tests/unit/pages/Review/SimpleReviewActions.test.tsx
+++ b/tests/unit/pages/Review/SimpleReviewActions.test.tsx
@@ -84,7 +84,12 @@ jest.mock('antd', () => {
         </button>
       </section>
     ) : null;
-  Modal.confirm = (options: { onOk?: () => void }) => mockConfirm(options);
+  Modal.useModal = () => [
+    {
+      confirm: (options: { onOk?: () => void }) => mockConfirm(options),
+    },
+    <span key='approval-modal-context' data-testid='approval-modal-context' />,
+  ];
 
   return {
     Button: ({
@@ -162,6 +167,15 @@ describe('SimpleReviewActions', () => {
     expect(approveButton).toHaveAttribute('data-button-size', 'small');
     expect(approveButton).toHaveAttribute('data-button-type', 'default');
     fireEvent.click(approveButton!);
+
+    expect(screen.getByTestId('approval-modal-context')).toBeInTheDocument();
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Confirm approval?',
+        okButtonProps: { type: 'primary' },
+        onOk: expect.any(Function),
+      }),
+    );
 
     await waitFor(() =>
       expect(approveReviewApiMock).toHaveBeenCalledWith('review-id', 'lifecyclemodels'),


### PR DESCRIPTION
Closes #792

## Summary

- 将审核通过图标替换为 `SafetyCertificateOutlined`，保留清晰的审核认证通过语义。
- 将审核员驳回按钮替换为共享驳回操作使用的 `FileExcelOutlined`。
- 两个操作均采用 `small`、`circle`、`default` 线框按钮，与相邻操作保持一致；驳回按钮不再使用红色危险样式。
- 审核通过确认弹窗改用上下文感知的 `Modal.useModal()`，使“确定”主按钮继承当前 theme 的主题色。
- 更新聚焦测试并刷新由源码上下文摘要变化影响的确定性四语言派生制品。

## Key Decisions

- 通过 `Modal.useModal()` 将确认弹窗挂载到页面 `ConfigProvider` 上下文中；“确定”按钮保持 Ant Design `primary` 类型，颜色来自 theme 的 `colorPrimary`，不写死色值。
- 复用共享驳回操作的图标与外观，避免同一语义在不同审核角色下出现两套视觉表达。
- 不改变 Tooltip、确认弹窗文案、驳回原因校验、角色权限、审批 API 或审核状态流转。

## Validation

- Review 操作聚焦 Jest：2 个套件、12 项测试通过。
- Locale delivery contract：1 个套件、18 项测试通过；派生制品双次生成幂等且 canonical。
- 目标 ESLint、Prettier、TypeScript、生产构建与 Docpact 严格检查通过。
- 受控 pre-push：411 个套件、5618 项测试通过；460/460 个受控源码文件达到语句、分支、函数、行 100% 覆盖率。

## Risks / Rollback

- 风险仅限审核操作和确认按钮的视觉表达；如需回滚，可恢复静态确认弹窗及原图标/按钮类型，业务请求链路无需调整。

## Workspace Integration

- routine PR 合入 `dev`；发布到 `main` 后再由 `lca-workspace` 更新子模块指针。
