### PR TITLE
fix: reconcile canonical TIDAS export tasks

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-08-10'
-lastReviewedCommit: 'c281df6e2fbdf3de23eea2da588e2c94420add2b'
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: authenticated task ownership, async generation guards, focused tests, and the exact Edge mirror remain covered by existing routes.'
+lastReviewedCommit: '93821284b4ac9d4ed08ac6f42498e48bd2d15fda'
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: canonical TIDAS export identity reconciliation, backend timestamps, focused tests, and the unchanged Edge mirror remain covered by existing routes.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: user-scoped task persistence and the generated Edge mirror stay within existing frontend, auth, and integration boundaries.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: canonical TIDAS task reconciliation and the unchanged Edge mirror stay within existing frontend, auth, and integration boundaries.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: Node 24, focused Jest, Umi setup, TypeScript, mirror sync, and managed-push workflow remain unchanged.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: Node 24, focused TIDAS task-center Jest, Umi setup, TypeScript, mirror sync, and managed-push workflow remain unchanged.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: task-center tests and mirror sync use the unchanged checked-push, Docpact, and full-gate policy.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: canonical task reconciliation tests use the unchanged checked-push, Docpact, and full-gate policy.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: task-center state is bound to authenticated user identity and the Edge runtime remains an exact generated mirror.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: task-center aliases now reconcile to canonical backend identity and timestamps while the Edge runtime remains an exact generated mirror.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -93,6 +93,10 @@ Rules:
 - shared service code that can be loaded by Node smoke scripts must tolerate a missing initialized Umi runtime and fall back without crossing the `src/services/**` data boundary
 - structured non-React content, such as the TIDAS import report descriptor, belongs in a typed pure module that consumes the registry's exact adapter topology; UI components render the descriptor instead of duplicating locale branches
 - semantic localization E2E serves the candidate frontend on loopback with the existing `main` environment configuration. Direct development mode uses `npm run start:main`; release mode exports a clean commit, builds and serves its static production bundle in the isolated container, and receives only a read-only tracked-main environment proof plus an optional protected users file and exact recovery-ledger mount. Its direct Supabase client remains a test-only setup/teardown boundary under `tests/e2e/**`, uses the supplied user session rather than service-role authority, and may touch only the exact UUID-scoped `codex-e2e` tuple recorded in its ignored ledger; shipped app-side data access remains in `src/services/**`
+
+### TIDAS Package Export Task Identity
+
+`src/services/tidasPackage/taskCenter.ts` owns the authenticated user's local UI projection for TIDAS package exports. The backend `workerJobId` is the canonical execution identity and `jobId` is the canonical package-request identity. Queue responses, persisted local aliases, polling results, and Worker refreshes that share either identity must reconcile into one visible task, retain the earliest local presentation identity, and adopt authoritative backend timestamps and lifecycle state. Local submission time and localStorage aliases must never replace backend identity, revive a removed alias, or make an old completed package appear to be a new export.
 
 ### Data Product Closure Preflight And Task Feed
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: focused auth/task-center tests, lint, generated Umi types, TypeScript, and exact-mirror checks remain the proof path.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: canonical TIDAS export alias/timestamp tests, lint, generated Umi types, TypeScript, and exact-mirror checks remain the proof path.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -72,6 +72,7 @@ npm run prepush:gate
 | --- | --- | --- | --- |
 | routes, pages, app runtime, shared UI | `npm run lint`; focused `npm run test:ci -- <jest-args>`; `npm run build` | `npm run prepush:gate` | shared UX changes often affect multiple entrypoints; Process LCIA query/evidence state changes include `tests/unit/pages/Processes/Components/processLciaResultsPanel.test.tsx` |
 | services or env selection | `npm run lint`; focused `npm run test:ci -- <jest-args>`; `npm run build` | `npm run prepush:gate` | companion proof may live in another repo if schema or Edge runtime changed |
+| TIDAS package export task identity or recovery | `npm run test:ci -- --runInBand tests/unit/services/tidasPackage/taskCenter.test.ts`; `npm run lint`; `npm run build` | final `npm run prepush:gate`; pair with Database package-cache pgTAP proof when enqueue semantics changed | Assert repeated queue responses, persisted aliases, poll completion/failure, and Worker refreshes sharing `workerJobId` or `jobId` produce one visible task; retain the earliest local presentation identity, use backend timestamps/state, and never revive an alias after canonical reconciliation. |
 | Process keyword search service or LCA picker scope | focused `tests/unit/services/processes/api.test.ts` plus the Process full-text data-workflow unit; `npm run lint`; `npm run build` | smoke against the exact non-production Database revision that exposes `search_processes_latest_v2`; cover public, personal, and `public_plus_owner_draft` scopes | Assert explicit `query_terms`, no direct app-side ILIKE field filter, and `owner_draft_only=true` only for the personal branch of the strict calculation scope. Database owns latest-version, owner/team/review, and `extracted_md` index semantics. |
 | LCA solve, result-query, contribution-path, or task-recovery scope contract | focused LCA API, task-center service/component, Process analysis, solve toolbar, impact compare/hotspot, and LCIA result panel suites; `npm run lint`; `npm run build` | smoke the authenticated Process analysis paths against matching non-production Edge and Database revisions | Assert every new request uses `full_library` by default or explicit `data_product`; deployment/cache labels never cross the API boundary; persisted historical task requests are normalized before recovery resubmission. |
 | Contact, FlowProperty, Source, or UnitGroup Hybrid Search service/page/picker | `npm run lint`; focused shared-helper, four service, four main-page, four picker, locale-contract, and production-request-guard Jest suites; `npm run build` | final `npm run prepush:gate` through `push:checked`; smoke the exact non-production frontend against matching Database and Edge revisions for `tg`/`co`/`my`/`te` | Keep UUID and empty-keyword paths unchanged; verify state/team forwarding and Team Data without a selected team; auth, transport, malformed-response, and mapping failures must remain `success: false` rather than a successful empty result. New read-only Edge paths require an exact production-request-guard allowlist entry. |

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -23,8 +23,8 @@ checkPaths:
   - playwright.config.ts
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: the database namespace boundary is unchanged and Next consumes the exact reviewed Edge commit through the mirror helper.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: TIDAS task alias reconciliation stays app-side, the database owns export cache lifecycle, and the Edge mirror is unchanged.'
 ---
 
 # Supabase Environment And Database Workflow
@@ -70,6 +70,7 @@ Rules:
 - `docker/volumes/functions/**` does not transfer Edge runtime ownership to Next: it is generated only by `docker/pull-edge-functions.sh --ref <40-character-commit-sha>`, must match that exact Edge tree plus its source receipt, and must delete files absent from the source commit
 - national-carbon process-flow graph cache reads go through `src/services/nationalCarbonGraphCache/objects.ts` and its signed object bundle; the frontend no longer owns a public cache base URL override and local direct-read debugging paths should not be reintroduced without a new runtime ownership decision
 - ordered-dataset shaping in `src/services/**` stays an app-side boundary even when it mirrors backend schema names
+- TIDAS package task reconciliation in `src/services/tidasPackage/taskCenter.ts` may coalesce local aliases by backend `workerJobId` or package `jobId` and adopt backend timestamps, but `database-engine` remains authoritative for mutable-scope cache lifecycle, fresh Worker job creation, package contents, and authorization
 - persisted Calculation Bundle and release readback go through `src/services/lcaReleases/**`: private bundle reads forward the current user session, public current-release and Process projections may be anonymous, and neither path accepts a service-role credential or exposes private object locators
 - closure checks, closure artifacts, result-package commands, publication reads, and the unified data-product task feed go through `src/services/dataProducts/**` and authenticated `app_data_product_commands`; closure requests preserve exact LCIA method `{ id, version }` identities from the reviewed static catalog, and Next consumes actor-bound curated closure, artifact-lifecycle, signed-download, and `task-summary.v2` projections rather than worker rows or private artifact locators. Signed artifact responses are navigation targets only: Next must not proxy, fetch, or buffer the artifact bytes.
 - Node-loaded smoke workflows may call shared service helpers; runtime fallbacks such as locale detection still belong in `src/services/**` and do not create database schema or Edge runtime ownership

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,8 +28,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: user-switch and stale-async regression coverage follows the existing maintenance strategy.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: canonical task-alias and delayed-async regression coverage follows the existing maintenance strategy.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: focused task-center/auth proof closes the regression without opening a repository-wide test backlog.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: focused canonical task-alias/timestamp proof closes the regression without opening a repository-wide test backlog.'
 ---
 
 # Testing Execution State
@@ -54,6 +54,7 @@ This is a checked-in reference, not a per-PR execution ledger. A delivery's post
 - repo is in full-closure maintenance mode
 - there is no active ordered coverage queue right now
 - touched code must stay at full closure
+- Issue #799 adds focused TIDAS task-center coverage for duplicate queue aliases, persisted alias hydration, canonical backend timestamps, one active poller, and post-coalescing failure routing; it creates no open coverage queue
 - Issue #778 adds hermetic contract coverage for the two deterministic release commands: JSON purity, non-mutating dry-run, qualification reuse and automatic exact-receipt generation, qualification/preflight failure before transport, rejection of unexpected untracked JSON, exact version fields, large-lockfile blob fallback, checked-push delegation, idempotent PR reuse, immutable promotion identity, independent version-candidate and cumulative `main`-to-candidate Docpact preflight, bounded automatic review, and fail-closed package/document/diagnostic/branch/dev/marker drift. A real isolated clone also proves the current review closure reaches a bounded fixed point without document-body changes. It creates no open coverage queue.
 - Issue #693 moves profile validation, generic visual-plan, account-secret, run-scoped origin, output-containment, access classification, and capture compatibility proof to workspace tooling.
 - Issue #748 adds a git-tracked scope-closure qualification adapter for the Next owner. Its isolated Chromium flow proves preparing, available, expired, and unavailable presentation; direct document navigation for bounded XLSX and machine-readable manifests; integrity/expiry metadata; localized 410 rerun guidance; and anonymous, standard-user, administrator, owner, and data-product-manager routing without production targets or mutation.

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,8 +31,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: deferred async results and user-switch isolation are covered with the existing focused service-unit pattern.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: canonical task aliases, deferred async results, and user-switch isolation use the focused service-unit pattern.'
 ---
 
 # Testing Patterns Reference
@@ -91,6 +91,7 @@ Special cases:
 - permission and URL-state pattern: use when behavior depends on auth, query params, or navigation state
 - data workflow fixture pattern: keep each `tests/data-workflows/fixtures/result/**` expected-result file aligned with its same-scope `fixtures/data/**` payload, workflow lib default path, and unit proof; the fixture relationship map lives in `tests/data-workflows/fixtures/result/README.md`
 - strict command-contract pattern: type the complete client payload, assert its exact serialized shape at the service boundary, and preserve versioned dataset identities as `{ id, version }` rather than weakening tests to identifier-only fixtures
+- canonical async-task pattern: create multiple local projections for one backend worker/package identity, resolve queue and poll promises out of order, and assert one retained task, one poller, backend timestamps, and error delivery to the retained identity
 - escalate to E2E only when browser-only behavior cannot be proved in Jest
 
 ## Component Pattern

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,8 +28,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: c281df6e2fbdf3de23eea2da588e2c94420add2b
-lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: the focused serial Jest and Umi setup flow remains sufficient; no new recovery exception is needed.'
+lastReviewedCommit: 93821284b4ac9d4ed08ac6f42498e48bd2d15fda
+lastReviewedNote: 'Reviewed for Next Issue #799 / workspace Issue #566: focused serial Jest remains sufficient for canonical task-alias and timestamp diagnosis.'
 ---
 
 # Testing Troubleshooting
@@ -58,6 +58,7 @@ Canonical baseline and proof ownership stays with `DEV.md` and `docs/agents/repo
 | element not found | query too early, wrong role/text, render path not reached | assert the prerequisite state first, then switch to semantic query |
 | a visible action exists but the expected request never starts | the control is present but still disabled while prerequisite data loads | wait for the control to become enabled, then interact; do not replace the product guard with an arbitrary delay |
 | mock not hit | wrong import path or mock order | verify module path and set mocks before importing the subject |
+| Task Center shows duplicate TIDAS exports or keeps an old completion timestamp after a new request | local submission/persisted aliases were treated as separate facts instead of reconciling the backend worker/package identity | run the focused `tests/unit/services/tidasPackage/taskCenter.test.ts` suite, compare `workerJobId` and `jobId`, and verify hydration, queue, polling, and Worker refresh all retain one canonical task with backend timestamps |
 | provider or context error | missing wrapper or wrong test utility | use the repo helper that already provides the required wrapper |
 | data workflow smoke assertion mismatch | `fixtures/data/**`, `fixtures/result/**`, workflow default path, or last-run artifact drifted apart | compare the case in `tests/data-workflows/fixtures/result/README.md`, then update the paired input fixture, expected-result Markdown, workflow lib default, and unit proof together |
 | `release:to-dev` or `release:promote-dev-to-main` returns a drift error | the requested version, Issue marker, dev merge SHA, branch candidate, or current remote ref no longer matches the planned identity | read the single JSON error and its `next_action`, inspect the referenced PR/SHA, then rerun dry-run against current remotes; do not force-update or reuse a mismatched release branch |

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb",
-    "auditedInputDigest": "03c019c43ff4114decfa1ea6ea60b2cd61ac02bab5ed9d81adccd70ee9717bb9"
+    "sourceManifestDigest": "3a946511e4b15336014f5e013d4373f38378814647b5ffbcd974a35cea56fadb",
+    "auditedInputDigest": "c7af7b7d21d5c2b04355c06db06a06786fa92cd45b4a70382d4ef39c39a08b97"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "5150319411e12de3b35031849232b637c17ccc4216492efdf19ab9f630704210",
+    "dossierDigest": "66a04a8f19c710b3852a3bfcebaa1019aba203bc12b6b9a2031fa4e3ac9be146",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,15 +144,15 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "1faf9a4b23b3ecc7cfa2ef06327e573ad77959c3b2f06a597991cde88fb43f32",
+      "sourceEvidenceDigest": "34d8d29fe21396bbc039b09aaa0053b155417663ad99b4f8d20efb4f88b4515f",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
           "route": "/",
           "viewState": "redirect-to-welcome",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "036cb78afa507e1fdafd160df2ca4c23dfab36658e88a642d43ee508412dbeec",
-          "focusedTestDigest": "f824a85204d13f2087377889b5a6a148e4e6dffba617f372bdfbbeed872af565",
+          "sourceDigest": "29240dabf05a4eb49d106f4a9d46f5bc57076f9931c58688d6a35353ec20002f",
+          "focusedTestDigest": "558f4b5ed639a35cd03039c02a8fb8d797cc1cf4f2d8cc2b98c6a25aaaa27b13",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "d4754f0ac91aaabda0250ca6a0977f131654b0900d1b14b36a4c840aa42f6825",
           "derivedMessageCount": 44,
@@ -177,8 +177,8 @@
           "route": "/welcome",
           "viewState": "overview",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "3604ade9f26a1d7db784220ad08051f1f83b0c6055be2ba795087074b4fde91a",
-          "focusedTestDigest": "418392ac9aac981f7ecf485d1e2c71dbd4ee6ccebcf9ab81f94ea032cd8c7488",
+          "sourceDigest": "3a47f5d7d04c79e1ee4e0ee95eefd2889346216d602939132e3f8716fe5dbd47",
+          "focusedTestDigest": "e8c000360bea280085a55324f6397948468001f9140068341ead3d7abba52bb9",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "811949b6e0dccca1b6aa510e63afebb8839888cf24907b1dc2bae6a1755bf3d3",
           "derivedMessageCount": 45,
@@ -203,8 +203,8 @@
           "route": "/welcome?view=carbon-footprint",
           "viewState": "carbon-footprint-guide",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "3604ade9f26a1d7db784220ad08051f1f83b0c6055be2ba795087074b4fde91a",
-          "focusedTestDigest": "e39969021d5bd28c592dd65672b78d5f445bac233a8d4f4415a6b367c29b7888",
+          "sourceDigest": "3a47f5d7d04c79e1ee4e0ee95eefd2889346216d602939132e3f8716fe5dbd47",
+          "focusedTestDigest": "505c9bd61093a1d5f7037032721a82bfda69dd6481e243e96111ee2883501a7e",
           "plannedBrowserAssertionCount": 3,
           "plannedBrowserAssertionDigest": "7dce46b0e253c9000c52c96a89b772057bc78fbf5d13a1db1094e52d13b71be3",
           "derivedMessageCount": 77,
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "6cc7d3e59e8d68f0bf31cbf273e34e523bec0b5bf35113f856cf9f6649997127",
+          "sourceDigest": "81cdf5260f0628c68834ad7480fcf22f0362b8d22d446806bc40a08393622d47",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "f4667f4ac6398ea620fe3d7141ba6a14dd0e798398dec141b5c0491b535063d0",
+          "sourceDigest": "d4437736c255556fa6c1a335125b456d8ba89ecb5a0a9a4603cf6a253724c117",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "f43de572d115ad87c41934094ac4a68f4fb2fc4e07f2e8dce9cfc98431095b7e",
+          "sourceDigest": "0f64fed1ff2725b709b8b3e31f6d8af67336805bf2d5efdec932fb666c78f76c",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -301,8 +301,8 @@
           "route": "/dashboard/national-carbon",
           "viewState": "national-carbon-dashboard",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "43f604b36e6bd595fc98faa2cab3493772cf90fc290cd3ef315d2e8deb9aa551",
-          "focusedTestDigest": "fe03a6a43234f8d97e811c961b198ace5193b1d3399bea8f82b86cca7da28ae1",
+          "sourceDigest": "bb9b960614008dc7200bcd239ee5ce29c64e68869bff9f6d34dd46db03588240",
+          "focusedTestDigest": "c9786a4637c251dbb06d9312d8cc6cfdb0937c316e1c5d95d543c495166799d3",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "95b95698b9168443cacad5913312e98989fb251f09feee48fbaf5f7203c57587",
           "derivedMessageCount": 264,
@@ -367,8 +367,8 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "8ade645875468d9ca1d46a8192198b981f47bf2af3443fb4fd0366f94fc9a120",
-          "focusedTestDigest": "342a74fe96651abf404aa2c6f2212d0c85b6057c35fa5f74d0b91ae0687fcf39",
+          "sourceDigest": "54fde5a5b291c98c7c8119ac5d565c3d547fdeca44b44dd5ada6833bcf70c4c2",
+          "focusedTestDigest": "d847dd197b921ae4e91f7b23627490186c3c4fc51a15caa788684f61e1e26e68",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
           "derivedMessageCount": 6,
@@ -1042,8 +1042,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
-          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
+          "sourceDigest": "302ccc4ae35fa69d5b4a27ff2abcfa38db8218ecb49218ead4007f2a12e5f174",
+          "focusedTestDigest": "b13bc3461ea49d945a22b38ed816e8c5535f30e9188b367186ee9dadc31f0a11",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "2895fd4f8bea1929f57ae1db7df4e1005286f945aa01db2768f45b61e05c0b84",
+      "rowEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "d6c1bc6280852cb57b841221a2231cbc97029cbbbf09da0c77a040e300e9d896"
+  "contextDigest": "9454e9f1e5ea77c53780d23e0fdc117f25a676d9f28b580de44d47e2fa5421aa"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb"
+    "sourceManifestDigest": "3a946511e4b15336014f5e013d4373f38378814647b5ffbcd974a35cea56fadb"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "d6c1bc6280852cb57b841221a2231cbc97029cbbbf09da0c77a040e300e9d896",
-    "qualityDigest": "78d0e7c203d778fe20373242755d50d4a49488d85befe08095d768173780309b",
+    "contextDigest": "9454e9f1e5ea77c53780d23e0fdc117f25a676d9f28b580de44d47e2fa5421aa",
+    "qualityDigest": "b3526ea4dd3158f93a6d513cf7b8c713e6ebdbb25ed06ead5f8f3017f6798c58",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "0c59ab166fd9f91ff606a9c6e713ff14ec524769cce04e33dd2a3ccdee66123f"
+  "activationDigest": "920c13986df871c9439039da254dabc17a90fc3e613ecd0f418ec15774f60640"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "03c019c43ff4114decfa1ea6ea60b2cd61ac02bab5ed9d81adccd70ee9717bb9",
+    "auditedInputDigest": "c7af7b7d21d5c2b04355c06db06a06786fa92cd45b4a70382d4ef39c39a08b97",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -13724,7 +13724,7 @@
         {
           "kind": "formatMessage",
           "path": "src/app.tsx",
-          "line": 228,
+          "line": 233,
           "column": 16,
           "symbol": "layout",
           "defaultMessage": "OpenAPI documentation",
@@ -13737,7 +13737,7 @@
           "argumentSignature": [],
           "placeholders": [],
           "locations": [
-            { "path": "src/app.tsx", "line": 228, "column": 16, "kind": "formatMessage" }
+            { "path": "src/app.tsx", "line": 233, "column": 16, "kind": "formatMessage" }
           ]
         }
       ]
@@ -25039,7 +25039,7 @@
         {
           "kind": "formatMessage",
           "path": "src/app.tsx",
-          "line": 169,
+          "line": 174,
           "column": 20,
           "symbol": "layout",
           "defaultMessage": "Data Dashboard",
@@ -25052,7 +25052,7 @@
           "argumentSignature": [],
           "placeholders": [],
           "locations": [
-            { "path": "src/app.tsx", "line": 169, "column": 20, "kind": "formatMessage" }
+            { "path": "src/app.tsx", "line": 174, "column": 20, "kind": "formatMessage" }
           ]
         }
       ]
@@ -25176,7 +25176,7 @@
         {
           "kind": "formatMessage",
           "path": "src/app.tsx",
-          "line": 185,
+          "line": 190,
           "column": 20,
           "symbol": "layout",
           "defaultMessage": "Data Processing",
@@ -25189,7 +25189,7 @@
           "argumentSignature": [],
           "placeholders": [],
           "locations": [
-            { "path": "src/app.tsx", "line": 185, "column": 20, "kind": "formatMessage" }
+            { "path": "src/app.tsx", "line": 190, "column": 20, "kind": "formatMessage" }
           ]
         }
       ]
@@ -130383,7 +130383,7 @@
         {
           "kind": "formatMessage",
           "path": "src/app.tsx",
-          "line": 116,
+          "line": 121,
           "column": 5,
           "symbol": "appTitle",
           "defaultMessage": null,

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb",
-    "contextDigest": "d6c1bc6280852cb57b841221a2231cbc97029cbbbf09da0c77a040e300e9d896"
+    "sourceManifestDigest": "3a946511e4b15336014f5e013d4373f38378814647b5ffbcd974a35cea56fadb",
+    "contextDigest": "9454e9f1e5ea77c53780d23e0fdc117f25a676d9f28b580de44d47e2fa5421aa"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "d3d2dc172a8865bdf5ad77608a758eeff11bcb9788bc9df2001f53167e547464",
-    "validationDigest": "1da9f934bda33ae24dd9b2fb2b858cd7c38a4fc51c174872983fc507617d9e91",
+    "digest": "aabcff9403703619c8b45ef89a76ddaa4162cfce31ec586bc9bf500f380c06e0",
+    "validationDigest": "aa9f80246ba9b4f32c3fb64d7de5b69a6cbeb09691ceef85f7296d58db7cba2f",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "78d0e7c203d778fe20373242755d50d4a49488d85befe08095d768173780309b"
+  "qualityDigest": "b3526ea4dd3158f93a6d513cf7b8c713e6ebdbb25ed06ead5f8f3017f6798c58"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "03c019c43ff4114decfa1ea6ea60b2cd61ac02bab5ed9d81adccd70ee9717bb9",
+    "auditedInputDigest": "c7af7b7d21d5c2b04355c06db06a06786fa92cd45b4a70382d4ef39c39a08b97",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "63cfae8373d6063d35883832fd2b3c2c06f24000529b6b60f257164ee76f14ba",
-    "dossierDigest": "5150319411e12de3b35031849232b637c17ccc4216492efdf19ab9f630704210",
+    "dossierDigest": "66a04a8f19c710b3852a3bfcebaa1019aba203bc12b6b9a2031fa4e3ac9be146",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "2895fd4f8bea1929f57ae1db7df4e1005286f945aa01db2768f45b61e05c0b84",
+    "routeEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "5150319411e12de3b35031849232b637c17ccc4216492efdf19ab9f630704210",
+        "dossierDigest": "66a04a8f19c710b3852a3bfcebaa1019aba203bc12b6b9a2031fa4e3ac9be146",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "1da9f934bda33ae24dd9b2fb2b858cd7c38a4fc51c174872983fc507617d9e91"
+  "validationDigest": "aa9f80246ba9b4f32c3fb64d7de5b69a6cbeb09691ceef85f7296d58db7cba2f"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb",
-    "auditedInputDigest": "03c019c43ff4114decfa1ea6ea60b2cd61ac02bab5ed9d81adccd70ee9717bb9"
+    "sourceManifestDigest": "3a946511e4b15336014f5e013d4373f38378814647b5ffbcd974a35cea56fadb",
+    "auditedInputDigest": "c7af7b7d21d5c2b04355c06db06a06786fa92cd45b4a70382d4ef39c39a08b97"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "2b8f833cc49268733f0f85588fa4d3e7017121a482479fea82ebd9f3f5ab14d3",
+    "dossierDigest": "c7a534295ae127b055ffc5cb030512377ab1576f216cc6de2f66614ad58fd9cc",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,15 +144,15 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "1faf9a4b23b3ecc7cfa2ef06327e573ad77959c3b2f06a597991cde88fb43f32",
+      "sourceEvidenceDigest": "34d8d29fe21396bbc039b09aaa0053b155417663ad99b4f8d20efb4f88b4515f",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
           "route": "/",
           "viewState": "redirect-to-welcome",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "036cb78afa507e1fdafd160df2ca4c23dfab36658e88a642d43ee508412dbeec",
-          "focusedTestDigest": "f824a85204d13f2087377889b5a6a148e4e6dffba617f372bdfbbeed872af565",
+          "sourceDigest": "29240dabf05a4eb49d106f4a9d46f5bc57076f9931c58688d6a35353ec20002f",
+          "focusedTestDigest": "558f4b5ed639a35cd03039c02a8fb8d797cc1cf4f2d8cc2b98c6a25aaaa27b13",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "d4754f0ac91aaabda0250ca6a0977f131654b0900d1b14b36a4c840aa42f6825",
           "derivedMessageCount": 44,
@@ -177,8 +177,8 @@
           "route": "/welcome",
           "viewState": "overview",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "3604ade9f26a1d7db784220ad08051f1f83b0c6055be2ba795087074b4fde91a",
-          "focusedTestDigest": "418392ac9aac981f7ecf485d1e2c71dbd4ee6ccebcf9ab81f94ea032cd8c7488",
+          "sourceDigest": "3a47f5d7d04c79e1ee4e0ee95eefd2889346216d602939132e3f8716fe5dbd47",
+          "focusedTestDigest": "e8c000360bea280085a55324f6397948468001f9140068341ead3d7abba52bb9",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "811949b6e0dccca1b6aa510e63afebb8839888cf24907b1dc2bae6a1755bf3d3",
           "derivedMessageCount": 45,
@@ -203,8 +203,8 @@
           "route": "/welcome?view=carbon-footprint",
           "viewState": "carbon-footprint-guide",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "3604ade9f26a1d7db784220ad08051f1f83b0c6055be2ba795087074b4fde91a",
-          "focusedTestDigest": "e39969021d5bd28c592dd65672b78d5f445bac233a8d4f4415a6b367c29b7888",
+          "sourceDigest": "3a47f5d7d04c79e1ee4e0ee95eefd2889346216d602939132e3f8716fe5dbd47",
+          "focusedTestDigest": "505c9bd61093a1d5f7037032721a82bfda69dd6481e243e96111ee2883501a7e",
           "plannedBrowserAssertionCount": 3,
           "plannedBrowserAssertionDigest": "7dce46b0e253c9000c52c96a89b772057bc78fbf5d13a1db1094e52d13b71be3",
           "derivedMessageCount": 77,
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "6cc7d3e59e8d68f0bf31cbf273e34e523bec0b5bf35113f856cf9f6649997127",
+          "sourceDigest": "81cdf5260f0628c68834ad7480fcf22f0362b8d22d446806bc40a08393622d47",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "f4667f4ac6398ea620fe3d7141ba6a14dd0e798398dec141b5c0491b535063d0",
+          "sourceDigest": "d4437736c255556fa6c1a335125b456d8ba89ecb5a0a9a4603cf6a253724c117",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "f43de572d115ad87c41934094ac4a68f4fb2fc4e07f2e8dce9cfc98431095b7e",
+          "sourceDigest": "0f64fed1ff2725b709b8b3e31f6d8af67336805bf2d5efdec932fb666c78f76c",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -301,8 +301,8 @@
           "route": "/dashboard/national-carbon",
           "viewState": "national-carbon-dashboard",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "43f604b36e6bd595fc98faa2cab3493772cf90fc290cd3ef315d2e8deb9aa551",
-          "focusedTestDigest": "fe03a6a43234f8d97e811c961b198ace5193b1d3399bea8f82b86cca7da28ae1",
+          "sourceDigest": "bb9b960614008dc7200bcd239ee5ce29c64e68869bff9f6d34dd46db03588240",
+          "focusedTestDigest": "c9786a4637c251dbb06d9312d8cc6cfdb0937c316e1c5d95d543c495166799d3",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "95b95698b9168443cacad5913312e98989fb251f09feee48fbaf5f7203c57587",
           "derivedMessageCount": 264,
@@ -367,8 +367,8 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "8ade645875468d9ca1d46a8192198b981f47bf2af3443fb4fd0366f94fc9a120",
-          "focusedTestDigest": "342a74fe96651abf404aa2c6f2212d0c85b6057c35fa5f74d0b91ae0687fcf39",
+          "sourceDigest": "54fde5a5b291c98c7c8119ac5d565c3d547fdeca44b44dd5ada6833bcf70c4c2",
+          "focusedTestDigest": "d847dd197b921ae4e91f7b23627490186c3c4fc51a15caa788684f61e1e26e68",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
           "derivedMessageCount": 6,
@@ -1042,8 +1042,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
-          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
+          "sourceDigest": "302ccc4ae35fa69d5b4a27ff2abcfa38db8218ecb49218ead4007f2a12e5f174",
+          "focusedTestDigest": "b13bc3461ea49d945a22b38ed816e8c5535f30e9188b367186ee9dadc31f0a11",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "2895fd4f8bea1929f57ae1db7df4e1005286f945aa01db2768f45b61e05c0b84",
+      "rowEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "23b2967425b63d6762845a777251236db150bd020cdb096ea3095823a5e14c82"
+  "contextDigest": "693c1df2863e816278c60b5781f266a304777f1fdaadae19f9dd83f4f657af1a"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb"
+    "sourceManifestDigest": "3a946511e4b15336014f5e013d4373f38378814647b5ffbcd974a35cea56fadb"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "23b2967425b63d6762845a777251236db150bd020cdb096ea3095823a5e14c82",
-    "qualityDigest": "6348cfb82baab245c3237d9ee74d01f8bdc618cdd698a71bfbbf149b3e5340e0",
+    "contextDigest": "693c1df2863e816278c60b5781f266a304777f1fdaadae19f9dd83f4f657af1a",
+    "qualityDigest": "c38406e145a3fd9820a96c2efe765575664d91f3eabfefc16d4fb3c4252f2b90",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "2efb20224ea983b73f88a692557dfd70b46bbcf6c17ea762f29fc5321f1c3078"
+  "activationDigest": "41fe8be117e6e9f3223129e08cb3997b92601de368659cd7b0418fea52ccc7d0"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb",
-    "contextDigest": "23b2967425b63d6762845a777251236db150bd020cdb096ea3095823a5e14c82"
+    "sourceManifestDigest": "3a946511e4b15336014f5e013d4373f38378814647b5ffbcd974a35cea56fadb",
+    "contextDigest": "693c1df2863e816278c60b5781f266a304777f1fdaadae19f9dd83f4f657af1a"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "9e42909d6644a8b637499138ebd644e1a7035965bacb632c092895b136f638fc",
-    "validationDigest": "82250729260154b85b3db84745bfd259fcbef6487074ea1201f32f02eb72e35b",
+    "digest": "dd7aee8c7aeb3e6833ebdc5268288e2d018d39530bb1c115247f1816a47df025",
+    "validationDigest": "d03ed2fb42e5d38811d898ff33d553792b1982f3afc5b8a97ae839c6962c66b8",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "6348cfb82baab245c3237d9ee74d01f8bdc618cdd698a71bfbbf149b3e5340e0"
+  "qualityDigest": "c38406e145a3fd9820a96c2efe765575664d91f3eabfefc16d4fb3c4252f2b90"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "03c019c43ff4114decfa1ea6ea60b2cd61ac02bab5ed9d81adccd70ee9717bb9",
+    "auditedInputDigest": "c7af7b7d21d5c2b04355c06db06a06786fa92cd45b4a70382d4ef39c39a08b97",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "7f0b344ed5cce17b04cbb9bf83ba8839e9d2863c549899470b0bbf1c52841c8b",
-    "dossierDigest": "2b8f833cc49268733f0f85588fa4d3e7017121a482479fea82ebd9f3f5ab14d3",
+    "dossierDigest": "c7a534295ae127b055ffc5cb030512377ab1576f216cc6de2f66614ad58fd9cc",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "2895fd4f8bea1929f57ae1db7df4e1005286f945aa01db2768f45b61e05c0b84",
+    "routeEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "2b8f833cc49268733f0f85588fa4d3e7017121a482479fea82ebd9f3f5ab14d3",
+        "dossierDigest": "c7a534295ae127b055ffc5cb030512377ab1576f216cc6de2f66614ad58fd9cc",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "82250729260154b85b3db84745bfd259fcbef6487074ea1201f32f02eb72e35b"
+  "validationDigest": "d03ed2fb42e5d38811d898ff33d553792b1982f3afc5b8a97ae839c6962c66b8"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb",
-    "auditedInputDigest": "03c019c43ff4114decfa1ea6ea60b2cd61ac02bab5ed9d81adccd70ee9717bb9"
+    "sourceManifestDigest": "3a946511e4b15336014f5e013d4373f38378814647b5ffbcd974a35cea56fadb",
+    "auditedInputDigest": "c7af7b7d21d5c2b04355c06db06a06786fa92cd45b4a70382d4ef39c39a08b97"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "ab7cc0eb5379d66225cd35417904817c9fde1a22ec0e0f4bb46846d6b9d720b1",
+    "dossierDigest": "557c1dc2a043ea4b618de1655e9940ef10ceab6ec1e8ea0f14c523ec3f9ece29",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,15 +144,15 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "1faf9a4b23b3ecc7cfa2ef06327e573ad77959c3b2f06a597991cde88fb43f32",
+      "sourceEvidenceDigest": "34d8d29fe21396bbc039b09aaa0053b155417663ad99b4f8d20efb4f88b4515f",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
           "route": "/",
           "viewState": "redirect-to-welcome",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "036cb78afa507e1fdafd160df2ca4c23dfab36658e88a642d43ee508412dbeec",
-          "focusedTestDigest": "f824a85204d13f2087377889b5a6a148e4e6dffba617f372bdfbbeed872af565",
+          "sourceDigest": "29240dabf05a4eb49d106f4a9d46f5bc57076f9931c58688d6a35353ec20002f",
+          "focusedTestDigest": "558f4b5ed639a35cd03039c02a8fb8d797cc1cf4f2d8cc2b98c6a25aaaa27b13",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "d4754f0ac91aaabda0250ca6a0977f131654b0900d1b14b36a4c840aa42f6825",
           "derivedMessageCount": 44,
@@ -177,8 +177,8 @@
           "route": "/welcome",
           "viewState": "overview",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "3604ade9f26a1d7db784220ad08051f1f83b0c6055be2ba795087074b4fde91a",
-          "focusedTestDigest": "418392ac9aac981f7ecf485d1e2c71dbd4ee6ccebcf9ab81f94ea032cd8c7488",
+          "sourceDigest": "3a47f5d7d04c79e1ee4e0ee95eefd2889346216d602939132e3f8716fe5dbd47",
+          "focusedTestDigest": "e8c000360bea280085a55324f6397948468001f9140068341ead3d7abba52bb9",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "811949b6e0dccca1b6aa510e63afebb8839888cf24907b1dc2bae6a1755bf3d3",
           "derivedMessageCount": 45,
@@ -203,8 +203,8 @@
           "route": "/welcome?view=carbon-footprint",
           "viewState": "carbon-footprint-guide",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "3604ade9f26a1d7db784220ad08051f1f83b0c6055be2ba795087074b4fde91a",
-          "focusedTestDigest": "e39969021d5bd28c592dd65672b78d5f445bac233a8d4f4415a6b367c29b7888",
+          "sourceDigest": "3a47f5d7d04c79e1ee4e0ee95eefd2889346216d602939132e3f8716fe5dbd47",
+          "focusedTestDigest": "505c9bd61093a1d5f7037032721a82bfda69dd6481e243e96111ee2883501a7e",
           "plannedBrowserAssertionCount": 3,
           "plannedBrowserAssertionDigest": "7dce46b0e253c9000c52c96a89b772057bc78fbf5d13a1db1094e52d13b71be3",
           "derivedMessageCount": 77,
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "6cc7d3e59e8d68f0bf31cbf273e34e523bec0b5bf35113f856cf9f6649997127",
+          "sourceDigest": "81cdf5260f0628c68834ad7480fcf22f0362b8d22d446806bc40a08393622d47",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "f4667f4ac6398ea620fe3d7141ba6a14dd0e798398dec141b5c0491b535063d0",
+          "sourceDigest": "d4437736c255556fa6c1a335125b456d8ba89ecb5a0a9a4603cf6a253724c117",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "f43de572d115ad87c41934094ac4a68f4fb2fc4e07f2e8dce9cfc98431095b7e",
+          "sourceDigest": "0f64fed1ff2725b709b8b3e31f6d8af67336805bf2d5efdec932fb666c78f76c",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -301,8 +301,8 @@
           "route": "/dashboard/national-carbon",
           "viewState": "national-carbon-dashboard",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "43f604b36e6bd595fc98faa2cab3493772cf90fc290cd3ef315d2e8deb9aa551",
-          "focusedTestDigest": "fe03a6a43234f8d97e811c961b198ace5193b1d3399bea8f82b86cca7da28ae1",
+          "sourceDigest": "bb9b960614008dc7200bcd239ee5ce29c64e68869bff9f6d34dd46db03588240",
+          "focusedTestDigest": "c9786a4637c251dbb06d9312d8cc6cfdb0937c316e1c5d95d543c495166799d3",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "95b95698b9168443cacad5913312e98989fb251f09feee48fbaf5f7203c57587",
           "derivedMessageCount": 264,
@@ -367,8 +367,8 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "8ade645875468d9ca1d46a8192198b981f47bf2af3443fb4fd0366f94fc9a120",
-          "focusedTestDigest": "342a74fe96651abf404aa2c6f2212d0c85b6057c35fa5f74d0b91ae0687fcf39",
+          "sourceDigest": "54fde5a5b291c98c7c8119ac5d565c3d547fdeca44b44dd5ada6833bcf70c4c2",
+          "focusedTestDigest": "d847dd197b921ae4e91f7b23627490186c3c4fc51a15caa788684f61e1e26e68",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
           "derivedMessageCount": 6,
@@ -1042,8 +1042,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
-          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
+          "sourceDigest": "302ccc4ae35fa69d5b4a27ff2abcfa38db8218ecb49218ead4007f2a12e5f174",
+          "focusedTestDigest": "b13bc3461ea49d945a22b38ed816e8c5535f30e9188b367186ee9dadc31f0a11",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "2895fd4f8bea1929f57ae1db7df4e1005286f945aa01db2768f45b61e05c0b84",
+      "rowEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "d8d793126342d540fce3cfc957eb0a77c38bc13bd63237ca1efe5d571d30e4c5"
+  "contextDigest": "73a7626e93538327835b386e31422e0d578241aaac68b7208af01c6519b2cf8f"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb"
+    "sourceManifestDigest": "3a946511e4b15336014f5e013d4373f38378814647b5ffbcd974a35cea56fadb"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "d8d793126342d540fce3cfc957eb0a77c38bc13bd63237ca1efe5d571d30e4c5",
-    "qualityDigest": "29fdfa71827bbf4d54794da3ba3358d877764105cf30afef433da6708ae9b369",
+    "contextDigest": "73a7626e93538327835b386e31422e0d578241aaac68b7208af01c6519b2cf8f",
+    "qualityDigest": "3dd049d1f850d14dbd83a138f03696a470f5abfc25e6dead29dec116446e0e0a",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "1d450b1724d429f38035a3ccc2dc0765596a7f29046980e6912bc8449cb2c989"
+  "activationDigest": "314c1e85445f89a4231478a05e5cb9f2f792b0c200a3dc0b7dd42538f5f3fe65"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb",
-    "contextDigest": "d8d793126342d540fce3cfc957eb0a77c38bc13bd63237ca1efe5d571d30e4c5"
+    "sourceManifestDigest": "3a946511e4b15336014f5e013d4373f38378814647b5ffbcd974a35cea56fadb",
+    "contextDigest": "73a7626e93538327835b386e31422e0d578241aaac68b7208af01c6519b2cf8f"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "3638f0a09a0351677903bc020feb76f613bbf83337e686c78471a12604f00895",
-    "validationDigest": "98122a0d94e0462d24ef87170326603aa3d26f758eb9dbf35549af2fa55432c3",
+    "digest": "c24c5e9806dadefab1d7ff9730c0211790c1a22d15405aac1511cf9c6a0065d1",
+    "validationDigest": "6edc677372c8a339d706898b91b034377ab6c4a07545a7afcba291bddf9d0ec2",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "29fdfa71827bbf4d54794da3ba3358d877764105cf30afef433da6708ae9b369"
+  "qualityDigest": "3dd049d1f850d14dbd83a138f03696a470f5abfc25e6dead29dec116446e0e0a"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "03c019c43ff4114decfa1ea6ea60b2cd61ac02bab5ed9d81adccd70ee9717bb9",
+    "auditedInputDigest": "c7af7b7d21d5c2b04355c06db06a06786fa92cd45b4a70382d4ef39c39a08b97",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "e2cf068bacfb65a87b837cf2a756accee40333aa79f3378ae3a270ebe73a394e",
-    "dossierDigest": "ab7cc0eb5379d66225cd35417904817c9fde1a22ec0e0f4bb46846d6b9d720b1",
+    "dossierDigest": "557c1dc2a043ea4b618de1655e9940ef10ceab6ec1e8ea0f14c523ec3f9ece29",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "2895fd4f8bea1929f57ae1db7df4e1005286f945aa01db2768f45b61e05c0b84",
+    "routeEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "ab7cc0eb5379d66225cd35417904817c9fde1a22ec0e0f4bb46846d6b9d720b1",
+        "dossierDigest": "557c1dc2a043ea4b618de1655e9940ef10ceab6ec1e8ea0f14c523ec3f9ece29",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "98122a0d94e0462d24ef87170326603aa3d26f758eb9dbf35549af2fa55432c3"
+  "validationDigest": "6edc677372c8a339d706898b91b034377ab6c4a07545a7afcba291bddf9d0ec2"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb",
-    "auditedInputDigest": "03c019c43ff4114decfa1ea6ea60b2cd61ac02bab5ed9d81adccd70ee9717bb9"
+    "sourceManifestDigest": "3a946511e4b15336014f5e013d4373f38378814647b5ffbcd974a35cea56fadb",
+    "auditedInputDigest": "c7af7b7d21d5c2b04355c06db06a06786fa92cd45b4a70382d4ef39c39a08b97"
   },
   "inventory": {
     "sourceMessageCount": 3101,
@@ -47,7 +47,7 @@
     "messageCount": 3101,
     "completeCount": 3101,
     "blockedCount": 0,
-    "dossierDigest": "0978e31e4471aabbe741b1fa68412d40318bac349413f9d75d4238871b781ad5",
+    "dossierDigest": "567d6f2dc32fd08cf365e8157bc172573758e7c82be69fd8590efc919dcac2c2",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -144,15 +144,15 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "1faf9a4b23b3ecc7cfa2ef06327e573ad77959c3b2f06a597991cde88fb43f32",
+      "sourceEvidenceDigest": "34d8d29fe21396bbc039b09aaa0053b155417663ad99b4f8d20efb4f88b4515f",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
           "route": "/",
           "viewState": "redirect-to-welcome",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "036cb78afa507e1fdafd160df2ca4c23dfab36658e88a642d43ee508412dbeec",
-          "focusedTestDigest": "f824a85204d13f2087377889b5a6a148e4e6dffba617f372bdfbbeed872af565",
+          "sourceDigest": "29240dabf05a4eb49d106f4a9d46f5bc57076f9931c58688d6a35353ec20002f",
+          "focusedTestDigest": "558f4b5ed639a35cd03039c02a8fb8d797cc1cf4f2d8cc2b98c6a25aaaa27b13",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "d4754f0ac91aaabda0250ca6a0977f131654b0900d1b14b36a4c840aa42f6825",
           "derivedMessageCount": 44,
@@ -177,8 +177,8 @@
           "route": "/welcome",
           "viewState": "overview",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "3604ade9f26a1d7db784220ad08051f1f83b0c6055be2ba795087074b4fde91a",
-          "focusedTestDigest": "418392ac9aac981f7ecf485d1e2c71dbd4ee6ccebcf9ab81f94ea032cd8c7488",
+          "sourceDigest": "3a47f5d7d04c79e1ee4e0ee95eefd2889346216d602939132e3f8716fe5dbd47",
+          "focusedTestDigest": "e8c000360bea280085a55324f6397948468001f9140068341ead3d7abba52bb9",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "811949b6e0dccca1b6aa510e63afebb8839888cf24907b1dc2bae6a1755bf3d3",
           "derivedMessageCount": 45,
@@ -203,8 +203,8 @@
           "route": "/welcome?view=carbon-footprint",
           "viewState": "carbon-footprint-guide",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "3604ade9f26a1d7db784220ad08051f1f83b0c6055be2ba795087074b4fde91a",
-          "focusedTestDigest": "e39969021d5bd28c592dd65672b78d5f445bac233a8d4f4415a6b367c29b7888",
+          "sourceDigest": "3a47f5d7d04c79e1ee4e0ee95eefd2889346216d602939132e3f8716fe5dbd47",
+          "focusedTestDigest": "505c9bd61093a1d5f7037032721a82bfda69dd6481e243e96111ee2883501a7e",
           "plannedBrowserAssertionCount": 3,
           "plannedBrowserAssertionDigest": "7dce46b0e253c9000c52c96a89b772057bc78fbf5d13a1db1094e52d13b71be3",
           "derivedMessageCount": 77,
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "6cc7d3e59e8d68f0bf31cbf273e34e523bec0b5bf35113f856cf9f6649997127",
+          "sourceDigest": "81cdf5260f0628c68834ad7480fcf22f0362b8d22d446806bc40a08393622d47",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "f4667f4ac6398ea620fe3d7141ba6a14dd0e798398dec141b5c0491b535063d0",
+          "sourceDigest": "d4437736c255556fa6c1a335125b456d8ba89ecb5a0a9a4603cf6a253724c117",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "f43de572d115ad87c41934094ac4a68f4fb2fc4e07f2e8dce9cfc98431095b7e",
+          "sourceDigest": "0f64fed1ff2725b709b8b3e31f6d8af67336805bf2d5efdec932fb666c78f76c",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -301,8 +301,8 @@
           "route": "/dashboard/national-carbon",
           "viewState": "national-carbon-dashboard",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "43f604b36e6bd595fc98faa2cab3493772cf90fc290cd3ef315d2e8deb9aa551",
-          "focusedTestDigest": "fe03a6a43234f8d97e811c961b198ace5193b1d3399bea8f82b86cca7da28ae1",
+          "sourceDigest": "bb9b960614008dc7200bcd239ee5ce29c64e68869bff9f6d34dd46db03588240",
+          "focusedTestDigest": "c9786a4637c251dbb06d9312d8cc6cfdb0937c316e1c5d95d543c495166799d3",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "95b95698b9168443cacad5913312e98989fb251f09feee48fbaf5f7203c57587",
           "derivedMessageCount": 264,
@@ -367,8 +367,8 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "8ade645875468d9ca1d46a8192198b981f47bf2af3443fb4fd0366f94fc9a120",
-          "focusedTestDigest": "342a74fe96651abf404aa2c6f2212d0c85b6057c35fa5f74d0b91ae0687fcf39",
+          "sourceDigest": "54fde5a5b291c98c7c8119ac5d565c3d547fdeca44b44dd5ada6833bcf70c4c2",
+          "focusedTestDigest": "d847dd197b921ae4e91f7b23627490186c3c4fc51a15caa788684f61e1e26e68",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
           "derivedMessageCount": 6,
@@ -1042,8 +1042,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "a9292e662933e53ce9023be2d510151e6b3cb2d0155ab8750a1dc14ce17fa32e",
-          "focusedTestDigest": "2cc8766171708d3fcc105e08c2810a20c3fec2b49bdacb5c97f9798ba2d78a55",
+          "sourceDigest": "302ccc4ae35fa69d5b4a27ff2abcfa38db8218ecb49218ead4007f2a12e5f174",
+          "focusedTestDigest": "b13bc3461ea49d945a22b38ed816e8c5535f30e9188b367186ee9dadc31f0a11",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "2895fd4f8bea1929f57ae1db7df4e1005286f945aa01db2768f45b61e05c0b84",
+      "rowEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "87baddeb9c3ad5defb2ab6660e2d4dc4ec3e72d714caf9f0c4840931dc5db3e5"
+  "contextDigest": "f2a410ef6ea72282a5cf2cefbaf9a50c580518f20f86c4c7c6894e62f3d2e464"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb"
+    "sourceManifestDigest": "3a946511e4b15336014f5e013d4373f38378814647b5ffbcd974a35cea56fadb"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "87baddeb9c3ad5defb2ab6660e2d4dc4ec3e72d714caf9f0c4840931dc5db3e5",
-    "qualityDigest": "6ab586d5eb44046b5551b6ca213f1c276415cb90bd8373a1e6ed414c151145d0",
+    "contextDigest": "f2a410ef6ea72282a5cf2cefbaf9a50c580518f20f86c4c7c6894e62f3d2e464",
+    "qualityDigest": "2f332a55d6eea1a14d1a8993e22dac516f0625128f90842f24a80079eff72734",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "fadab60a32ae4f87ab7b97d8b5046ca493011586ebb3d40881a6cd391ff378da"
+  "activationDigest": "71f73075c275fdb57693060b7a98930b807d0f3271054cc07d8b531274ffe1af"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "5bf00462449e7014801b488c45d57333e1c065f671c0a2eea3e703afd5e23beb",
-    "contextDigest": "87baddeb9c3ad5defb2ab6660e2d4dc4ec3e72d714caf9f0c4840931dc5db3e5"
+    "sourceManifestDigest": "3a946511e4b15336014f5e013d4373f38378814647b5ffbcd974a35cea56fadb",
+    "contextDigest": "f2a410ef6ea72282a5cf2cefbaf9a50c580518f20f86c4c7c6894e62f3d2e464"
   },
   "catalog": {
     "messageCount": 3101,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "9c5871479b0c56eb54fe414311c52b350eb50f68b46a915cd62bc266a145fbbb",
-    "validationDigest": "6da52ef5bde1fa05b9a67434f161d9b30805bb9bca90be4335570042223ba1a0",
+    "digest": "708ed0c27eaeaf020c27cd2bb2cff443e468db164740a0c07ef7c1a6b7bf0c3f",
+    "validationDigest": "7cb2ccb85bea11d7cfd2254cd54d50c5adc79037931e6b50c7b321053f60a504",
     "laneCount": 1,
     "validatedMessageCount": 3101,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "6ab586d5eb44046b5551b6ca213f1c276415cb90bd8373a1e6ed414c151145d0"
+  "qualityDigest": "2f332a55d6eea1a14d1a8993e22dac516f0625128f90842f24a80079eff72734"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "03c019c43ff4114decfa1ea6ea60b2cd61ac02bab5ed9d81adccd70ee9717bb9",
+    "auditedInputDigest": "c7af7b7d21d5c2b04355c06db06a06786fa92cd45b4a70382d4ef39c39a08b97",
     "validatedMessageCount": 3101,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1377,
     "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
     "catalogDigest": "075aa55cf0865e8d71ddc4187a94a8046bebae1669fee5dac855c094ada89ebe",
-    "dossierDigest": "0978e31e4471aabbe741b1fa68412d40318bac349413f9d75d4238871b781ad5",
+    "dossierDigest": "567d6f2dc32fd08cf365e8157bc172573758e7c82be69fd8590efc919dcac2c2",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "2895fd4f8bea1929f57ae1db7df4e1005286f945aa01db2768f45b61e05c0b84",
+    "routeEvidenceDigest": "0ea6455459814bce0d1e4d103d0ce8643d95f72b765623021b3d8c797545f2ea",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "0cf569e55e92ec781e8f9959d392d07117c20ce894f405eb73ee6268fba747cc",
         "highRiskMessageCount": 1377,
         "highRiskMessageDigest": "0788e9c540202d234af605e47cd663819dfb4b2a424e007ead40a1b8fe2e68cc",
-        "dossierDigest": "0978e31e4471aabbe741b1fa68412d40318bac349413f9d75d4238871b781ad5",
+        "dossierDigest": "567d6f2dc32fd08cf365e8157bc172573758e7c82be69fd8590efc919dcac2c2",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "6da52ef5bde1fa05b9a67434f161d9b30805bb9bca90be4335570042223ba1a0"
+  "validationDigest": "7cb2ccb85bea11d7cfd2254cd54d50c5adc79037931e6b50c7b321053f60a504"
 }

--- a/src/services/tidasPackage/taskCenter.ts
+++ b/src/services/tidasPackage/taskCenter.ts
@@ -121,6 +121,85 @@ function isActiveGeneration(generation: number): boolean {
   return taskOwnerId !== null && generation === taskGeneration;
 }
 
+function runForActiveGeneration<T>(generation: number, operation: () => T, inactiveResult: T): T {
+  if (!isActiveGeneration(generation)) {
+    return inactiveResult;
+  }
+  return operation();
+}
+
+function sharesCanonicalTaskIdentity(
+  left: TidasPackageBackgroundTask,
+  right: TidasPackageBackgroundTask,
+): boolean {
+  return Boolean(
+    (left.workerJobId && right.workerJobId && left.workerJobId === right.workerJobId) ||
+    (left.jobId && right.jobId && left.jobId === right.jobId),
+  );
+}
+
+function earlierTask(
+  left: TidasPackageBackgroundTask,
+  right: TidasPackageBackgroundTask,
+): TidasPackageBackgroundTask {
+  if (left.sequence !== right.sequence) {
+    return left.sequence < right.sequence ? left : right;
+  }
+  return Date.parse(left.createdAt) <= Date.parse(right.createdAt) ? left : right;
+}
+
+function earlierIso(left: string, right: string): string {
+  return Date.parse(left) <= Date.parse(right) ? left : right;
+}
+
+function laterTask(
+  left: TidasPackageBackgroundTask,
+  right: TidasPackageBackgroundTask,
+): TidasPackageBackgroundTask {
+  return Date.parse(left.updatedAt) >= Date.parse(right.updatedAt) ? left : right;
+}
+
+function mergeLocalTaskAliases(
+  left: TidasPackageBackgroundTask,
+  right: TidasPackageBackgroundTask,
+): TidasPackageBackgroundTask {
+  const canonical = earlierTask(left, right);
+  const latest = laterTask(left, right);
+  const fallback = latest === left ? right : left;
+
+  return {
+    ...canonical,
+    ...latest,
+    id: canonical.id,
+    sequence: canonical.sequence,
+    kind: canonical.kind,
+    request: canonical.request ?? latest.request,
+    createdAt: earlierIso(left.createdAt, right.createdAt),
+    workerJobId: latest.workerJobId ?? fallback.workerJobId,
+    jobKind: latest.jobKind ?? fallback.jobKind,
+    jobId: latest.jobId ?? fallback.jobId,
+    scope: latest.scope ?? fallback.scope,
+    rootCount: latest.rootCount || fallback.rootCount,
+    filename: latest.filename ?? fallback.filename,
+    error: latest.error ?? fallback.error,
+  };
+}
+
+function coalesceCanonicalTaskAliases(
+  next: TidasPackageBackgroundTask[],
+): TidasPackageBackgroundTask[] {
+  const coalesced: TidasPackageBackgroundTask[] = [];
+  for (const task of next) {
+    const matchingIndex = coalesced.findIndex((item) => sharesCanonicalTaskIdentity(item, task));
+    if (matchingIndex < 0) {
+      coalesced.push(task);
+      continue;
+    }
+    coalesced[matchingIndex] = mergeLocalTaskAliases(coalesced[matchingIndex], task);
+  }
+  return coalesced;
+}
+
 function persistTasksToStorage(): void {
   if (!canUseStorage() || !taskOwnerId) {
     return;
@@ -146,7 +225,7 @@ function setTasks(next: TidasPackageBackgroundTask[], generation = taskGeneratio
   if (!isActiveGeneration(generation)) {
     return;
   }
-  tasks = next
+  tasks = coalesceCanonicalTaskAliases(next)
     .slice()
     .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt))
     .slice(0, MAX_TASK_ITEMS);
@@ -333,14 +412,11 @@ function readTasksFromStorage(): TidasPackageBackgroundTask[] {
   }
 }
 
-function upsertTask(
+function upsertActiveTask(
   taskId: string,
   patch: Partial<TidasPackageBackgroundTask>,
-  generation = taskGeneration,
+  generation: number,
 ): void {
-  if (!isActiveGeneration(generation)) {
-    return;
-  }
   const index = tasks.findIndex((item) => item.id === taskId);
   if (index < 0) {
     return;
@@ -361,6 +437,14 @@ function upsertTask(
   const next = tasks.slice();
   next[index] = updated;
   setTasks(next, generation);
+}
+
+function upsertTask(
+  taskId: string,
+  patch: Partial<TidasPackageBackgroundTask>,
+  generation: number,
+): void {
+  runForActiveGeneration(generation, () => upsertActiveTask(taskId, patch, generation), undefined);
 }
 
 function toErrorMessage(error: unknown): string {
@@ -577,8 +661,11 @@ function taskFromWorkerJob(
   };
 }
 
-function mergeWorkerJobTask(serverTask: TidasPackageBackgroundTask): TidasPackageBackgroundTask {
-  const current = tasks.find((item) =>
+function mergeWorkerJobTask(
+  serverTask: TidasPackageBackgroundTask,
+  currentTasks: TidasPackageBackgroundTask[],
+): TidasPackageBackgroundTask {
+  const matches = currentTasks.filter((item) =>
     Boolean(
       (serverTask.workerJobId && item.workerJobId === serverTask.workerJobId) ||
       item.id === serverTask.id ||
@@ -586,9 +673,17 @@ function mergeWorkerJobTask(serverTask: TidasPackageBackgroundTask): TidasPackag
     ),
   );
 
-  if (!current) {
+  if (matches.length === 0) {
     return serverTask;
   }
+
+  const current = matches.reduce(earlierTask);
+  const createdAt = matches.reduce(
+    (earliest, item) => earlierIso(earliest, item.createdAt),
+    serverTask.createdAt,
+  );
+  const updatedAt =
+    Date.parse(serverTask.updatedAt) >= Date.parse(createdAt) ? serverTask.updatedAt : createdAt;
 
   return {
     ...current,
@@ -596,20 +691,18 @@ function mergeWorkerJobTask(serverTask: TidasPackageBackgroundTask): TidasPackag
     id: current.id,
     sequence: current.sequence,
     request: current.request,
-    createdAt: current.createdAt,
+    createdAt,
+    updatedAt,
     scope: current.scope ?? serverTask.scope,
     rootCount: current.rootCount || serverTask.rootCount,
   };
 }
 
-function applyJobToTask(
+function applyJobToActiveTask(
   taskId: string,
   job: TidasPackageJobResponse,
-  generation = taskGeneration,
+  generation: number,
 ): void {
-  if (!isActiveGeneration(generation)) {
-    return;
-  }
   const current = tasks.find((item) => item.id === taskId);
   const phase = phaseFromJob(job);
   const isCompleted = phase === 'completed';
@@ -644,11 +737,15 @@ function applyJobToTask(
   );
 }
 
-async function pollTask(taskId: string, jobId: string, generation = taskGeneration): Promise<void> {
-  if (!isActiveGeneration(generation)) {
-    return;
-  }
+function applyJobToTask(taskId: string, job: TidasPackageJobResponse, generation: number): void {
+  runForActiveGeneration(
+    generation,
+    () => applyJobToActiveTask(taskId, job, generation),
+    undefined,
+  );
+}
 
+async function pollActiveTask(taskId: string, jobId: string, generation: number): Promise<void> {
   const pollerKey = `${generation}:${taskId}`;
   if (activePollers.has(pollerKey)) {
     return;
@@ -731,11 +828,20 @@ async function pollTask(taskId: string, jobId: string, generation = taskGenerati
   }
 }
 
+function pollTask(taskId: string, jobId: string, generation: number): Promise<void> {
+  return runForActiveGeneration(
+    generation,
+    () => pollActiveTask(taskId, jobId, generation),
+    Promise.resolve(),
+  );
+}
+
 async function runExportTask(
   taskId: string,
   request: ExportTidasPackageRequest,
   generation: number,
 ): Promise<void> {
+  let activeTaskId = taskId;
   try {
     const queued = await queueExportTidasPackageApi(request);
     if (!isActiveGeneration(generation)) {
@@ -744,28 +850,40 @@ async function runExportTask(
     if (queued.error || !queued.data?.ok) {
       throw queued.error ?? new Error((queued.data as any)?.message ?? 'Export failed');
     }
+    const queuedData = queued.data;
 
     upsertTask(
       taskId,
       {
-        phase: queued.data.mode === 'queued' ? 'queued' : 'submitting',
+        phase: queuedData.mode === 'queued' ? 'queued' : 'submitting',
         state: 'running',
         message:
-          queued.data.mode === 'cache_hit'
+          queuedData.mode === 'cache_hit'
             ? 'Checking cached export package'
-            : `Export task queued (${queued.data.job_id})`,
-        workerJobId: queued.data.worker_job_id ?? undefined,
-        jobId: queued.data.job_id,
-        scope: queued.data.scope,
-        rootCount: queued.data.root_count ?? 0,
+            : `Export task queued (${queuedData.job_id})`,
+        workerJobId: queuedData.worker_job_id ?? undefined,
+        jobId: queuedData.job_id,
+        scope: queuedData.scope,
+        rootCount: queuedData.root_count ?? 0,
       },
       generation,
     );
 
-    await pollTask(taskId, queued.data.job_id, generation);
+    const canonicalTaskId = tasks.find((item) =>
+      Boolean(
+        (queuedData.worker_job_id && item.workerJobId === queuedData.worker_job_id) ||
+        item.jobId === queuedData.job_id,
+      ),
+    )?.id;
+    if (!canonicalTaskId) {
+      return;
+    }
+
+    activeTaskId = canonicalTaskId;
+    await pollTask(canonicalTaskId, queuedData.job_id, generation);
   } catch (error) {
     upsertTask(
-      taskId,
+      activeTaskId,
       {
         phase: 'failed',
         state: 'failed',
@@ -806,13 +924,16 @@ export async function refreshTidasPackageTasksFromWorkerJobs(): Promise<
 
   const merged = tasks.slice();
   for (const serverTask of serverTasks) {
-    const nextTask = mergeWorkerJobTask(serverTask);
-    const existingIndex = merged.findIndex((item) => item.id === nextTask.id);
-    if (existingIndex >= 0) {
-      merged[existingIndex] = nextTask;
-    } else {
-      merged.push(nextTask);
-    }
+    const matchingIds = new Set(
+      merged
+        .filter(
+          (item) => item.id === serverTask.id || sharesCanonicalTaskIdentity(item, serverTask),
+        )
+        .map((item) => item.id),
+    );
+    const nextTask = mergeWorkerJobTask(serverTask, merged);
+    const remaining = merged.filter((item) => !matchingIds.has(item.id));
+    merged.splice(0, merged.length, ...remaining, nextTask);
   }
 
   setTasks(merged, generation);
@@ -823,10 +944,7 @@ export async function refreshTidasPackageTasksFromWorkerJobs(): Promise<
   return tasks;
 }
 
-function hydrateTasksFromStorage(generation: number): void {
-  if (!isActiveGeneration(generation)) {
-    return;
-  }
+function hydrateActiveTasksFromStorage(generation: number): void {
   const restored = readTasksFromStorage();
   if (restored.length > 0) {
     setTasks(restored, generation);
@@ -843,6 +961,10 @@ function hydrateTasksFromStorage(generation: number): void {
   }
 
   void refreshTidasPackageTasksFromWorkerJobs().catch(() => undefined);
+}
+
+function hydrateTasksFromStorage(generation: number): void {
+  runForActiveGeneration(generation, () => hydrateActiveTasksFromStorage(generation), undefined);
 }
 
 export function bindTidasPackageTaskCenterOwner(ownerId: string | null | undefined): void {

--- a/tests/unit/services/tidasPackage/taskCenter.test.ts
+++ b/tests/unit/services/tidasPackage/taskCenter.test.ts
@@ -94,6 +94,40 @@ describe('tidasPackage/taskCenter', () => {
     await waitFor(() => expect(mockRequestWorkerJobsApi).toHaveBeenCalledTimes(1));
   });
 
+  it('rejects invalid owner-bound operations and keeps unbound helpers inert', async () => {
+    const taskCenter = loadUnboundTaskCenterModule();
+
+    expect(() => taskCenter.getTidasPackageTaskStorageKey(undefined as any)).toThrow(
+      'authenticated user id',
+    );
+    expect(() => taskCenter.getTidasPackageTaskStorageKey('   ')).toThrow('authenticated user id');
+    expect(() => taskCenter.submitTidasPackageExportTask({ scope: 'current_user' })).toThrow(
+      'requires an authenticated user',
+    );
+    await expect(taskCenter.refreshTidasPackageTasksFromWorkerJobs()).resolves.toEqual([]);
+
+    taskCenter.removeTidasPackageTask('missing');
+    taskCenter.clearFinishedTidasPackageTasks();
+    taskCenter.bindTidasPackageTaskCenterOwner(null);
+    taskCenter.bindTidasPackageTaskCenterOwner(DEFAULT_OWNER_ID);
+    taskCenter.bindTidasPackageTaskCenterOwner(null);
+    taskCenter.bindTidasPackageTaskCenterOwner(null);
+    expect(taskCenter.listTidasPackageTasks()).toEqual([]);
+  });
+
+  it('absorbs background refresh errors while hydrating an authenticated owner', async () => {
+    mockRequestWorkerJobsApi.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'background refresh failed' },
+    });
+
+    const taskCenter = loadTaskCenterModule();
+    await flushPromises();
+
+    expect(taskCenter.listTidasPackageTasks()).toEqual([]);
+    expect(mockRequestWorkerJobsApi).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps persisted task snapshots isolated when authenticated users switch', async () => {
     const firstQueue = createDeferred<any>();
     mockQueueExportTidasPackageApi
@@ -206,6 +240,68 @@ describe('tidasPackage/taskCenter', () => {
       error: null,
     });
     await flushPromises();
+    expect(taskCenter.listTidasPackageTasks()).toEqual([]);
+  });
+
+  it('ignores queue rejection updates after the authenticated user changes', async () => {
+    const queue = createDeferred<any>();
+    mockQueueExportTidasPackageApi.mockReturnValueOnce(queue.promise);
+
+    const taskCenter = loadTaskCenterModule('user-a');
+    taskCenter.submitTidasPackageExportTask({ scope: 'current_user' });
+    taskCenter.bindTidasPackageTaskCenterOwner('user-b');
+
+    queue.reject(new Error('stale queue rejection'));
+    await flushPromises();
+
+    expect(taskCenter.listTidasPackageTasks()).toEqual([]);
+  });
+
+  it('stops polling after an owner switch or local task removal', async () => {
+    jest.useFakeTimers();
+    mockQueueExportTidasPackageApi
+      .mockResolvedValueOnce({
+        data: {
+          ok: true,
+          mode: 'queued',
+          job_id: 'stale-owner-job',
+          scope: 'current_user',
+          root_count: 0,
+        },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: {
+          ok: true,
+          mode: 'queued',
+          job_id: 'removed-task-job',
+          scope: 'current_user',
+          root_count: 0,
+        },
+        error: null,
+      });
+    mockGetTidasPackageJobApi.mockResolvedValue({
+      data: {
+        ok: true,
+        status: 'running',
+        job_id: 'running-job',
+        diagnostics: {},
+        artifacts_by_kind: {},
+      },
+      error: null,
+    });
+
+    const taskCenter = loadTaskCenterModule('user-a');
+    taskCenter.submitTidasPackageExportTask({ scope: 'current_user' });
+    await flushPromises();
+    taskCenter.bindTidasPackageTaskCenterOwner('user-b');
+    await jest.advanceTimersByTimeAsync(1600);
+    expect(taskCenter.listTidasPackageTasks()).toEqual([]);
+
+    const removed = taskCenter.submitTidasPackageExportTask({ scope: 'current_user' });
+    await flushPromises();
+    taskCenter.removeTidasPackageTask(removed.id);
+    await jest.advanceTimersByTimeAsync(1600);
     expect(taskCenter.listTidasPackageTasks()).toEqual([]);
   });
 
@@ -520,6 +616,269 @@ describe('tidasPackage/taskCenter', () => {
         message: 'Import task queued (package-import-1)',
       }),
     ]);
+  });
+
+  it('coalesces repeated local submissions that resolve to one canonical backend job', async () => {
+    const pendingPoll = createDeferred<any>();
+    mockQueueExportTidasPackageApi.mockResolvedValue({
+      data: {
+        ok: true,
+        mode: 'in_progress',
+        job_id: 'shared-package-job',
+        worker_job_id: 'shared-worker-job',
+        scope: 'current_user',
+        root_count: 0,
+      },
+      error: null,
+    });
+    mockGetTidasPackageJobApi.mockReturnValue(pendingPoll.promise);
+
+    const taskCenter = loadTaskCenterModule();
+    const first = taskCenter.submitTidasPackageExportTask({ scope: 'current_user' });
+    const second = taskCenter.submitTidasPackageExportTask({ scope: 'current_user' });
+
+    await waitFor(() => {
+      expect(taskCenter.listTidasPackageTasks()).toEqual([
+        expect.objectContaining({
+          id: first.id,
+          workerJobId: 'shared-worker-job',
+          jobId: 'shared-package-job',
+          state: 'running',
+        }),
+      ]);
+    });
+    expect(taskCenter.listTidasPackageTasks()[0].id).not.toBe(second.id);
+    expect(mockGetTidasPackageJobApi).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies a post-coalescing poll rejection to the retained canonical task', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        savedAt: new Date().toISOString(),
+        tasks: [
+          {
+            id: 'retained-canonical-task',
+            sequence: 1,
+            kind: 'tidas_package_export',
+            request: { scope: 'current_user' },
+            state: 'completed',
+            phase: 'completed',
+            message: 'cached',
+            createdAt: '2026-08-10T07:14:41.590Z',
+            updatedAt: '2026-08-10T07:14:44.000Z',
+            workerJobId: 'coalesced-worker-job',
+            jobId: 'coalesced-package-job',
+            scope: 'current_user',
+            rootCount: 0,
+          },
+        ],
+      }),
+    );
+    mockQueueExportTidasPackageApi.mockResolvedValue({
+      data: {
+        ok: true,
+        mode: 'cache_hit',
+        job_id: 'coalesced-package-job',
+        worker_job_id: 'coalesced-worker-job',
+        scope: 'current_user',
+        root_count: 0,
+      },
+      error: null,
+    });
+    mockGetTidasPackageJobApi.mockRejectedValue(new Error('coalesced poll rejected'));
+
+    const taskCenter = loadTaskCenterModule();
+    taskCenter.submitTidasPackageExportTask({ scope: 'current_user' });
+
+    await waitFor(() => {
+      expect(taskCenter.listTidasPackageTasks()).toEqual([
+        expect.objectContaining({
+          id: 'retained-canonical-task',
+          state: 'failed',
+          phase: 'failed',
+          error: 'coalesced poll rejected',
+        }),
+      ]);
+    });
+  });
+
+  it('collapses persisted aliases and restores canonical Worker timestamps on refresh', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        savedAt: '2026-08-10T15:20:00.000Z',
+        tasks: [
+          {
+            id: 'original-local-task',
+            sequence: 1,
+            kind: 'tidas_package_export',
+            request: { scope: 'current_user' },
+            state: 'completed',
+            phase: 'completed',
+            message: 'original',
+            createdAt: '2026-08-10T15:14:41.590Z',
+            updatedAt: '2026-08-10T15:14:44.000Z',
+            workerJobId: 'canonical-worker-job',
+            jobId: 'canonical-package-job',
+            scope: 'current_user',
+            rootCount: 0,
+          },
+          {
+            id: 'later-local-alias',
+            sequence: 1,
+            kind: 'tidas_package_export',
+            request: { scope: 'current_user' },
+            state: 'completed',
+            phase: 'completed',
+            message: 'alias',
+            createdAt: '2026-08-10T15:20:00.000Z',
+            updatedAt: '2026-08-10T15:20:00.000Z',
+            workerJobId: 'canonical-worker-job',
+            jobId: 'canonical-package-job',
+            scope: 'current_user',
+            rootCount: 0,
+          },
+        ],
+      }),
+    );
+    mockRequestWorkerJobsApi.mockResolvedValue({
+      data: [
+        {
+          id: 'canonical-worker-job',
+          jobKind: 'tidas.export_package',
+          status: 'completed',
+          subjectType: 'lca_package_job',
+          subjectId: 'canonical-package-job',
+          subjectVersion: 'current_user',
+          createdAt: '2026-08-10T15:14:41.590Z',
+          updatedAt: '2026-08-10T15:14:44.000Z',
+        },
+      ],
+      error: null,
+    });
+
+    const taskCenter = loadTaskCenterModule();
+    expect(taskCenter.listTidasPackageTasks()).toHaveLength(1);
+
+    await waitFor(() => {
+      expect(taskCenter.listTidasPackageTasks()).toEqual([
+        expect.objectContaining({
+          id: 'original-local-task',
+          workerJobId: 'canonical-worker-job',
+          jobId: 'canonical-package-job',
+          createdAt: '2026-08-10T15:14:41.590Z',
+          updatedAt: '2026-08-10T15:14:44.000Z',
+          state: 'completed',
+        }),
+      ]);
+    });
+  });
+
+  it('reconciles partial aliases and clamps impossible Worker timestamps', async () => {
+    const workerRefresh = createDeferred<any>();
+    mockRequestWorkerJobsApi.mockReturnValueOnce(workerRefresh.promise);
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        savedAt: '2026-08-10T11:05:00.000Z',
+        tasks: [
+          {
+            id: 'later-job-alias',
+            sequence: 1,
+            kind: 'tidas_package_export',
+            request: { scope: 'open_data' },
+            state: 'completed',
+            phase: 'completed',
+            message: 'later job alias',
+            createdAt: '2026-08-10T10:05:00.000Z',
+            updatedAt: '2026-08-10T10:05:00.000Z',
+            jobId: 'shared-package-job',
+          },
+          {
+            id: 'canonical-job-task',
+            sequence: 1,
+            kind: 'tidas_package_export',
+            state: 'completed',
+            phase: 'completed',
+            message: 'canonical job task',
+            createdAt: '2026-08-10T10:00:00.000Z',
+            updatedAt: '2026-08-10T10:00:00.000Z',
+            workerJobId: 'fallback-worker-job',
+            jobId: 'shared-package-job',
+            scope: 'current_user',
+          },
+          {
+            id: 'canonical-worker-task',
+            sequence: 2,
+            kind: 'tidas_package_export',
+            state: 'completed',
+            phase: 'completed',
+            message: 'canonical worker task',
+            createdAt: '2026-08-10T11:00:00.000Z',
+            updatedAt: '2026-08-10T11:00:00.000Z',
+            workerJobId: 'shared-worker-job',
+            jobId: 'fallback-package-job',
+            scope: 'open_data',
+          },
+          {
+            id: 'later-worker-alias',
+            sequence: 3,
+            kind: 'tidas_package_export',
+            state: 'completed',
+            phase: 'completed',
+            message: 'later worker alias',
+            createdAt: '2026-08-10T11:01:00.000Z',
+            updatedAt: '2026-08-10T11:01:00.000Z',
+            workerJobId: 'shared-worker-job',
+          },
+        ],
+      }),
+    );
+
+    const taskCenter = loadTaskCenterModule();
+    expect(taskCenter.listTidasPackageTasks()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'canonical-job-task',
+          request: { scope: 'open_data' },
+          workerJobId: 'fallback-worker-job',
+          jobId: 'shared-package-job',
+          scope: 'current_user',
+        }),
+        expect.objectContaining({
+          id: 'canonical-worker-task',
+          workerJobId: 'shared-worker-job',
+          jobId: 'fallback-package-job',
+          scope: 'open_data',
+        }),
+      ]),
+    );
+
+    workerRefresh.resolve({
+      data: [
+        {
+          id: 'shared-worker-job',
+          jobKind: 'tidas.export_package',
+          status: 'completed',
+          subjectType: 'lca_package_job',
+          subjectId: 'fallback-package-job',
+          createdAt: '2026-08-10T11:00:00.000Z',
+          updatedAt: '2026-08-10T10:59:00.000Z',
+        },
+      ],
+      error: null,
+    });
+
+    await waitFor(() => {
+      expect(
+        taskCenter.listTidasPackageTasks().find((item) => item.id === 'canonical-worker-task')
+          ?.updatedAt,
+      ).toBe('2026-08-10T11:00:00.000Z');
+    });
   });
 
   it('maps canonical export worker_jobs phase and artifact fallback branches', async () => {
@@ -1392,6 +1751,43 @@ describe('tidasPackage/taskCenter', () => {
     listener.mockClear();
     taskCenter.removeTidasPackageTask('running-task');
     expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('returns a completed download without mutating the next authenticated owner', async () => {
+    const download = createDeferred<any>();
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        savedAt: new Date().toISOString(),
+        tasks: [
+          {
+            id: 'stale-download-task',
+            state: 'completed',
+            phase: 'completed',
+            message: 'ready',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            sequence: 1,
+            jobId: 'stale-download-job',
+          },
+        ],
+      }),
+    );
+    mockDownloadReadyTidasPackageExportApi.mockReturnValueOnce(download.promise);
+
+    const taskCenter = loadTaskCenterModule();
+    const pending = taskCenter.downloadTidasPackageExportTask('stale-download-task');
+    taskCenter.bindTidasPackageTaskCenterOwner('user-b');
+    download.resolve({
+      data: { ok: true, filename: 'stale-owner.zip', job_id: 'stale-download-job' },
+      error: null,
+    });
+
+    await expect(pending).resolves.toEqual(
+      expect.objectContaining({ filename: 'stale-owner.zip' }),
+    );
+    expect(taskCenter.listTidasPackageTasks()).toEqual([]);
   });
 
   it('uses the default filename when downloading tasks that never recorded one locally', async () => {


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#799

## Summary
- Coalesce queue responses, persisted aliases, polling results, and Worker refresh rows that share a canonical worker or package identity.
- Retain one visible task while adopting authoritative backend lifecycle state and timestamps.

## Key Decisions
- Prefer workerJobId as the canonical execution identity and jobId as the package-request identity; either identity is sufficient to reconcile aliases.
- Retain the earliest local presentation identity and route delayed failures to that retained task without weakening authenticated generation guards.

## Validation
- 35/35 focused task-center tests passed with 100% statements, branches, functions, and lines for taskCenter.ts.
- Locale artifact generation is idempotent and the previously failing locale contract suites pass 30/30.
- Final prepush gate passed 411/411 suites and 5640/5640 tests; all 461 tracked source files are 100/100/100/100 covered.
- ESLint, Prettier, TypeScript, production build, reference-resource checks, LCIA cache validation, and Docpact base-to-head gate passed.

## Risks / Rollback
- The change is limited to the authenticated local task projection; backend package creation remains authoritative in database-engine #455.
- Rollback by reverting the task-center reconciliation commit; persisted aliases will then render separately again.

## Workspace Integration
- Targets tiangong-lca-next dev and depends on database-engine PR #456 for fresh mutable-scope package contents; root integration remains pending until child main promotion.