### PR TITLE
fix: retain pending package export tasks during refresh

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-08-10'
-lastReviewedCommit: 'c281df6e2fbdf3de23eea2da588e2c94420add2b'
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: authenticated task ownership, async generation guards, focused tests, and the exact Edge mirror remain covered by existing routes.'
+lastReviewedCommit: '93821284b4ac9d4ed08ac6f42498e48bd2d15fda'
+lastReviewedNote: 'Reviewed the Issue #799 Dev regression follow-up: optimistic task retention and regenerated canonical locale artifacts remain covered by the existing service, test, and gate routes.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: user-scoped task persistence and the generated Edge mirror stay within existing frontend, auth, and integration boundaries.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed the Issue #799 Dev regression follow-up: optimistic package-task retention and canonical locale-artifact regeneration stay within existing frontend, validation, and integration boundaries.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: Node 24, focused Jest, Umi setup, TypeScript, mirror sync, and managed-push workflow remain unchanged.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed the Issue #799 Dev regression follow-up: Node 24, focused Jest, Umi setup, locale idempotence, TypeScript, build, Docpact, and managed push remain unchanged.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: task-center tests and mirror sync use the unchanged checked-push, Docpact, and full-gate policy.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed the Issue #799 Dev regression follow-up: the task-retention fix and canonical locale-artifact refresh use the unchanged checked-push, Docpact, and full-gate policy.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: task-center state is bound to authenticated user identity and the Edge runtime remains an exact generated mirror.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed the Issue #799 Dev regression follow-up: an optimistic package task stays visible until canonical Worker reconciliation, without changing service ownership or the Edge mirror.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: focused auth/task-center tests, lint, generated Umi types, TypeScript, and exact-mirror checks remain the proof path.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed the Issue #799 Dev regression follow-up: focused task-center proof plus locale-artifact idempotence, lint, TypeScript, build, and Docpact remain the validation path.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -23,8 +23,8 @@ checkPaths:
   - playwright.config.ts
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: the database namespace boundary is unchanged and Next consumes the exact reviewed Edge commit through the mirror helper.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed the Issue #799 Dev regression follow-up: optimistic task retention is app-side merge behavior and does not change the database, authentication, or Edge ownership boundary.'
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,8 +28,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: user-switch and stale-async regression coverage follows the existing maintenance strategy.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed the Issue #799 Dev regression follow-up: the full-history clock-skew case and regenerated canonical locale evidence follow the existing test maintenance strategy.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: focused task-center/auth proof closes the regression without opening a repository-wide test backlog.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed the Issue #799 Dev regression follow-up: focused task-center regressions close the optimistic-retention gap, and canonical locale evidence adds no new test backlog.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,8 +31,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: deferred async results and user-switch isolation are covered with the existing focused service-unit pattern.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed the Issue #799 Dev regression follow-up: a deferred queue and full-history fixture use the focused service-unit pattern; locale evidence stays generator-owned.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,8 +28,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: the focused serial Jest and Umi setup flow remains sufficient; no new recovery exception is needed.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed the Issue #799 Dev regression follow-up: focused serial Jest, Umi setup, and canonical locale regeneration are sufficient; no recovery exception is needed.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb",
-    "auditedInputDigest": "03c019c43ff4114decfa1ea6ea60b2cd61ac02bab5ed9d81adccd70ee9717bb9"
+    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec",
+    "auditedInputDigest": "afa22c8fb401c3ef023a064eb231b297091bfd5a563a090229ff269a4e1413bf"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "5150319411e12de3b35031849232b637c17ccc4216492efdf19ab9f630704210",
+    "dossierDigest": "0c1e299e44ad38047da532fc98d6a9d08026a6c5d942032aaddf831cfd45313c",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,15 +144,15 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "1faf9a4b23b3ecc7cfa2ef06327e573ad77959c3b2f06a597991cde88fb43f32",
+      "sourceEvidenceDigest": "34d8d29fe21396bbc039b09aaa0053b155417663ad99b4f8d20efb4f88b4515f",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
           "route": "/",
           "viewState": "redirect-to-welcome",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "036cb78afa507e1fdafd160df2ca4c23dfab36658e88a642d43ee508412dbeec",
-          "focusedTestDigest": "f824a85204d13f2087377889b5a6a148e4e6dffba617f372bdfbbeed872af565",
+          "sourceDigest": "29240dabf05a4eb49d106f4a9d46f5bc57076f9931c58688d6a35353ec20002f",
+          "focusedTestDigest": "558f4b5ed639a35cd03039c02a8fb8d797cc1cf4f2d8cc2b98c6a25aaaa27b13",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "d4754f0ac91aaabda0250ca6a0977f131654b0900d1b14b36a4c840aa42f6825",
           "derivedMessageCount": 44,
@@ -177,8 +177,8 @@
           "route": "/welcome",
           "viewState": "overview",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "3604ade9f26a1d7db784220ad08051f1f83b0c6055be2ba795087074b4fde91a",
-          "focusedTestDigest": "418392ac9aac981f7ecf485d1e2c71dbd4ee6ccebcf9ab81f94ea032cd8c7488",
+          "sourceDigest": "3a47f5d7d04c79e1ee4e0ee95eefd2889346216d602939132e3f8716fe5dbd47",
+          "focusedTestDigest": "e8c000360bea280085a55324f6397948468001f9140068341ead3d7abba52bb9",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "811949b6e0dccca1b6aa510e63afebb8839888cf24907b1dc2bae6a1755bf3d3",
           "derivedMessageCount": 45,
@@ -203,8 +203,8 @@
           "route": "/welcome?view=carbon-footprint",
           "viewState": "carbon-footprint-guide",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "3604ade9f26a1d7db784220ad08051f1f83b0c6055be2ba795087074b4fde91a",
-          "focusedTestDigest": "e39969021d5bd28c592dd65672b78d5f445bac233a8d4f4415a6b367c29b7888",
+          "sourceDigest": "3a47f5d7d04c79e1ee4e0ee95eefd2889346216d602939132e3f8716fe5dbd47",
+          "focusedTestDigest": "505c9bd61093a1d5f7037032721a82bfda69dd6481e243e96111ee2883501a7e",
           "plannedBrowserAssertionCount": 3,
           "plannedBrowserAssertionDigest": "7dce46b0e253c9000c52c96a89b772057bc78fbf5d13a1db1094e52d13b71be3",
           "derivedMessageCount": 77,
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "6cc7d3e59e8d68f0bf31cbf273e34e523bec0b5bf35113f856cf9f6649997127",
+          "sourceDigest": "81cdf5260f0628c68834ad7480fcf22f0362b8d22d446806bc40a08393622d47",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "f4667f4ac6398ea620fe3d7141ba6a14dd0e798398dec141b5c0491b535063d0",
+          "sourceDigest": "d4437736c255556fa6c1a335125b456d8ba89ecb5a0a9a4603cf6a253724c117",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "f43de572d115ad87c41934094ac4a68f4fb2fc4e07f2e8dce9cfc98431095b7e",
+          "sourceDigest": "0f64fed1ff2725b709b8b3e31f6d8af67336805bf2d5efdec932fb666c78f76c",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -301,8 +301,8 @@
           "route": "/dashboard/national-carbon",
           "viewState": "national-carbon-dashboard",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "43f604b36e6bd595fc98faa2cab3493772cf90fc290cd3ef315d2e8deb9aa551",
-          "focusedTestDigest": "fe03a6a43234f8d97e811c961b198ace5193b1d3399bea8f82b86cca7da28ae1",
+          "sourceDigest": "bb9b960614008dc7200bcd239ee5ce29c64e68869bff9f6d34dd46db03588240",
+          "focusedTestDigest": "c9786a4637c251dbb06d9312d8cc6cfdb0937c316e1c5d95d543c495166799d3",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "95b95698b9168443cacad5913312e98989fb251f09feee48fbaf5f7203c57587",
           "derivedMessageCount": 264,
@@ -367,8 +367,8 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "8ade645875468d9ca1d46a8192198b981f47bf2af3443fb4fd0366f94fc9a120",
-          "focusedTestDigest": "342a74fe96651abf404aa2c6f2212d0c85b6057c35fa5f74d0b91ae0687fcf39",
+          "sourceDigest": "54fde5a5b291c98c7c8119ac5d565c3d547fdeca44b44dd5ada6833bcf70c4c2",
+          "focusedTestDigest": "d847dd197b921ae4e91f7b23627490186c3c4fc51a15caa788684f61e1e26e68",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
           "derivedMessageCount": 6,
@@ -1042,8 +1042,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
-          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
+          "sourceDigest": "302ccc4ae35fa69d5b4a27ff2abcfa38db8218ecb49218ead4007f2a12e5f174",
+          "focusedTestDigest": "b13bc3461ea49d945a22b38ed816e8c5535f30e9188b367186ee9dadc31f0a11",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "2895fd4f8bea1929f57ae1db7df4e1005286f945aa01db2768f45b61e05c0b84",
+      "rowEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "d6c1bc6280852cb57b841221a2231cbc97029cbbbf09da0c77a040e300e9d896"
+  "contextDigest": "90a6d7aec87f04baf3f6d3cac65ad9bbad2c7f593e22472bc3a17363d0a858d5"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec",
-    "auditedInputDigest": "afa22c8fb401c3ef023a064eb231b297091bfd5a563a090229ff269a4e1413bf"
+    "sourceManifestDigest": "a48804ddb0f63c96595fcc0d539c3eae5a58d93e73d7c38b15ee5bbc0016d1a5",
+    "auditedInputDigest": "5efc838f892f973ca776ee96a86c67e12cd7d2bd7abb04c6219d58671589acfb"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "0c1e299e44ad38047da532fc98d6a9d08026a6c5d942032aaddf831cfd45313c",
+    "dossierDigest": "80565adaa082991b1a092a6557b668c13e213370b61d098142b72075a05c148d",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "90a6d7aec87f04baf3f6d3cac65ad9bbad2c7f593e22472bc3a17363d0a858d5"
+  "contextDigest": "97041595aae8b9be0180b5c60dbd76b9e6b9acc208217261dcf9f6f104d06dc1"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec"
+    "sourceManifestDigest": "a48804ddb0f63c96595fcc0d539c3eae5a58d93e73d7c38b15ee5bbc0016d1a5"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "90a6d7aec87f04baf3f6d3cac65ad9bbad2c7f593e22472bc3a17363d0a858d5",
-    "qualityDigest": "851aaad818762f96806e47e1042315f077c2797bc527a7ce5d2e05bc22d5298e",
+    "contextDigest": "97041595aae8b9be0180b5c60dbd76b9e6b9acc208217261dcf9f6f104d06dc1",
+    "qualityDigest": "2da124cb343c91c14937375c326279288ec34228c10540a5229d014726eca1b9",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "86054637bc52a68e95558d01ca1d64406ecefd8f2dd200cbc56604a9e0981417"
+  "activationDigest": "607ac5fdb8b56e85f4f6e359c69157933c7a218f1782adcd9573eadad6e652e7"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb"
+    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "d6c1bc6280852cb57b841221a2231cbc97029cbbbf09da0c77a040e300e9d896",
-    "qualityDigest": "78d0e7c203d778fe20373242755d50d4a49488d85befe08095d768173780309b",
+    "contextDigest": "90a6d7aec87f04baf3f6d3cac65ad9bbad2c7f593e22472bc3a17363d0a858d5",
+    "qualityDigest": "851aaad818762f96806e47e1042315f077c2797bc527a7ce5d2e05bc22d5298e",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "0c59ab166fd9f91ff606a9c6e713ff14ec524769cce04e33dd2a3ccdee66123f"
+  "activationDigest": "86054637bc52a68e95558d01ca1d64406ecefd8f2dd200cbc56604a9e0981417"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "afa22c8fb401c3ef023a064eb231b297091bfd5a563a090229ff269a4e1413bf",
+    "auditedInputDigest": "5efc838f892f973ca776ee96a86c67e12cd7d2bd7abb04c6219d58671589acfb",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "03c019c43ff4114decfa1ea6ea60b2cd61ac02bab5ed9d81adccd70ee9717bb9",
+    "auditedInputDigest": "afa22c8fb401c3ef023a064eb231b297091bfd5a563a090229ff269a4e1413bf",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -13724,7 +13724,7 @@
         {
           "kind": "formatMessage",
           "path": "src/app.tsx",
-          "line": 228,
+          "line": 233,
           "column": 16,
           "symbol": "layout",
           "defaultMessage": "OpenAPI documentation",
@@ -13737,7 +13737,7 @@
           "argumentSignature": [],
           "placeholders": [],
           "locations": [
-            { "path": "src/app.tsx", "line": 228, "column": 16, "kind": "formatMessage" }
+            { "path": "src/app.tsx", "line": 233, "column": 16, "kind": "formatMessage" }
           ]
         }
       ]
@@ -25039,7 +25039,7 @@
         {
           "kind": "formatMessage",
           "path": "src/app.tsx",
-          "line": 169,
+          "line": 174,
           "column": 20,
           "symbol": "layout",
           "defaultMessage": "Data Dashboard",
@@ -25052,7 +25052,7 @@
           "argumentSignature": [],
           "placeholders": [],
           "locations": [
-            { "path": "src/app.tsx", "line": 169, "column": 20, "kind": "formatMessage" }
+            { "path": "src/app.tsx", "line": 174, "column": 20, "kind": "formatMessage" }
           ]
         }
       ]
@@ -25176,7 +25176,7 @@
         {
           "kind": "formatMessage",
           "path": "src/app.tsx",
-          "line": 185,
+          "line": 190,
           "column": 20,
           "symbol": "layout",
           "defaultMessage": "Data Processing",
@@ -25189,7 +25189,7 @@
           "argumentSignature": [],
           "placeholders": [],
           "locations": [
-            { "path": "src/app.tsx", "line": 185, "column": 20, "kind": "formatMessage" }
+            { "path": "src/app.tsx", "line": 190, "column": 20, "kind": "formatMessage" }
           ]
         }
       ]
@@ -130383,7 +130383,7 @@
         {
           "kind": "formatMessage",
           "path": "src/app.tsx",
-          "line": 116,
+          "line": 121,
           "column": 5,
           "symbol": "appTitle",
           "defaultMessage": null,

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb",
-    "contextDigest": "d6c1bc6280852cb57b841221a2231cbc97029cbbbf09da0c77a040e300e9d896"
+    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec",
+    "contextDigest": "90a6d7aec87f04baf3f6d3cac65ad9bbad2c7f593e22472bc3a17363d0a858d5"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "d3d2dc172a8865bdf5ad77608a758eeff11bcb9788bc9df2001f53167e547464",
-    "validationDigest": "1da9f934bda33ae24dd9b2fb2b858cd7c38a4fc51c174872983fc507617d9e91",
+    "digest": "517e628a8daca49747bf17eded340f7ff4873d3cdb65dad63def4f8afbb95b7b",
+    "validationDigest": "6b4c2608d07e791cc4fee09f999319ce92fe714ad76b3984254f39fdced91f53",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "78d0e7c203d778fe20373242755d50d4a49488d85befe08095d768173780309b"
+  "qualityDigest": "851aaad818762f96806e47e1042315f077c2797bc527a7ce5d2e05bc22d5298e"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec",
-    "contextDigest": "90a6d7aec87f04baf3f6d3cac65ad9bbad2c7f593e22472bc3a17363d0a858d5"
+    "sourceManifestDigest": "a48804ddb0f63c96595fcc0d539c3eae5a58d93e73d7c38b15ee5bbc0016d1a5",
+    "contextDigest": "97041595aae8b9be0180b5c60dbd76b9e6b9acc208217261dcf9f6f104d06dc1"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "517e628a8daca49747bf17eded340f7ff4873d3cdb65dad63def4f8afbb95b7b",
-    "validationDigest": "6b4c2608d07e791cc4fee09f999319ce92fe714ad76b3984254f39fdced91f53",
+    "digest": "a23b69f4a7a6f77210fe72fae37960d8b8c00809e216818517368c6a2191defe",
+    "validationDigest": "ab8d01fb08fe8e5cd1bb8abb2357911a28b5363e81f94eccbb5835fdb6d99b35",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "851aaad818762f96806e47e1042315f077c2797bc527a7ce5d2e05bc22d5298e"
+  "qualityDigest": "2da124cb343c91c14937375c326279288ec34228c10540a5229d014726eca1b9"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "afa22c8fb401c3ef023a064eb231b297091bfd5a563a090229ff269a4e1413bf",
+    "auditedInputDigest": "5efc838f892f973ca776ee96a86c67e12cd7d2bd7abb04c6219d58671589acfb",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
-    "dossierDigest": "0c1e299e44ad38047da532fc98d6a9d08026a6c5d942032aaddf831cfd45313c",
+    "dossierDigest": "80565adaa082991b1a092a6557b668c13e213370b61d098142b72075a05c148d",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "0c1e299e44ad38047da532fc98d6a9d08026a6c5d942032aaddf831cfd45313c",
+        "dossierDigest": "80565adaa082991b1a092a6557b668c13e213370b61d098142b72075a05c148d",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "6b4c2608d07e791cc4fee09f999319ce92fe714ad76b3984254f39fdced91f53"
+  "validationDigest": "ab8d01fb08fe8e5cd1bb8abb2357911a28b5363e81f94eccbb5835fdb6d99b35"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "03c019c43ff4114decfa1ea6ea60b2cd61ac02bab5ed9d81adccd70ee9717bb9",
+    "auditedInputDigest": "afa22c8fb401c3ef023a064eb231b297091bfd5a563a090229ff269a4e1413bf",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
-    "dossierDigest": "5150319411e12de3b35031849232b637c17ccc4216492efdf19ab9f630704210",
+    "dossierDigest": "0c1e299e44ad38047da532fc98d6a9d08026a6c5d942032aaddf831cfd45313c",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "2895fd4f8bea1929f57ae1db7df4e1005286f945aa01db2768f45b61e05c0b84",
+    "routeEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "5150319411e12de3b35031849232b637c17ccc4216492efdf19ab9f630704210",
+        "dossierDigest": "0c1e299e44ad38047da532fc98d6a9d08026a6c5d942032aaddf831cfd45313c",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "1da9f934bda33ae24dd9b2fb2b858cd7c38a4fc51c174872983fc507617d9e91"
+  "validationDigest": "6b4c2608d07e791cc4fee09f999319ce92fe714ad76b3984254f39fdced91f53"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec",
-    "auditedInputDigest": "afa22c8fb401c3ef023a064eb231b297091bfd5a563a090229ff269a4e1413bf"
+    "sourceManifestDigest": "a48804ddb0f63c96595fcc0d539c3eae5a58d93e73d7c38b15ee5bbc0016d1a5",
+    "auditedInputDigest": "5efc838f892f973ca776ee96a86c67e12cd7d2bd7abb04c6219d58671589acfb"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "0242cd5242e6725300e6d0014db9d7a99ab91e6bca203a552b1cfb1710cb7413",
+    "dossierDigest": "84d03b0e0264bcc735b82c4266fd91e9b2621f9139348fe09afa5348fe425857",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "6c13dcbddf32555bfc0140a3fc204b05d15ac2ab3128581b5532712f6ea08647"
+  "contextDigest": "28ab8bea8b95d779b20d549b55633aa1b0c2f2ef0e743070f6abd1f948964cad"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb",
-    "auditedInputDigest": "03c019c43ff4114decfa1ea6ea60b2cd61ac02bab5ed9d81adccd70ee9717bb9"
+    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec",
+    "auditedInputDigest": "afa22c8fb401c3ef023a064eb231b297091bfd5a563a090229ff269a4e1413bf"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "2b8f833cc49268733f0f85588fa4d3e7017121a482479fea82ebd9f3f5ab14d3",
+    "dossierDigest": "0242cd5242e6725300e6d0014db9d7a99ab91e6bca203a552b1cfb1710cb7413",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,15 +144,15 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "1faf9a4b23b3ecc7cfa2ef06327e573ad77959c3b2f06a597991cde88fb43f32",
+      "sourceEvidenceDigest": "34d8d29fe21396bbc039b09aaa0053b155417663ad99b4f8d20efb4f88b4515f",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
           "route": "/",
           "viewState": "redirect-to-welcome",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "036cb78afa507e1fdafd160df2ca4c23dfab36658e88a642d43ee508412dbeec",
-          "focusedTestDigest": "f824a85204d13f2087377889b5a6a148e4e6dffba617f372bdfbbeed872af565",
+          "sourceDigest": "29240dabf05a4eb49d106f4a9d46f5bc57076f9931c58688d6a35353ec20002f",
+          "focusedTestDigest": "558f4b5ed639a35cd03039c02a8fb8d797cc1cf4f2d8cc2b98c6a25aaaa27b13",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "d4754f0ac91aaabda0250ca6a0977f131654b0900d1b14b36a4c840aa42f6825",
           "derivedMessageCount": 44,
@@ -177,8 +177,8 @@
           "route": "/welcome",
           "viewState": "overview",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "3604ade9f26a1d7db784220ad08051f1f83b0c6055be2ba795087074b4fde91a",
-          "focusedTestDigest": "418392ac9aac981f7ecf485d1e2c71dbd4ee6ccebcf9ab81f94ea032cd8c7488",
+          "sourceDigest": "3a47f5d7d04c79e1ee4e0ee95eefd2889346216d602939132e3f8716fe5dbd47",
+          "focusedTestDigest": "e8c000360bea280085a55324f6397948468001f9140068341ead3d7abba52bb9",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "811949b6e0dccca1b6aa510e63afebb8839888cf24907b1dc2bae6a1755bf3d3",
           "derivedMessageCount": 45,
@@ -203,8 +203,8 @@
           "route": "/welcome?view=carbon-footprint",
           "viewState": "carbon-footprint-guide",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "3604ade9f26a1d7db784220ad08051f1f83b0c6055be2ba795087074b4fde91a",
-          "focusedTestDigest": "e39969021d5bd28c592dd65672b78d5f445bac233a8d4f4415a6b367c29b7888",
+          "sourceDigest": "3a47f5d7d04c79e1ee4e0ee95eefd2889346216d602939132e3f8716fe5dbd47",
+          "focusedTestDigest": "505c9bd61093a1d5f7037032721a82bfda69dd6481e243e96111ee2883501a7e",
           "plannedBrowserAssertionCount": 3,
           "plannedBrowserAssertionDigest": "7dce46b0e253c9000c52c96a89b772057bc78fbf5d13a1db1094e52d13b71be3",
           "derivedMessageCount": 77,
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "6cc7d3e59e8d68f0bf31cbf273e34e523bec0b5bf35113f856cf9f6649997127",
+          "sourceDigest": "81cdf5260f0628c68834ad7480fcf22f0362b8d22d446806bc40a08393622d47",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "f4667f4ac6398ea620fe3d7141ba6a14dd0e798398dec141b5c0491b535063d0",
+          "sourceDigest": "d4437736c255556fa6c1a335125b456d8ba89ecb5a0a9a4603cf6a253724c117",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "f43de572d115ad87c41934094ac4a68f4fb2fc4e07f2e8dce9cfc98431095b7e",
+          "sourceDigest": "0f64fed1ff2725b709b8b3e31f6d8af67336805bf2d5efdec932fb666c78f76c",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -301,8 +301,8 @@
           "route": "/dashboard/national-carbon",
           "viewState": "national-carbon-dashboard",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "43f604b36e6bd595fc98faa2cab3493772cf90fc290cd3ef315d2e8deb9aa551",
-          "focusedTestDigest": "fe03a6a43234f8d97e811c961b198ace5193b1d3399bea8f82b86cca7da28ae1",
+          "sourceDigest": "bb9b960614008dc7200bcd239ee5ce29c64e68869bff9f6d34dd46db03588240",
+          "focusedTestDigest": "c9786a4637c251dbb06d9312d8cc6cfdb0937c316e1c5d95d543c495166799d3",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "95b95698b9168443cacad5913312e98989fb251f09feee48fbaf5f7203c57587",
           "derivedMessageCount": 264,
@@ -367,8 +367,8 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "8ade645875468d9ca1d46a8192198b981f47bf2af3443fb4fd0366f94fc9a120",
-          "focusedTestDigest": "342a74fe96651abf404aa2c6f2212d0c85b6057c35fa5f74d0b91ae0687fcf39",
+          "sourceDigest": "54fde5a5b291c98c7c8119ac5d565c3d547fdeca44b44dd5ada6833bcf70c4c2",
+          "focusedTestDigest": "d847dd197b921ae4e91f7b23627490186c3c4fc51a15caa788684f61e1e26e68",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
           "derivedMessageCount": 6,
@@ -1042,8 +1042,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
-          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
+          "sourceDigest": "302ccc4ae35fa69d5b4a27ff2abcfa38db8218ecb49218ead4007f2a12e5f174",
+          "focusedTestDigest": "b13bc3461ea49d945a22b38ed816e8c5535f30e9188b367186ee9dadc31f0a11",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "2895fd4f8bea1929f57ae1db7df4e1005286f945aa01db2768f45b61e05c0b84",
+      "rowEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "23b2967425b63d6762845a777251236db150bd020cdb096ea3095823a5e14c82"
+  "contextDigest": "6c13dcbddf32555bfc0140a3fc204b05d15ac2ab3128581b5532712f6ea08647"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec"
+    "sourceManifestDigest": "a48804ddb0f63c96595fcc0d539c3eae5a58d93e73d7c38b15ee5bbc0016d1a5"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "6c13dcbddf32555bfc0140a3fc204b05d15ac2ab3128581b5532712f6ea08647",
-    "qualityDigest": "1e2e75ac2b5706c4a2ae21d397f9fee3fe6f4414ff437b299938f1b26201a102",
+    "contextDigest": "28ab8bea8b95d779b20d549b55633aa1b0c2f2ef0e743070f6abd1f948964cad",
+    "qualityDigest": "d01f97692943d79c8a66d00c66a40297e3a19da79c604c10d97b70757a07aaa5",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "0869703b979cb0638ee76f5bb55ca3f1ff66128c21c1510ce7437ce0dcd02944"
+  "activationDigest": "1ae26c3eac1d41d8fbcc9a0604eafc7679870f844f4a6f24e0e4e21358822d8a"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb"
+    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "23b2967425b63d6762845a777251236db150bd020cdb096ea3095823a5e14c82",
-    "qualityDigest": "6348cfb82baab245c3237d9ee74d01f8bdc618cdd698a71bfbbf149b3e5340e0",
+    "contextDigest": "6c13dcbddf32555bfc0140a3fc204b05d15ac2ab3128581b5532712f6ea08647",
+    "qualityDigest": "1e2e75ac2b5706c4a2ae21d397f9fee3fe6f4414ff437b299938f1b26201a102",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "2efb20224ea983b73f88a692557dfd70b46bbcf6c17ea762f29fc5321f1c3078"
+  "activationDigest": "0869703b979cb0638ee76f5bb55ca3f1ff66128c21c1510ce7437ce0dcd02944"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec",
-    "contextDigest": "6c13dcbddf32555bfc0140a3fc204b05d15ac2ab3128581b5532712f6ea08647"
+    "sourceManifestDigest": "a48804ddb0f63c96595fcc0d539c3eae5a58d93e73d7c38b15ee5bbc0016d1a5",
+    "contextDigest": "28ab8bea8b95d779b20d549b55633aa1b0c2f2ef0e743070f6abd1f948964cad"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "124490d0c5369b67ea5a51db654c5ff89892d73e78121516161290ed776eb2b5",
-    "validationDigest": "40721f7032b4ba39e5d9b380759d06330e8e4c6cc149971b4b134aaaaf9c5a4e",
+    "digest": "71bfc131343271d137be5329149c34765146f3e2182b747f1ab0d5b7ad0ecb83",
+    "validationDigest": "7d0855a7bb88329753239f0d3febd1b2c325e5083cf4fb6edc519b9da1f1518a",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "1e2e75ac2b5706c4a2ae21d397f9fee3fe6f4414ff437b299938f1b26201a102"
+  "qualityDigest": "d01f97692943d79c8a66d00c66a40297e3a19da79c604c10d97b70757a07aaa5"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb",
-    "contextDigest": "23b2967425b63d6762845a777251236db150bd020cdb096ea3095823a5e14c82"
+    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec",
+    "contextDigest": "6c13dcbddf32555bfc0140a3fc204b05d15ac2ab3128581b5532712f6ea08647"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "9e42909d6644a8b637499138ebd644e1a7035965bacb632c092895b136f638fc",
-    "validationDigest": "82250729260154b85b3db84745bfd259fcbef6487074ea1201f32f02eb72e35b",
+    "digest": "124490d0c5369b67ea5a51db654c5ff89892d73e78121516161290ed776eb2b5",
+    "validationDigest": "40721f7032b4ba39e5d9b380759d06330e8e4c6cc149971b4b134aaaaf9c5a4e",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "6348cfb82baab245c3237d9ee74d01f8bdc618cdd698a71bfbbf149b3e5340e0"
+  "qualityDigest": "1e2e75ac2b5706c4a2ae21d397f9fee3fe6f4414ff437b299938f1b26201a102"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "03c019c43ff4114decfa1ea6ea60b2cd61ac02bab5ed9d81adccd70ee9717bb9",
+    "auditedInputDigest": "afa22c8fb401c3ef023a064eb231b297091bfd5a563a090229ff269a4e1413bf",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
-    "dossierDigest": "2b8f833cc49268733f0f85588fa4d3e7017121a482479fea82ebd9f3f5ab14d3",
+    "dossierDigest": "0242cd5242e6725300e6d0014db9d7a99ab91e6bca203a552b1cfb1710cb7413",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "2895fd4f8bea1929f57ae1db7df4e1005286f945aa01db2768f45b61e05c0b84",
+    "routeEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "2b8f833cc49268733f0f85588fa4d3e7017121a482479fea82ebd9f3f5ab14d3",
+        "dossierDigest": "0242cd5242e6725300e6d0014db9d7a99ab91e6bca203a552b1cfb1710cb7413",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "82250729260154b85b3db84745bfd259fcbef6487074ea1201f32f02eb72e35b"
+  "validationDigest": "40721f7032b4ba39e5d9b380759d06330e8e4c6cc149971b4b134aaaaf9c5a4e"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "afa22c8fb401c3ef023a064eb231b297091bfd5a563a090229ff269a4e1413bf",
+    "auditedInputDigest": "5efc838f892f973ca776ee96a86c67e12cd7d2bd7abb04c6219d58671589acfb",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
-    "dossierDigest": "0242cd5242e6725300e6d0014db9d7a99ab91e6bca203a552b1cfb1710cb7413",
+    "dossierDigest": "84d03b0e0264bcc735b82c4266fd91e9b2621f9139348fe09afa5348fe425857",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "0242cd5242e6725300e6d0014db9d7a99ab91e6bca203a552b1cfb1710cb7413",
+        "dossierDigest": "84d03b0e0264bcc735b82c4266fd91e9b2621f9139348fe09afa5348fe425857",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "40721f7032b4ba39e5d9b380759d06330e8e4c6cc149971b4b134aaaaf9c5a4e"
+  "validationDigest": "7d0855a7bb88329753239f0d3febd1b2c325e5083cf4fb6edc519b9da1f1518a"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec",
-    "auditedInputDigest": "afa22c8fb401c3ef023a064eb231b297091bfd5a563a090229ff269a4e1413bf"
+    "sourceManifestDigest": "a48804ddb0f63c96595fcc0d539c3eae5a58d93e73d7c38b15ee5bbc0016d1a5",
+    "auditedInputDigest": "5efc838f892f973ca776ee96a86c67e12cd7d2bd7abb04c6219d58671589acfb"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "34b470d3b287e170beba08d457a5fad813b3508572fd72921991649f280e8c2d",
+    "dossierDigest": "850fc23dd90f0668ed50a9dd6a17968723ccd1e2b06c5cad5a499b4ca0029eb9",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "b22691446f6a781fc4c5140064453cc55cd0be39c60607cc76293b1a85ef09e3"
+  "contextDigest": "572bc2337e97d7627a78cfdcc88bd89e4748f5894260f57c22176d3b2a2dbac4"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb",
-    "auditedInputDigest": "03c019c43ff4114decfa1ea6ea60b2cd61ac02bab5ed9d81adccd70ee9717bb9"
+    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec",
+    "auditedInputDigest": "afa22c8fb401c3ef023a064eb231b297091bfd5a563a090229ff269a4e1413bf"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "ab7cc0eb5379d66225cd35417904817c9fde1a22ec0e0f4bb46846d6b9d720b1",
+    "dossierDigest": "34b470d3b287e170beba08d457a5fad813b3508572fd72921991649f280e8c2d",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,15 +144,15 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "1faf9a4b23b3ecc7cfa2ef06327e573ad77959c3b2f06a597991cde88fb43f32",
+      "sourceEvidenceDigest": "34d8d29fe21396bbc039b09aaa0053b155417663ad99b4f8d20efb4f88b4515f",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
           "route": "/",
           "viewState": "redirect-to-welcome",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "036cb78afa507e1fdafd160df2ca4c23dfab36658e88a642d43ee508412dbeec",
-          "focusedTestDigest": "f824a85204d13f2087377889b5a6a148e4e6dffba617f372bdfbbeed872af565",
+          "sourceDigest": "29240dabf05a4eb49d106f4a9d46f5bc57076f9931c58688d6a35353ec20002f",
+          "focusedTestDigest": "558f4b5ed639a35cd03039c02a8fb8d797cc1cf4f2d8cc2b98c6a25aaaa27b13",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "d4754f0ac91aaabda0250ca6a0977f131654b0900d1b14b36a4c840aa42f6825",
           "derivedMessageCount": 44,
@@ -177,8 +177,8 @@
           "route": "/welcome",
           "viewState": "overview",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "3604ade9f26a1d7db784220ad08051f1f83b0c6055be2ba795087074b4fde91a",
-          "focusedTestDigest": "418392ac9aac981f7ecf485d1e2c71dbd4ee6ccebcf9ab81f94ea032cd8c7488",
+          "sourceDigest": "3a47f5d7d04c79e1ee4e0ee95eefd2889346216d602939132e3f8716fe5dbd47",
+          "focusedTestDigest": "e8c000360bea280085a55324f6397948468001f9140068341ead3d7abba52bb9",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "811949b6e0dccca1b6aa510e63afebb8839888cf24907b1dc2bae6a1755bf3d3",
           "derivedMessageCount": 45,
@@ -203,8 +203,8 @@
           "route": "/welcome?view=carbon-footprint",
           "viewState": "carbon-footprint-guide",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "3604ade9f26a1d7db784220ad08051f1f83b0c6055be2ba795087074b4fde91a",
-          "focusedTestDigest": "e39969021d5bd28c592dd65672b78d5f445bac233a8d4f4415a6b367c29b7888",
+          "sourceDigest": "3a47f5d7d04c79e1ee4e0ee95eefd2889346216d602939132e3f8716fe5dbd47",
+          "focusedTestDigest": "505c9bd61093a1d5f7037032721a82bfda69dd6481e243e96111ee2883501a7e",
           "plannedBrowserAssertionCount": 3,
           "plannedBrowserAssertionDigest": "7dce46b0e253c9000c52c96a89b772057bc78fbf5d13a1db1094e52d13b71be3",
           "derivedMessageCount": 77,
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "6cc7d3e59e8d68f0bf31cbf273e34e523bec0b5bf35113f856cf9f6649997127",
+          "sourceDigest": "81cdf5260f0628c68834ad7480fcf22f0362b8d22d446806bc40a08393622d47",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "f4667f4ac6398ea620fe3d7141ba6a14dd0e798398dec141b5c0491b535063d0",
+          "sourceDigest": "d4437736c255556fa6c1a335125b456d8ba89ecb5a0a9a4603cf6a253724c117",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "f43de572d115ad87c41934094ac4a68f4fb2fc4e07f2e8dce9cfc98431095b7e",
+          "sourceDigest": "0f64fed1ff2725b709b8b3e31f6d8af67336805bf2d5efdec932fb666c78f76c",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -301,8 +301,8 @@
           "route": "/dashboard/national-carbon",
           "viewState": "national-carbon-dashboard",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "43f604b36e6bd595fc98faa2cab3493772cf90fc290cd3ef315d2e8deb9aa551",
-          "focusedTestDigest": "fe03a6a43234f8d97e811c961b198ace5193b1d3399bea8f82b86cca7da28ae1",
+          "sourceDigest": "bb9b960614008dc7200bcd239ee5ce29c64e68869bff9f6d34dd46db03588240",
+          "focusedTestDigest": "c9786a4637c251dbb06d9312d8cc6cfdb0937c316e1c5d95d543c495166799d3",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "95b95698b9168443cacad5913312e98989fb251f09feee48fbaf5f7203c57587",
           "derivedMessageCount": 264,
@@ -367,8 +367,8 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "8ade645875468d9ca1d46a8192198b981f47bf2af3443fb4fd0366f94fc9a120",
-          "focusedTestDigest": "342a74fe96651abf404aa2c6f2212d0c85b6057c35fa5f74d0b91ae0687fcf39",
+          "sourceDigest": "54fde5a5b291c98c7c8119ac5d565c3d547fdeca44b44dd5ada6833bcf70c4c2",
+          "focusedTestDigest": "d847dd197b921ae4e91f7b23627490186c3c4fc51a15caa788684f61e1e26e68",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
           "derivedMessageCount": 6,
@@ -1042,8 +1042,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
-          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
+          "sourceDigest": "302ccc4ae35fa69d5b4a27ff2abcfa38db8218ecb49218ead4007f2a12e5f174",
+          "focusedTestDigest": "b13bc3461ea49d945a22b38ed816e8c5535f30e9188b367186ee9dadc31f0a11",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "2895fd4f8bea1929f57ae1db7df4e1005286f945aa01db2768f45b61e05c0b84",
+      "rowEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "d8d793126342d540fce3cfc957eb0a77c38bc13bd63237ca1efe5d571d30e4c5"
+  "contextDigest": "b22691446f6a781fc4c5140064453cc55cd0be39c60607cc76293b1a85ef09e3"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb"
+    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "d8d793126342d540fce3cfc957eb0a77c38bc13bd63237ca1efe5d571d30e4c5",
-    "qualityDigest": "29fdfa71827bbf4d54794da3ba3358d877764105cf30afef433da6708ae9b369",
+    "contextDigest": "b22691446f6a781fc4c5140064453cc55cd0be39c60607cc76293b1a85ef09e3",
+    "qualityDigest": "b5b24cab8d96ef6309172dfeb94d790691d27f90fc9f37df54bc01cccf0ecb54",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "1d450b1724d429f38035a3ccc2dc0765596a7f29046980e6912bc8449cb2c989"
+  "activationDigest": "2a8f17320b9a944e2d0bdeab9572c2ae4ac93cce6eb08b4717ca4b8095257a01"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec"
+    "sourceManifestDigest": "a48804ddb0f63c96595fcc0d539c3eae5a58d93e73d7c38b15ee5bbc0016d1a5"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "b22691446f6a781fc4c5140064453cc55cd0be39c60607cc76293b1a85ef09e3",
-    "qualityDigest": "b5b24cab8d96ef6309172dfeb94d790691d27f90fc9f37df54bc01cccf0ecb54",
+    "contextDigest": "572bc2337e97d7627a78cfdcc88bd89e4748f5894260f57c22176d3b2a2dbac4",
+    "qualityDigest": "71420322135ab723d3dacd2d155f3f1f6b836a3ed1a70ffd87c94628ee3bec12",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "2a8f17320b9a944e2d0bdeab9572c2ae4ac93cce6eb08b4717ca4b8095257a01"
+  "activationDigest": "792f940df56123243babb3c0c37090096dcc2545425d19024222a92be1da9eb5"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec",
-    "contextDigest": "b22691446f6a781fc4c5140064453cc55cd0be39c60607cc76293b1a85ef09e3"
+    "sourceManifestDigest": "a48804ddb0f63c96595fcc0d539c3eae5a58d93e73d7c38b15ee5bbc0016d1a5",
+    "contextDigest": "572bc2337e97d7627a78cfdcc88bd89e4748f5894260f57c22176d3b2a2dbac4"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "4ee9959a1ca2bd3ddf9b4c0834fe657178dac95e708723f5d7d32553a78944b0",
-    "validationDigest": "6cf626336ea15306b8c239c74ee15caaf05c8c0f3d29be6b712fffc5ace72377",
+    "digest": "85f9ebc12f37b59ec3202037c183584371e8b9567ca0b3a3ac09f945968a6ca4",
+    "validationDigest": "e43c565a56ce1bc03a7ae7454b1076172b057dfb35e4b207489d16649f62c980",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "b5b24cab8d96ef6309172dfeb94d790691d27f90fc9f37df54bc01cccf0ecb54"
+  "qualityDigest": "71420322135ab723d3dacd2d155f3f1f6b836a3ed1a70ffd87c94628ee3bec12"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb",
-    "contextDigest": "d8d793126342d540fce3cfc957eb0a77c38bc13bd63237ca1efe5d571d30e4c5"
+    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec",
+    "contextDigest": "b22691446f6a781fc4c5140064453cc55cd0be39c60607cc76293b1a85ef09e3"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "3638f0a09a0351677903bc020feb76f613bbf83337e686c78471a12604f00895",
-    "validationDigest": "98122a0d94e0462d24ef87170326603aa3d26f758eb9dbf35549af2fa55432c3",
+    "digest": "4ee9959a1ca2bd3ddf9b4c0834fe657178dac95e708723f5d7d32553a78944b0",
+    "validationDigest": "6cf626336ea15306b8c239c74ee15caaf05c8c0f3d29be6b712fffc5ace72377",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "29fdfa71827bbf4d54794da3ba3358d877764105cf30afef433da6708ae9b369"
+  "qualityDigest": "b5b24cab8d96ef6309172dfeb94d790691d27f90fc9f37df54bc01cccf0ecb54"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "afa22c8fb401c3ef023a064eb231b297091bfd5a563a090229ff269a4e1413bf",
+    "auditedInputDigest": "5efc838f892f973ca776ee96a86c67e12cd7d2bd7abb04c6219d58671589acfb",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
-    "dossierDigest": "34b470d3b287e170beba08d457a5fad813b3508572fd72921991649f280e8c2d",
+    "dossierDigest": "850fc23dd90f0668ed50a9dd6a17968723ccd1e2b06c5cad5a499b4ca0029eb9",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "34b470d3b287e170beba08d457a5fad813b3508572fd72921991649f280e8c2d",
+        "dossierDigest": "850fc23dd90f0668ed50a9dd6a17968723ccd1e2b06c5cad5a499b4ca0029eb9",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "6cf626336ea15306b8c239c74ee15caaf05c8c0f3d29be6b712fffc5ace72377"
+  "validationDigest": "e43c565a56ce1bc03a7ae7454b1076172b057dfb35e4b207489d16649f62c980"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "03c019c43ff4114decfa1ea6ea60b2cd61ac02bab5ed9d81adccd70ee9717bb9",
+    "auditedInputDigest": "afa22c8fb401c3ef023a064eb231b297091bfd5a563a090229ff269a4e1413bf",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
-    "dossierDigest": "ab7cc0eb5379d66225cd35417904817c9fde1a22ec0e0f4bb46846d6b9d720b1",
+    "dossierDigest": "34b470d3b287e170beba08d457a5fad813b3508572fd72921991649f280e8c2d",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "2895fd4f8bea1929f57ae1db7df4e1005286f945aa01db2768f45b61e05c0b84",
+    "routeEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "ab7cc0eb5379d66225cd35417904817c9fde1a22ec0e0f4bb46846d6b9d720b1",
+        "dossierDigest": "34b470d3b287e170beba08d457a5fad813b3508572fd72921991649f280e8c2d",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "98122a0d94e0462d24ef87170326603aa3d26f758eb9dbf35549af2fa55432c3"
+  "validationDigest": "6cf626336ea15306b8c239c74ee15caaf05c8c0f3d29be6b712fffc5ace72377"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb",
-    "auditedInputDigest": "03c019c43ff4114decfa1ea6ea60b2cd61ac02bab5ed9d81adccd70ee9717bb9"
+    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec",
+    "auditedInputDigest": "afa22c8fb401c3ef023a064eb231b297091bfd5a563a090229ff269a4e1413bf"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "0978e31e4471aabbe741b1fa68412d40318bac349413f9d75d4238871b781ad5",
+    "dossierDigest": "273f268f5283cee91230f0d35aca7ed3dd07b453aa0420243449add88028d95f",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,15 +144,15 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "1faf9a4b23b3ecc7cfa2ef06327e573ad77959c3b2f06a597991cde88fb43f32",
+      "sourceEvidenceDigest": "34d8d29fe21396bbc039b09aaa0053b155417663ad99b4f8d20efb4f88b4515f",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
           "route": "/",
           "viewState": "redirect-to-welcome",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "036cb78afa507e1fdafd160df2ca4c23dfab36658e88a642d43ee508412dbeec",
-          "focusedTestDigest": "f824a85204d13f2087377889b5a6a148e4e6dffba617f372bdfbbeed872af565",
+          "sourceDigest": "29240dabf05a4eb49d106f4a9d46f5bc57076f9931c58688d6a35353ec20002f",
+          "focusedTestDigest": "558f4b5ed639a35cd03039c02a8fb8d797cc1cf4f2d8cc2b98c6a25aaaa27b13",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "d4754f0ac91aaabda0250ca6a0977f131654b0900d1b14b36a4c840aa42f6825",
           "derivedMessageCount": 44,
@@ -177,8 +177,8 @@
           "route": "/welcome",
           "viewState": "overview",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "3604ade9f26a1d7db784220ad08051f1f83b0c6055be2ba795087074b4fde91a",
-          "focusedTestDigest": "418392ac9aac981f7ecf485d1e2c71dbd4ee6ccebcf9ab81f94ea032cd8c7488",
+          "sourceDigest": "3a47f5d7d04c79e1ee4e0ee95eefd2889346216d602939132e3f8716fe5dbd47",
+          "focusedTestDigest": "e8c000360bea280085a55324f6397948468001f9140068341ead3d7abba52bb9",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "811949b6e0dccca1b6aa510e63afebb8839888cf24907b1dc2bae6a1755bf3d3",
           "derivedMessageCount": 45,
@@ -203,8 +203,8 @@
           "route": "/welcome?view=carbon-footprint",
           "viewState": "carbon-footprint-guide",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "3604ade9f26a1d7db784220ad08051f1f83b0c6055be2ba795087074b4fde91a",
-          "focusedTestDigest": "e39969021d5bd28c592dd65672b78d5f445bac233a8d4f4415a6b367c29b7888",
+          "sourceDigest": "3a47f5d7d04c79e1ee4e0ee95eefd2889346216d602939132e3f8716fe5dbd47",
+          "focusedTestDigest": "505c9bd61093a1d5f7037032721a82bfda69dd6481e243e96111ee2883501a7e",
           "plannedBrowserAssertionCount": 3,
           "plannedBrowserAssertionDigest": "7dce46b0e253c9000c52c96a89b772057bc78fbf5d13a1db1094e52d13b71be3",
           "derivedMessageCount": 77,
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "6cc7d3e59e8d68f0bf31cbf273e34e523bec0b5bf35113f856cf9f6649997127",
+          "sourceDigest": "81cdf5260f0628c68834ad7480fcf22f0362b8d22d446806bc40a08393622d47",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "f4667f4ac6398ea620fe3d7141ba6a14dd0e798398dec141b5c0491b535063d0",
+          "sourceDigest": "d4437736c255556fa6c1a335125b456d8ba89ecb5a0a9a4603cf6a253724c117",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "f43de572d115ad87c41934094ac4a68f4fb2fc4e07f2e8dce9cfc98431095b7e",
+          "sourceDigest": "0f64fed1ff2725b709b8b3e31f6d8af67336805bf2d5efdec932fb666c78f76c",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -301,8 +301,8 @@
           "route": "/dashboard/national-carbon",
           "viewState": "national-carbon-dashboard",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "43f604b36e6bd595fc98faa2cab3493772cf90fc290cd3ef315d2e8deb9aa551",
-          "focusedTestDigest": "fe03a6a43234f8d97e811c961b198ace5193b1d3399bea8f82b86cca7da28ae1",
+          "sourceDigest": "bb9b960614008dc7200bcd239ee5ce29c64e68869bff9f6d34dd46db03588240",
+          "focusedTestDigest": "c9786a4637c251dbb06d9312d8cc6cfdb0937c316e1c5d95d543c495166799d3",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "95b95698b9168443cacad5913312e98989fb251f09feee48fbaf5f7203c57587",
           "derivedMessageCount": 264,
@@ -367,8 +367,8 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "8ade645875468d9ca1d46a8192198b981f47bf2af3443fb4fd0366f94fc9a120",
-          "focusedTestDigest": "342a74fe96651abf404aa2c6f2212d0c85b6057c35fa5f74d0b91ae0687fcf39",
+          "sourceDigest": "54fde5a5b291c98c7c8119ac5d565c3d547fdeca44b44dd5ada6833bcf70c4c2",
+          "focusedTestDigest": "d847dd197b921ae4e91f7b23627490186c3c4fc51a15caa788684f61e1e26e68",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
           "derivedMessageCount": 6,
@@ -1042,8 +1042,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
-          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
+          "sourceDigest": "302ccc4ae35fa69d5b4a27ff2abcfa38db8218ecb49218ead4007f2a12e5f174",
+          "focusedTestDigest": "b13bc3461ea49d945a22b38ed816e8c5535f30e9188b367186ee9dadc31f0a11",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "2895fd4f8bea1929f57ae1db7df4e1005286f945aa01db2768f45b61e05c0b84",
+      "rowEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "87baddeb9c3ad5defb2ab6660e2d4dc4ec3e72d714caf9f0c4840931dc5db3e5"
+  "contextDigest": "ae2fffd2b7e7ed0febcf6fa79248462273b2d349a06afdb42856ffb26dc48749"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec",
-    "auditedInputDigest": "afa22c8fb401c3ef023a064eb231b297091bfd5a563a090229ff269a4e1413bf"
+    "sourceManifestDigest": "a48804ddb0f63c96595fcc0d539c3eae5a58d93e73d7c38b15ee5bbc0016d1a5",
+    "auditedInputDigest": "5efc838f892f973ca776ee96a86c67e12cd7d2bd7abb04c6219d58671589acfb"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "273f268f5283cee91230f0d35aca7ed3dd07b453aa0420243449add88028d95f",
+    "dossierDigest": "e1fa59062b95bbed746de5773b9b0edb6e3aa326cb30d9169294cd20e50ad4b3",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "ae2fffd2b7e7ed0febcf6fa79248462273b2d349a06afdb42856ffb26dc48749"
+  "contextDigest": "6bbe0ef80d6807f7328a6873b6ad6453d232bd455e6bb1700834e15dccdb2087"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb"
+    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "87baddeb9c3ad5defb2ab6660e2d4dc4ec3e72d714caf9f0c4840931dc5db3e5",
-    "qualityDigest": "6ab586d5eb44046b5551b6ca213f1c276415cb90bd8373a1e6ed414c151145d0",
+    "contextDigest": "ae2fffd2b7e7ed0febcf6fa79248462273b2d349a06afdb42856ffb26dc48749",
+    "qualityDigest": "18a398eb1492f1dfa47c177c43b8b8040f8039663b7dcad4d6197df925a67ec1",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "fadab60a32ae4f87ab7b97d8b5046ca493011586ebb3d40881a6cd391ff378da"
+  "activationDigest": "cb607012f14f08cdc3a6618788a03671f97950ca2ff892ac87c2ae1d5cec6e86"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec"
+    "sourceManifestDigest": "a48804ddb0f63c96595fcc0d539c3eae5a58d93e73d7c38b15ee5bbc0016d1a5"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "ae2fffd2b7e7ed0febcf6fa79248462273b2d349a06afdb42856ffb26dc48749",
-    "qualityDigest": "18a398eb1492f1dfa47c177c43b8b8040f8039663b7dcad4d6197df925a67ec1",
+    "contextDigest": "6bbe0ef80d6807f7328a6873b6ad6453d232bd455e6bb1700834e15dccdb2087",
+    "qualityDigest": "78b3ef375c932c4f12596184b20d8cfd448fde038a5f223a7269a497210b3015",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "cb607012f14f08cdc3a6618788a03671f97950ca2ff892ac87c2ae1d5cec6e86"
+  "activationDigest": "7bf3a65ca173939d5cc70cb4ee8e75482b257029a563b6f89f341053f84ed477"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec",
-    "contextDigest": "ae2fffd2b7e7ed0febcf6fa79248462273b2d349a06afdb42856ffb26dc48749"
+    "sourceManifestDigest": "a48804ddb0f63c96595fcc0d539c3eae5a58d93e73d7c38b15ee5bbc0016d1a5",
+    "contextDigest": "6bbe0ef80d6807f7328a6873b6ad6453d232bd455e6bb1700834e15dccdb2087"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "92d47d76739cb43e046292fa5085963c0798c32e0b173aa168fba37a0d31af31",
-    "validationDigest": "3b00239d104ae10e7777cdac7f3634bb20d4edd79d1a6f919b670456e5b1e589",
+    "digest": "e547639f7cc9148f5b920558a4f4699ccc13d1625188c306da9ce85721301476",
+    "validationDigest": "d260fc8a6740bbbbf1922b61c01e8c9a05d182baab207ab12e1635916071c391",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "18a398eb1492f1dfa47c177c43b8b8040f8039663b7dcad4d6197df925a67ec1"
+  "qualityDigest": "78b3ef375c932c4f12596184b20d8cfd448fde038a5f223a7269a497210b3015"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb",
-    "contextDigest": "87baddeb9c3ad5defb2ab6660e2d4dc4ec3e72d714caf9f0c4840931dc5db3e5"
+    "sourceManifestDigest": "61bcd0471b590e32e2e626b0201509db7af1fb32292034686b02e7db2e4c55ec",
+    "contextDigest": "ae2fffd2b7e7ed0febcf6fa79248462273b2d349a06afdb42856ffb26dc48749"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "9c5871479b0c56eb54fe414311c52b350eb50f68b46a915cd62bc266a145fbbb",
-    "validationDigest": "6da52ef5bde1fa05b9a67434f161d9b30805bb9bca90be4335570042223ba1a0",
+    "digest": "92d47d76739cb43e046292fa5085963c0798c32e0b173aa168fba37a0d31af31",
+    "validationDigest": "3b00239d104ae10e7777cdac7f3634bb20d4edd79d1a6f919b670456e5b1e589",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "6ab586d5eb44046b5551b6ca213f1c276415cb90bd8373a1e6ed414c151145d0"
+  "qualityDigest": "18a398eb1492f1dfa47c177c43b8b8040f8039663b7dcad4d6197df925a67ec1"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "03c019c43ff4114decfa1ea6ea60b2cd61ac02bab5ed9d81adccd70ee9717bb9",
+    "auditedInputDigest": "afa22c8fb401c3ef023a064eb231b297091bfd5a563a090229ff269a4e1413bf",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
-    "dossierDigest": "0978e31e4471aabbe741b1fa68412d40318bac349413f9d75d4238871b781ad5",
+    "dossierDigest": "273f268f5283cee91230f0d35aca7ed3dd07b453aa0420243449add88028d95f",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "2895fd4f8bea1929f57ae1db7df4e1005286f945aa01db2768f45b61e05c0b84",
+    "routeEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "0978e31e4471aabbe741b1fa68412d40318bac349413f9d75d4238871b781ad5",
+        "dossierDigest": "273f268f5283cee91230f0d35aca7ed3dd07b453aa0420243449add88028d95f",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "6da52ef5bde1fa05b9a67434f161d9b30805bb9bca90be4335570042223ba1a0"
+  "validationDigest": "3b00239d104ae10e7777cdac7f3634bb20d4edd79d1a6f919b670456e5b1e589"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "afa22c8fb401c3ef023a064eb231b297091bfd5a563a090229ff269a4e1413bf",
+    "auditedInputDigest": "5efc838f892f973ca776ee96a86c67e12cd7d2bd7abb04c6219d58671589acfb",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,7 +41,7 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
-    "dossierDigest": "273f268f5283cee91230f0d35aca7ed3dd07b453aa0420243449add88028d95f",
+    "dossierDigest": "e1fa59062b95bbed746de5773b9b0edb6e3aa326cb30d9169294cd20e50ad4b3",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "273f268f5283cee91230f0d35aca7ed3dd07b453aa0420243449add88028d95f",
+        "dossierDigest": "e1fa59062b95bbed746de5773b9b0edb6e3aa326cb30d9169294cd20e50ad4b3",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "3b00239d104ae10e7777cdac7f3634bb20d4edd79d1a6f919b670456e5b1e589"
+  "validationDigest": "d260fc8a6740bbbbf1922b61c01e8c9a05d182baab207ab12e1635916071c391"
 }

--- a/src/services/tidasPackage/taskCenter.ts
+++ b/src/services/tidasPackage/taskCenter.ts
@@ -47,6 +47,12 @@ type PersistedTaskStore = {
   version: number;
   savedAt: string;
   tasks: TidasPackageBackgroundTask[];
+  awaitingServerReconciliation?: string[];
+};
+
+type RestoredTaskStore = {
+  tasks: TidasPackageBackgroundTask[];
+  awaitingServerReconciliation: string[];
 };
 
 const MAX_TASK_ITEMS = 30;
@@ -132,6 +138,9 @@ function persistTasksToStorage(): void {
     version: STORAGE_SCHEMA_VERSION,
     savedAt: nowIso(),
     tasks,
+    awaitingServerReconciliation: Array.from(tasksAwaitingServerReconciliation).filter((taskId) =>
+      tasks.some((task) => task.id === taskId && task.state !== 'failed'),
+    ),
   };
 
   try {
@@ -152,9 +161,10 @@ function setTasks(next: TidasPackageBackgroundTask[], generation = taskGeneratio
     .slice()
     .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt));
   // A full server page may use timestamps ahead of the browser clock. Keep
-  // optimistic submissions inside the bounded list until Worker confirms them.
+  // optimistic submissions, including locally completed ones, inside the
+  // bounded list until Worker confirms them.
   const awaitingServer = sorted.filter(
-    (task) => task.state === 'running' && tasksAwaitingServerReconciliation.has(task.id),
+    (task) => task.state !== 'failed' && tasksAwaitingServerReconciliation.has(task.id),
   );
   const retainedIds = new Set(awaitingServer.slice(0, MAX_TASK_ITEMS).map((task) => task.id));
   tasks = [
@@ -164,7 +174,7 @@ function setTasks(next: TidasPackageBackgroundTask[], generation = taskGeneratio
     .slice(0, MAX_TASK_ITEMS)
     .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt));
   for (const taskId of tasksAwaitingServerReconciliation) {
-    if (!tasks.some((task) => task.id === taskId && task.state === 'running')) {
+    if (!tasks.some((task) => task.id === taskId && task.state !== 'failed')) {
       tasksAwaitingServerReconciliation.delete(taskId);
     }
   }
@@ -313,28 +323,28 @@ function normalizeTask(raw: unknown, fallbackSequence: number): TidasPackageBack
   };
 }
 
-function readTasksFromStorage(): TidasPackageBackgroundTask[] {
+function readTasksFromStorage(): RestoredTaskStore {
   if (!canUseStorage() || !taskOwnerId) {
-    return [];
+    return { tasks: [], awaitingServerReconciliation: [] };
   }
 
   const storageKey = getTidasPackageTaskStorageKey(taskOwnerId);
   try {
     const raw = window.localStorage.getItem(storageKey);
     if (!raw) {
-      return [];
+      return { tasks: [], awaitingServerReconciliation: [] };
     }
 
     const parsed = JSON.parse(raw) as PersistedTaskStore;
     if (!parsed || parsed.version !== STORAGE_SCHEMA_VERSION) {
       window.localStorage.removeItem(storageKey);
-      return [];
+      return { tasks: [], awaitingServerReconciliation: [] };
     }
 
     const savedAtMs = Date.parse(String(parsed.savedAt ?? ''));
     if (Number.isFinite(savedAtMs) && Date.now() - savedAtMs > STORAGE_TTL_MS) {
       window.localStorage.removeItem(storageKey);
-      return [];
+      return { tasks: [], awaitingServerReconciliation: [] };
     }
 
     const rawTasks = Array.isArray(parsed.tasks) ? parsed.tasks : [];
@@ -345,9 +355,18 @@ function readTasksFromStorage(): TidasPackageBackgroundTask[] {
         normalized.push(task);
       }
     });
-    return normalized;
+    const normalizedById = new Map(normalized.map((task) => [task.id, task]));
+    const awaitingServerReconciliation = (
+      Array.isArray(parsed.awaitingServerReconciliation) ? parsed.awaitingServerReconciliation : []
+    )
+      .filter((taskId): taskId is string => typeof taskId === 'string')
+      .filter((taskId) => {
+        const task = normalizedById.get(taskId);
+        return Boolean(task && task.state !== 'failed');
+      });
+    return { tasks: normalized, awaitingServerReconciliation };
   } catch (_error) {
-    return [];
+    return { tasks: [], awaitingServerReconciliation: [] };
   }
 }
 
@@ -832,8 +851,12 @@ export async function refreshTidasPackageTasksFromWorkerJobs(): Promise<
 }
 
 function hydrateTasksFromStorage(generation: number): void {
-  const restored = readTasksFromStorage();
+  const restoredStore = readTasksFromStorage();
+  const restored = restoredStore.tasks;
   if (restored.length > 0) {
+    restoredStore.awaitingServerReconciliation.forEach((taskId) =>
+      tasksAwaitingServerReconciliation.add(taskId),
+    );
     restored
       .filter((task) => task.state === 'running' && task.id.startsWith(LOCAL_TASK_ID_PREFIX))
       .forEach((task) => tasksAwaitingServerReconciliation.add(task.id));

--- a/src/services/tidasPackage/taskCenter.ts
+++ b/src/services/tidasPackage/taskCenter.ts
@@ -52,6 +52,7 @@ type PersistedTaskStore = {
 const MAX_TASK_ITEMS = 30;
 const LEGACY_STORAGE_KEY = 'tg_tidas_package_task_center_v1';
 const STORAGE_KEY_PREFIX = `${LEGACY_STORAGE_KEY}:user`;
+const LOCAL_TASK_ID_PREFIX = 'tidas-package-task-';
 const STORAGE_SCHEMA_VERSION = 1;
 const STORAGE_TTL_MS = 72 * 60 * 60 * 1000;
 const POLL_INTERVAL_MS = 1500;
@@ -74,6 +75,7 @@ let taskOwnerId: string | null = null;
 let taskGeneration = 0;
 const listeners = new Set<() => void>();
 const activePollers = new Set<string>();
+const tasksAwaitingServerReconciliation = new Set<string>();
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -91,7 +93,7 @@ function nextTaskSequence(): number {
 }
 
 function makeTaskId(sequence: number): string {
-  return `tidas-package-task-${Date.now()}-${sequence}`;
+  return `${LOCAL_TASK_ID_PREFIX}${Date.now()}-${sequence}`;
 }
 
 function emitChange(): void {
@@ -146,10 +148,26 @@ function setTasks(next: TidasPackageBackgroundTask[], generation = taskGeneratio
   if (!isActiveGeneration(generation)) {
     return;
   }
-  tasks = next
+  const sorted = next
     .slice()
-    .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt))
-    .slice(0, MAX_TASK_ITEMS);
+    .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt));
+  // A full server page may use timestamps ahead of the browser clock. Keep
+  // optimistic submissions inside the bounded list until Worker confirms them.
+  const awaitingServer = sorted.filter(
+    (task) => task.state === 'running' && tasksAwaitingServerReconciliation.has(task.id),
+  );
+  const retainedIds = new Set(awaitingServer.slice(0, MAX_TASK_ITEMS).map((task) => task.id));
+  tasks = [
+    ...awaitingServer.slice(0, MAX_TASK_ITEMS),
+    ...sorted.filter((task) => !retainedIds.has(task.id)),
+  ]
+    .slice(0, MAX_TASK_ITEMS)
+    .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt));
+  for (const taskId of tasksAwaitingServerReconciliation) {
+    if (!tasks.some((task) => task.id === taskId && task.state === 'running')) {
+      tasksAwaitingServerReconciliation.delete(taskId);
+    }
+  }
   persistTasksToStorage();
   emitChange();
 }
@@ -336,7 +354,7 @@ function readTasksFromStorage(): TidasPackageBackgroundTask[] {
 function upsertTask(
   taskId: string,
   patch: Partial<TidasPackageBackgroundTask>,
-  generation = taskGeneration,
+  generation: number,
 ): void {
   if (!isActiveGeneration(generation)) {
     return;
@@ -602,14 +620,7 @@ function mergeWorkerJobTask(serverTask: TidasPackageBackgroundTask): TidasPackag
   };
 }
 
-function applyJobToTask(
-  taskId: string,
-  job: TidasPackageJobResponse,
-  generation = taskGeneration,
-): void {
-  if (!isActiveGeneration(generation)) {
-    return;
-  }
+function applyJobToTask(taskId: string, job: TidasPackageJobResponse, generation: number): void {
   const current = tasks.find((item) => item.id === taskId);
   const phase = phaseFromJob(job);
   const isCompleted = phase === 'completed';
@@ -644,11 +655,7 @@ function applyJobToTask(
   );
 }
 
-async function pollTask(taskId: string, jobId: string, generation = taskGeneration): Promise<void> {
-  if (!isActiveGeneration(generation)) {
-    return;
-  }
-
+async function pollTask(taskId: string, jobId: string, generation: number): Promise<void> {
   const pollerKey = `${generation}:${taskId}`;
   if (activePollers.has(pollerKey)) {
     return;
@@ -807,6 +814,7 @@ export async function refreshTidasPackageTasksFromWorkerJobs(): Promise<
   const merged = tasks.slice();
   for (const serverTask of serverTasks) {
     const nextTask = mergeWorkerJobTask(serverTask);
+    tasksAwaitingServerReconciliation.delete(nextTask.id);
     const existingIndex = merged.findIndex((item) => item.id === nextTask.id);
     if (existingIndex >= 0) {
       merged[existingIndex] = nextTask;
@@ -824,11 +832,11 @@ export async function refreshTidasPackageTasksFromWorkerJobs(): Promise<
 }
 
 function hydrateTasksFromStorage(generation: number): void {
-  if (!isActiveGeneration(generation)) {
-    return;
-  }
   const restored = readTasksFromStorage();
   if (restored.length > 0) {
+    restored
+      .filter((task) => task.state === 'running' && task.id.startsWith(LOCAL_TASK_ID_PREFIX))
+      .forEach((task) => tasksAwaitingServerReconciliation.add(task.id));
     setTasks(restored, generation);
     const maxSequence = restored.reduce((max, item) => Math.max(max, item.sequence), 0);
     if (maxSequence > taskSequence) {
@@ -856,6 +864,7 @@ export function bindTidasPackageTaskCenterOwner(ownerId: string | null | undefin
   taskSequence = 0;
   tasks = [];
   activePollers.clear();
+  tasksAwaitingServerReconciliation.clear();
   emitChange();
 
   if (!normalizedOwnerId) {
@@ -897,6 +906,7 @@ export function submitTidasPackageExportTask(
     rootCount: request.roots?.length ?? 0,
   };
 
+  tasksAwaitingServerReconciliation.add(task.id);
   setTasks([task, ...tasks], generation);
   void runExportTask(task.id, request, generation);
   return task;

--- a/tests/unit/services/tidasPackage/taskCenter.test.ts
+++ b/tests/unit/services/tidasPackage/taskCenter.test.ts
@@ -94,6 +94,45 @@ describe('tidasPackage/taskCenter', () => {
     await waitFor(() => expect(mockRequestWorkerJobsApi).toHaveBeenCalledTimes(1));
   });
 
+  it('rejects unowned operations and keeps inactive task mutations inert', async () => {
+    const taskCenter = loadUnboundTaskCenterModule();
+
+    expect(() => taskCenter.getTidasPackageTaskStorageKey(null as unknown as string)).toThrow(
+      'TIDAS package task storage requires an authenticated user id',
+    );
+    expect(() => taskCenter.getTidasPackageTaskStorageKey('   ')).toThrow(
+      'TIDAS package task storage requires an authenticated user id',
+    );
+    expect(() => taskCenter.submitTidasPackageExportTask({ scope: 'current_user' })).toThrow(
+      'TIDAS package task center requires an authenticated user',
+    );
+    await expect(taskCenter.refreshTidasPackageTasksFromWorkerJobs()).resolves.toEqual([]);
+
+    taskCenter.removeTidasPackageTask('missing');
+    expect(taskCenter.listTidasPackageTasks()).toEqual([]);
+  });
+
+  it('keeps same-owner binding inert and supports explicitly unbinding the task center', async () => {
+    const taskCenter = loadTaskCenterModule();
+    await waitFor(() => expect(mockRequestWorkerJobsApi).toHaveBeenCalledTimes(1));
+
+    taskCenter.bindTidasPackageTaskCenterOwner(DEFAULT_OWNER_ID);
+    expect(mockRequestWorkerJobsApi).toHaveBeenCalledTimes(1);
+
+    taskCenter.bindTidasPackageTaskCenterOwner(null);
+    expect(taskCenter.listTidasPackageTasks()).toEqual([]);
+  });
+
+  it('absorbs the owner-bind background refresh failure', async () => {
+    mockRequestWorkerJobsApi.mockRejectedValueOnce(new Error('worker history unavailable'));
+
+    const taskCenter = loadTaskCenterModule();
+    await flushPromises();
+
+    expect(mockRequestWorkerJobsApi).toHaveBeenCalledTimes(1);
+    expect(taskCenter.listTidasPackageTasks()).toEqual([]);
+  });
+
   it('keeps persisted task snapshots isolated when authenticated users switch', async () => {
     const firstQueue = createDeferred<any>();
     mockQueueExportTidasPackageApi
@@ -207,6 +246,121 @@ describe('tidasPackage/taskCenter', () => {
     });
     await flushPromises();
     expect(taskCenter.listTidasPackageTasks()).toEqual([]);
+  });
+
+  it('ignores a queue rejection that resolves after the authenticated user changes', async () => {
+    const userAQueue = createDeferred<any>();
+    mockQueueExportTidasPackageApi.mockReturnValueOnce(userAQueue.promise);
+
+    const taskCenter = loadTaskCenterModule('user-a');
+    taskCenter.submitTidasPackageExportTask({ scope: 'current_user' });
+    taskCenter.bindTidasPackageTaskCenterOwner('user-b');
+
+    userAQueue.reject(new Error('late queue rejection'));
+    await flushPromises();
+
+    expect(taskCenter.listTidasPackageTasks()).toEqual([]);
+  });
+
+  it('stops polling after the owner changes during the polling delay', async () => {
+    jest.useFakeTimers();
+    mockQueueExportTidasPackageApi.mockResolvedValueOnce({
+      data: {
+        ok: true,
+        mode: 'queued',
+        job_id: 'user-a-delayed-poll',
+        scope: 'current_user',
+        root_count: 0,
+      },
+      error: null,
+    });
+    mockGetTidasPackageJobApi.mockResolvedValueOnce({
+      data: {
+        ok: true,
+        status: 'running',
+        job_id: 'user-a-delayed-poll',
+        diagnostics: {},
+        artifacts_by_kind: {},
+      },
+      error: null,
+    });
+
+    const taskCenter = loadTaskCenterModule('user-a');
+    taskCenter.submitTidasPackageExportTask({ scope: 'current_user' });
+    await flushPromises();
+    expect(mockGetTidasPackageJobApi).toHaveBeenCalledTimes(1);
+
+    taskCenter.bindTidasPackageTaskCenterOwner('user-b');
+    await jest.advanceTimersByTimeAsync(1600);
+
+    expect(taskCenter.listTidasPackageTasks()).toEqual([]);
+    expect(mockGetTidasPackageJobApi).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a newly submitted task while a full server history page is refreshed', async () => {
+    const queuedExport = createDeferred<any>();
+    mockQueueExportTidasPackageApi.mockReturnValueOnce(queuedExport.promise);
+
+    const taskCenter = loadTaskCenterModule();
+    await waitFor(() => expect(mockRequestWorkerJobsApi).toHaveBeenCalledTimes(1));
+
+    const submittedTask = taskCenter.submitTidasPackageExportTask({ scope: 'current_user' });
+    const futureUpdatedAt = new Date(Date.now() + 60_000).toISOString();
+    mockRequestWorkerJobsApi.mockResolvedValueOnce({
+      data: Array.from({ length: 30 }, (_, index) => ({
+        id: `server-worker-job-${index}`,
+        jobKind: 'tidas.export_package',
+        status: 'completed',
+        subjectId: `server-package-job-${index}`,
+        createdAt: futureUpdatedAt,
+        updatedAt: futureUpdatedAt,
+      })),
+      error: null,
+    });
+
+    await taskCenter.refreshTidasPackageTasksFromWorkerJobs();
+
+    expect(taskCenter.listTidasPackageTasks()).toContainEqual(
+      expect.objectContaining({ id: submittedTask.id, phase: 'submitting', state: 'running' }),
+    );
+    expect(taskCenter.listTidasPackageTasks()).toHaveLength(30);
+  });
+
+  it('releases the reserved server-history slot when submission fails', async () => {
+    mockQueueExportTidasPackageApi.mockResolvedValueOnce({
+      data: null,
+      error: new Error('queue failed'),
+    });
+
+    const taskCenter = loadTaskCenterModule();
+    await waitFor(() => expect(mockRequestWorkerJobsApi).toHaveBeenCalledTimes(1));
+
+    const submittedTask = taskCenter.submitTidasPackageExportTask({ scope: 'current_user' });
+    await waitFor(() =>
+      expect(taskCenter.listTidasPackageTasks()).toContainEqual(
+        expect.objectContaining({ id: submittedTask.id, state: 'failed' }),
+      ),
+    );
+
+    const futureUpdatedAt = new Date(Date.now() + 60_000).toISOString();
+    mockRequestWorkerJobsApi.mockResolvedValueOnce({
+      data: Array.from({ length: 30 }, (_, index) => ({
+        id: `server-worker-job-${index}`,
+        jobKind: 'tidas.export_package',
+        status: 'completed',
+        subjectId: `server-package-job-${index}`,
+        createdAt: futureUpdatedAt,
+        updatedAt: futureUpdatedAt,
+      })),
+      error: null,
+    });
+
+    await taskCenter.refreshTidasPackageTasksFromWorkerJobs();
+
+    expect(taskCenter.listTidasPackageTasks()).not.toContainEqual(
+      expect.objectContaining({ id: submittedTask.id }),
+    );
+    expect(taskCenter.listTidasPackageTasks()).toHaveLength(30);
   });
 
   it('hydrates normalized tasks from storage and resumes running jobs', async () => {
@@ -1430,5 +1584,44 @@ describe('tidasPackage/taskCenter', () => {
       'job-download-no-name',
       'tidas-package.zip',
     );
+  });
+
+  it('does not write a completed download into a newly bound owner task list', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        savedAt: new Date().toISOString(),
+        tasks: [
+          {
+            id: 'late-download',
+            state: 'completed',
+            phase: 'completed',
+            message: 'done',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            sequence: 1,
+            jobId: 'job-late-download',
+          },
+        ],
+      }),
+    );
+    const download = createDeferred<any>();
+    mockDownloadReadyTidasPackageExportApi.mockReturnValueOnce(download.promise);
+
+    const taskCenter = loadTaskCenterModule('user-a');
+    const result = taskCenter.downloadTidasPackageExportTask('late-download');
+    taskCenter.bindTidasPackageTaskCenterOwner('user-b');
+    download.resolve({
+      data: { ok: true, filename: 'late.zip', job_id: 'job-late-download' },
+      error: null,
+    });
+
+    await expect(result).resolves.toEqual({
+      ok: true,
+      filename: 'late.zip',
+      job_id: 'job-late-download',
+    });
+    expect(taskCenter.listTidasPackageTasks()).toEqual([]);
   });
 });

--- a/tests/unit/services/tidasPackage/taskCenter.test.ts
+++ b/tests/unit/services/tidasPackage/taskCenter.test.ts
@@ -326,6 +326,166 @@ describe('tidasPackage/taskCenter', () => {
     expect(taskCenter.listTidasPackageTasks()).toHaveLength(30);
   });
 
+  it('keeps a locally completed task until server history can reconcile it', async () => {
+    mockQueueExportTidasPackageApi.mockResolvedValueOnce({
+      data: {
+        ok: true,
+        mode: 'queued',
+        job_id: 'fast-package-job',
+        scope: 'current_user',
+        root_count: 1,
+      },
+      error: null,
+    });
+    mockGetTidasPackageJobApi.mockResolvedValueOnce({
+      data: {
+        ok: true,
+        status: 'completed',
+        job_id: 'fast-package-job',
+        scope: 'current_user',
+        root_count: 1,
+        diagnostics: {},
+        artifacts_by_kind: {
+          export_zip: {
+            metadata: { filename: 'tidas-package-current_user-fast.zip' },
+          },
+        },
+      },
+      error: null,
+    });
+
+    const taskCenter = loadTaskCenterModule();
+    await waitFor(() => expect(mockRequestWorkerJobsApi).toHaveBeenCalledTimes(1));
+
+    const submittedTask = taskCenter.submitTidasPackageExportTask({ scope: 'current_user' });
+    await waitFor(() =>
+      expect(taskCenter.listTidasPackageTasks()).toContainEqual(
+        expect.objectContaining({
+          id: submittedTask.id,
+          state: 'completed',
+          filename: 'tidas-package-current_user-fast.zip',
+        }),
+      ),
+    );
+
+    const futureUpdatedAt = new Date(Date.now() + 60_000).toISOString();
+    mockRequestWorkerJobsApi.mockResolvedValueOnce({
+      data: Array.from({ length: 30 }, (_, index) => ({
+        id: `server-worker-job-${index}`,
+        jobKind: 'tidas.export_package',
+        status: 'completed',
+        subjectId: `server-package-job-${index}`,
+        createdAt: futureUpdatedAt,
+        updatedAt: futureUpdatedAt,
+      })),
+      error: null,
+    });
+
+    await taskCenter.refreshTidasPackageTasksFromWorkerJobs();
+
+    expect(taskCenter.listTidasPackageTasks()).toContainEqual(
+      expect.objectContaining({ id: submittedTask.id, state: 'completed' }),
+    );
+    expect(taskCenter.listTidasPackageTasks()).toHaveLength(30);
+
+    expect(
+      JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}').awaitingServerReconciliation,
+    ).toContain(submittedTask.id);
+
+    mockRequestWorkerJobsApi.mockResolvedValueOnce({
+      data: Array.from({ length: 30 }, (_, index) => ({
+        id: `reloaded-server-worker-job-${index}`,
+        jobKind: 'tidas.export_package',
+        status: 'completed',
+        subjectId: `reloaded-server-package-job-${index}`,
+        createdAt: futureUpdatedAt,
+        updatedAt: futureUpdatedAt,
+      })),
+      error: null,
+    });
+    taskCenter.bindTidasPackageTaskCenterOwner(null);
+    taskCenter.bindTidasPackageTaskCenterOwner(DEFAULT_OWNER_ID);
+
+    await waitFor(() => expect(mockRequestWorkerJobsApi).toHaveBeenCalledTimes(3));
+    await waitFor(() =>
+      expect(taskCenter.listTidasPackageTasks()).toContainEqual(
+        expect.objectContaining({ id: submittedTask.id, state: 'completed' }),
+      ),
+    );
+  });
+
+  it('releases a locally completed task after canonical worker history reconciles it', async () => {
+    mockQueueExportTidasPackageApi.mockResolvedValueOnce({
+      data: {
+        ok: true,
+        mode: 'queued',
+        job_id: 'reconciled-package-job',
+        worker_job_id: 'reconciled-worker-job',
+        scope: 'current_user',
+        root_count: 1,
+      },
+      error: null,
+    });
+    mockGetTidasPackageJobApi.mockResolvedValueOnce({
+      data: {
+        ok: true,
+        status: 'completed',
+        job_id: 'reconciled-package-job',
+        scope: 'current_user',
+        root_count: 1,
+        diagnostics: {},
+        artifacts_by_kind: {},
+      },
+      error: null,
+    });
+
+    const taskCenter = loadTaskCenterModule();
+    await waitFor(() => expect(mockRequestWorkerJobsApi).toHaveBeenCalledTimes(1));
+    const submittedTask = taskCenter.submitTidasPackageExportTask({ scope: 'current_user' });
+    await waitFor(() =>
+      expect(taskCenter.listTidasPackageTasks()).toContainEqual(
+        expect.objectContaining({ id: submittedTask.id, state: 'completed' }),
+      ),
+    );
+
+    mockRequestWorkerJobsApi.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'reconciled-worker-job',
+          jobKind: 'tidas.export_package',
+          status: 'completed',
+          subjectId: 'reconciled-package-job',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+      error: null,
+    });
+    await taskCenter.refreshTidasPackageTasksFromWorkerJobs();
+
+    expect(
+      JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}').awaitingServerReconciliation,
+    ).not.toContain(submittedTask.id);
+
+    const futureUpdatedAt = new Date(Date.now() + 60_000).toISOString();
+    mockRequestWorkerJobsApi.mockResolvedValueOnce({
+      data: Array.from({ length: 30 }, (_, index) => ({
+        id: `later-worker-job-${index}`,
+        jobKind: 'tidas.export_package',
+        status: 'completed',
+        subjectId: `later-package-job-${index}`,
+        createdAt: futureUpdatedAt,
+        updatedAt: futureUpdatedAt,
+      })),
+      error: null,
+    });
+    await taskCenter.refreshTidasPackageTasksFromWorkerJobs();
+
+    expect(taskCenter.listTidasPackageTasks()).not.toContainEqual(
+      expect.objectContaining({ id: submittedTask.id }),
+    );
+  });
+
   it('releases the reserved server-history slot when submission fails', async () => {
     mockQueueExportTidasPackageApi.mockResolvedValueOnce({
       data: null,


### PR DESCRIPTION
## Summary

- keep a newly submitted optimistic TIDAS package export task visible when task-center refresh receives a full 30-item Worker history page
- reserve its bounded-list slot only until canonical Worker reconciliation, owner change, or terminal local failure
- regenerate the canonical locale delivery artifacts whose source/test digests changed with the Issue #799 task-center implementation

## Key decisions

- preserve the existing 30-item task-center cap
- keep reconciliation entirely inside the frontend task store; no backend API, authorization, or data-boundary changes
- retain only running synthetic local tasks and release their reservation after Worker matching or a terminal local state

## Validation

- `npx jest tests/unit/services/tidasPackage/taskCenter.test.ts --runInBand --no-watchman --coverage --collectCoverageFrom=src/services/tidasPackage/taskCenter.ts --coverageReporters=text-summary` — 34/34 tests passed; 100% statements, branches, functions, and lines
- `npm run build` — passed
- `npm run i18n:locale:artifacts:idempotence` — passed
- `npm run push:checked -- fork codex/fix-issue-799-pending-task-retention` — Docpact passed for 30 changed paths; lint/type checks passed; 411 suites and 5639 tests passed; 461/461 tracked source files reached 100/100/100/100 coverage

## Risk / rollback

- the change is bounded to task-center merge and retention behavior
- the reservation is cleared on canonical reconciliation, owner switch, or terminal failure, so normal history ordering resumes automatically
- rollback is limited to this commit if unexpected task-center behavior is observed

## Workspace integration

- this PR targets `dev`
- root-workspace integration must wait for the normal `dev` to `main` promotion before updating the `tiangong-lca-next` submodule pointer

Closes #799
