### PR TITLE
fix: isolate TIDAS package tasks by authenticated user

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-09"
-lastReviewedCommit: "9b5d05e7ad315db37002c44b0b012f2a84beec5d"
-lastReviewedNote: 'Reviewed for Issues #778 and #780: existing ownership routes cover the merged grouped-review candidate plus automatic qualification evidence, composed-candidate preflight, release orchestration, tests, and governed release docs.'
+lastReviewedAt: '2026-08-10'
+lastReviewedCommit: 'c281df6e2fbdf3de23eea2da588e2c94420add2b'
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: authenticated task ownership, async generation guards, focused tests, and the exact Edge mirror remain covered by existing routes.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,9 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: 9b5d05e7ad315db37002c44b0b012f2a84beec5d
-lastReviewedNote: 'Reviewed for Issues #778 and #780: deterministic release preflight and grouped-review delivery remain within the documented dev-to-main, quality-gate, and root-integration boundaries.'
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: user-scoped task persistence and the generated Edge mirror stay within existing frontend, auth, and integration boundaries.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -29,9 +29,9 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - .nvmrc
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: 9b5d05e7ad315db37002c44b0b012f2a84beec5d
-lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged candidate keeps the Node 24, focused-proof, semantic qualification, managed-push, and deterministic release-command workflow.'
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: Node 24, focused Jest, Umi setup, TypeScript, mirror sync, and managed-push workflow remain unchanged.'
 ---
 
 # Development Bootstrap

--- a/docker/volumes/functions/.source-revision.json
+++ b/docker/volumes/functions/.source-revision.json
@@ -1,5 +1,5 @@
 {
   "repository": "https://github.com/linancn/tiangong-lca-edge-functions.git",
-  "commit": "515fef453affa4b0d3f459bf0fa26ea80e9ac213",
+  "commit": "b4869b6f1f9e7b26dc3e18efc2a26749cfd00b9e",
   "sourcePath": "supabase/functions"
 }

--- a/docker/volumes/functions/_shared/lca_all_unit_solve_queue.ts
+++ b/docker/volumes/functions/_shared/lca_all_unit_solve_queue.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
+import type { LcaSnapshotScope } from './lca_snapshot_capabilities.ts';
 import type { LcaCalculationEvidenceBinding } from './lca_snapshot_scope.ts';
 
 import {
@@ -23,7 +24,7 @@ type AllUnitSolvePayload = {
 
 type AllUnitSolveNormalizedRequest = {
   version: string;
-  scope: string;
+  scope: LcaSnapshotScope;
   snapshot_id: string;
   demand_mode: 'all_unit';
   solve: { return_x: false; return_g: false; return_h: true };
@@ -45,7 +46,7 @@ export type LcaAllUnitSolveQueueResult =
 export async function ensureLcaAllUnitSolveQueued(
   supabase: SupabaseClient,
   args: {
-    scope: string;
+    scope: LcaSnapshotScope;
     snapshotId: string;
     userId: string;
     calculationEvidenceBinding?: LcaCalculationEvidenceBinding | null;

--- a/docker/volumes/functions/_shared/lca_snapshot_build_queue.ts
+++ b/docker/volumes/functions/_shared/lca_snapshot_build_queue.ts
@@ -1,5 +1,7 @@
 import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
+import type { LcaSnapshotScope } from './lca_snapshot_capabilities.ts';
+
 import {
   buildLcaMethodFactorSourceContract,
   buildLciaFactorCoverageContract,
@@ -38,7 +40,7 @@ const VERSIONED_SCOPE_SNAPSHOT_BUILD_REQUEST_VERSION = 'lca_snapshot_build_v2';
 export async function ensureLcaSnapshotBuildQueued(
   supabase: SupabaseClient,
   args: {
-    scope: string;
+    scope: LcaSnapshotScope;
     dataScope: LcaDataScope;
     userId: string;
     requestRoots?: readonly LcaSnapshotRequestRoot[];

--- a/docker/volumes/functions/_shared/lca_snapshot_capabilities.ts
+++ b/docker/volumes/functions/_shared/lca_snapshot_capabilities.ts
@@ -1,5 +1,22 @@
 import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
+export const DEFAULT_LCA_SNAPSHOT_SCOPE = 'full_library' as const;
+export type LcaSnapshotScope = typeof DEFAULT_LCA_SNAPSHOT_SCOPE | 'data_product';
+
+export function parseLcaSnapshotScope(value: unknown): LcaSnapshotScope | null {
+  if (value === undefined || value === null) {
+    return DEFAULT_LCA_SNAPSHOT_SCOPE;
+  }
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const scope = value.trim();
+  if (!scope) {
+    return DEFAULT_LCA_SNAPSHOT_SCOPE;
+  }
+  return scope === 'full_library' || scope === 'data_product' ? scope : null;
+}
+
 export type LcaSnapshotCandidate = {
   snapshotId: string;
   scope: string;
@@ -31,7 +48,7 @@ export type LcaSnapshotCandidatesResult =
 export async function queryLcaSnapshotCandidates(
   client: Pick<SupabaseClient, 'rpc'>,
   request: {
-    scope: 'full_library' | 'data_product';
+    scope: LcaSnapshotScope;
     snapshotId?: string | null;
     processFilterContains?: unknown;
     limit?: number;

--- a/docker/volumes/functions/_shared/tidas_package.ts
+++ b/docker/volumes/functions/_shared/tidas_package.ts
@@ -701,6 +701,24 @@ export function buildPackageJobDiagnosticsSummary(args: {
     normalizeNullableNumber(exportArtifact.artifact_byte_size);
   const stage = normalizeNullableString(diagnostics.stage ?? diagnostics.phase);
   const uploadMode = normalizeNullableString(diagnostics.upload_mode);
+
+  // A successful terminal status is authoritative. Diagnostics and request
+  // cache rows can outlive an earlier failed attempt, but must not make the
+  // completed job look failed to API consumers.
+  if (args.status === 'ready' || args.status === 'completed') {
+    return {
+      error_code: null,
+      message: null,
+      stage,
+      upload_mode: uploadMode,
+      artifact_byte_size: artifactByteSize,
+      http_status: null,
+      storage_error_code: null,
+      is_oversize: false,
+      source: 'none',
+    };
+  }
+
   const httpStatus = normalizeNullableNumber(diagnostics.http_status);
   const isOversize = normalizedErrorCode === 'artifact_too_large';
   const message =

--- a/docker/volumes/functions/lca_contribution_path/index.ts
+++ b/docker/volumes/functions/lca_contribution_path/index.ts
@@ -5,7 +5,11 @@ import { authenticateRequest, AuthMethod } from '../_shared/auth.ts';
 import { corsHeaders } from '../_shared/cors.ts';
 import { validateProcessEntriesInDataScope } from '../_shared/lca_process_scope.ts';
 import { ensureLcaSnapshotBuildQueued } from '../_shared/lca_snapshot_build_queue.ts';
-import { queryLcaSnapshotCandidates } from '../_shared/lca_snapshot_capabilities.ts';
+import {
+  parseLcaSnapshotScope,
+  queryLcaSnapshotCandidates,
+  type LcaSnapshotScope,
+} from '../_shared/lca_snapshot_capabilities.ts';
 import {
   buildLcaCalculationEvidenceBinding,
   buildSnapshotContainsFilter,
@@ -143,7 +147,10 @@ Deno.serve(async (req) => {
     return json({ error: 'invalid_payload' }, 400);
   }
 
-  const scope = (body.scope ?? 'prod').trim() || 'prod';
+  const scope = parseLcaSnapshotScope(body.scope);
+  if (!scope) {
+    return json({ error: 'invalid_scope' }, 400);
+  }
   const dataScope = parseLcaDataScope(body.data_scope);
   const processId = body.process_id?.trim() ?? '';
   const processVersion = body.process_version?.trim() ?? '';
@@ -389,7 +396,7 @@ function parseContributionPathOptions(
 }
 
 async function resolveReadySnapshot(
-  scope: string,
+  scope: LcaSnapshotScope,
   requestedSnapshotId?: string,
   userId?: string,
   dataScope: LcaDataScope = 'current_user',
@@ -436,7 +443,7 @@ async function resolveReadySnapshot(
   }
 
   const candidates = await queryLcaSnapshotCandidates(supabaseClient, {
-    scope: scope === 'data_product' ? 'data_product' : 'full_library',
+    scope,
     limit: 1,
   });
   if (!candidates.ok) {
@@ -456,13 +463,13 @@ async function resolveReadySnapshot(
 }
 
 async function fetchReadySnapshotForDataScope(
-  scope: string,
+  scope: LcaSnapshotScope,
   userId: string,
   dataScope: LcaDataScope,
 ): Promise<ScopedSnapshotResolution> {
   const expectedProcessFilter = await buildSnapshotProcessFilter(dataScope, userId);
   const result = await queryLcaSnapshotCandidates(supabaseClient, {
-    scope: scope === 'data_product' ? 'data_product' : 'full_library',
+    scope,
     processFilterContains: buildSnapshotContainsFilter(expectedProcessFilter),
     limit: 100,
   });

--- a/docker/volumes/functions/lca_query_results/index.ts
+++ b/docker/volumes/functions/lca_query_results/index.ts
@@ -18,7 +18,11 @@ import {
   validateProcessEntriesInDataScope,
 } from '../_shared/lca_process_scope.ts';
 import { ensureLcaSnapshotBuildQueued } from '../_shared/lca_snapshot_build_queue.ts';
-import { queryLcaSnapshotCandidates } from '../_shared/lca_snapshot_capabilities.ts';
+import {
+  parseLcaSnapshotScope,
+  queryLcaSnapshotCandidates,
+  type LcaSnapshotScope,
+} from '../_shared/lca_snapshot_capabilities.ts';
 import {
   buildLcaCalculationEvidenceBinding,
   buildSnapshotContainsFilter,
@@ -165,7 +169,10 @@ Deno.serve(async (req) => {
     return json({ error: 'invalid_payload' }, 400);
   }
 
-  const scope = (body.scope ?? 'prod').trim() || 'prod';
+  const scope = parseLcaSnapshotScope(body.scope);
+  if (!scope) {
+    return json({ error: 'invalid_scope' }, 400);
+  }
   const dataScope = parseLcaDataScope(body.data_scope);
   const mode = body.mode;
   const allowFallback = body.allow_fallback ?? true;
@@ -608,7 +615,7 @@ async function resolveCalculationEvidenceBinding(
 }
 
 async function resolveReadySnapshot(
-  scope: string,
+  scope: LcaSnapshotScope,
   requestedSnapshotId?: string,
   userId?: string,
   dataScope: LcaDataScope = 'current_user',
@@ -655,7 +662,7 @@ async function resolveReadySnapshot(
   }
 
   const candidates = await queryLcaSnapshotCandidates(supabaseClient, {
-    scope: scope === 'data_product' ? 'data_product' : 'full_library',
+    scope,
     limit: 1,
   });
   if (!candidates.ok) {
@@ -675,13 +682,13 @@ async function resolveReadySnapshot(
 }
 
 async function fetchReadySnapshotForDataScope(
-  scope: string,
+  scope: LcaSnapshotScope,
   userId: string,
   dataScope: LcaDataScope,
 ): Promise<ScopedSnapshotResolution> {
   const expectedProcessFilter = await buildSnapshotProcessFilter(dataScope, userId);
   const result = await queryLcaSnapshotCandidates(supabaseClient, {
-    scope: scope === 'data_product' ? 'data_product' : 'full_library',
+    scope,
     processFilterContains: buildSnapshotContainsFilter(expectedProcessFilter),
     limit: 100,
   });

--- a/docker/volumes/functions/lca_solve/index.ts
+++ b/docker/volumes/functions/lca_solve/index.ts
@@ -11,7 +11,11 @@ import {
   type NormalizedSingleProcessDemand,
 } from '../_shared/lca_process_scope.ts';
 import { ensureLcaSnapshotBuildQueued } from '../_shared/lca_snapshot_build_queue.ts';
-import { queryLcaSnapshotCandidates } from '../_shared/lca_snapshot_capabilities.ts';
+import {
+  parseLcaSnapshotScope,
+  queryLcaSnapshotCandidates,
+  type LcaSnapshotScope,
+} from '../_shared/lca_snapshot_capabilities.ts';
 import {
   buildLcaCalculationEvidenceBinding,
   buildSnapshotContainsFilter,
@@ -128,7 +132,10 @@ Deno.serve(async (req) => {
     return json({ error: 'request_roots_not_allowed' }, 400);
   }
 
-  const scope = (body.scope ?? 'prod').trim() || 'prod';
+  const scope = parseLcaSnapshotScope(body.scope);
+  if (!scope) {
+    return json({ error: 'invalid_scope' }, 400);
+  }
   const requestedSnapshotId = body.snapshot_id?.trim() || undefined;
   const dataScope = parseLcaDataScope(body.data_scope);
   const demandMode = body.demand_mode ?? 'single';
@@ -245,7 +252,7 @@ Deno.serve(async (req) => {
   let normalizedRequest:
     | {
         version: string;
-        scope: string;
+        scope: LcaSnapshotScope;
         snapshot_id: string;
         demand_mode: 'single';
         demand: { process_index: number; amount: number };
@@ -255,7 +262,7 @@ Deno.serve(async (req) => {
       }
     | {
         version: string;
-        scope: string;
+        scope: LcaSnapshotScope;
         snapshot_id: string;
         demand_mode: 'all_unit';
         solve: { return_x: boolean; return_g: boolean; return_h: boolean };
@@ -499,7 +506,7 @@ async function resolveCalculationEvidenceBinding(input: {
 }
 
 async function resolveReadySnapshot(
-  scope: string,
+  scope: LcaSnapshotScope,
   dataScope: LcaDataScope,
   requestedSnapshotId?: string,
   userId?: string,
@@ -544,7 +551,7 @@ async function resolveReadySnapshot(
   }
 
   const candidates = await queryLcaSnapshotCandidates(supabaseClient, {
-    scope: scope === 'data_product' ? 'data_product' : 'full_library',
+    scope,
     limit: 1,
   });
   if (!candidates.ok) {
@@ -566,14 +573,14 @@ async function resolveReadySnapshot(
 }
 
 async function fetchScopedReadySnapshot(
-  scope: string,
+  scope: LcaSnapshotScope,
   dataScope: LcaDataScope,
   userId: string,
   requestRoots: readonly LcaSnapshotRequestRoot[] = [],
 ): Promise<ScopedSnapshotResolution> {
   const expectedProcessFilter = await buildSnapshotProcessFilter(dataScope, userId, requestRoots);
   const result = await queryLcaSnapshotCandidates(supabaseClient, {
-    scope: scope === 'data_product' ? 'data_product' : 'full_library',
+    scope,
     processFilterContains: buildSnapshotContainsFilter(expectedProcessFilter),
     limit: 100,
   });

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -30,9 +30,9 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: 9b5d05e7ad315db37002c44b0b012f2a84beec5d
-lastReviewedNote: 'Reviewed for Issues #778 and #780: dual-scope Docpact review and the grouped-review candidate continue through the unchanged checked-push and retry-receipt policy.'
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: task-center tests and mirror sync use the unchanged checked-push, Docpact, and full-gate policy.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,9 +25,9 @@ checkPaths:
   - playwright.config.ts
   - config/docs-capture/**
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: 9b5d05e7ad315db37002c44b0b012f2a84beec5d
-lastReviewedNote: 'Reviewed for Issues #778 and #780: release automation preserves existing runtime boundaries while grouped-review queue, selection, and dataset views remain database-authority consumers.'
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: task-center state is bound to authenticated user identity and the Edge runtime remains an exact generated mirror.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,9 +30,9 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: 9b5d05e7ad315db37002c44b0b012f2a84beec5d
-lastReviewedNote: 'Reviewed for Issues #778 and #780: the merged proof matrix covers independent release paths plus the seven-type Root/Reference queue, selection, and dataset-view behavior.'
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: focused auth/task-center tests, lint, generated Umi types, TypeScript, and exact-mirror checks remain the proof path.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -22,9 +22,9 @@ checkPaths:
   - scripts/e2e/**
   - playwright.config.ts
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: 9b5d05e7ad315db37002c44b0b012f2a84beec5d
-lastReviewedNote: 'Reviewed for database-engine Issue #422: Next defaults RPC calls to api, keeps only nine core entities on explicit public access, and consumes the exact reviewed Edge mirror.'
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: the database namespace boundary is unchanged and Next consumes the exact reviewed Edge commit through the mirror helper.'
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -27,9 +27,9 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - package.json
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: 9b5d05e7ad315db37002c44b0b012f2a84beec5d
-lastReviewedNote: 'Reviewed for Issues #778 and #780: release-path and grouped-review coverage extend bounded proof without changing the repository testing strategy.'
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: user-switch and stale-async regression coverage follows the existing maintenance strategy.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -29,9 +29,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: 9b5d05e7ad315db37002c44b0b012f2a84beec5d
-lastReviewedNote: 'Reviewed for Issues #778 and #780: hermetic release-preflight and grouped-review regression proof leave no new repository-wide test backlog.'
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: focused task-center/auth proof closes the regression without opening a repository-wide test backlog.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -30,9 +30,9 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: 9b5d05e7ad315db37002c44b0b012f2a84beec5d
-lastReviewedNote: 'Reviewed for Issues #778 and #780: release proof and grouped-review tests continue to use existing bounded Docpact and service/UI testing patterns.'
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: deferred async results and user-switch isolation are covered with the existing focused service-unit pattern.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -27,9 +27,9 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: 9b5d05e7ad315db37002c44b0b012f2a84beec5d
-lastReviewedNote: 'Reviewed for Issues #778 and #780: automatic dual-scope release review and focused grouped-review proof require no new recovery exception.'
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: the focused serial Jest and Umi setup flow remains sufficient; no new recovery exception is needed.'
 ---
 
 # Testing Troubleshooting

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -19,6 +19,7 @@ import { getCurrentUser as queryCurrentUser } from '@/services/auth';
 import { LOGIN_PATH, isAnonymousAllowedPath } from '@/services/general/publicRoutePolicy';
 import { resolveBrowserRuntimeLocale } from '@/services/general/runtimeLocale';
 import { getSystemUserRoleApi } from '@/services/roles/api';
+import { bindTidasPackageTaskCenterOwner } from '@/services/tidasPackage/taskCenter';
 import styles from '@/style/custom.less';
 import { DashboardOutlined, DatabaseOutlined, LinkOutlined } from '@ant-design/icons';
 import type { Settings as LayoutSettings } from '@ant-design/pro-components';
@@ -71,14 +72,17 @@ export async function getInitialState(): Promise<{
     try {
       const msg = await queryCurrentUser();
       if (!msg) {
+        bindTidasPackageTaskCenterOwner(null);
         history.push(LOGIN_PATH);
         return null;
       }
+      bindTidasPackageTaskCenterOwner(msg.userid);
       return {
         ...msg,
         access: await getSystemAccess(),
       };
     } catch (error) {
+      bindTidasPackageTaskCenterOwner(null);
       history.push(LOGIN_PATH);
     }
     return null;
@@ -101,6 +105,7 @@ export async function getInitialState(): Promise<{
       isDarkMode,
     };
   }
+  bindTidasPackageTaskCenterOwner(null);
   return {
     fetchUserInfo,
     settings: updatedSettings as Partial<LayoutSettings>,

--- a/src/services/auth/api.ts
+++ b/src/services/auth/api.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/services/supabase';
+import { bindTidasPackageTaskCenterOwner } from '@/services/tidasPackage/taskCenter';
 
 /**
  * Get current authenticated user information
@@ -50,6 +51,7 @@ export async function login(body: Auth.LoginParams): Promise<Auth.LoginResult> {
  * @returns Error if logout failed, null if successful
  */
 export async function logout() {
+  bindTidasPackageTaskCenterOwner(null);
   const { error } = await supabase.auth.signOut();
   return error;
 }

--- a/src/services/tidasPackage/taskCenter.ts
+++ b/src/services/tidasPackage/taskCenter.ts
@@ -50,7 +50,8 @@ type PersistedTaskStore = {
 };
 
 const MAX_TASK_ITEMS = 30;
-const STORAGE_KEY = 'tg_tidas_package_task_center_v1';
+const LEGACY_STORAGE_KEY = 'tg_tidas_package_task_center_v1';
+const STORAGE_KEY_PREFIX = `${LEGACY_STORAGE_KEY}:user`;
 const STORAGE_SCHEMA_VERSION = 1;
 const STORAGE_TTL_MS = 72 * 60 * 60 * 1000;
 const POLL_INTERVAL_MS = 1500;
@@ -69,6 +70,8 @@ const TIDAS_PACKAGE_WORKER_JOB_STATUSES: WorkerJobStatus[] = [
 
 let taskSequence = 0;
 let tasks: TidasPackageBackgroundTask[] = [];
+let taskOwnerId: string | null = null;
+let taskGeneration = 0;
 const listeners = new Set<() => void>();
 const activePollers = new Set<string>();
 
@@ -101,8 +104,25 @@ function canUseStorage(): boolean {
   return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
 }
 
+function normalizeTaskOwnerId(ownerId: string | null | undefined): string | null {
+  const normalized = typeof ownerId === 'string' ? ownerId.trim() : '';
+  return normalized || null;
+}
+
+export function getTidasPackageTaskStorageKey(ownerId: string): string {
+  const normalized = normalizeTaskOwnerId(ownerId);
+  if (!normalized) {
+    throw new Error('TIDAS package task storage requires an authenticated user id');
+  }
+  return `${STORAGE_KEY_PREFIX}:${encodeURIComponent(normalized)}`;
+}
+
+function isActiveGeneration(generation: number): boolean {
+  return taskOwnerId !== null && generation === taskGeneration;
+}
+
 function persistTasksToStorage(): void {
-  if (!canUseStorage()) {
+  if (!canUseStorage() || !taskOwnerId) {
     return;
   }
 
@@ -113,13 +133,19 @@ function persistTasksToStorage(): void {
   };
 
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    window.localStorage.setItem(
+      getTidasPackageTaskStorageKey(taskOwnerId),
+      JSON.stringify(payload),
+    );
   } catch (_error) {
     // Ignore storage failures.
   }
 }
 
-function setTasks(next: TidasPackageBackgroundTask[]): void {
+function setTasks(next: TidasPackageBackgroundTask[], generation = taskGeneration): void {
+  if (!isActiveGeneration(generation)) {
+    return;
+  }
   tasks = next
     .slice()
     .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt))
@@ -270,25 +296,26 @@ function normalizeTask(raw: unknown, fallbackSequence: number): TidasPackageBack
 }
 
 function readTasksFromStorage(): TidasPackageBackgroundTask[] {
-  if (!canUseStorage()) {
+  if (!canUseStorage() || !taskOwnerId) {
     return [];
   }
 
+  const storageKey = getTidasPackageTaskStorageKey(taskOwnerId);
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const raw = window.localStorage.getItem(storageKey);
     if (!raw) {
       return [];
     }
 
     const parsed = JSON.parse(raw) as PersistedTaskStore;
     if (!parsed || parsed.version !== STORAGE_SCHEMA_VERSION) {
-      window.localStorage.removeItem(STORAGE_KEY);
+      window.localStorage.removeItem(storageKey);
       return [];
     }
 
     const savedAtMs = Date.parse(String(parsed.savedAt ?? ''));
     if (Number.isFinite(savedAtMs) && Date.now() - savedAtMs > STORAGE_TTL_MS) {
-      window.localStorage.removeItem(STORAGE_KEY);
+      window.localStorage.removeItem(storageKey);
       return [];
     }
 
@@ -306,7 +333,14 @@ function readTasksFromStorage(): TidasPackageBackgroundTask[] {
   }
 }
 
-function upsertTask(taskId: string, patch: Partial<TidasPackageBackgroundTask>): void {
+function upsertTask(
+  taskId: string,
+  patch: Partial<TidasPackageBackgroundTask>,
+  generation = taskGeneration,
+): void {
+  if (!isActiveGeneration(generation)) {
+    return;
+  }
   const index = tasks.findIndex((item) => item.id === taskId);
   if (index < 0) {
     return;
@@ -326,7 +360,7 @@ function upsertTask(taskId: string, patch: Partial<TidasPackageBackgroundTask>):
 
   const next = tasks.slice();
   next[index] = updated;
-  setTasks(next);
+  setTasks(next, generation);
 }
 
 function toErrorMessage(error: unknown): string {
@@ -568,80 +602,110 @@ function mergeWorkerJobTask(serverTask: TidasPackageBackgroundTask): TidasPackag
   };
 }
 
-function applyJobToTask(taskId: string, job: TidasPackageJobResponse): void {
+function applyJobToTask(
+  taskId: string,
+  job: TidasPackageJobResponse,
+  generation = taskGeneration,
+): void {
+  if (!isActiveGeneration(generation)) {
+    return;
+  }
   const current = tasks.find((item) => item.id === taskId);
   const phase = phaseFromJob(job);
   const isCompleted = phase === 'completed';
   const isFailed = phase === 'failed';
 
-  upsertTask(taskId, {
-    phase,
-    state: isCompleted ? 'completed' : isFailed ? 'failed' : 'running',
-    message: messageFromJob(job, current?.request),
-    jobId: job.job_id,
-    scope: job.scope,
-    rootCount:
-      typeof job.root_count === 'number' && Number.isFinite(job.root_count) ? job.root_count : 0,
-    filename: filenameFromJob(job, current?.request),
-    error: isFailed
-      ? (current?.error ??
-        normalizeTidasPackageExportErrorMessage(
-          typeof job.request_cache?.error_message === 'string'
-            ? job.request_cache.error_message
-            : typeof job.diagnostics?.error === 'string'
-              ? job.diagnostics.error
-              : typeof job.diagnostics?.message === 'string'
-                ? job.diagnostics.message
-                : null,
-          'TIDAS package export failed',
-        ))
-      : undefined,
-  });
+  upsertTask(
+    taskId,
+    {
+      phase,
+      state: isCompleted ? 'completed' : isFailed ? 'failed' : 'running',
+      message: messageFromJob(job, current?.request),
+      jobId: job.job_id,
+      scope: job.scope,
+      rootCount:
+        typeof job.root_count === 'number' && Number.isFinite(job.root_count) ? job.root_count : 0,
+      filename: filenameFromJob(job, current?.request),
+      error: isFailed
+        ? (current?.error ??
+          normalizeTidasPackageExportErrorMessage(
+            typeof job.request_cache?.error_message === 'string'
+              ? job.request_cache.error_message
+              : typeof job.diagnostics?.error === 'string'
+                ? job.diagnostics.error
+                : typeof job.diagnostics?.message === 'string'
+                  ? job.diagnostics.message
+                  : null,
+            'TIDAS package export failed',
+          ))
+        : undefined,
+    },
+    generation,
+  );
 }
 
-async function pollTask(taskId: string, jobId: string): Promise<void> {
-  if (activePollers.has(taskId)) {
+async function pollTask(taskId: string, jobId: string, generation = taskGeneration): Promise<void> {
+  if (!isActiveGeneration(generation)) {
     return;
   }
 
-  activePollers.add(taskId);
+  const pollerKey = `${generation}:${taskId}`;
+  if (activePollers.has(pollerKey)) {
+    return;
+  }
+
+  activePollers.add(pollerKey);
   const startedAt = Date.now();
   let consecutiveErrors = 0;
   try {
     while (Date.now() - startedAt <= POLL_TIMEOUT_MS) {
+      if (!isActiveGeneration(generation)) {
+        return;
+      }
       const task = tasks.find((item) => item.id === taskId);
       if (!task || task.state !== 'running') {
         return;
       }
 
       const { data, error } = await getTidasPackageJobApi(jobId);
+      if (!isActiveGeneration(generation)) {
+        return;
+      }
       if (error || !data?.ok) {
         consecutiveErrors += 1;
         if (consecutiveErrors >= POLL_TRANSIENT_ERROR_RETRY_LIMIT) {
-          upsertTask(taskId, {
-            phase: 'failed',
-            state: 'failed',
-            message: 'Export task failed',
-            error: normalizeTidasPackageExportErrorMessage(
-              error?.message,
-              'Failed to load TIDAS package job status',
-            ),
-          });
+          upsertTask(
+            taskId,
+            {
+              phase: 'failed',
+              state: 'failed',
+              message: 'Export task failed',
+              error: normalizeTidasPackageExportErrorMessage(
+                error?.message,
+                'Failed to load TIDAS package job status',
+              ),
+            },
+            generation,
+          );
           return;
         }
 
-        upsertTask(taskId, {
-          phase: task.phase === 'submitting' ? 'queued' : task.phase,
-          state: 'running',
-          message: `Connection interrupted while checking export status, retrying (${consecutiveErrors}/${POLL_TRANSIENT_ERROR_RETRY_LIMIT})`,
-          error: undefined,
-        });
+        upsertTask(
+          taskId,
+          {
+            phase: task.phase === 'submitting' ? 'queued' : task.phase,
+            state: 'running',
+            message: `Connection interrupted while checking export status, retrying (${consecutiveErrors}/${POLL_TRANSIENT_ERROR_RETRY_LIMIT})`,
+            error: undefined,
+          },
+          generation,
+        );
         await delay(POLL_INTERVAL_MS);
         continue;
       }
 
       consecutiveErrors = 0;
-      applyJobToTask(taskId, data);
+      applyJobToTask(taskId, data, generation);
       if (data.status === 'failed' || data.status === 'stale') {
         return;
       }
@@ -652,57 +716,83 @@ async function pollTask(taskId: string, jobId: string): Promise<void> {
       await delay(POLL_INTERVAL_MS);
     }
 
-    upsertTask(taskId, {
-      phase: 'failed',
-      state: 'failed',
-      message: 'Export task timed out',
-      error: 'tidas_package_export_timeout',
-    });
+    upsertTask(
+      taskId,
+      {
+        phase: 'failed',
+        state: 'failed',
+        message: 'Export task timed out',
+        error: 'tidas_package_export_timeout',
+      },
+      generation,
+    );
   } finally {
-    activePollers.delete(taskId);
+    activePollers.delete(pollerKey);
   }
 }
 
-async function runExportTask(taskId: string, request: ExportTidasPackageRequest): Promise<void> {
+async function runExportTask(
+  taskId: string,
+  request: ExportTidasPackageRequest,
+  generation: number,
+): Promise<void> {
   try {
     const queued = await queueExportTidasPackageApi(request);
+    if (!isActiveGeneration(generation)) {
+      return;
+    }
     if (queued.error || !queued.data?.ok) {
       throw queued.error ?? new Error((queued.data as any)?.message ?? 'Export failed');
     }
 
-    upsertTask(taskId, {
-      phase: queued.data.mode === 'queued' ? 'queued' : 'submitting',
-      state: 'running',
-      message:
-        queued.data.mode === 'cache_hit'
-          ? 'Checking cached export package'
-          : `Export task queued (${queued.data.job_id})`,
-      workerJobId: queued.data.worker_job_id ?? undefined,
-      jobId: queued.data.job_id,
-      scope: queued.data.scope,
-      rootCount: queued.data.root_count ?? 0,
-    });
+    upsertTask(
+      taskId,
+      {
+        phase: queued.data.mode === 'queued' ? 'queued' : 'submitting',
+        state: 'running',
+        message:
+          queued.data.mode === 'cache_hit'
+            ? 'Checking cached export package'
+            : `Export task queued (${queued.data.job_id})`,
+        workerJobId: queued.data.worker_job_id ?? undefined,
+        jobId: queued.data.job_id,
+        scope: queued.data.scope,
+        rootCount: queued.data.root_count ?? 0,
+      },
+      generation,
+    );
 
-    await pollTask(taskId, queued.data.job_id);
+    await pollTask(taskId, queued.data.job_id, generation);
   } catch (error) {
-    upsertTask(taskId, {
-      phase: 'failed',
-      state: 'failed',
-      message: 'Export task failed',
-      error: toErrorMessage(error),
-    });
+    upsertTask(
+      taskId,
+      {
+        phase: 'failed',
+        state: 'failed',
+        message: 'Export task failed',
+        error: toErrorMessage(error),
+      },
+      generation,
+    );
   }
 }
 
 export async function refreshTidasPackageTasksFromWorkerJobs(): Promise<
   TidasPackageBackgroundTask[]
 > {
+  const generation = taskGeneration;
+  if (!isActiveGeneration(generation)) {
+    return tasks;
+  }
   const result = await requestWorkerJobsApi({
     action: 'list',
     subjectType: 'lca_package_job',
     statuses: TIDAS_PACKAGE_WORKER_JOB_STATUSES,
     limit: MAX_TASK_ITEMS,
   });
+  if (!isActiveGeneration(generation)) {
+    return tasks;
+  }
   if (result.error) {
     throw new Error(result.error.message || 'Failed to refresh TIDAS package worker jobs');
   }
@@ -725,7 +815,7 @@ export async function refreshTidasPackageTasksFromWorkerJobs(): Promise<
     }
   }
 
-  setTasks(merged);
+  setTasks(merged, generation);
   const maxSequence = tasks.reduce((max, item) => Math.max(max, item.sequence), 0);
   if (maxSequence > taskSequence) {
     taskSequence = maxSequence;
@@ -733,10 +823,13 @@ export async function refreshTidasPackageTasksFromWorkerJobs(): Promise<
   return tasks;
 }
 
-function hydrateTasksFromStorage(): void {
+function hydrateTasksFromStorage(generation: number): void {
+  if (!isActiveGeneration(generation)) {
+    return;
+  }
   const restored = readTasksFromStorage();
   if (restored.length > 0) {
-    setTasks(restored);
+    setTasks(restored, generation);
     const maxSequence = restored.reduce((max, item) => Math.max(max, item.sequence), 0);
     if (maxSequence > taskSequence) {
       taskSequence = maxSequence;
@@ -745,16 +838,50 @@ function hydrateTasksFromStorage(): void {
     restored
       .filter((item) => item.state === 'running' && item.jobId)
       .forEach((item) => {
-        void pollTask(item.id, item.jobId!);
+        void pollTask(item.id, item.jobId!, generation);
       });
   }
 
   void refreshTidasPackageTasksFromWorkerJobs().catch(() => undefined);
 }
 
+export function bindTidasPackageTaskCenterOwner(ownerId: string | null | undefined): void {
+  const normalizedOwnerId = normalizeTaskOwnerId(ownerId);
+  if (normalizedOwnerId === taskOwnerId) {
+    return;
+  }
+
+  taskGeneration += 1;
+  taskOwnerId = normalizedOwnerId;
+  taskSequence = 0;
+  tasks = [];
+  activePollers.clear();
+  emitChange();
+
+  if (!normalizedOwnerId) {
+    return;
+  }
+
+  if (canUseStorage()) {
+    try {
+      // The pre-fix global snapshot cannot be attributed to an authenticated
+      // owner, so it is deliberately discarded rather than migrated.
+      window.localStorage.removeItem(LEGACY_STORAGE_KEY);
+    } catch (_error) {
+      // Ignore storage failures.
+    }
+  }
+
+  hydrateTasksFromStorage(taskGeneration);
+}
+
 export function submitTidasPackageExportTask(
   request: ExportTidasPackageRequest,
 ): TidasPackageBackgroundTask {
+  if (!taskOwnerId) {
+    throw new Error('TIDAS package task center requires an authenticated user');
+  }
+  const generation = taskGeneration;
   const createdAt = nowIso();
   const sequence = nextTaskSequence();
   const task: TidasPackageBackgroundTask = {
@@ -770,14 +897,15 @@ export function submitTidasPackageExportTask(
     rootCount: request.roots?.length ?? 0,
   };
 
-  setTasks([task, ...tasks]);
-  void runExportTask(task.id, request);
+  setTasks([task, ...tasks], generation);
+  void runExportTask(task.id, request, generation);
   return task;
 }
 
 export async function downloadTidasPackageExportTask(
   taskId: string,
 ): Promise<ExportTidasPackageResponse> {
+  const generation = taskGeneration;
   const task = tasks.find((item) => item.id === taskId);
   if (!task?.jobId) {
     throw new Error('Package export task is missing job information');
@@ -791,10 +919,18 @@ export async function downloadTidasPackageExportTask(
     throw result.error ?? new Error('Failed to download TIDAS package');
   }
 
-  upsertTask(taskId, {
-    filename: result.data.filename,
-    message: `Export package ready (${result.data.filename})`,
-  });
+  if (!isActiveGeneration(generation)) {
+    return result.data;
+  }
+
+  upsertTask(
+    taskId,
+    {
+      filename: result.data.filename,
+      message: `Export package ready (${result.data.filename})`,
+    },
+    generation,
+  );
 
   return result.data;
 }
@@ -817,5 +953,3 @@ export function subscribeTidasPackageTasks(listener: () => void): () => void {
     listeners.delete(listener);
   };
 }
-
-hydrateTasksFromStorage();

--- a/tests/unit/app.test.tsx
+++ b/tests/unit/app.test.tsx
@@ -5,6 +5,7 @@ const mockQueryCurrentUser = jest.fn();
 const mockGetSystemUserRoleApi = jest.fn();
 const mockGetLocalizedAppTitle = jest.fn(() => 'Localized TianGong');
 const mockResolveBrowserRuntimeLocale = jest.fn(() => 'de-DE');
+const mockBindTidasPackageTaskCenterOwner = jest.fn();
 const mockHistory = {
   location: {
     pathname: '/tgdata',
@@ -69,6 +70,11 @@ jest.mock('@/services/auth', () => ({
 jest.mock('@/services/roles/api', () => ({
   __esModule: true,
   getSystemUserRoleApi: (...args: any[]) => mockGetSystemUserRoleApi(...args),
+}));
+
+jest.mock('@/services/tidasPackage/taskCenter', () => ({
+  __esModule: true,
+  bindTidasPackageTaskCenterOwner: (...args: any[]) => mockBindTidasPackageTaskCenterOwner(...args),
 }));
 
 jest.mock('@/services/general/runtimeLocale', () => ({
@@ -178,6 +184,15 @@ describe('app runtime config', () => {
     });
   });
 
+  it('binds the package task center to the authenticated user before rendering', async () => {
+    const { getInitialState } = require('@/app');
+    mockQueryCurrentUser.mockResolvedValueOnce({ name: 'Current User', userid: 'user-a' });
+
+    await getInitialState();
+
+    expect(mockBindTidasPackageTaskCenterOwner).toHaveBeenCalledWith('user-a');
+  });
+
   it('getInitialState loads dashboard users so admin route access can gate the page', async () => {
     const { getInitialState } = require('@/app');
     mockHistory.location.pathname = '/dashboard/national-carbon';
@@ -236,6 +251,7 @@ describe('app runtime config', () => {
     const state = await getInitialState();
 
     expect(mockHistory.push).toHaveBeenCalledWith('/user/login');
+    expect(mockBindTidasPackageTaskCenterOwner).toHaveBeenCalledWith(null);
     expect(state.currentUser).toBeNull();
   });
 
@@ -273,6 +289,7 @@ describe('app runtime config', () => {
       const state = await getInitialState();
 
       expect(mockQueryCurrentUser).not.toHaveBeenCalled();
+      expect(mockBindTidasPackageTaskCenterOwner).toHaveBeenCalledWith(null);
       expect(state.currentUser).toBeUndefined();
       expect(typeof state.fetchUserInfo).toBe('function');
     },

--- a/tests/unit/services/auth/api.test.ts
+++ b/tests/unit/services/auth/api.test.ts
@@ -22,6 +22,7 @@ import {
   updateTeamNotificationTime,
 } from '@/services/auth/api';
 import { supabase } from '@/services/supabase';
+import { bindTidasPackageTaskCenterOwner } from '@/services/tidasPackage/taskCenter';
 
 jest.mock('@/services/supabase', () => ({
   supabase: {
@@ -36,6 +37,10 @@ jest.mock('@/services/supabase', () => ({
       getUser: jest.fn(),
     },
   },
+}));
+
+jest.mock('@/services/tidasPackage/taskCenter', () => ({
+  bindTidasPackageTaskCenterOwner: jest.fn(),
 }));
 
 const authMock = (
@@ -170,6 +175,7 @@ describe('Auth API service (src/services/auth/api.ts)', () => {
 
       const result = await logout();
 
+      expect(bindTidasPackageTaskCenterOwner).toHaveBeenCalledWith(null);
       expect(authMock.signOut).toHaveBeenCalledTimes(1);
       expect(result).toBeNull();
     });

--- a/tests/unit/services/supabase/schemaBoundary.test.ts
+++ b/tests/unit/services/supabase/schemaBoundary.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const ROOT = process.cwd();
-const EXPECTED_EDGE_COMMIT = '515fef453affa4b0d3f459bf0fa26ea80e9ac213';
+const EXPECTED_EDGE_COMMIT = 'b4869b6f1f9e7b26dc3e18efc2a26749cfd00b9e';
 const NON_CORE_RELATIONS = ['roles', 'teams', 'users', 'comments', 'reviews'];
 
 function sourceFiles(directory: string): string[] {

--- a/tests/unit/services/tidasPackage/taskCenter.test.ts
+++ b/tests/unit/services/tidasPackage/taskCenter.test.ts
@@ -1,6 +1,10 @@
 import { waitFor } from '@testing-library/react';
 
-const STORAGE_KEY = 'tg_tidas_package_task_center_v1';
+const LEGACY_STORAGE_KEY = 'tg_tidas_package_task_center_v1';
+const DEFAULT_OWNER_ID = 'user-a';
+const storageKeyForOwner = (ownerId: string) =>
+  `${LEGACY_STORAGE_KEY}:user:${encodeURIComponent(ownerId)}`;
+const STORAGE_KEY = storageKeyForOwner(DEFAULT_OWNER_ID);
 
 const mockQueueExportTidasPackageApi = jest.fn();
 const mockGetTidasPackageJobApi = jest.fn();
@@ -19,12 +23,28 @@ jest.mock('@/services/workerJobs/api', () => ({
   requestWorkerJobsApi: (...args: any[]) => mockRequestWorkerJobsApi(...args),
 }));
 
-function loadTaskCenterModule() {
+function loadUnboundTaskCenterModule() {
   let loaded: any;
   jest.isolateModules(() => {
     loaded = require('@/services/tidasPackage/taskCenter');
   });
   return loaded as typeof import('@/services/tidasPackage/taskCenter');
+}
+
+function loadTaskCenterModule(ownerId = DEFAULT_OWNER_ID) {
+  const loaded = loadUnboundTaskCenterModule();
+  loaded.bindTidasPackageTaskCenterOwner(ownerId);
+  return loaded;
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
 }
 
 const flushPromises = async () => {
@@ -42,6 +62,151 @@ describe('tidasPackage/taskCenter', () => {
     mockRequestWorkerJobsApi.mockResolvedValue({ data: [], error: null });
     jest.useRealTimers();
     localStorage.clear();
+  });
+
+  it('stays inert until an authenticated owner is bound and discards legacy global storage', async () => {
+    localStorage.setItem(
+      LEGACY_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        savedAt: new Date().toISOString(),
+        tasks: [
+          {
+            id: 'legacy-task',
+            state: 'completed',
+            phase: 'completed',
+            message: 'must not hydrate',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            sequence: 1,
+          },
+        ],
+      }),
+    );
+
+    const taskCenter = loadUnboundTaskCenterModule();
+    expect(taskCenter.listTidasPackageTasks()).toEqual([]);
+    expect(mockRequestWorkerJobsApi).not.toHaveBeenCalled();
+
+    taskCenter.bindTidasPackageTaskCenterOwner(DEFAULT_OWNER_ID);
+    expect(localStorage.getItem(LEGACY_STORAGE_KEY)).toBeNull();
+    expect(taskCenter.listTidasPackageTasks()).toEqual([]);
+    await waitFor(() => expect(mockRequestWorkerJobsApi).toHaveBeenCalledTimes(1));
+  });
+
+  it('keeps persisted task snapshots isolated when authenticated users switch', async () => {
+    const firstQueue = createDeferred<any>();
+    mockQueueExportTidasPackageApi
+      .mockReturnValueOnce(firstQueue.promise)
+      .mockResolvedValueOnce({ data: null, error: new Error('user-b fixture') });
+
+    const taskCenter = loadTaskCenterModule('user-a');
+    const userATask = taskCenter.submitTidasPackageExportTask({ scope: 'current_user' });
+    expect(JSON.parse(localStorage.getItem(storageKeyForOwner('user-a')) ?? '{}').tasks).toEqual([
+      expect.objectContaining({ id: userATask.id }),
+    ]);
+
+    taskCenter.bindTidasPackageTaskCenterOwner('user-b');
+    expect(taskCenter.listTidasPackageTasks()).toEqual([]);
+    const userBTask = taskCenter.submitTidasPackageExportTask({ scope: 'open_data' });
+    await waitFor(() => {
+      expect(taskCenter.listTidasPackageTasks()).toEqual([
+        expect.objectContaining({ id: userBTask.id, state: 'failed' }),
+      ]);
+    });
+
+    firstQueue.resolve({
+      data: {
+        ok: true,
+        mode: 'queued',
+        job_id: 'user-a-job',
+        scope: 'current_user',
+        root_count: 0,
+      },
+      error: null,
+    });
+    await flushPromises();
+    expect(taskCenter.listTidasPackageTasks()).toEqual([
+      expect.objectContaining({ id: userBTask.id }),
+    ]);
+    expect(localStorage.getItem(storageKeyForOwner('user-b'))).not.toBeNull();
+
+    taskCenter.bindTidasPackageTaskCenterOwner('user-a');
+    expect(taskCenter.listTidasPackageTasks()).toEqual([
+      expect.objectContaining({ id: userATask.id, phase: 'submitting' }),
+    ]);
+  });
+
+  it('ignores a worker refresh that resolves after the authenticated user changes', async () => {
+    const userARefresh = createDeferred<any>();
+    mockRequestWorkerJobsApi.mockReturnValueOnce(userARefresh.promise).mockResolvedValueOnce({
+      data: [
+        {
+          id: 'user-b-worker-job',
+          jobKind: 'tidas.export_package',
+          status: 'completed',
+          subjectId: 'user-b-package-job',
+        },
+      ],
+      error: null,
+    });
+
+    const taskCenter = loadTaskCenterModule('user-a');
+    taskCenter.bindTidasPackageTaskCenterOwner('user-b');
+    await waitFor(() => {
+      expect(taskCenter.listTidasPackageTasks()).toEqual([
+        expect.objectContaining({ id: 'user-b-worker-job' }),
+      ]);
+    });
+
+    userARefresh.resolve({
+      data: [
+        {
+          id: 'user-a-worker-job',
+          jobKind: 'tidas.export_package',
+          status: 'completed',
+          subjectId: 'user-a-package-job',
+        },
+      ],
+      error: null,
+    });
+    await flushPromises();
+    expect(taskCenter.listTidasPackageTasks()).toEqual([
+      expect.objectContaining({ id: 'user-b-worker-job' }),
+    ]);
+  });
+
+  it('ignores a package poll that resolves after the authenticated user changes', async () => {
+    const userAPoll = createDeferred<any>();
+    mockQueueExportTidasPackageApi.mockResolvedValueOnce({
+      data: {
+        ok: true,
+        mode: 'queued',
+        job_id: 'user-a-package-job',
+        scope: 'current_user',
+        root_count: 0,
+      },
+      error: null,
+    });
+    mockGetTidasPackageJobApi.mockReturnValueOnce(userAPoll.promise);
+
+    const taskCenter = loadTaskCenterModule('user-a');
+    taskCenter.submitTidasPackageExportTask({ scope: 'current_user' });
+    await waitFor(() => expect(mockGetTidasPackageJobApi).toHaveBeenCalledTimes(1));
+
+    taskCenter.bindTidasPackageTaskCenterOwner('user-b');
+    userAPoll.resolve({
+      data: {
+        ok: true,
+        status: 'completed',
+        job_id: 'user-a-package-job',
+        diagnostics: {},
+        artifacts_by_kind: {},
+      },
+      error: null,
+    });
+    await flushPromises();
+    expect(taskCenter.listTidasPackageTasks()).toEqual([]);
   });
 
   it('hydrates normalized tasks from storage and resumes running jobs', async () => {


### PR DESCRIPTION
Closes #799

## Summary
- Bind task-center state and persistence to the authenticated user, with a distinct encoded storage key per owner.
- Invalidate stale queue, refresh, poll, and download state writes when authentication generation changes.
- Mirror the exact reviewed Edge commit and update the canonical source receipt boundary.

## Key Decisions
- Discard the legacy unowned global localStorage snapshot because it cannot be safely attributed to a user.
- Clear in-memory tasks immediately on logout, anonymous routes, authentication failures, and user switches.

## Validation
- 93 focused Jest tests passed across task center, app auth binding, logout, and schema boundary.
- Focused ESLint, Prettier, Umi-generated TypeScript, and npm run tsc all passed.
- Docpact staged lint passed for all 26 changed paths.

## Risks / Rollback
- Existing legacy task history is intentionally dropped once an authenticated owner binds; server worker history rehydrates canonical tasks.

## Workspace Integration
- PR targets dev and pins Edge PR #273 commit b4869b6f1f9e7b26dc3e18efc2a26749cfd00b9e. Root main integration waits for both child changes to reach main.