### PR TITLE
fix: show review submitter names

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "f26b54d064f8f408982a169a0ddda0381395826d"
+lastReviewedAt: "2026-08-09"
+lastReviewedCommit: "4f96234f03418295df7b27badefc2958f9c18c37"
 lastReviewedNote: 'Reviewed for Issues #778 and #780: existing ownership routes cover the merged grouped-review candidate plus automatic qualification evidence, composed-candidate preflight, release orchestration, tests, and governed release docs.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-09"
-lastReviewedCommit: "be18e70370533dce97086185378a3e5bf2602a18"
+lastReviewedCommit: "aa70fe66d5cbfbc23d6ff50fce05f945177c48d3"
 lastReviewedNote: 'Reviewed for Issues #778 and #780: existing ownership routes cover the merged grouped-review candidate plus automatic qualification evidence, composed-candidate preflight, release orchestration, tests, and governed release docs.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
+lastReviewedCommit: 5becd3ae1ffdaa75d8d326534f61b2bf992ed941
 lastReviewedNote: 'Reviewed for Issues #778 and #780: deterministic release preflight and grouped-review delivery remain within the documented dev-to-main, quality-gate, and root-integration boundaries.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: b8af46e993cb0ea0d01c1c79809ea6f62040f59f
 lastReviewedNote: 'Reviewed for Issues #778 and #780: deterministic release preflight and grouped-review delivery remain within the documented dev-to-main, quality-gate, and root-integration boundaries.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
+lastReviewedCommit: 5becd3ae1ffdaa75d8d326534f61b2bf992ed941
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged candidate keeps the Node 24, focused-proof, semantic qualification, managed-push, and deterministic release-command workflow.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - .nvmrc
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: b8af46e993cb0ea0d01c1c79809ea6f62040f59f
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged candidate keeps the Node 24, focused-proof, semantic qualification, managed-push, and deterministic release-command workflow.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
+lastReviewedCommit: aa70fe66d5cbfbc23d6ff50fce05f945177c48d3
 lastReviewedNote: 'Reviewed for Issues #778 and #780: dual-scope Docpact review and the grouped-review candidate continue through the unchanged checked-push and retry-receipt policy.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 4f96234f03418295df7b27badefc2958f9c18c37
 lastReviewedNote: 'Reviewed for Issues #778 and #780: dual-scope Docpact review and the grouped-review candidate continue through the unchanged checked-push and retry-receipt policy.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - playwright.config.ts
   - config/docs-capture/**
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 4f96234f03418295df7b27badefc2958f9c18c37
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release automation preserves existing runtime boundaries while grouped-review queue, selection, and dataset views remain database-authority consumers.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
+lastReviewedCommit: aa70fe66d5cbfbc23d6ff50fce05f945177c48d3
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release automation preserves existing runtime boundaries while grouped-review queue, selection, and dataset views remain database-authority consumers.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 4f96234f03418295df7b27badefc2958f9c18c37
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged proof matrix covers independent release paths plus the seven-type Root/Reference queue, selection, and dataset-view behavior.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
+lastReviewedCommit: aa70fe66d5cbfbc23d6ff50fce05f945177c48d3
 lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged proof matrix covers independent release paths plus the seven-type Root/Reference queue, selection, and dataset-view behavior.'
 related:
   - ../AGENTS.md

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/e2e/**
   - playwright.config.ts
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 6e0eacef1d999381e6c6aef8e49001847a3c29b5
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 4f96234f03418295df7b27badefc2958f9c18c37
 lastReviewedNote: 'Reviewed for database-engine Issue #422: Next defaults RPC calls to api, keeps only nine core entities on explicit public access, and consumes the exact reviewed Edge mirror.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - package.json
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 4f96234f03418295df7b27badefc2958f9c18c37
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release-path and grouped-review coverage extend bounded proof without changing the repository testing strategy.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
+lastReviewedCommit: aa70fe66d5cbfbc23d6ff50fce05f945177c48d3
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release-path and grouped-review coverage extend bounded proof without changing the repository testing strategy.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
+lastReviewedCommit: aa70fe66d5cbfbc23d6ff50fce05f945177c48d3
 lastReviewedNote: 'Reviewed for Issues #778 and #780: hermetic release-preflight and grouped-review regression proof leave no new repository-wide test backlog.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 4f96234f03418295df7b27badefc2958f9c18c37
 lastReviewedNote: 'Reviewed for Issues #778 and #780: hermetic release-preflight and grouped-review regression proof leave no new repository-wide test backlog.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
+lastReviewedCommit: aa70fe66d5cbfbc23d6ff50fce05f945177c48d3
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release proof and grouped-review tests continue to use existing bounded Docpact and service/UI testing patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -30,8 +30,8 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 4f96234f03418295df7b27badefc2958f9c18c37
 lastReviewedNote: 'Reviewed for Issues #778 and #780: release proof and grouped-review tests continue to use existing bounded Docpact and service/UI testing patterns.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: be18e70370533dce97086185378a3e5bf2602a18
+lastReviewedCommit: aa70fe66d5cbfbc23d6ff50fce05f945177c48d3
 lastReviewedNote: 'Reviewed for Issues #778 and #780: automatic dual-scope release review and focused grouped-review proof require no new recovery exception.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -27,8 +27,8 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: f26b54d064f8f408982a169a0ddda0381395826d
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 4f96234f03418295df7b27badefc2958f9c18c37
 lastReviewedNote: 'Reviewed for Issues #778 and #780: automatic dual-scope release review and focused grouped-review proof require no new recovery exception.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
-    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858"
+    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a",
+    "auditedInputDigest": "11cc8d4d491acdce7e824a52cb892b373184160ab6e7961f020fe92fe38cec3d"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "49092b48ae9b16af90a49415fec0c1bb70a634b9bab628c3f91ef7fb2968a315",
+    "dossierDigest": "c01f66bd321f519cebada9f2233fd298dd79eddae070958ec288f5ff4d17d149",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "069c773023e8841822696fcbe0dc127610503fbb0bce76d8495d883d1164b0e4"
+  "contextDigest": "4acfd57c65553c4627140d2b588118d1247d51ee41b1edf7a41001fe5b857141"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a",
-    "auditedInputDigest": "11cc8d4d491acdce7e824a52cb892b373184160ab6e7961f020fe92fe38cec3d"
+    "sourceManifestDigest": "04cced4eb8f5595c5cea95f0394246f1adb6f6c097581c8d52c76171f1b3c496",
+    "auditedInputDigest": "7d09f9f35ebb0b88b6b332f0b1a0fe3415162ef40d4657b580b117d773a66386"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "c01f66bd321f519cebada9f2233fd298dd79eddae070958ec288f5ff4d17d149",
+    "dossierDigest": "90015061aa8579281dc7948e7654875c816ec48056babd0ec7f349e8ca416c3d",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "4acfd57c65553c4627140d2b588118d1247d51ee41b1edf7a41001fe5b857141"
+  "contextDigest": "1ebb80f5560dd03e47349559b4af065e86960f951324803ef39d8b2390cc4dbf"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a"
+    "sourceManifestDigest": "04cced4eb8f5595c5cea95f0394246f1adb6f6c097581c8d52c76171f1b3c496"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4acfd57c65553c4627140d2b588118d1247d51ee41b1edf7a41001fe5b857141",
-    "qualityDigest": "b1019772b74f70987407e513660e03e818c720110c161b43279e84f5c4b9f953",
+    "contextDigest": "1ebb80f5560dd03e47349559b4af065e86960f951324803ef39d8b2390cc4dbf",
+    "qualityDigest": "124fc163123ff7d063d83f928223f23fe9800ee837c0926c6078d40c7f97886b",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "a998a57a7db69e6b19407ddb82e03d3b66eba326704b7524c01dec2a50bebae3"
+  "activationDigest": "024790710c294c71519816a6265d049daf54ac0c86177226cf598d0155fe0d38"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9"
+    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "069c773023e8841822696fcbe0dc127610503fbb0bce76d8495d883d1164b0e4",
-    "qualityDigest": "52fc2b4d6ed512e70cdd02b5447e82bba2076840ee3a55fbe1b30c2e839f66ba",
+    "contextDigest": "4acfd57c65553c4627140d2b588118d1247d51ee41b1edf7a41001fe5b857141",
+    "qualityDigest": "b1019772b74f70987407e513660e03e818c720110c161b43279e84f5c4b9f953",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "7d3072d1e777d5cf48c557b17441b34d812ae271d880a1bb3a24bba570bd530b"
+  "activationDigest": "a998a57a7db69e6b19407ddb82e03d3b66eba326704b7524c01dec2a50bebae3"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858",
+    "auditedInputDigest": "11cc8d4d491acdce7e824a52cb892b373184160ab6e7961f020fe92fe38cec3d",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "11cc8d4d491acdce7e824a52cb892b373184160ab6e7961f020fe92fe38cec3d",
+    "auditedInputDigest": "7d09f9f35ebb0b88b6b332f0b1a0fe3415162ef40d4657b580b117d773a66386",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
-    "contextDigest": "069c773023e8841822696fcbe0dc127610503fbb0bce76d8495d883d1164b0e4"
+    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a",
+    "contextDigest": "4acfd57c65553c4627140d2b588118d1247d51ee41b1edf7a41001fe5b857141"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "8c18fcdf4966a771a5aac60fe00c952b743bfd34bd27c0bad368a77046376707",
-    "validationDigest": "6629a38843a1654a0efc533a3cfb4a8465166dcbc60d194eaa7229426e5717df",
+    "digest": "f197d5e17c63948f8f30b1e42e2559401adc2880731b6fc18224abf8429e9e3b",
+    "validationDigest": "62b6242083884ca84b93713fbfa0745916c0f01d45ec372e72ce23d71d705931",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "52fc2b4d6ed512e70cdd02b5447e82bba2076840ee3a55fbe1b30c2e839f66ba"
+  "qualityDigest": "b1019772b74f70987407e513660e03e818c720110c161b43279e84f5c4b9f953"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a",
-    "contextDigest": "4acfd57c65553c4627140d2b588118d1247d51ee41b1edf7a41001fe5b857141"
+    "sourceManifestDigest": "04cced4eb8f5595c5cea95f0394246f1adb6f6c097581c8d52c76171f1b3c496",
+    "contextDigest": "1ebb80f5560dd03e47349559b4af065e86960f951324803ef39d8b2390cc4dbf"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "f197d5e17c63948f8f30b1e42e2559401adc2880731b6fc18224abf8429e9e3b",
-    "validationDigest": "62b6242083884ca84b93713fbfa0745916c0f01d45ec372e72ce23d71d705931",
+    "digest": "98898323ba94491aa2dc530f840b5860d5eb34a765751cab0238b7b5e9a44948",
+    "validationDigest": "e654615dbb9829520aff8c784d0174b70982591827c6afb8104b7b5a39427a61",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "b1019772b74f70987407e513660e03e818c720110c161b43279e84f5c4b9f953"
+  "qualityDigest": "124fc163123ff7d063d83f928223f23fe9800ee837c0926c6078d40c7f97886b"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858",
+    "auditedInputDigest": "11cc8d4d491acdce7e824a52cb892b373184160ab6e7961f020fe92fe38cec3d",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
-    "dossierDigest": "49092b48ae9b16af90a49415fec0c1bb70a634b9bab628c3f91ef7fb2968a315",
+    "dossierDigest": "c01f66bd321f519cebada9f2233fd298dd79eddae070958ec288f5ff4d17d149",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "49092b48ae9b16af90a49415fec0c1bb70a634b9bab628c3f91ef7fb2968a315",
+        "dossierDigest": "c01f66bd321f519cebada9f2233fd298dd79eddae070958ec288f5ff4d17d149",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "6629a38843a1654a0efc533a3cfb4a8465166dcbc60d194eaa7229426e5717df"
+  "validationDigest": "62b6242083884ca84b93713fbfa0745916c0f01d45ec372e72ce23d71d705931"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "11cc8d4d491acdce7e824a52cb892b373184160ab6e7961f020fe92fe38cec3d",
+    "auditedInputDigest": "7d09f9f35ebb0b88b6b332f0b1a0fe3415162ef40d4657b580b117d773a66386",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
-    "dossierDigest": "c01f66bd321f519cebada9f2233fd298dd79eddae070958ec288f5ff4d17d149",
+    "dossierDigest": "90015061aa8579281dc7948e7654875c816ec48056babd0ec7f349e8ca416c3d",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "c01f66bd321f519cebada9f2233fd298dd79eddae070958ec288f5ff4d17d149",
+        "dossierDigest": "90015061aa8579281dc7948e7654875c816ec48056babd0ec7f349e8ca416c3d",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "62b6242083884ca84b93713fbfa0745916c0f01d45ec372e72ce23d71d705931"
+  "validationDigest": "e654615dbb9829520aff8c784d0174b70982591827c6afb8104b7b5a39427a61"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
-    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858"
+    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a",
+    "auditedInputDigest": "11cc8d4d491acdce7e824a52cb892b373184160ab6e7961f020fe92fe38cec3d"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "637555d5e12222d2e311dde8e39b081ebbab2fe8dd7206344d7890d98ef49dbb",
+    "dossierDigest": "2a0d557ef8d2d9abca8b8f16b6270d1b9d31c800b3c172daf6d1fd05a62cef52",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "4d34fd93f20a467e99721a8dde665890a6a304acb2f14bc3f86f7acab69257a8"
+  "contextDigest": "79e05c9c547d58ce62f14e6916b25a7dea1e009b441e8811347ea82039d0dcd8"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a",
-    "auditedInputDigest": "11cc8d4d491acdce7e824a52cb892b373184160ab6e7961f020fe92fe38cec3d"
+    "sourceManifestDigest": "04cced4eb8f5595c5cea95f0394246f1adb6f6c097581c8d52c76171f1b3c496",
+    "auditedInputDigest": "7d09f9f35ebb0b88b6b332f0b1a0fe3415162ef40d4657b580b117d773a66386"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "2a0d557ef8d2d9abca8b8f16b6270d1b9d31c800b3c172daf6d1fd05a62cef52",
+    "dossierDigest": "a8471ca82849b1ebad14b60673e573b8d3973e4c4f888b5636de8cfe06ca200f",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "79e05c9c547d58ce62f14e6916b25a7dea1e009b441e8811347ea82039d0dcd8"
+  "contextDigest": "b32c9b74e153039290f4523e2e7a2ae58fdc2bd421f172897e3c479db9247e5a"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9"
+    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4d34fd93f20a467e99721a8dde665890a6a304acb2f14bc3f86f7acab69257a8",
-    "qualityDigest": "e9b5dc488b81d5a9c476ab68a4f36c20bb72ddd7f048e109ec398046450385e7",
+    "contextDigest": "79e05c9c547d58ce62f14e6916b25a7dea1e009b441e8811347ea82039d0dcd8",
+    "qualityDigest": "a3a42672c5a08351040577eb3e43789316b636221faf6b4cf227cd27194086ec",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "0a74a0042d321a1823c2cab2908e6bfc2840a4730399df20224ae4010dfa2bcc"
+  "activationDigest": "bf464d5d0282f9462d5e9b75d5fa4bffa2e9410591a700808b3ce5f728337b8c"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a"
+    "sourceManifestDigest": "04cced4eb8f5595c5cea95f0394246f1adb6f6c097581c8d52c76171f1b3c496"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "79e05c9c547d58ce62f14e6916b25a7dea1e009b441e8811347ea82039d0dcd8",
-    "qualityDigest": "a3a42672c5a08351040577eb3e43789316b636221faf6b4cf227cd27194086ec",
+    "contextDigest": "b32c9b74e153039290f4523e2e7a2ae58fdc2bd421f172897e3c479db9247e5a",
+    "qualityDigest": "7c1d8ee7482ad4c3bf69e3fc0e5f7f833f6c5c6926f3888da878e99d449ab1a7",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "bf464d5d0282f9462d5e9b75d5fa4bffa2e9410591a700808b3ce5f728337b8c"
+  "activationDigest": "ea0e6e2de5df57be40be4399db6035d8f133a9cb98562b1bebd7db60f68e9e09"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
-    "contextDigest": "4d34fd93f20a467e99721a8dde665890a6a304acb2f14bc3f86f7acab69257a8"
+    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a",
+    "contextDigest": "79e05c9c547d58ce62f14e6916b25a7dea1e009b441e8811347ea82039d0dcd8"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "096800de4db14e86c059c872889e330963389032b9d644895bdfe12cc5bf5664",
-    "validationDigest": "2de8d9f884455beb28590b14ea5ed52947d1bf0756b964a2737e301fe4ffbdac",
+    "digest": "e2ef5adc867726bc6b9626064a3458146a50fbb07a35df8edff5e0135f41ab62",
+    "validationDigest": "c4262b94b1441602870dd0ee8b2d5ee07a4b23c52f3515f30aec6882de72db0f",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "e9b5dc488b81d5a9c476ab68a4f36c20bb72ddd7f048e109ec398046450385e7"
+  "qualityDigest": "a3a42672c5a08351040577eb3e43789316b636221faf6b4cf227cd27194086ec"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a",
-    "contextDigest": "79e05c9c547d58ce62f14e6916b25a7dea1e009b441e8811347ea82039d0dcd8"
+    "sourceManifestDigest": "04cced4eb8f5595c5cea95f0394246f1adb6f6c097581c8d52c76171f1b3c496",
+    "contextDigest": "b32c9b74e153039290f4523e2e7a2ae58fdc2bd421f172897e3c479db9247e5a"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "e2ef5adc867726bc6b9626064a3458146a50fbb07a35df8edff5e0135f41ab62",
-    "validationDigest": "c4262b94b1441602870dd0ee8b2d5ee07a4b23c52f3515f30aec6882de72db0f",
+    "digest": "9a329ff1547839e82b01601d8ac5e7ed628a985517daf752cc684f958c4d7d5c",
+    "validationDigest": "9257d9d83eb70b4007928a69185dac551636e50b2cfe0dccea94a7540a655c87",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "a3a42672c5a08351040577eb3e43789316b636221faf6b4cf227cd27194086ec"
+  "qualityDigest": "7c1d8ee7482ad4c3bf69e3fc0e5f7f833f6c5c6926f3888da878e99d449ab1a7"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "11cc8d4d491acdce7e824a52cb892b373184160ab6e7961f020fe92fe38cec3d",
+    "auditedInputDigest": "7d09f9f35ebb0b88b6b332f0b1a0fe3415162ef40d4657b580b117d773a66386",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
-    "dossierDigest": "2a0d557ef8d2d9abca8b8f16b6270d1b9d31c800b3c172daf6d1fd05a62cef52",
+    "dossierDigest": "a8471ca82849b1ebad14b60673e573b8d3973e4c4f888b5636de8cfe06ca200f",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "2a0d557ef8d2d9abca8b8f16b6270d1b9d31c800b3c172daf6d1fd05a62cef52",
+        "dossierDigest": "a8471ca82849b1ebad14b60673e573b8d3973e4c4f888b5636de8cfe06ca200f",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "c4262b94b1441602870dd0ee8b2d5ee07a4b23c52f3515f30aec6882de72db0f"
+  "validationDigest": "9257d9d83eb70b4007928a69185dac551636e50b2cfe0dccea94a7540a655c87"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858",
+    "auditedInputDigest": "11cc8d4d491acdce7e824a52cb892b373184160ab6e7961f020fe92fe38cec3d",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
-    "dossierDigest": "637555d5e12222d2e311dde8e39b081ebbab2fe8dd7206344d7890d98ef49dbb",
+    "dossierDigest": "2a0d557ef8d2d9abca8b8f16b6270d1b9d31c800b3c172daf6d1fd05a62cef52",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "637555d5e12222d2e311dde8e39b081ebbab2fe8dd7206344d7890d98ef49dbb",
+        "dossierDigest": "2a0d557ef8d2d9abca8b8f16b6270d1b9d31c800b3c172daf6d1fd05a62cef52",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "2de8d9f884455beb28590b14ea5ed52947d1bf0756b964a2737e301fe4ffbdac"
+  "validationDigest": "c4262b94b1441602870dd0ee8b2d5ee07a4b23c52f3515f30aec6882de72db0f"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
-    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858"
+    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a",
+    "auditedInputDigest": "11cc8d4d491acdce7e824a52cb892b373184160ab6e7961f020fe92fe38cec3d"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "087c774b56add49d807f6ca751bd0e3a51b709751dcf52b64052d9be48a59ae4",
+    "dossierDigest": "1e8b6d5172087fd6af8bd380550e951372c77dbe34b3d6bae33b0c1fac42a3e6",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "6c33d01e8a3a80f6af1a33209a7578c297f71d92ee1e334e545fa6b461aaf983"
+  "contextDigest": "dfd949bb0a5a3ef0eeaadc605e82089f150437ed4526f5c2290b3c064bc65a1a"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a",
-    "auditedInputDigest": "11cc8d4d491acdce7e824a52cb892b373184160ab6e7961f020fe92fe38cec3d"
+    "sourceManifestDigest": "04cced4eb8f5595c5cea95f0394246f1adb6f6c097581c8d52c76171f1b3c496",
+    "auditedInputDigest": "7d09f9f35ebb0b88b6b332f0b1a0fe3415162ef40d4657b580b117d773a66386"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "1e8b6d5172087fd6af8bd380550e951372c77dbe34b3d6bae33b0c1fac42a3e6",
+    "dossierDigest": "c5154deb3aaa4678019f8262dca512e031de65d4a71a82656507a66910add69e",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "dfd949bb0a5a3ef0eeaadc605e82089f150437ed4526f5c2290b3c064bc65a1a"
+  "contextDigest": "fd1ea8c82ce4e8fe6362c831fff06dcd4d8727af2afb66513b4701b45f06bb6f"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9"
+    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "6c33d01e8a3a80f6af1a33209a7578c297f71d92ee1e334e545fa6b461aaf983",
-    "qualityDigest": "ea979a83edb576da0dc8b19ffbf4034466a5cdde4a592ef587a6569b899cd5e2",
+    "contextDigest": "dfd949bb0a5a3ef0eeaadc605e82089f150437ed4526f5c2290b3c064bc65a1a",
+    "qualityDigest": "79c53757ffcbeca8a733a3fbef3ae34ed20bbce570336e5e141bfe1d7821b8f9",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "2419aed98b5010bc97f2cce28bbcdd51508161febb64d4d94fba17980e788539"
+  "activationDigest": "14ec37c3637e2ec72c19f123e224491bad0cb7a291097bad5e4e28231c44eebe"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a"
+    "sourceManifestDigest": "04cced4eb8f5595c5cea95f0394246f1adb6f6c097581c8d52c76171f1b3c496"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "dfd949bb0a5a3ef0eeaadc605e82089f150437ed4526f5c2290b3c064bc65a1a",
-    "qualityDigest": "79c53757ffcbeca8a733a3fbef3ae34ed20bbce570336e5e141bfe1d7821b8f9",
+    "contextDigest": "fd1ea8c82ce4e8fe6362c831fff06dcd4d8727af2afb66513b4701b45f06bb6f",
+    "qualityDigest": "41a969e7e5a542dad92780857028de67aec0b8eaee46b25ab10c685035f57696",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "14ec37c3637e2ec72c19f123e224491bad0cb7a291097bad5e4e28231c44eebe"
+  "activationDigest": "8ef5078f18cf69672efe0dd939049017a34fc458fd828f21f99854828cf5a8cd"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a",
-    "contextDigest": "dfd949bb0a5a3ef0eeaadc605e82089f150437ed4526f5c2290b3c064bc65a1a"
+    "sourceManifestDigest": "04cced4eb8f5595c5cea95f0394246f1adb6f6c097581c8d52c76171f1b3c496",
+    "contextDigest": "fd1ea8c82ce4e8fe6362c831fff06dcd4d8727af2afb66513b4701b45f06bb6f"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "ceb9bc7ccf40ebd764abd7a7dfad7aa1f8fda35f4e858d4853dfe692951848f4",
-    "validationDigest": "c267d07b1414962d5bc9cf1f929c31b68977c843ec8a9b80fbab284f85b08462",
+    "digest": "ee93ffd497b108e960302191a6866a2c4efa1bd6edb24fb75d2e9e447356f43c",
+    "validationDigest": "cc16925924dbaf17d32e1e6d2b8a0fcf82250aef7af584a9ea0c7e2013b214a2",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "79c53757ffcbeca8a733a3fbef3ae34ed20bbce570336e5e141bfe1d7821b8f9"
+  "qualityDigest": "41a969e7e5a542dad92780857028de67aec0b8eaee46b25ab10c685035f57696"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
-    "contextDigest": "6c33d01e8a3a80f6af1a33209a7578c297f71d92ee1e334e545fa6b461aaf983"
+    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a",
+    "contextDigest": "dfd949bb0a5a3ef0eeaadc605e82089f150437ed4526f5c2290b3c064bc65a1a"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "150f9639e6d99212f74fd1ddffff8fc6bf05bedb6449fafeb8f95cf1f2c9e9a8",
-    "validationDigest": "b9a8c413ff931e29f27be45d22cea95dfda0c069d57df70667405938078a3960",
+    "digest": "ceb9bc7ccf40ebd764abd7a7dfad7aa1f8fda35f4e858d4853dfe692951848f4",
+    "validationDigest": "c267d07b1414962d5bc9cf1f929c31b68977c843ec8a9b80fbab284f85b08462",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "ea979a83edb576da0dc8b19ffbf4034466a5cdde4a592ef587a6569b899cd5e2"
+  "qualityDigest": "79c53757ffcbeca8a733a3fbef3ae34ed20bbce570336e5e141bfe1d7821b8f9"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858",
+    "auditedInputDigest": "11cc8d4d491acdce7e824a52cb892b373184160ab6e7961f020fe92fe38cec3d",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
-    "dossierDigest": "087c774b56add49d807f6ca751bd0e3a51b709751dcf52b64052d9be48a59ae4",
+    "dossierDigest": "1e8b6d5172087fd6af8bd380550e951372c77dbe34b3d6bae33b0c1fac42a3e6",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "087c774b56add49d807f6ca751bd0e3a51b709751dcf52b64052d9be48a59ae4",
+        "dossierDigest": "1e8b6d5172087fd6af8bd380550e951372c77dbe34b3d6bae33b0c1fac42a3e6",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "b9a8c413ff931e29f27be45d22cea95dfda0c069d57df70667405938078a3960"
+  "validationDigest": "c267d07b1414962d5bc9cf1f929c31b68977c843ec8a9b80fbab284f85b08462"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "11cc8d4d491acdce7e824a52cb892b373184160ab6e7961f020fe92fe38cec3d",
+    "auditedInputDigest": "7d09f9f35ebb0b88b6b332f0b1a0fe3415162ef40d4657b580b117d773a66386",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
-    "dossierDigest": "1e8b6d5172087fd6af8bd380550e951372c77dbe34b3d6bae33b0c1fac42a3e6",
+    "dossierDigest": "c5154deb3aaa4678019f8262dca512e031de65d4a71a82656507a66910add69e",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "1e8b6d5172087fd6af8bd380550e951372c77dbe34b3d6bae33b0c1fac42a3e6",
+        "dossierDigest": "c5154deb3aaa4678019f8262dca512e031de65d4a71a82656507a66910add69e",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "c267d07b1414962d5bc9cf1f929c31b68977c843ec8a9b80fbab284f85b08462"
+  "validationDigest": "cc16925924dbaf17d32e1e6d2b8a0fcf82250aef7af584a9ea0c7e2013b214a2"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
-    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858"
+    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a",
+    "auditedInputDigest": "11cc8d4d491acdce7e824a52cb892b373184160ab6e7961f020fe92fe38cec3d"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "d7de591ef47e06efcf5144b93de90e2d631f2bf17614db603e6d6d10aa3c14e5",
+    "dossierDigest": "0f7c81bfbc1163ac615f8eb0d0959265a247e3e89600c43d6508596a7a5e8ff4",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "4d94171760a8b4e83cebd57e0a914c0f50b1f94b9ad853dba7ff61d0248eaf7e"
+  "contextDigest": "80c10c3b47ce381c933aafceafe79833a77703672a74e88646204aba484f3558"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a",
-    "auditedInputDigest": "11cc8d4d491acdce7e824a52cb892b373184160ab6e7961f020fe92fe38cec3d"
+    "sourceManifestDigest": "04cced4eb8f5595c5cea95f0394246f1adb6f6c097581c8d52c76171f1b3c496",
+    "auditedInputDigest": "7d09f9f35ebb0b88b6b332f0b1a0fe3415162ef40d4657b580b117d773a66386"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "0f7c81bfbc1163ac615f8eb0d0959265a247e3e89600c43d6508596a7a5e8ff4",
+    "dossierDigest": "faf90eb51089dac90bbe42900e768474473254b1e1adb3c1db025fd4188bcf78",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "80c10c3b47ce381c933aafceafe79833a77703672a74e88646204aba484f3558"
+  "contextDigest": "4b1d86591b33f1765957517edd0b979693217ced5c763bb7f6283f0df1b39f13"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9"
+    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4d94171760a8b4e83cebd57e0a914c0f50b1f94b9ad853dba7ff61d0248eaf7e",
-    "qualityDigest": "650ff946876e9a5ea7db6334c35e48a36df0b335a9a537b94b7abe6c982a47df",
+    "contextDigest": "80c10c3b47ce381c933aafceafe79833a77703672a74e88646204aba484f3558",
+    "qualityDigest": "92025d6d392fdc5a299389452c8446f6d906dd13c251abc9c6156bbd47bbccbb",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "4b91c787f01ecce57cb772270bc4edc3ecb1d30931b2c236b2daeebdd3c0432e"
+  "activationDigest": "7e289ac2d68a93b072a18f871aae82e3b896c9373134d1044333061acaaae729"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a"
+    "sourceManifestDigest": "04cced4eb8f5595c5cea95f0394246f1adb6f6c097581c8d52c76171f1b3c496"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "80c10c3b47ce381c933aafceafe79833a77703672a74e88646204aba484f3558",
-    "qualityDigest": "92025d6d392fdc5a299389452c8446f6d906dd13c251abc9c6156bbd47bbccbb",
+    "contextDigest": "4b1d86591b33f1765957517edd0b979693217ced5c763bb7f6283f0df1b39f13",
+    "qualityDigest": "e7cca2dbcdbeac26e44a61a07f1b1fadc772d5b36c4554844d11d402806acaa1",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "7e289ac2d68a93b072a18f871aae82e3b896c9373134d1044333061acaaae729"
+  "activationDigest": "ef9209537bfa46f19982c3377ef06851840a2dd00aee563f2456451e96da1887"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a",
-    "contextDigest": "80c10c3b47ce381c933aafceafe79833a77703672a74e88646204aba484f3558"
+    "sourceManifestDigest": "04cced4eb8f5595c5cea95f0394246f1adb6f6c097581c8d52c76171f1b3c496",
+    "contextDigest": "4b1d86591b33f1765957517edd0b979693217ced5c763bb7f6283f0df1b39f13"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "9c61a4502ca2ba9153ef6c1b032c6deb2ede3b22f2f48a38cf30f1287e6ede4f",
-    "validationDigest": "8852d4294feae00b1d7d93fcb05ea2f603a09f3d2d95bbe54d0b4d35f8d9807f",
+    "digest": "c32c01801d758f56b6bd382d6345e5dbca7199c8c115aa8d727e1c494456e3b0",
+    "validationDigest": "f83c08092c4ed529c64173303d60f164626802f30edf9dbf008ea9b57c7aa976",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "92025d6d392fdc5a299389452c8446f6d906dd13c251abc9c6156bbd47bbccbb"
+  "qualityDigest": "e7cca2dbcdbeac26e44a61a07f1b1fadc772d5b36c4554844d11d402806acaa1"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ba42287d1301ce99ab59f2166590f97c1376a53b883df6050d3bbdf57506c8e9",
-    "contextDigest": "4d94171760a8b4e83cebd57e0a914c0f50b1f94b9ad853dba7ff61d0248eaf7e"
+    "sourceManifestDigest": "6765002b10a473e5c2bf43f7d3fbbe01817e6ad82b200f9c4d5a69f98916c19a",
+    "contextDigest": "80c10c3b47ce381c933aafceafe79833a77703672a74e88646204aba484f3558"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "86fb1b0f23ad09baf8857accc396db1de41a3824dbbd5a428c2cfce0c446cbfd",
-    "validationDigest": "8e9acac9897fab2ef2395f91e6d1555aa241b0d3ebb1a51d8d4491225c9dfa9a",
+    "digest": "9c61a4502ca2ba9153ef6c1b032c6deb2ede3b22f2f48a38cf30f1287e6ede4f",
+    "validationDigest": "8852d4294feae00b1d7d93fcb05ea2f603a09f3d2d95bbe54d0b4d35f8d9807f",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "650ff946876e9a5ea7db6334c35e48a36df0b335a9a537b94b7abe6c982a47df"
+  "qualityDigest": "92025d6d392fdc5a299389452c8446f6d906dd13c251abc9c6156bbd47bbccbb"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "11cc8d4d491acdce7e824a52cb892b373184160ab6e7961f020fe92fe38cec3d",
+    "auditedInputDigest": "7d09f9f35ebb0b88b6b332f0b1a0fe3415162ef40d4657b580b117d773a66386",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
-    "dossierDigest": "0f7c81bfbc1163ac615f8eb0d0959265a247e3e89600c43d6508596a7a5e8ff4",
+    "dossierDigest": "faf90eb51089dac90bbe42900e768474473254b1e1adb3c1db025fd4188bcf78",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "0f7c81bfbc1163ac615f8eb0d0959265a247e3e89600c43d6508596a7a5e8ff4",
+        "dossierDigest": "faf90eb51089dac90bbe42900e768474473254b1e1adb3c1db025fd4188bcf78",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "8852d4294feae00b1d7d93fcb05ea2f603a09f3d2d95bbe54d0b4d35f8d9807f"
+  "validationDigest": "f83c08092c4ed529c64173303d60f164626802f30edf9dbf008ea9b57c7aa976"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "535ecbfeedd44d62bc95ba01c98ad10307ec4b54b3ecb3edc29a4dba8543b858",
+    "auditedInputDigest": "11cc8d4d491acdce7e824a52cb892b373184160ab6e7961f020fe92fe38cec3d",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
-    "dossierDigest": "d7de591ef47e06efcf5144b93de90e2d631f2bf17614db603e6d6d10aa3c14e5",
+    "dossierDigest": "0f7c81bfbc1163ac615f8eb0d0959265a247e3e89600c43d6508596a7a5e8ff4",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "cd01022077766804ccf2b63ce8c25328adcf8dc692ac930685c6c528d6d844bf",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "d7de591ef47e06efcf5144b93de90e2d631f2bf17614db603e6d6d10aa3c14e5",
+        "dossierDigest": "0f7c81bfbc1163ac615f8eb0d0959265a247e3e89600c43d6508596a7a5e8ff4",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "8e9acac9897fab2ef2395f91e6d1555aa241b0d3ebb1a51d8d4491225c9dfa9a"
+  "validationDigest": "8852d4294feae00b1d7d93fcb05ea2f603a09f3d2d95bbe54d0b4d35f8d9807f"
 }

--- a/src/services/reviews/api.ts
+++ b/src/services/reviews/api.ts
@@ -6,7 +6,7 @@ import {
 import { getLifeCyclesByIdAndVersion } from '@/services/lifeCycleModels/api';
 import { supabase } from '@/services/supabase';
 import type { SupabaseError, SupabaseMutationResult } from '@/services/supabase/data';
-import { getUserId } from '@/services/users/api';
+import { getUserId, getUsersByIds } from '@/services/users/api';
 import type { WorkerJobResult } from '@/services/workerJobs/api';
 import { FunctionRegion } from '@supabase/supabase-js';
 import { getLangText, jsonToList } from '../general/util';
@@ -206,6 +206,12 @@ type ReviewMemberQueueRpcRow = {
   total_count?: number | string | null;
 };
 
+type VisibleReviewUser = {
+  id?: string | null;
+  email?: string | null;
+  display_name?: string | null;
+};
+
 function compareStableHashKeys(left: string, right: string): number {
   const leftBytes = STABLE_HASH_KEY_ENCODER.encode(left);
   const rightBytes = STABLE_HASH_KEY_ENCODER.encode(right);
@@ -369,11 +375,50 @@ function normalizeTotalCount(value: number | string | null | undefined) {
   return Number(value ?? 0) || 0;
 }
 
+function normalizeReviewUserText(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function getReviewSubmitterId(row: Pick<ReviewItemRpcRow, 'json'>) {
+  return normalizeReviewUserText(row?.json?.user?.id);
+}
+
+async function getReviewSubmitterNamesById(rows: Array<Pick<ReviewItemRpcRow, 'json'>>) {
+  const userIds = [...new Set(rows.map(getReviewSubmitterId).filter((id): id is string => !!id))];
+  const namesById = new Map<string, string>();
+
+  if (userIds.length === 0) {
+    return namesById;
+  }
+
+  try {
+    const users = (await getUsersByIds(userIds)) as VisibleReviewUser[] | null;
+    (users ?? []).forEach((user) => {
+      const userId = normalizeReviewUserText(user.id);
+      const userName =
+        normalizeReviewUserText(user.display_name) ?? normalizeReviewUserText(user.email);
+      if (userId && userName) {
+        namesById.set(userId, userName);
+      }
+    });
+  } catch (_error) {
+    // Identity enrichment is best-effort; retained review snapshots remain the safe fallback.
+  }
+
+  return namesById;
+}
+
 function mapReviewRowToTableData(
   row: ReviewItemRpcRow,
   lang: string,
   lifecycleModels: any[],
-  comments: { state_code: number }[] = [],
+  {
+    comments = [],
+    submitterNamesById = new Map(),
+  }: {
+    comments?: { state_code: number }[];
+    submitterNamesById?: ReadonlyMap<string, string>;
+  } = {},
 ) {
   const model = lifecycleModels?.find(
     (candidate) =>
@@ -384,6 +429,12 @@ function mapReviewRowToTableData(
   const reviewKind = row.review_kind ?? row?.json?.review_kind;
   const targetTable = row.target_table ?? row?.json?.data?.table;
   const stateCode = row.state_code ?? row.review_state_code;
+  const submitterId = getReviewSubmitterId(row);
+  const submitterName =
+    (submitterId ? submitterNamesById.get(submitterId) : undefined) ??
+    normalizeReviewUserText(row?.json?.user?.name) ??
+    normalizeReviewUserText(row?.json?.user?.email) ??
+    '-';
 
   return {
     key: row.id,
@@ -401,7 +452,7 @@ function mapReviewRowToTableData(
         ? genProcessName(modelName ?? {}, lang)
         : genProcessName(row?.json?.data?.name ?? {}, lang)) || '-',
     teamName: getLangText(row?.json?.team?.name ?? {}, lang),
-    userName: row?.json?.user?.name ?? row?.json?.user?.email ?? '-',
+    userName: submitterName,
     createAt: row.created_at ? new Date(row.created_at).toISOString() : undefined,
     modifiedAt: row.modified_at ? new Date(row.modified_at).toISOString() : undefined,
     deadline: row.deadline ? new Date(row.deadline).toISOString() : row.deadline,
@@ -760,11 +811,16 @@ export async function getReviewsTableDataOfReviewMember(
       version: row?.json?.data?.version,
     }))
     .filter((item) => item.id);
-  const modelResult = await getLifeCyclesByIdAndVersion(processes);
+  const [modelResult, submitterNamesById] = await Promise.all([
+    getLifeCyclesByIdAndVersion(processes),
+    getReviewSubmitterNamesById(rows),
+  ]);
   const lifecycleModels = Array.isArray(modelResult?.data) ? modelResult.data : [];
 
   return Promise.resolve({
-    data: rows.map((row) => mapReviewRowToTableData(row, lang, lifecycleModels)),
+    data: rows.map((row) =>
+      mapReviewRowToTableData(row, lang, lifecycleModels, { submitterNamesById }),
+    ),
     page: params?.current ?? 1,
     success: true,
     total: normalizeTotalCount(rows[0]?.total_count),
@@ -805,21 +861,22 @@ export async function getReviewsTableDataOfReviewAdmin(
       version: row?.json?.data?.version,
     }))
     .filter((item) => item.id);
-  const modelResult = await getLifeCyclesByIdAndVersion(processes);
+  const [modelResult, submitterNamesById] = await Promise.all([
+    getLifeCyclesByIdAndVersion(processes),
+    getReviewSubmitterNamesById(rows),
+  ]);
   const lifecycleModels = Array.isArray(modelResult?.data) ? modelResult.data : [];
 
   return Promise.resolve({
     data: rows.map((row) =>
-      mapReviewRowToTableData(
-        row,
-        lang,
-        lifecycleModels,
-        Array.isArray(row.comment_state_codes)
+      mapReviewRowToTableData(row, lang, lifecycleModels, {
+        comments: Array.isArray(row.comment_state_codes)
           ? row.comment_state_codes
               .map((stateCode) => ({ state_code: Number(stateCode) }))
               .filter((comment) => isCurrentAssignedReviewerCommentState(comment.state_code))
           : [],
-      ),
+        submitterNamesById,
+      }),
     ),
     page: params?.current ?? 1,
     success: true,

--- a/src/services/reviews/api.ts
+++ b/src/services/reviews/api.ts
@@ -414,11 +414,11 @@ function mapReviewRowToTableData(
   lifecycleModels: any[],
   {
     comments = [],
-    submitterNamesById = new Map(),
+    submitterNamesById,
   }: {
     comments?: { state_code: number }[];
-    submitterNamesById?: ReadonlyMap<string, string>;
-  } = {},
+    submitterNamesById: ReadonlyMap<string, string>;
+  },
 ) {
   const model = lifecycleModels?.find(
     (candidate) =>

--- a/tests/unit/services/reviews/api.test.ts
+++ b/tests/unit/services/reviews/api.test.ts
@@ -1483,6 +1483,37 @@ describe('getReviewsTableDataOfReviewMember', () => {
     expect(result.data[0].userName).toBe('Snapshot Submitter');
   });
 
+  it('keeps the retained review snapshot when no visible identity rows are returned', async () => {
+    mockRpc.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'review-member-profile-missing',
+          target_table: 'contacts',
+          json: {
+            data: { id: 'contact-profile-missing', version: '01.00.000' },
+            user: {
+              id: 'submitter-profile-missing',
+              email: 'snapshot-missing@example.com',
+            },
+          },
+        },
+      ],
+      error: null,
+    });
+    mockGetUsersByIds.mockResolvedValueOnce(null);
+
+    const result = await reviewsApi.getReviewsTableDataOfReviewMember(
+      { pageSize: 10, current: 1 },
+      {},
+      'pending',
+      'en',
+      { user_id: 'reviewer-1' },
+    );
+
+    expect(mockGetUsersByIds).toHaveBeenCalledWith(['submitter-profile-missing']);
+    expect(result.data[0].userName).toBe('snapshot-missing@example.com');
+  });
+
   it('maps reviewer-rejected comments with lifecycle model enrichment', async () => {
     mockRpc.mockResolvedValueOnce({
       data: [

--- a/tests/unit/services/reviews/api.test.ts
+++ b/tests/unit/services/reviews/api.test.ts
@@ -83,12 +83,14 @@ jest.mock('@/services/general/util', () => {
 });
 
 const mockGetUserId = jest.fn();
+const mockGetUsersByIds = jest.fn();
 let realGenProcessName: (...args: any[]) => any;
 const originalCrypto = globalThis.crypto;
 
 jest.mock('@/services/users/api', () => ({
   __esModule: true,
   getUserId: (...args: any[]) => mockGetUserId.apply(null, args),
+  getUsersByIds: (...args: any[]) => mockGetUsersByIds.apply(null, args),
 }));
 
 import * as reviewsApi from '@/services/reviews/api';
@@ -138,6 +140,8 @@ beforeEach(() => {
     return '-';
   });
   mockGetUserId.mockReset();
+  mockGetUsersByIds.mockReset();
+  mockGetUsersByIds.mockResolvedValue([]);
   mockGetUserId.mockResolvedValue('user-default');
 });
 
@@ -1409,6 +1413,76 @@ describe('getReviewsTableDataOfReviewMember', () => {
     expect(result).toEqual({ data: [], success: true, total: 0 });
   });
 
+  it.each([
+    { type: 'pending' as const },
+    { type: 'reviewed' as const },
+    { type: 'reviewer-rejected' as const },
+  ])('enriches $type rows from the current visible identity profile', async ({ type }) => {
+    mockRpc.mockResolvedValueOnce({
+      data: [
+        {
+          id: `review-member-${type}`,
+          target_table: 'contacts',
+          json: {
+            data: { id: `contact-${type}`, version: '01.00.000' },
+            user: { id: 'submitter-1', name: 'Stale Snapshot Name' },
+          },
+        },
+      ],
+      error: null,
+    });
+    mockGetUsersByIds.mockResolvedValueOnce([
+      {
+        id: 'submitter-1',
+        email: 'submitter@example.com',
+        display_name: 'Current Submitter',
+      },
+    ]);
+
+    const result = await reviewsApi.getReviewsTableDataOfReviewMember(
+      { pageSize: 10, current: 1 },
+      {},
+      type,
+      'en',
+      { user_id: 'reviewer-1' },
+    );
+
+    expect(mockGetUsersByIds).toHaveBeenCalledTimes(1);
+    expect(mockGetUsersByIds).toHaveBeenCalledWith(['submitter-1']);
+    expect(result.data[0].userName).toBe('Current Submitter');
+  });
+
+  it('keeps the retained review snapshot when identity enrichment fails', async () => {
+    mockRpc.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'review-member-profile-failure',
+          target_table: 'contacts',
+          json: {
+            data: { id: 'contact-profile-failure', version: '01.00.000' },
+            user: {
+              id: 'submitter-profile-failure',
+              name: 'Snapshot Submitter',
+              email: 'snapshot@example.com',
+            },
+          },
+        },
+      ],
+      error: null,
+    });
+    mockGetUsersByIds.mockRejectedValueOnce(new Error('identity lookup failed'));
+
+    const result = await reviewsApi.getReviewsTableDataOfReviewMember(
+      { pageSize: 10, current: 1 },
+      {},
+      'pending',
+      'en',
+      { user_id: 'reviewer-1' },
+    );
+
+    expect(result.data[0].userName).toBe('Snapshot Submitter');
+  });
+
   it('maps reviewer-rejected comments with lifecycle model enrichment', async () => {
     mockRpc.mockResolvedValueOnce({
       data: [
@@ -1772,6 +1846,69 @@ describe('getReviewsTableDataOfReviewAdmin', () => {
       p_sort_order: 'descend',
     });
     expect(result).toEqual({ data: [], success: true, total: 0 });
+  });
+
+  it.each([
+    { type: 'unassigned' as const },
+    { type: 'assigned' as const },
+    { type: 'admin-rejected' as const },
+  ])('batch-enriches and deduplicates submitters for $type rows', async ({ type }) => {
+    mockRpc.mockResolvedValueOnce({
+      data: [
+        {
+          id: `review-admin-${type}-1`,
+          target_table: 'contacts',
+          json: {
+            data: { id: `contact-${type}-1`, version: '01.00.000' },
+            user: { id: 'submitter-1', name: 'Stale Snapshot Name' },
+          },
+        },
+        {
+          id: `review-admin-${type}-2`,
+          target_table: 'sources',
+          json: {
+            data: { id: `source-${type}-2`, version: '01.00.000' },
+            user: { id: 'submitter-2' },
+          },
+        },
+        {
+          id: `review-admin-${type}-3`,
+          target_table: 'flows',
+          json: {
+            data: { id: `flow-${type}-3`, version: '01.00.000' },
+            user: { id: 'submitter-1' },
+          },
+        },
+      ],
+      error: null,
+    });
+    mockGetUsersByIds.mockResolvedValueOnce([
+      {
+        id: 'submitter-1',
+        email: 'submitter-1@example.com',
+        display_name: 'Current Submitter',
+      },
+      {
+        id: 'submitter-2',
+        email: 'submitter-2@example.com',
+        display_name: '   ',
+      },
+    ]);
+
+    const result = await reviewsApi.getReviewsTableDataOfReviewAdmin(
+      { pageSize: 10, current: 1 },
+      {},
+      type,
+      'en',
+    );
+
+    expect(mockGetUsersByIds).toHaveBeenCalledTimes(1);
+    expect(mockGetUsersByIds).toHaveBeenCalledWith(['submitter-1', 'submitter-2']);
+    expect(result.data.map((row: any) => row.userName)).toEqual([
+      'Current Submitter',
+      'submitter-2@example.com',
+      'Current Submitter',
+    ]);
   });
 
   it('applies assigned query filters and maps table data', async () => {


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#796

## Summary
- Batch-load current visible submitter profiles once per review queue page and map them into the shared review table rows.
- Apply the fallback order current display name, current email, retained snapshot name, retained snapshot email, then dash across admin and reviewer queues.

## Key Decisions
- Reuse the existing authorized qry_identity_get_visible_users boundary; do not change database visibility or queue pagination contracts.
- Run identity and lifecycle enrichment in parallel and keep identity enrichment best-effort so historical snapshots remain available.

## Validation
- npx jest tests/unit/services/reviews/api.test.ts --runInBand --no-watchman --coverage --collectCoverageFrom=src/services/reviews/api.ts: 88 passed; 100% statements, branches, functions, and lines.
- npm run prepush:gate via checked push: 411 suites passed; all 460 tracked source files are at 100/100/100/100.
- npm run build and npm run docpact:gate passed.

## Risks / Rollback
- Low: one bounded identity RPC per page; rollback by reverting the service mapping and generated locale artifact commits.

## Follow-ups
- No live backend smoke test was run because this local task did not use an authenticated product environment.

## Workspace Integration
- Routine Next PR targets dev; workspace submodule integration remains Pending until the change is promoted to child main.