### PR TITLE
Add role-separated batch review actions

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-11"
-lastReviewedCommit: "07467b98423473223d84f5169415062d33eaaa15"
+lastReviewedAt: '2026-08-11'
+lastReviewedCommit: '5400b798ea4ff948c2776b0d66fb2e52489e4066'
 lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: canonical artifacts and 100%-branch-covered unit/integration tests cover server-backed filters, intersection behavior, and the 50-row default.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 07467b98423473223d84f5169415062d33eaaa15
+lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
 lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: review queues add server-backed filters and a 50-row default with 100% AssignmentReview branch coverage, while preserving Database-owned authorization and totals.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 07467b98423473223d84f5169415062d33eaaa15
+lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
 lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: Node 24, deterministic artifacts, 100%-branch-covered review tests, TypeScript, build, and managed checked-push remain the delivery path.'
 ---
 

--- a/docs/agents/data_audit_instruction.md
+++ b/docs/agents/data_audit_instruction.md
@@ -19,7 +19,7 @@ checkPaths:
   - src/pages/Review/**
   - src/pages/ManageSystem/**
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 07467b98423473223d84f5169415062d33eaaa15
+lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
 lastReviewedNote: 'Reviewed for Issue #807: flat Root/Reference queues add display-mode and exact data-type controls with server-owned filtering and a 50-row default; Process/Lifecycle Model relationship child tables remain unfiltered.'
 ---
 
@@ -41,7 +41,7 @@ lastReviewedNote: 'Reviewed for Issue #807: flat Root/Reference queues add displ
 | `reviews`         | Root, Reference, and immutable legacy review tasks |
 | `comments`        | assigned Review Member opinions                    |
 
-New reviews use `review_kind = root | reference`. Migrated legacy source rows retain `review_kind = null` and remain read-only history. A Root Review stores its append-only reference relation in `scope_history`; a Reference Review is shared by every Root Review that uses the same exact dataset revision.
+New reviews use `review_kind = root | reference`. Migrated legacy source rows retain `review_kind = null` and remain read-only history. Root-to-Reference relationships are derived from the current dataset JSON and formally submitted Reviewer comments; a Reference Review is shared by every Root Review that uses the same exact dataset revision.
 
 ## Status Codes
 
@@ -88,6 +88,14 @@ New reviews use `review_kind = root | reference`. Migrated legacy source rows re
 | Review Admin finally approves | after all current Review Members have completed, `comments.state_code -> 2`, `reviews.state_code -> 2`, and only the exact review target moves `20 -> 100` |
 
 Review Member outcomes are advisory. Review Admin may finally approve even when every Review Member used `-3`, and may reject before every Review Member has completed. A Root Review may be approved while its Reference Reviews are still pending; this does not approve or release those references. Conversely, a Reference Review continues independently when its only Root Review is rejected.
+
+## Batch Decision Boundary
+
+- Review Admin `unassigned` selections expose batch reject only; this is a final admin rejection.
+- Review Admin `assigned` selections expose batch approve and reject; both are final admin decisions.
+- Review Member `pending` selections expose batch approve and reject; these submit only that member's advisory Comment outcome and never finalize the Review.
+- Every selected Review is processed independently. A stale or unauthorized row is reported as an item failure without rolling back successful rows.
+- Batch actions reuse the same state transitions, authorization, rejection-reason rules, and Process/Lifecycle Model metadata requirements as the corresponding single-item command.
 
 Process and Lifecycle Model Root Reviews retain their existing metadata form and metadata writeback. Contact, Source, Unit Group, Flow Property, Flow, and every Reference Review use only approve/reject actions: approve requires no opinion; reject requires a reason.
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 07467b98423473223d84f5169415062d33eaaa15
+lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
 lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: review-filter unit/integration tests close all AssignmentReview branches and continue through the unchanged checked-push policy.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 07467b98423473223d84f5169415062d33eaaa15
+lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
 lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: flat review queues expose display-mode and exact data-type controls, delegate filtering/counts to Database, default to 50 rows, and retain unfiltered relationship child tables.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 07467b98423473223d84f5169415062d33eaaa15
+lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
 lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: review queue proof covers forwarding, compatibility/intersections, reset, 50-row defaults, deterministic artifacts, integration rendering, and 100% AssignmentReview branches.'
 related:
   - ../AGENTS.md

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -23,7 +23,7 @@ checkPaths:
   - playwright.config.ts
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 07467b98423473223d84f5169415062d33eaaa15
+lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
 lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: Next forwards review display mode and exact target type to v3 queue RPCs; Database remains authoritative for filtering, totals, pagination, validation, and the 50-row default.'
 ---
 

--- a/docs/agents/team_management.md
+++ b/docs/agents/team_management.md
@@ -20,7 +20,7 @@ checkPaths:
   - src/pages/Review/**
   - src/pages/ManageSystem/**
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 07467b98423473223d84f5169415062d33eaaa15
+lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
 lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: review display/type filters and the 50-row default do not change team roles, review authority, or membership-constrained visibility.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 07467b98423473223d84f5169415062d33eaaa15
+lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
 lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: filter contracts, integration rendering, and explicit all/member filter branches preserve the 100% coverage maintenance strategy.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 07467b98423473223d84f5169415062d33eaaa15
+lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
 lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: AssignmentReview filters/default pagination have canonical artifacts, integration proof, and explicit 100% branch closure.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 07467b98423473223d84f5169415062d33eaaa15
+lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
 lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: flat-queue tests cover controls, forwarding, reset, 50-row defaults, integration mocks, and both sides of every new branch.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 07467b98423473223d84f5169415062d33eaaa15
+lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
 lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: keep integration mocks aligned and exercise both all/type and Admin/Member filter branches before rerunning the strict 100% coverage gate.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "4f27bcf3501430f5928d5aedb722795ce73ce53f899d0898648e11db3c4603ab",
-    "auditedInputDigest": "863ddedfc01a4dac3be5369d0d6115ead307bed96cd385a05b427a2fcad15b7d"
+    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723",
+    "auditedInputDigest": "87f3df83f41836dd1f32b5e25335ff71b23cc831bd0fa7c944d490cdb9345d6a"
   },
   "inventory": {
-    "sourceMessageCount": 3107,
-    "localeMessageCount": 3107,
+    "sourceMessageCount": 3114,
+    "localeMessageCount": 3114,
     "leafModuleCount": 30,
     "dynamicFamilyCount": 17,
     "dynamicCallsiteCount": 39,
@@ -44,36 +44,36 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3107,
-    "completeCount": 3107,
+    "messageCount": 3114,
+    "completeCount": 3114,
     "blockedCount": 0,
-    "dossierDigest": "5d6133e43db5fdf755759a63118b805ee170667ba5c35a94cbc8c0073735e70a",
-    "catalogDigest": "05641d12a9d5e42d488da5edaada871f6754280a2e458627f10116c0373598b1",
+    "dossierDigest": "9f05dfc8fafbc61c6362e009df503bc35bec74738f2eb0e743590d61abc3a9e2",
+    "catalogDigest": "05d9ac48d37d0eafb48ec463e6b33e2be831295ef25d4afba5dfce8ff96ff832",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
     "roleCounts": {
-      "error-or-validation": 362,
+      "error-or-validation": 363,
       "explanatory-copy": 110,
       "field-guidance": 49,
-      "label-or-body-copy": 1252,
+      "label-or-body-copy": 1255,
       "navigation-or-tab": 226,
       "reserved-catalog-copy": 277,
       "status-or-empty-state": 100,
-      "success-notification": 181,
+      "success-notification": 182,
       "title-or-heading": 239,
-      "user-action": 311
+      "user-action": 313
     },
     "stateCounts": {
-      "destructive-or-rejecting-action": 45,
-      "failure-or-invalid-input": 362,
-      "interactive-ready": 521,
+      "destructive-or-rejecting-action": 47,
+      "failure-or-invalid-input": 363,
+      "interactive-ready": 522,
       "retained-not-currently-reachable": 356,
-      "successful-completion": 181,
-      "visible": 1642
+      "successful-completion": 182,
+      "visible": 1644
     },
-    "riskCounts": { "high": 1383, "low": 1502, "medium": 222 },
-    "highRiskMessageCount": 1383,
-    "highRiskMessageDigest": "8040e7c73965f644e0d0d592ff4de3476d0ff83ce6db175003e6524274cedebd"
+    "riskCounts": { "high": 1390, "low": 1502, "medium": 222 },
+    "highRiskMessageCount": 1390,
+    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0"
   },
   "typedContentDossiers": {
     "sourcePath": "src/components/ImportTidasPackage/reportContent.ts",
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4114,
+    "literalReferenceCount": 4124,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale de-DE --message <MESSAGE_ID>"
@@ -503,7 +503,7 @@
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "b1442ddd3a928a5a99c5020c2dceee3994fcd8744aa2e03c62f980625d38446b",
-          "focusedTestDigest": "855881c8dffba21d074a43c3b4c41a03c4270e7792a43ba4799a7b0ee4313f1c",
+          "focusedTestDigest": "e71ebdedaa744976d65be9341bae9fae3658e2158c6360f623c1260225b59854",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "0fe9fde9469f5c4c22c71f2fdaa50fd1d399b662a5c84940b48ea85519fa42a1",
+      "rowEvidenceDigest": "41c96657d29d1e29e7abf90448aaf3ccb2c30445cd39ce5357a3e3459f6b4953",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "34be449d18eb230cbd6609e99e5462670b29648792a99aa781b183696493d997"
+  "contextDigest": "4f2bbb9a6d3183c3b3b4ffafabea01b2830cedff0eb49d622240d894ad61cb10"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "4f27bcf3501430f5928d5aedb722795ce73ce53f899d0898648e11db3c4603ab"
+    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "34be449d18eb230cbd6609e99e5462670b29648792a99aa781b183696493d997",
-    "qualityDigest": "cb1b270091e91f91e8461709418d35059e89edec4ed88c826fdde57fde397f96",
+    "contextDigest": "4f2bbb9a6d3183c3b3b4ffafabea01b2830cedff0eb49d622240d894ad61cb10",
+    "qualityDigest": "7467d11c191ba948d4be726d5a3598251c9088c0c332831c6e98f29dd47d3d1b",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "990523aa00274e2386091871703159819dd9d877d231ffcf499abbbe26f502e6"
+  "activationDigest": "4fe5f7ea4e1c081feaee41b4b587b839f93d6b71b59e3c76e28af3d5150e391b"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "863ddedfc01a4dac3be5369d0d6115ead307bed96cd385a05b427a2fcad15b7d",
+    "auditedInputDigest": "87f3df83f41836dd1f32b5e25335ff71b23cc831bd0fa7c944d490cdb9345d6a",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -69,13 +69,13 @@
   "summary": {
     "localeCount": 4,
     "localeLeafModuleCounts": { "en-US": 30, "zh-CN": 30, "de-DE": 30, "fr-FR": 30 },
-    "localeUniqueKeyCounts": { "en-US": 3107, "zh-CN": 3107, "de-DE": 3107, "fr-FR": 3107 },
-    "canonicalCandidateKeyCount": 3107,
-    "activeStaticKeyCount": 2109,
+    "localeUniqueKeyCounts": { "en-US": 3114, "zh-CN": 3114, "de-DE": 3114, "fr-FR": 3114 },
+    "canonicalCandidateKeyCount": 3114,
+    "activeStaticKeyCount": 2116,
     "activeDynamicKeyCount": 367,
     "reservedKeyCount": 631,
-    "productionSourceFileCount": 436,
-    "literalReferenceCount": 4114,
+    "productionSourceFileCount": 437,
+    "literalReferenceCount": 4124,
     "dynamicCallsiteCount": 39,
     "dynamicCallsiteSummaryCount": 39,
     "registeredDynamicCallsiteCount": 39,
@@ -16403,6 +16403,15 @@
       },
       "references": [
         {
+          "kind": "formatMessage",
+          "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+          "line": 153,
+          "column": 20,
+          "symbol": "BatchReviewActions",
+          "defaultMessage": "Reject Reason",
+          "defaultMessageExpression": null
+        },
+        {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/RejectReview/index.tsx",
           "line": 131,
@@ -16427,6 +16436,12 @@
           "argumentSignature": [],
           "placeholders": [],
           "locations": [
+            {
+              "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+              "line": 153,
+              "column": 20,
+              "kind": "formatMessage"
+            },
             {
               "path": "src/pages/Review/Components/RejectReview/index.tsx",
               "line": 131,
@@ -26434,7 +26449,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 313,
+          "line": 315,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -27366,7 +27381,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 333,
+          "line": 335,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -27435,7 +27450,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 321,
+          "line": 323,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -27504,7 +27519,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 317,
+          "line": 319,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -27809,7 +27824,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 329,
+          "line": 331,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -27878,7 +27893,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 325,
+          "line": 327,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -28030,7 +28045,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 309,
+          "line": 311,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -28571,7 +28586,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1162,
+          "line": 1175,
           "column": 17,
           "symbol": "AssignmentReview",
           "defaultMessage": "Review Management",
@@ -28595,7 +28610,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1162,
+              "line": 1175,
               "column": 17,
               "kind": "FormattedMessage"
             },
@@ -206103,7 +206118,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 102,
+            "line": 109,
             "column": 3,
             "module": "pages_review"
           }
@@ -206114,7 +206129,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 102,
+            "line": 109,
             "column": 3,
             "module": "pages_review"
           }
@@ -206125,7 +206140,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 102,
+            "line": 109,
             "column": 3,
             "module": "pages_review"
           }
@@ -206136,7 +206151,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 102,
+            "line": 109,
             "column": 3,
             "module": "pages_review"
           }
@@ -206186,7 +206201,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 103,
+            "line": 110,
             "column": 3,
             "module": "pages_review"
           }
@@ -206197,7 +206212,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 103,
+            "line": 110,
             "column": 3,
             "module": "pages_review"
           }
@@ -206208,7 +206223,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 103,
+            "line": 110,
             "column": 3,
             "module": "pages_review"
           }
@@ -206219,7 +206234,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 103,
+            "line": 110,
             "column": 3,
             "module": "pages_review"
           }
@@ -206269,7 +206284,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 99,
+            "line": 106,
             "column": 3,
             "module": "pages_review"
           }
@@ -206280,7 +206295,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 99,
+            "line": 106,
             "column": 3,
             "module": "pages_review"
           }
@@ -206291,7 +206306,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 99,
+            "line": 106,
             "column": 3,
             "module": "pages_review"
           }
@@ -206302,7 +206317,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 99,
+            "line": 106,
             "column": 3,
             "module": "pages_review"
           }
@@ -206352,7 +206367,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 100,
+            "line": 107,
             "column": 3,
             "module": "pages_review"
           }
@@ -206363,7 +206378,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 100,
+            "line": 107,
             "column": 3,
             "module": "pages_review"
           }
@@ -206374,7 +206389,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 100,
+            "line": 107,
             "column": 3,
             "module": "pages_review"
           }
@@ -206385,7 +206400,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 100,
+            "line": 107,
             "column": 3,
             "module": "pages_review"
           }
@@ -206411,7 +206426,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 96,
+            "line": 103,
             "column": 3,
             "module": "pages_review"
           }
@@ -206422,7 +206437,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 96,
+            "line": 103,
             "column": 3,
             "module": "pages_review"
           }
@@ -206433,7 +206448,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 96,
+            "line": 103,
             "column": 3,
             "module": "pages_review"
           }
@@ -206444,7 +206459,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 96,
+            "line": 103,
             "column": 3,
             "module": "pages_review"
           }
@@ -206494,7 +206509,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 97,
+            "line": 104,
             "column": 3,
             "module": "pages_review"
           }
@@ -206505,7 +206520,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 97,
+            "line": 104,
             "column": 3,
             "module": "pages_review"
           }
@@ -206516,7 +206531,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 97,
+            "line": 104,
             "column": 3,
             "module": "pages_review"
           }
@@ -206527,7 +206542,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 97,
+            "line": 104,
             "column": 3,
             "module": "pages_review"
           }
@@ -206577,7 +206592,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 94,
+            "line": 101,
             "column": 3,
             "module": "pages_review"
           }
@@ -206588,7 +206603,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 94,
+            "line": 101,
             "column": 3,
             "module": "pages_review"
           }
@@ -206599,7 +206614,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 94,
+            "line": 101,
             "column": 3,
             "module": "pages_review"
           }
@@ -206610,7 +206625,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 94,
+            "line": 101,
             "column": 3,
             "module": "pages_review"
           }
@@ -206675,7 +206690,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 92,
+            "line": 99,
             "column": 3,
             "module": "pages_review"
           }
@@ -206686,7 +206701,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 92,
+            "line": 99,
             "column": 3,
             "module": "pages_review"
           }
@@ -206697,7 +206712,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 92,
+            "line": 99,
             "column": 3,
             "module": "pages_review"
           }
@@ -206708,7 +206723,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 92,
+            "line": 99,
             "column": 3,
             "module": "pages_review"
           }
@@ -206758,7 +206773,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 93,
+            "line": 100,
             "column": 3,
             "module": "pages_review"
           }
@@ -206769,7 +206784,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 93,
+            "line": 100,
             "column": 3,
             "module": "pages_review"
           }
@@ -206780,7 +206795,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 93,
+            "line": 100,
             "column": 3,
             "module": "pages_review"
           }
@@ -206791,7 +206806,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 93,
+            "line": 100,
             "column": 3,
             "module": "pages_review"
           }
@@ -206852,7 +206867,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 88,
+            "line": 95,
             "column": 3,
             "module": "pages_review"
           }
@@ -206884,7 +206899,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 608,
+          "line": 610,
           "column": 14,
           "symbol": "AssignmentReview",
           "defaultMessage": "Actions",
@@ -206893,7 +206908,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 728,
+          "line": 730,
           "column": 14,
           "symbol": "AssignmentReview",
           "defaultMessage": "Actions",
@@ -206902,7 +206917,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 777,
+          "line": 779,
           "column": 18,
           "symbol": "AssignmentReview",
           "defaultMessage": "Actions",
@@ -206911,7 +206926,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 845,
+          "line": 847,
           "column": 18,
           "symbol": "AssignmentReview",
           "defaultMessage": "Actions",
@@ -206920,7 +206935,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 935,
+          "line": 937,
           "column": 18,
           "symbol": "AssignmentReview",
           "defaultMessage": "Actions",
@@ -206944,31 +206959,31 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 608,
+              "line": 610,
               "column": 14,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 728,
+              "line": 730,
               "column": 14,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 777,
+              "line": 779,
               "column": 18,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 845,
+              "line": 847,
               "column": 18,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 935,
+              "line": 937,
               "column": 18,
               "kind": "FormattedMessage"
             },
@@ -206999,7 +207014,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 90,
+            "line": 97,
             "column": 3,
             "module": "pages_review"
           }
@@ -207010,7 +207025,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 90,
+            "line": 97,
             "column": 3,
             "module": "pages_review"
           }
@@ -207021,7 +207036,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 90,
+            "line": 97,
             "column": 3,
             "module": "pages_review"
           }
@@ -207032,7 +207047,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 90,
+            "line": 97,
             "column": 3,
             "module": "pages_review"
           }
@@ -207097,7 +207112,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 89,
+            "line": 96,
             "column": 3,
             "module": "pages_review"
           }
@@ -207108,7 +207123,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 89,
+            "line": 96,
             "column": 3,
             "module": "pages_review"
           }
@@ -207119,7 +207134,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 89,
+            "line": 96,
             "column": 3,
             "module": "pages_review"
           }
@@ -207130,7 +207145,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 89,
+            "line": 96,
             "column": 3,
             "module": "pages_review"
           }
@@ -207173,6 +207188,632 @@
               "line": 439,
               "column": 18,
               "kind": "FormattedMessage"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pages.review.batch.approve",
+      "category": "active-static",
+      "dynamicFamilies": [],
+      "moduleOwnership": {
+        "en-US": ["pages_review"],
+        "zh-CN": ["pages_review"],
+        "de-DE": ["pages_review"],
+        "fr-FR": ["pages_review"]
+      },
+      "translations": {
+        "en-US": {
+          "value": "Batch approve",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/en-US/pages_review.ts",
+            "line": 69,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "zh-CN": {
+          "value": "批量通过",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/zh-CN/pages_review.ts",
+            "line": 68,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "de-DE": {
+          "value": "Auswahl genehmigen",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/de-DE/pages_review.ts",
+            "line": 69,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "fr-FR": {
+          "value": "Approuver la sélection",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/fr-FR/pages_review.ts",
+            "line": 69,
+            "column": 3,
+            "module": "pages_review"
+          }
+        }
+      },
+      "references": [
+        {
+          "kind": "formatMessage",
+          "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+          "line": 95,
+          "column": 15,
+          "symbol": "confirmApprove",
+          "defaultMessage": "Batch approve",
+          "defaultMessageExpression": null
+        },
+        {
+          "kind": "formatMessage",
+          "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+          "line": 114,
+          "column": 14,
+          "symbol": "BatchReviewActions",
+          "defaultMessage": "Batch approve",
+          "defaultMessageExpression": null
+        }
+      ],
+      "defaultMessages": [
+        {
+          "value": "Batch approve",
+          "argumentSignature": [],
+          "placeholders": [],
+          "locations": [
+            {
+              "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+              "line": 95,
+              "column": 15,
+              "kind": "formatMessage"
+            },
+            {
+              "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+              "line": 114,
+              "column": 14,
+              "kind": "formatMessage"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pages.review.batch.approve.confirm",
+      "category": "active-static",
+      "dynamicFamilies": [],
+      "moduleOwnership": {
+        "en-US": ["pages_review"],
+        "zh-CN": ["pages_review"],
+        "de-DE": ["pages_review"],
+        "fr-FR": ["pages_review"]
+      },
+      "translations": {
+        "en-US": {
+          "value": "Approve {count} selected reviews?",
+          "argumentSignature": [{ "name": "count", "type": "simple" }],
+          "placeholders": ["count"],
+          "source": {
+            "path": "src/locales/en-US/pages_review.ts",
+            "line": 71,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "zh-CN": {
+          "value": "确定通过已选择的 {count} 个审核任务吗？",
+          "argumentSignature": [{ "name": "count", "type": "simple" }],
+          "placeholders": ["count"],
+          "source": {
+            "path": "src/locales/zh-CN/pages_review.ts",
+            "line": 70,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "de-DE": {
+          "value": "{count} ausgewählte Prüfungen genehmigen?",
+          "argumentSignature": [{ "name": "count", "type": "simple" }],
+          "placeholders": ["count"],
+          "source": {
+            "path": "src/locales/de-DE/pages_review.ts",
+            "line": 71,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "fr-FR": {
+          "value": "Approuver les {count} revues sélectionnées ?",
+          "argumentSignature": [{ "name": "count", "type": "simple" }],
+          "placeholders": ["count"],
+          "source": {
+            "path": "src/locales/fr-FR/pages_review.ts",
+            "line": 71,
+            "column": 3,
+            "module": "pages_review"
+          }
+        }
+      },
+      "references": [
+        {
+          "kind": "formatMessage",
+          "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+          "line": 88,
+          "column": 14,
+          "symbol": "confirmApprove",
+          "defaultMessage": "Approve {count} selected reviews?",
+          "defaultMessageExpression": null
+        }
+      ],
+      "defaultMessages": [
+        {
+          "value": "Approve {count} selected reviews?",
+          "argumentSignature": [{ "name": "count", "type": "simple" }],
+          "placeholders": ["count"],
+          "locations": [
+            {
+              "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+              "line": 88,
+              "column": 14,
+              "kind": "formatMessage"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pages.review.batch.error",
+      "category": "active-static",
+      "dynamicFamilies": [],
+      "moduleOwnership": {
+        "en-US": ["pages_review"],
+        "zh-CN": ["pages_review"],
+        "de-DE": ["pages_review"],
+        "fr-FR": ["pages_review"]
+      },
+      "translations": {
+        "en-US": {
+          "value": "Unable to process the selected reviews.",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/en-US/pages_review.ts",
+            "line": 75,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "zh-CN": {
+          "value": "无法处理已选择的审核任务。",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/zh-CN/pages_review.ts",
+            "line": 74,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "de-DE": {
+          "value": "Die ausgewählten Prüfungen konnten nicht verarbeitet werden.",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/de-DE/pages_review.ts",
+            "line": 75,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "fr-FR": {
+          "value": "Impossible de traiter les revues sélectionnées.",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/fr-FR/pages_review.ts",
+            "line": 75,
+            "column": 3,
+            "module": "pages_review"
+          }
+        }
+      },
+      "references": [
+        {
+          "kind": "formatMessage",
+          "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+          "line": 71,
+          "column": 9,
+          "symbol": "submit",
+          "defaultMessage": "Unable to process the selected reviews.",
+          "defaultMessageExpression": null
+        }
+      ],
+      "defaultMessages": [
+        {
+          "value": "Unable to process the selected reviews.",
+          "argumentSignature": [],
+          "placeholders": [],
+          "locations": [
+            {
+              "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+              "line": 71,
+              "column": 9,
+              "kind": "formatMessage"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pages.review.batch.partial",
+      "category": "active-static",
+      "dynamicFamilies": [],
+      "moduleOwnership": {
+        "en-US": ["pages_review"],
+        "zh-CN": ["pages_review"],
+        "de-DE": ["pages_review"],
+        "fr-FR": ["pages_review"]
+      },
+      "translations": {
+        "en-US": {
+          "value": "{succeeded} succeeded and {failed} failed.",
+          "argumentSignature": [
+            { "name": "failed", "type": "simple" },
+            { "name": "succeeded", "type": "simple" }
+          ],
+          "placeholders": ["failed", "succeeded"],
+          "source": {
+            "path": "src/locales/en-US/pages_review.ts",
+            "line": 74,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "zh-CN": {
+          "value": "成功 {succeeded} 个，失败 {failed} 个。",
+          "argumentSignature": [
+            { "name": "failed", "type": "simple" },
+            { "name": "succeeded", "type": "simple" }
+          ],
+          "placeholders": ["failed", "succeeded"],
+          "source": {
+            "path": "src/locales/zh-CN/pages_review.ts",
+            "line": 73,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "de-DE": {
+          "value": "{succeeded} erfolgreich, {failed} fehlgeschlagen.",
+          "argumentSignature": [
+            { "name": "failed", "type": "simple" },
+            { "name": "succeeded", "type": "simple" }
+          ],
+          "placeholders": ["failed", "succeeded"],
+          "source": {
+            "path": "src/locales/de-DE/pages_review.ts",
+            "line": 74,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "fr-FR": {
+          "value": "{succeeded} réussies et {failed} échouées.",
+          "argumentSignature": [
+            { "name": "failed", "type": "simple" },
+            { "name": "succeeded", "type": "simple" }
+          ],
+          "placeholders": ["failed", "succeeded"],
+          "source": {
+            "path": "src/locales/fr-FR/pages_review.ts",
+            "line": 74,
+            "column": 3,
+            "module": "pages_review"
+          }
+        }
+      },
+      "references": [
+        {
+          "kind": "formatMessage",
+          "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+          "line": 46,
+          "column": 11,
+          "symbol": "submit",
+          "defaultMessage": "{succeeded} succeeded and {failed} failed.",
+          "defaultMessageExpression": null
+        }
+      ],
+      "defaultMessages": [
+        {
+          "value": "{succeeded} succeeded and {failed} failed.",
+          "argumentSignature": [
+            { "name": "failed", "type": "simple" },
+            { "name": "succeeded", "type": "simple" }
+          ],
+          "placeholders": ["failed", "succeeded"],
+          "locations": [
+            {
+              "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+              "line": 46,
+              "column": 11,
+              "kind": "formatMessage"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pages.review.batch.reject",
+      "category": "active-static",
+      "dynamicFamilies": [],
+      "moduleOwnership": {
+        "en-US": ["pages_review"],
+        "zh-CN": ["pages_review"],
+        "de-DE": ["pages_review"],
+        "fr-FR": ["pages_review"]
+      },
+      "translations": {
+        "en-US": {
+          "value": "Batch reject",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/en-US/pages_review.ts",
+            "line": 70,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "zh-CN": {
+          "value": "批量驳回",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/zh-CN/pages_review.ts",
+            "line": 69,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "de-DE": {
+          "value": "Auswahl ablehnen",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/de-DE/pages_review.ts",
+            "line": 70,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "fr-FR": {
+          "value": "Rejeter la sélection",
+          "argumentSignature": [],
+          "placeholders": [],
+          "source": {
+            "path": "src/locales/fr-FR/pages_review.ts",
+            "line": 70,
+            "column": 3,
+            "module": "pages_review"
+          }
+        }
+      },
+      "references": [
+        {
+          "kind": "formatMessage",
+          "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+          "line": 126,
+          "column": 12,
+          "symbol": "BatchReviewActions",
+          "defaultMessage": "Batch reject",
+          "defaultMessageExpression": null
+        },
+        {
+          "kind": "formatMessage",
+          "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+          "line": 141,
+          "column": 17,
+          "symbol": "BatchReviewActions",
+          "defaultMessage": "Batch reject",
+          "defaultMessageExpression": null
+        }
+      ],
+      "defaultMessages": [
+        {
+          "value": "Batch reject",
+          "argumentSignature": [],
+          "placeholders": [],
+          "locations": [
+            {
+              "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+              "line": 126,
+              "column": 12,
+              "kind": "formatMessage"
+            },
+            {
+              "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+              "line": 141,
+              "column": 17,
+              "kind": "formatMessage"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pages.review.batch.reject.confirm",
+      "category": "active-static",
+      "dynamicFamilies": [],
+      "moduleOwnership": {
+        "en-US": ["pages_review"],
+        "zh-CN": ["pages_review"],
+        "de-DE": ["pages_review"],
+        "fr-FR": ["pages_review"]
+      },
+      "translations": {
+        "en-US": {
+          "value": "Reject {count} selected reviews",
+          "argumentSignature": [{ "name": "count", "type": "simple" }],
+          "placeholders": ["count"],
+          "source": {
+            "path": "src/locales/en-US/pages_review.ts",
+            "line": 72,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "zh-CN": {
+          "value": "驳回已选择的 {count} 个审核任务",
+          "argumentSignature": [{ "name": "count", "type": "simple" }],
+          "placeholders": ["count"],
+          "source": {
+            "path": "src/locales/zh-CN/pages_review.ts",
+            "line": 71,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "de-DE": {
+          "value": "{count} ausgewählte Prüfungen ablehnen",
+          "argumentSignature": [{ "name": "count", "type": "simple" }],
+          "placeholders": ["count"],
+          "source": {
+            "path": "src/locales/de-DE/pages_review.ts",
+            "line": 72,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "fr-FR": {
+          "value": "Rejeter les {count} revues sélectionnées",
+          "argumentSignature": [{ "name": "count", "type": "simple" }],
+          "placeholders": ["count"],
+          "source": {
+            "path": "src/locales/fr-FR/pages_review.ts",
+            "line": 72,
+            "column": 3,
+            "module": "pages_review"
+          }
+        }
+      },
+      "references": [
+        {
+          "kind": "formatMessage",
+          "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+          "line": 134,
+          "column": 16,
+          "symbol": "BatchReviewActions",
+          "defaultMessage": "Reject {count} selected reviews",
+          "defaultMessageExpression": null
+        }
+      ],
+      "defaultMessages": [
+        {
+          "value": "Reject {count} selected reviews",
+          "argumentSignature": [{ "name": "count", "type": "simple" }],
+          "placeholders": ["count"],
+          "locations": [
+            {
+              "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+              "line": 134,
+              "column": 16,
+              "kind": "formatMessage"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "pages.review.batch.success",
+      "category": "active-static",
+      "dynamicFamilies": [],
+      "moduleOwnership": {
+        "en-US": ["pages_review"],
+        "zh-CN": ["pages_review"],
+        "de-DE": ["pages_review"],
+        "fr-FR": ["pages_review"]
+      },
+      "translations": {
+        "en-US": {
+          "value": "{count} reviews processed successfully.",
+          "argumentSignature": [{ "name": "count", "type": "simple" }],
+          "placeholders": ["count"],
+          "source": {
+            "path": "src/locales/en-US/pages_review.ts",
+            "line": 73,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "zh-CN": {
+          "value": "已成功处理 {count} 个审核任务。",
+          "argumentSignature": [{ "name": "count", "type": "simple" }],
+          "placeholders": ["count"],
+          "source": {
+            "path": "src/locales/zh-CN/pages_review.ts",
+            "line": 72,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "de-DE": {
+          "value": "{count} Prüfungen wurden erfolgreich verarbeitet.",
+          "argumentSignature": [{ "name": "count", "type": "simple" }],
+          "placeholders": ["count"],
+          "source": {
+            "path": "src/locales/de-DE/pages_review.ts",
+            "line": 73,
+            "column": 3,
+            "module": "pages_review"
+          }
+        },
+        "fr-FR": {
+          "value": "{count} revues ont été traitées avec succès.",
+          "argumentSignature": [{ "name": "count", "type": "simple" }],
+          "placeholders": ["count"],
+          "source": {
+            "path": "src/locales/fr-FR/pages_review.ts",
+            "line": 73,
+            "column": 3,
+            "module": "pages_review"
+          }
+        }
+      },
+      "references": [
+        {
+          "kind": "formatMessage",
+          "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+          "line": 56,
+          "column": 11,
+          "symbol": "submit",
+          "defaultMessage": "{count} reviews processed successfully.",
+          "defaultMessageExpression": null
+        }
+      ],
+      "defaultMessages": [
+        {
+          "value": "{count} reviews processed successfully.",
+          "argumentSignature": [{ "name": "count", "type": "simple" }],
+          "placeholders": ["count"],
+          "locations": [
+            {
+              "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+              "line": 56,
+              "column": 11,
+              "kind": "formatMessage"
             }
           ]
         }
@@ -207819,7 +208460,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 340,
+          "line": 342,
           "column": 14,
           "symbol": "targetTableOptions",
           "defaultMessage": "All data types",
@@ -207834,7 +208475,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 340,
+              "line": 342,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -207902,7 +208543,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1106,
+          "line": 1108,
           "column": 29,
           "symbol": "filterControls",
           "defaultMessage": "Data type",
@@ -207917,7 +208558,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1106,
+              "line": 1108,
               "column": 29,
               "kind": "formatMessage"
             }
@@ -207985,7 +208626,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 282,
+          "line": 284,
           "column": 14,
           "symbol": "displayModeOptions",
           "defaultMessage": "All reviews",
@@ -208000,7 +208641,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 282,
+              "line": 284,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -208068,7 +208709,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1096,
+          "line": 1098,
           "column": 29,
           "symbol": "filterControls",
           "defaultMessage": "Display mode",
@@ -208083,7 +208724,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1096,
+              "line": 1098,
               "column": 29,
               "kind": "formatMessage"
             }
@@ -208151,7 +208792,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 289,
+          "line": 291,
           "column": 14,
           "symbol": "displayModeOptions",
           "defaultMessage": "Process and model reviews",
@@ -208166,7 +208807,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 289,
+              "line": 291,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -208234,7 +208875,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 296,
+          "line": 298,
           "column": 14,
           "symbol": "displayModeOptions",
           "defaultMessage": "Other reviews",
@@ -208249,7 +208890,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 296,
+              "line": 298,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -208876,7 +209517,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 136,
+            "line": 143,
             "column": 3,
             "module": "pages_review"
           }
@@ -208887,7 +209528,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 136,
+            "line": 143,
             "column": 3,
             "module": "pages_review"
           }
@@ -208898,7 +209539,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 136,
+            "line": 143,
             "column": 3,
             "module": "pages_review"
           }
@@ -208909,7 +209550,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 136,
+            "line": 143,
             "column": 3,
             "module": "pages_review"
           }
@@ -208959,7 +209600,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 125,
+            "line": 132,
             "column": 3,
             "module": "pages_review"
           }
@@ -208970,7 +209611,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 125,
+            "line": 132,
             "column": 3,
             "module": "pages_review"
           }
@@ -208981,7 +209622,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 125,
+            "line": 132,
             "column": 3,
             "module": "pages_review"
           }
@@ -208992,7 +209633,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 125,
+            "line": 132,
             "column": 3,
             "module": "pages_review"
           }
@@ -209057,7 +209698,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 133,
+            "line": 140,
             "column": 3,
             "module": "pages_review"
           }
@@ -209068,7 +209709,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 133,
+            "line": 140,
             "column": 3,
             "module": "pages_review"
           }
@@ -209079,7 +209720,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 133,
+            "line": 140,
             "column": 3,
             "module": "pages_review"
           }
@@ -209090,7 +209731,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 133,
+            "line": 140,
             "column": 3,
             "module": "pages_review"
           }
@@ -209140,7 +209781,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 134,
+            "line": 141,
             "column": 3,
             "module": "pages_review"
           }
@@ -209151,7 +209792,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 134,
+            "line": 141,
             "column": 3,
             "module": "pages_review"
           }
@@ -209162,7 +209803,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 134,
+            "line": 141,
             "column": 3,
             "module": "pages_review"
           }
@@ -209173,7 +209814,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 134,
+            "line": 141,
             "column": 3,
             "module": "pages_review"
           }
@@ -209199,7 +209840,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 135,
+            "line": 142,
             "column": 3,
             "module": "pages_review"
           }
@@ -209210,7 +209851,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 135,
+            "line": 142,
             "column": 3,
             "module": "pages_review"
           }
@@ -209221,7 +209862,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 135,
+            "line": 142,
             "column": 3,
             "module": "pages_review"
           }
@@ -209232,7 +209873,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 135,
+            "line": 142,
             "column": 3,
             "module": "pages_review"
           }
@@ -209503,7 +210144,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 132,
+            "line": 139,
             "column": 3,
             "module": "pages_review"
           }
@@ -209514,7 +210155,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 132,
+            "line": 139,
             "column": 3,
             "module": "pages_review"
           }
@@ -209525,7 +210166,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 132,
+            "line": 139,
             "column": 3,
             "module": "pages_review"
           }
@@ -209536,7 +210177,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 132,
+            "line": 139,
             "column": 3,
             "module": "pages_review"
           }
@@ -209797,7 +210438,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 138,
+            "line": 145,
             "column": 3,
             "module": "pages_review"
           }
@@ -209808,7 +210449,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 138,
+            "line": 145,
             "column": 3,
             "module": "pages_review"
           }
@@ -209819,7 +210460,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 138,
+            "line": 145,
             "column": 3,
             "module": "pages_review"
           }
@@ -209830,7 +210471,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 138,
+            "line": 145,
             "column": 3,
             "module": "pages_review"
           }
@@ -210076,7 +210717,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 127,
+            "line": 134,
             "column": 3,
             "module": "pages_review"
           }
@@ -210087,7 +210728,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 127,
+            "line": 134,
             "column": 3,
             "module": "pages_review"
           }
@@ -210098,7 +210739,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 127,
+            "line": 134,
             "column": 3,
             "module": "pages_review"
           }
@@ -210109,7 +210750,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 127,
+            "line": 134,
             "column": 3,
             "module": "pages_review"
           }
@@ -210242,7 +210883,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 123,
+            "line": 130,
             "column": 3,
             "module": "pages_review"
           }
@@ -210253,7 +210894,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 123,
+            "line": 130,
             "column": 3,
             "module": "pages_review"
           }
@@ -210264,7 +210905,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 123,
+            "line": 130,
             "column": 3,
             "module": "pages_review"
           }
@@ -210275,7 +210916,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 123,
+            "line": 130,
             "column": 3,
             "module": "pages_review"
           }
@@ -210301,7 +210942,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 129,
+            "line": 136,
             "column": 3,
             "module": "pages_review"
           }
@@ -210312,7 +210953,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 129,
+            "line": 136,
             "column": 3,
             "module": "pages_review"
           }
@@ -210323,7 +210964,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 129,
+            "line": 136,
             "column": 3,
             "module": "pages_review"
           }
@@ -210334,7 +210975,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 129,
+            "line": 136,
             "column": 3,
             "module": "pages_review"
           }
@@ -210384,7 +211025,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 128,
+            "line": 135,
             "column": 3,
             "module": "pages_review"
           }
@@ -210395,7 +211036,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 128,
+            "line": 135,
             "column": 3,
             "module": "pages_review"
           }
@@ -210406,7 +211047,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 128,
+            "line": 135,
             "column": 3,
             "module": "pages_review"
           }
@@ -210417,7 +211058,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 128,
+            "line": 135,
             "column": 3,
             "module": "pages_review"
           }
@@ -210844,7 +211485,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 137,
+            "line": 144,
             "column": 3,
             "module": "pages_review"
           }
@@ -210855,7 +211496,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 137,
+            "line": 144,
             "column": 3,
             "module": "pages_review"
           }
@@ -210866,7 +211507,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 137,
+            "line": 144,
             "column": 3,
             "module": "pages_review"
           }
@@ -210877,7 +211518,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 137,
+            "line": 144,
             "column": 3,
             "module": "pages_review"
           }
@@ -210927,7 +211568,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 126,
+            "line": 133,
             "column": 3,
             "module": "pages_review"
           }
@@ -210938,7 +211579,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 126,
+            "line": 133,
             "column": 3,
             "module": "pages_review"
           }
@@ -210949,7 +211590,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 126,
+            "line": 133,
             "column": 3,
             "module": "pages_review"
           }
@@ -210960,7 +211601,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 126,
+            "line": 133,
             "column": 3,
             "module": "pages_review"
           }
@@ -211152,7 +211793,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 131,
+            "line": 138,
             "column": 3,
             "module": "pages_review"
           }
@@ -211163,7 +211804,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 131,
+            "line": 138,
             "column": 3,
             "module": "pages_review"
           }
@@ -211174,7 +211815,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 131,
+            "line": 138,
             "column": 3,
             "module": "pages_review"
           }
@@ -211185,7 +211826,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 131,
+            "line": 138,
             "column": 3,
             "module": "pages_review"
           }
@@ -211235,7 +211876,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 124,
+            "line": 131,
             "column": 3,
             "module": "pages_review"
           }
@@ -211246,7 +211887,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 124,
+            "line": 131,
             "column": 3,
             "module": "pages_review"
           }
@@ -211257,7 +211898,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 124,
+            "line": 131,
             "column": 3,
             "module": "pages_review"
           }
@@ -211268,7 +211909,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 124,
+            "line": 131,
             "column": 3,
             "module": "pages_review"
           }
@@ -211318,7 +211959,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 130,
+            "line": 137,
             "column": 3,
             "module": "pages_review"
           }
@@ -211329,7 +211970,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 130,
+            "line": 137,
             "column": 3,
             "module": "pages_review"
           }
@@ -211340,7 +211981,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 130,
+            "line": 137,
             "column": 3,
             "module": "pages_review"
           }
@@ -211351,7 +211992,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 130,
+            "line": 137,
             "column": 3,
             "module": "pages_review"
           }
@@ -211589,7 +212230,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 78,
+            "line": 85,
             "column": 3,
             "module": "pages_review"
           }
@@ -211600,7 +212241,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 77,
+            "line": 84,
             "column": 3,
             "module": "pages_review"
           }
@@ -211611,7 +212252,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 78,
+            "line": 85,
             "column": 3,
             "module": "pages_review"
           }
@@ -211622,7 +212263,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 78,
+            "line": 85,
             "column": 3,
             "module": "pages_review"
           }
@@ -211648,7 +212289,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 70,
+            "line": 77,
             "column": 3,
             "module": "pages_review"
           }
@@ -211659,7 +212300,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 69,
+            "line": 76,
             "column": 3,
             "module": "pages_review"
           }
@@ -211670,7 +212311,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 70,
+            "line": 77,
             "column": 3,
             "module": "pages_review"
           }
@@ -211681,7 +212322,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 70,
+            "line": 77,
             "column": 3,
             "module": "pages_review"
           }
@@ -211691,7 +212332,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 598,
+          "line": 600,
           "column": 9,
           "symbol": "subColumns",
           "defaultMessage": "Review Progress",
@@ -211700,7 +212341,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 761,
+          "line": 763,
           "column": 13,
           "symbol": "AssignmentReview",
           "defaultMessage": "Review Progress",
@@ -211715,13 +212356,13 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 598,
+              "line": 600,
               "column": 9,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 761,
+              "line": 763,
               "column": 13,
               "kind": "FormattedMessage"
             }
@@ -211746,7 +212387,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 86,
+            "line": 93,
             "column": 3,
             "module": "pages_review"
           }
@@ -211757,7 +212398,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 85,
+            "line": 92,
             "column": 3,
             "module": "pages_review"
           }
@@ -211768,7 +212409,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 86,
+            "line": 93,
             "column": 3,
             "module": "pages_review"
           }
@@ -211779,7 +212420,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 86,
+            "line": 93,
             "column": 3,
             "module": "pages_review"
           }
@@ -211829,7 +212470,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 85,
+            "line": 92,
             "column": 3,
             "module": "pages_review"
           }
@@ -211840,7 +212481,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 84,
+            "line": 91,
             "column": 3,
             "module": "pages_review"
           }
@@ -211851,7 +212492,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 85,
+            "line": 92,
             "column": 3,
             "module": "pages_review"
           }
@@ -211862,7 +212503,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 85,
+            "line": 92,
             "column": 3,
             "module": "pages_review"
           }
@@ -211912,7 +212553,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 80,
+            "line": 87,
             "column": 3,
             "module": "pages_review"
           }
@@ -211923,7 +212564,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 79,
+            "line": 86,
             "column": 3,
             "module": "pages_review"
           }
@@ -211934,7 +212575,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 80,
+            "line": 87,
             "column": 3,
             "module": "pages_review"
           }
@@ -211945,7 +212586,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 80,
+            "line": 87,
             "column": 3,
             "module": "pages_review"
           }
@@ -211995,7 +212636,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 79,
+            "line": 86,
             "column": 3,
             "module": "pages_review"
           }
@@ -212006,7 +212647,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 78,
+            "line": 85,
             "column": 3,
             "module": "pages_review"
           }
@@ -212017,7 +212658,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 79,
+            "line": 86,
             "column": 3,
             "module": "pages_review"
           }
@@ -212028,7 +212669,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 79,
+            "line": 86,
             "column": 3,
             "module": "pages_review"
           }
@@ -212078,7 +212719,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 72,
+            "line": 79,
             "column": 3,
             "module": "pages_review"
           }
@@ -212089,7 +212730,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 71,
+            "line": 78,
             "column": 3,
             "module": "pages_review"
           }
@@ -212100,7 +212741,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 72,
+            "line": 79,
             "column": 3,
             "module": "pages_review"
           }
@@ -212111,7 +212752,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 72,
+            "line": 79,
             "column": 3,
             "module": "pages_review"
           }
@@ -212161,7 +212802,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 71,
+            "line": 78,
             "column": 3,
             "module": "pages_review"
           }
@@ -212172,7 +212813,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 70,
+            "line": 77,
             "column": 3,
             "module": "pages_review"
           }
@@ -212183,7 +212824,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 71,
+            "line": 78,
             "column": 3,
             "module": "pages_review"
           }
@@ -212194,7 +212835,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 71,
+            "line": 78,
             "column": 3,
             "module": "pages_review"
           }
@@ -212244,7 +212885,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 81,
+            "line": 88,
             "column": 3,
             "module": "pages_review"
           }
@@ -212255,7 +212896,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 80,
+            "line": 87,
             "column": 3,
             "module": "pages_review"
           }
@@ -212266,7 +212907,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 81,
+            "line": 88,
             "column": 3,
             "module": "pages_review"
           }
@@ -212277,7 +212918,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 81,
+            "line": 88,
             "column": 3,
             "module": "pages_review"
           }
@@ -212327,7 +212968,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 82,
+            "line": 89,
             "column": 3,
             "module": "pages_review"
           }
@@ -212338,7 +212979,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 81,
+            "line": 88,
             "column": 3,
             "module": "pages_review"
           }
@@ -212349,7 +212990,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 82,
+            "line": 89,
             "column": 3,
             "module": "pages_review"
           }
@@ -212360,7 +213001,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 82,
+            "line": 89,
             "column": 3,
             "module": "pages_review"
           }
@@ -212410,7 +213051,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 83,
+            "line": 90,
             "column": 3,
             "module": "pages_review"
           }
@@ -212421,7 +213062,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 82,
+            "line": 89,
             "column": 3,
             "module": "pages_review"
           }
@@ -212432,7 +213073,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 83,
+            "line": 90,
             "column": 3,
             "module": "pages_review"
           }
@@ -212443,7 +213084,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 83,
+            "line": 90,
             "column": 3,
             "module": "pages_review"
           }
@@ -212493,7 +213134,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 84,
+            "line": 91,
             "column": 3,
             "module": "pages_review"
           }
@@ -212504,7 +213145,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 83,
+            "line": 90,
             "column": 3,
             "module": "pages_review"
           }
@@ -212515,7 +213156,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 84,
+            "line": 91,
             "column": 3,
             "module": "pages_review"
           }
@@ -212526,7 +213167,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 84,
+            "line": 91,
             "column": 3,
             "module": "pages_review"
           }
@@ -212576,7 +213217,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 77,
+            "line": 84,
             "column": 3,
             "module": "pages_review"
           }
@@ -212587,7 +213228,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 76,
+            "line": 83,
             "column": 3,
             "module": "pages_review"
           }
@@ -212598,7 +213239,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 77,
+            "line": 84,
             "column": 3,
             "module": "pages_review"
           }
@@ -212609,7 +213250,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 77,
+            "line": 84,
             "column": 3,
             "module": "pages_review"
           }
@@ -212659,7 +213300,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 75,
+            "line": 82,
             "column": 3,
             "module": "pages_review"
           }
@@ -212670,7 +213311,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 74,
+            "line": 81,
             "column": 3,
             "module": "pages_review"
           }
@@ -212681,7 +213322,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 75,
+            "line": 82,
             "column": 3,
             "module": "pages_review"
           }
@@ -212692,7 +213333,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 75,
+            "line": 82,
             "column": 3,
             "module": "pages_review"
           }
@@ -212742,7 +213383,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 73,
+            "line": 80,
             "column": 3,
             "module": "pages_review"
           }
@@ -212753,7 +213394,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 72,
+            "line": 79,
             "column": 3,
             "module": "pages_review"
           }
@@ -212764,7 +213405,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 73,
+            "line": 80,
             "column": 3,
             "module": "pages_review"
           }
@@ -212775,7 +213416,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 73,
+            "line": 80,
             "column": 3,
             "module": "pages_review"
           }
@@ -212825,7 +213466,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 74,
+            "line": 81,
             "column": 3,
             "module": "pages_review"
           }
@@ -212836,7 +213477,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 73,
+            "line": 80,
             "column": 3,
             "module": "pages_review"
           }
@@ -212847,7 +213488,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 74,
+            "line": 81,
             "column": 3,
             "module": "pages_review"
           }
@@ -212858,7 +213499,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 74,
+            "line": 81,
             "column": 3,
             "module": "pages_review"
           }
@@ -212908,7 +213549,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 76,
+            "line": 83,
             "column": 3,
             "module": "pages_review"
           }
@@ -212919,7 +213560,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 75,
+            "line": 82,
             "column": 3,
             "module": "pages_review"
           }
@@ -212930,7 +213571,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 76,
+            "line": 83,
             "column": 3,
             "module": "pages_review"
           }
@@ -212941,7 +213582,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 76,
+            "line": 83,
             "column": 3,
             "module": "pages_review"
           }
@@ -212991,7 +213632,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 87,
+            "line": 94,
             "column": 3,
             "module": "pages_review"
           }
@@ -213002,7 +213643,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 86,
+            "line": 93,
             "column": 3,
             "module": "pages_review"
           }
@@ -213013,7 +213654,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 87,
+            "line": 94,
             "column": 3,
             "module": "pages_review"
           }
@@ -213024,7 +213665,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 87,
+            "line": 94,
             "column": 3,
             "module": "pages_review"
           }
@@ -213176,7 +213817,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 565,
+          "line": 567,
           "column": 23,
           "symbol": "status",
           "defaultMessage": "Approved",
@@ -213191,7 +213832,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 565,
+              "line": 567,
               "column": 23,
               "kind": "formatMessage"
             }
@@ -213259,7 +213900,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 581,
+          "line": 583,
           "column": 27,
           "symbol": "status",
           "defaultMessage": "In review",
@@ -213274,7 +213915,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 581,
+              "line": 583,
               "column": 27,
               "kind": "formatMessage"
             }
@@ -213342,7 +213983,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 573,
+          "line": 575,
           "column": 25,
           "symbol": "status",
           "defaultMessage": "Rejected",
@@ -213357,7 +213998,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 573,
+              "line": 575,
               "column": 25,
               "kind": "formatMessage"
             }
@@ -213425,7 +214066,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 588,
+          "line": 590,
           "column": 27,
           "symbol": "status",
           "defaultMessage": "Unassigned",
@@ -213440,7 +214081,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 588,
+              "line": 590,
               "column": 27,
               "kind": "formatMessage"
             }
@@ -213508,7 +214149,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 547,
+          "line": 549,
           "column": 14,
           "symbol": "subColumns",
           "defaultMessage": "Data type",
@@ -213523,7 +214164,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 547,
+              "line": 549,
               "column": 14,
               "kind": "FormattedMessage"
             }
@@ -213591,7 +214232,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 552,
+          "line": 554,
           "column": 14,
           "symbol": "subColumns",
           "defaultMessage": "Data version",
@@ -213606,7 +214247,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 552,
+              "line": 554,
               "column": 14,
               "kind": "FormattedMessage"
             }
@@ -213923,7 +214564,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1141,
+          "line": 1143,
           "column": 21,
           "symbol": "AssignmentReview",
           "defaultMessage": "Failed to load referenced reviews. Reselect the root review to retry.",
@@ -213938,7 +214579,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1141,
+              "line": 1143,
               "column": 21,
               "kind": "FormattedMessage"
             }
@@ -214006,7 +214647,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1133,
+          "line": 1135,
           "column": 21,
           "symbol": "AssignmentReview",
           "defaultMessage": "Loading referenced reviews...",
@@ -214021,7 +214662,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1133,
+              "line": 1135,
               "column": 21,
               "kind": "FormattedMessage"
             }
@@ -214101,7 +214742,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1122,
+          "line": 1124,
           "column": 19,
           "symbol": "AssignmentReview",
           "defaultMessage": "Selected {rootCount} root reviews and {referenceCount} reference reviews",
@@ -214119,7 +214760,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1122,
+              "line": 1124,
               "column": 19,
               "kind": "FormattedMessage"
             }
@@ -214964,7 +215605,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 717,
+          "line": 719,
           "column": 9,
           "symbol": "columns",
           "defaultMessage": "Submitted at",
@@ -214979,7 +215620,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 717,
+              "line": 719,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -215047,7 +215688,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 535,
+          "line": 537,
           "column": 9,
           "symbol": "subColumns",
           "defaultMessage": "Data name",
@@ -215056,7 +215697,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 681,
+          "line": 683,
           "column": 9,
           "symbol": "columns",
           "defaultMessage": "Data name",
@@ -215071,13 +215712,13 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 535,
+              "line": 537,
               "column": 9,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 681,
+              "line": 683,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -215145,7 +215786,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 752,
+          "line": 754,
           "column": 13,
           "symbol": "AssignmentReview",
           "defaultMessage": "Deadline",
@@ -215154,7 +215795,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 837,
+          "line": 839,
           "column": 13,
           "symbol": "AssignmentReview",
           "defaultMessage": "Deadline",
@@ -215163,7 +215804,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 927,
+          "line": 929,
           "column": 13,
           "symbol": "AssignmentReview",
           "defaultMessage": "Deadline",
@@ -215178,19 +215819,19 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 752,
+              "line": 754,
               "column": 13,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 837,
+              "line": 839,
               "column": 13,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 927,
+              "line": 929,
               "column": 13,
               "kind": "FormattedMessage"
             }
@@ -215435,7 +216076,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 701,
+          "line": 703,
           "column": 9,
           "symbol": "columns",
           "defaultMessage": "User Name",
@@ -215450,7 +216091,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 701,
+              "line": 703,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -215708,7 +216349,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 557,
+          "line": 559,
           "column": 14,
           "symbol": "subColumns",
           "defaultMessage": "Status",
@@ -215729,7 +216370,7 @@
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 557,
+              "line": 559,
               "column": 14,
               "kind": "FormattedMessage"
             }
@@ -216273,7 +216914,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 980,
+          "line": 982,
           "column": 16,
           "symbol": "getSubTitle",
           "defaultMessage": "Assigned Task",
@@ -216297,7 +216938,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 980,
+              "line": 982,
               "column": 16,
               "kind": "FormattedMessage"
             }
@@ -216457,7 +217098,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 984,
+          "line": 986,
           "column": 16,
           "symbol": "getSubTitle",
           "defaultMessage": "Pending Review",
@@ -216481,7 +217122,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 984,
+              "line": 986,
               "column": 16,
               "kind": "FormattedMessage"
             }
@@ -216549,7 +217190,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 986,
+          "line": 988,
           "column": 16,
           "symbol": "getSubTitle",
           "defaultMessage": "Rejected",
@@ -216573,7 +217214,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 986,
+              "line": 988,
               "column": 16,
               "kind": "FormattedMessage"
             }
@@ -216641,7 +217282,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 989,
+          "line": 991,
           "column": 11,
           "symbol": "getSubTitle",
           "defaultMessage": "Rejected Task",
@@ -216665,7 +217306,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 989,
+              "line": 991,
               "column": 11,
               "kind": "FormattedMessage"
             }
@@ -216733,7 +217374,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 982,
+          "line": 984,
           "column": 16,
           "symbol": "getSubTitle",
           "defaultMessage": "Reviewed",
@@ -216757,7 +217398,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 982,
+              "line": 984,
               "column": 16,
               "kind": "FormattedMessage"
             }
@@ -216825,7 +217466,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 977,
+          "line": 979,
           "column": 11,
           "symbol": "getSubTitle",
           "defaultMessage": "Unassigned Task",
@@ -216849,7 +217490,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 977,
+              "line": 979,
               "column": 11,
               "kind": "FormattedMessage"
             }
@@ -217327,7 +217968,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 110,
+            "line": 117,
             "column": 3,
             "module": "pages_review"
           }
@@ -217338,7 +217979,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 110,
+            "line": 117,
             "column": 3,
             "module": "pages_review"
           }
@@ -217349,7 +217990,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 110,
+            "line": 117,
             "column": 3,
             "module": "pages_review"
           }
@@ -217360,7 +218001,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 110,
+            "line": 117,
             "column": 3,
             "module": "pages_review"
           }
@@ -217410,7 +218051,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 121,
+            "line": 128,
             "column": 3,
             "module": "pages_review"
           }
@@ -217421,7 +218062,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 121,
+            "line": 128,
             "column": 3,
             "module": "pages_review"
           }
@@ -217432,7 +218073,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 121,
+            "line": 128,
             "column": 3,
             "module": "pages_review"
           }
@@ -217443,7 +218084,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 121,
+            "line": 128,
             "column": 3,
             "module": "pages_review"
           }
@@ -217469,7 +218110,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 115,
+            "line": 122,
             "column": 3,
             "module": "pages_review"
           }
@@ -217480,7 +218121,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 115,
+            "line": 122,
             "column": 3,
             "module": "pages_review"
           }
@@ -217491,7 +218132,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 115,
+            "line": 122,
             "column": 3,
             "module": "pages_review"
           }
@@ -217502,7 +218143,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 115,
+            "line": 122,
             "column": 3,
             "module": "pages_review"
           }
@@ -217528,7 +218169,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 114,
+            "line": 121,
             "column": 3,
             "module": "pages_review"
           }
@@ -217539,7 +218180,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 114,
+            "line": 121,
             "column": 3,
             "module": "pages_review"
           }
@@ -217550,7 +218191,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 114,
+            "line": 121,
             "column": 3,
             "module": "pages_review"
           }
@@ -217561,7 +218202,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 114,
+            "line": 121,
             "column": 3,
             "module": "pages_review"
           }
@@ -217587,7 +218228,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 108,
+            "line": 115,
             "column": 3,
             "module": "pages_review"
           }
@@ -217598,7 +218239,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 108,
+            "line": 115,
             "column": 3,
             "module": "pages_review"
           }
@@ -217609,7 +218250,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 108,
+            "line": 115,
             "column": 3,
             "module": "pages_review"
           }
@@ -217620,7 +218261,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 108,
+            "line": 115,
             "column": 3,
             "module": "pages_review"
           }
@@ -217670,7 +218311,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 120,
+            "line": 127,
             "column": 3,
             "module": "pages_review"
           }
@@ -217681,7 +218322,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 120,
+            "line": 127,
             "column": 3,
             "module": "pages_review"
           }
@@ -217692,7 +218333,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 120,
+            "line": 127,
             "column": 3,
             "module": "pages_review"
           }
@@ -217703,7 +218344,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 120,
+            "line": 127,
             "column": 3,
             "module": "pages_review"
           }
@@ -217729,7 +218370,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 116,
+            "line": 123,
             "column": 3,
             "module": "pages_review"
           }
@@ -217740,7 +218381,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 116,
+            "line": 123,
             "column": 3,
             "module": "pages_review"
           }
@@ -217751,7 +218392,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 116,
+            "line": 123,
             "column": 3,
             "module": "pages_review"
           }
@@ -217762,7 +218403,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 116,
+            "line": 123,
             "column": 3,
             "module": "pages_review"
           }
@@ -217788,7 +218429,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 117,
+            "line": 124,
             "column": 3,
             "module": "pages_review"
           }
@@ -217799,7 +218440,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 117,
+            "line": 124,
             "column": 3,
             "module": "pages_review"
           }
@@ -217810,7 +218451,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 117,
+            "line": 124,
             "column": 3,
             "module": "pages_review"
           }
@@ -217821,7 +218462,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 117,
+            "line": 124,
             "column": 3,
             "module": "pages_review"
           }
@@ -217847,7 +218488,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 119,
+            "line": 126,
             "column": 3,
             "module": "pages_review"
           }
@@ -217858,7 +218499,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 119,
+            "line": 126,
             "column": 3,
             "module": "pages_review"
           }
@@ -217869,7 +218510,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 119,
+            "line": 126,
             "column": 3,
             "module": "pages_review"
           }
@@ -217880,7 +218521,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 119,
+            "line": 126,
             "column": 3,
             "module": "pages_review"
           }
@@ -217906,7 +218547,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 118,
+            "line": 125,
             "column": 3,
             "module": "pages_review"
           }
@@ -217917,7 +218558,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 118,
+            "line": 125,
             "column": 3,
             "module": "pages_review"
           }
@@ -217928,7 +218569,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 118,
+            "line": 125,
             "column": 3,
             "module": "pages_review"
           }
@@ -217939,7 +218580,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 118,
+            "line": 125,
             "column": 3,
             "module": "pages_review"
           }
@@ -217965,7 +218606,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 113,
+            "line": 120,
             "column": 3,
             "module": "pages_review"
           }
@@ -217976,7 +218617,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 113,
+            "line": 120,
             "column": 3,
             "module": "pages_review"
           }
@@ -217987,7 +218628,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 113,
+            "line": 120,
             "column": 3,
             "module": "pages_review"
           }
@@ -217998,7 +218639,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 113,
+            "line": 120,
             "column": 3,
             "module": "pages_review"
           }
@@ -218024,7 +218665,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 109,
+            "line": 116,
             "column": 3,
             "module": "pages_review"
           }
@@ -218035,7 +218676,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 109,
+            "line": 116,
             "column": 3,
             "module": "pages_review"
           }
@@ -218046,7 +218687,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 109,
+            "line": 116,
             "column": 3,
             "module": "pages_review"
           }
@@ -218057,7 +218698,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 109,
+            "line": 116,
             "column": 3,
             "module": "pages_review"
           }
@@ -218107,7 +218748,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 107,
+            "line": 114,
             "column": 3,
             "module": "pages_review"
           }
@@ -218118,7 +218759,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 107,
+            "line": 114,
             "column": 3,
             "module": "pages_review"
           }
@@ -218129,7 +218770,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 107,
+            "line": 114,
             "column": 3,
             "module": "pages_review"
           }
@@ -218140,7 +218781,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 107,
+            "line": 114,
             "column": 3,
             "module": "pages_review"
           }
@@ -218190,7 +218831,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 106,
+            "line": 113,
             "column": 3,
             "module": "pages_review"
           }
@@ -218201,7 +218842,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 106,
+            "line": 113,
             "column": 3,
             "module": "pages_review"
           }
@@ -218212,7 +218853,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 106,
+            "line": 113,
             "column": 3,
             "module": "pages_review"
           }
@@ -218223,7 +218864,7 @@
           "placeholders": [],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 106,
+            "line": 113,
             "column": 3,
             "module": "pages_review"
           }
@@ -218273,7 +218914,7 @@
           "placeholders": ["action"],
           "source": {
             "path": "src/locales/en-US/pages_review.ts",
-            "line": 111,
+            "line": 118,
             "column": 3,
             "module": "pages_review"
           }
@@ -218284,7 +218925,7 @@
           "placeholders": ["action"],
           "source": {
             "path": "src/locales/zh-CN/pages_review.ts",
-            "line": 111,
+            "line": 118,
             "column": 3,
             "module": "pages_review"
           }
@@ -218295,7 +218936,7 @@
           "placeholders": ["action"],
           "source": {
             "path": "src/locales/de-DE/pages_review.ts",
-            "line": 111,
+            "line": 118,
             "column": 3,
             "module": "pages_review"
           }
@@ -218306,7 +218947,7 @@
           "placeholders": ["action"],
           "source": {
             "path": "src/locales/fr-FR/pages_review.ts",
-            "line": 111,
+            "line": 118,
             "column": 3,
             "module": "pages_review"
           }
@@ -218615,7 +219256,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1038,
+          "line": 1040,
           "column": 30,
           "symbol": "AssignmentReview",
           "defaultMessage": null,
@@ -219770,7 +220411,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 134,
+          "line": 135,
           "column": 5,
           "symbol": "defaultTableAlertOptionRender",
           "defaultMessage": "Clear selection",
@@ -219881,7 +220522,7 @@
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 134,
+              "line": 135,
               "column": 5,
               "kind": "FormattedMessage"
             },
@@ -230570,7 +231211,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 674,
+          "line": 676,
           "column": 14,
           "symbol": "columns",
           "defaultMessage": "Index",
@@ -230795,7 +231436,7 @@
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 674,
+              "line": 676,
               "column": 14,
               "kind": "FormattedMessage"
             },

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,12 +3,12 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "4f27bcf3501430f5928d5aedb722795ce73ce53f899d0898648e11db3c4603ab",
-    "contextDigest": "34be449d18eb230cbd6609e99e5462670b29648792a99aa781b183696493d997"
+    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723",
+    "contextDigest": "4f2bbb9a6d3183c3b3b4ffafabea01b2830cedff0eb49d622240d894ad61cb10"
   },
   "catalog": {
-    "messageCount": 3107,
-    "catalogDigest": "05641d12a9d5e42d488da5edaada871f6754280a2e458627f10116c0373598b1",
+    "messageCount": 3114,
+    "catalogDigest": "05d9ac48d37d0eafb48ec463e6b33e2be831295ef25d4afba5dfce8ff96ff832",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
@@ -21,7 +21,7 @@
     "acceptedDeclaredSourceEqualityDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
     "forbiddenGlossaryMatchCount": 0,
     "forbiddenGlossaryMatchDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
-    "suspiciousSourceEqualityRatio": 0.01126488574187319,
+    "suspiciousSourceEqualityRatio": 0.01123956326268465,
     "maxSuspiciousSourceEqualityRatio": 0.02
   },
   "automatedChecks": {
@@ -41,16 +41,16 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "0901fce5688f2274dce31dafe6be1c8ea5d6e7b96e63f0aec0463825cdcbde79",
-    "validationDigest": "208733e775dc0deaa121ac65ad6e67c230853a96f5495aabd2da1e0d92ce529c",
+    "digest": "8e4cc4140b6c9bef7de3ae2dbfb80b10a2e6b571dfe907907ff1b8860d3e9d74",
+    "validationDigest": "6118ee8339b197b381515b19fe022e72b1bf4f434b62e1fded88e574df90c4fc",
     "laneCount": 1,
-    "validatedMessageCount": 3107,
+    "validatedMessageCount": 3114,
     "validatedModuleCount": 31,
-    "highRiskMessageCount": 1383,
-    "highRiskMessageDigest": "8040e7c73965f644e0d0d592ff4de3476d0ff83ce6db175003e6524274cedebd",
+    "highRiskMessageCount": 1390,
+    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635",
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "cb1b270091e91f91e8461709418d35059e89edec4ed88c826fdde57fde397f96"
+  "qualityDigest": "7467d11c191ba948d4be726d5a3598251c9088c0c332831c6e98f29dd47d3d1b"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "863ddedfc01a4dac3be5369d0d6115ead307bed96cd385a05b427a2fcad15b7d",
-    "validatedMessageCount": 3107,
+    "auditedInputDigest": "87f3df83f41836dd1f32b5e25335ff71b23cc831bd0fa7c944d490cdb9345d6a",
+    "validatedMessageCount": 3114,
     "validatedModules": [
       "$entry",
       "component",
@@ -38,12 +38,12 @@
       "settings",
       "validator"
     ],
-    "highRiskMessageCount": 1383,
-    "highRiskMessageDigest": "8040e7c73965f644e0d0d592ff4de3476d0ff83ce6db175003e6524274cedebd",
-    "catalogDigest": "05641d12a9d5e42d488da5edaada871f6754280a2e458627f10116c0373598b1",
-    "dossierDigest": "5d6133e43db5fdf755759a63118b805ee170667ba5c35a94cbc8c0073735e70a",
+    "highRiskMessageCount": 1390,
+    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
+    "catalogDigest": "05d9ac48d37d0eafb48ec463e6b33e2be831295ef25d4afba5dfce8ff96ff832",
+    "dossierDigest": "9f05dfc8fafbc61c6362e009df503bc35bec74738f2eb0e743590d61abc3a9e2",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "0fe9fde9469f5c4c22c71f2fdaa50fd1d399b662a5c84940b48ea85519fa42a1",
+    "routeEvidenceDigest": "41c96657d29d1e29e7abf90448aaf3ccb2c30445cd39ce5357a3e3459f6b4953",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -92,11 +92,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3107,
-        "messageDigest": "04efe4411b2ca0b7d67feed52332b657e75801779cd43bac15e3a8bd0b832b6c",
-        "highRiskMessageCount": 1383,
-        "highRiskMessageDigest": "8040e7c73965f644e0d0d592ff4de3476d0ff83ce6db175003e6524274cedebd",
-        "dossierDigest": "5d6133e43db5fdf755759a63118b805ee170667ba5c35a94cbc8c0073735e70a",
+        "messageCount": 3114,
+        "messageDigest": "7e7b1cc9be2d7f7c8b74f069bddc34a36f242da8b1e5626f00a289473cc58ef2",
+        "highRiskMessageCount": 1390,
+        "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
+        "dossierDigest": "9f05dfc8fafbc61c6362e009df503bc35bec74738f2eb0e743590d61abc3a9e2",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "208733e775dc0deaa121ac65ad6e67c230853a96f5495aabd2da1e0d92ce529c"
+  "validationDigest": "6118ee8339b197b381515b19fe022e72b1bf4f434b62e1fded88e574df90c4fc"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "4f27bcf3501430f5928d5aedb722795ce73ce53f899d0898648e11db3c4603ab",
-    "auditedInputDigest": "863ddedfc01a4dac3be5369d0d6115ead307bed96cd385a05b427a2fcad15b7d"
+    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723",
+    "auditedInputDigest": "87f3df83f41836dd1f32b5e25335ff71b23cc831bd0fa7c944d490cdb9345d6a"
   },
   "inventory": {
-    "sourceMessageCount": 3107,
-    "localeMessageCount": 3107,
+    "sourceMessageCount": 3114,
+    "localeMessageCount": 3114,
     "leafModuleCount": 30,
     "dynamicFamilyCount": 17,
     "dynamicCallsiteCount": 39,
@@ -44,36 +44,36 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3107,
-    "completeCount": 3107,
+    "messageCount": 3114,
+    "completeCount": 3114,
     "blockedCount": 0,
-    "dossierDigest": "d7f19b4096fcd215fe69780ca5da4b041f0431464592324bf84f52ddb1c97d0f",
-    "catalogDigest": "b3b9dd4af0e0c8ec81f8a46c3c072095eb9a58959db437900aee1206f293b60f",
+    "dossierDigest": "78fa368841d6d6e672bb2ea8a3624564d6d0600f6994247403c6f0ef532df0e6",
+    "catalogDigest": "aa8b61be8b056c7640170905371ff7564d95a4b3c11b2dd6dfbb0c43faf71a29",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
     "roleCounts": {
-      "error-or-validation": 362,
+      "error-or-validation": 363,
       "explanatory-copy": 110,
       "field-guidance": 49,
-      "label-or-body-copy": 1252,
+      "label-or-body-copy": 1255,
       "navigation-or-tab": 226,
       "reserved-catalog-copy": 277,
       "status-or-empty-state": 100,
-      "success-notification": 181,
+      "success-notification": 182,
       "title-or-heading": 239,
-      "user-action": 311
+      "user-action": 313
     },
     "stateCounts": {
-      "destructive-or-rejecting-action": 45,
-      "failure-or-invalid-input": 362,
-      "interactive-ready": 521,
+      "destructive-or-rejecting-action": 47,
+      "failure-or-invalid-input": 363,
+      "interactive-ready": 522,
       "retained-not-currently-reachable": 356,
-      "successful-completion": 181,
-      "visible": 1642
+      "successful-completion": 182,
+      "visible": 1644
     },
-    "riskCounts": { "high": 1383, "low": 1523, "medium": 201 },
-    "highRiskMessageCount": 1383,
-    "highRiskMessageDigest": "8040e7c73965f644e0d0d592ff4de3476d0ff83ce6db175003e6524274cedebd"
+    "riskCounts": { "high": 1390, "low": 1523, "medium": 201 },
+    "highRiskMessageCount": 1390,
+    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0"
   },
   "typedContentDossiers": {
     "sourcePath": "src/components/ImportTidasPackage/reportContent.ts",
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4114,
+    "literalReferenceCount": 4124,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale en-US --message <MESSAGE_ID>"
@@ -503,7 +503,7 @@
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "b1442ddd3a928a5a99c5020c2dceee3994fcd8744aa2e03c62f980625d38446b",
-          "focusedTestDigest": "855881c8dffba21d074a43c3b4c41a03c4270e7792a43ba4799a7b0ee4313f1c",
+          "focusedTestDigest": "e71ebdedaa744976d65be9341bae9fae3658e2158c6360f623c1260225b59854",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "0fe9fde9469f5c4c22c71f2fdaa50fd1d399b662a5c84940b48ea85519fa42a1",
+      "rowEvidenceDigest": "41c96657d29d1e29e7abf90448aaf3ccb2c30445cd39ce5357a3e3459f6b4953",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "79220b03086bcdbd1542bae190b7710110ec506f14c9005351620f44f97fbcc9"
+  "contextDigest": "401c245b48eb1ab7c0973cb7bc69ab24c537b76662d893a1e3b2e8313adafa91"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "4f27bcf3501430f5928d5aedb722795ce73ce53f899d0898648e11db3c4603ab"
+    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "79220b03086bcdbd1542bae190b7710110ec506f14c9005351620f44f97fbcc9",
-    "qualityDigest": "51a6eda54257f88f6ab76d9372808c88590c46cc844100418bd15deeb123052c",
+    "contextDigest": "401c245b48eb1ab7c0973cb7bc69ab24c537b76662d893a1e3b2e8313adafa91",
+    "qualityDigest": "7c46407185cff54c6fdbda22bc73b412119d6712bde78bd74abaab95169e1694",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "f91b964ebc02add32f446bf2e4417c3739073fca2470efae8db3a654f47b61a6"
+  "activationDigest": "4c38e5b3c6ede8c07dc35191ae901c69eeff837b3ccb7236a4a4fe2e8179097e"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,25 +3,25 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "4f27bcf3501430f5928d5aedb722795ce73ce53f899d0898648e11db3c4603ab",
-    "contextDigest": "79220b03086bcdbd1542bae190b7710110ec506f14c9005351620f44f97fbcc9"
+    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723",
+    "contextDigest": "401c245b48eb1ab7c0973cb7bc69ab24c537b76662d893a1e3b2e8313adafa91"
   },
   "catalog": {
-    "messageCount": 3107,
-    "catalogDigest": "b3b9dd4af0e0c8ec81f8a46c3c072095eb9a58959db437900aee1206f293b60f",
+    "messageCount": 3114,
+    "catalogDigest": "aa8b61be8b056c7640170905371ff7564d95a4b3c11b2dd6dfbb0c43faf71a29",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
     "cjkLeakCount": 0,
-    "suspiciousSourceEqualityCount": 3029,
-    "suspiciousSourceEqualityDigest": "79e2ebe55746afdbf449f4ad0b83b2267fc9d7988a07bce6f6fc013dbf64acfb",
+    "suspiciousSourceEqualityCount": 3036,
+    "suspiciousSourceEqualityDigest": "c8c8ce3199775178ecb508e500154d3d28445e1070af7ecade31a6be036bd4a7",
     "acceptedTechnicalSourceEqualityCount": 77,
     "acceptedTechnicalSourceEqualityDigest": "2c498f32e45a368d8f4ddb6987df879250152a55da7babd4f4dbeb717b3d0583",
     "acceptedDeclaredSourceEqualityCount": 0,
     "acceptedDeclaredSourceEqualityDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
     "forbiddenGlossaryMatchCount": 0,
     "forbiddenGlossaryMatchDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
-    "suspiciousSourceEqualityRatio": 0.9748953974895398,
+    "suspiciousSourceEqualityRatio": 0.9749518304431599,
     "maxSuspiciousSourceEqualityRatio": 1
   },
   "automatedChecks": {
@@ -41,16 +41,16 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "ccfeff4371a21b09d754662c924744122613481b2e72cfeafadeefcadef04293",
-    "validationDigest": "ddf5136d71958149e194887fbf7c3f8db5fbfe812141acb39be4b6650be0c5c9",
+    "digest": "63e947a0addb2fa1b8f2f2b7967a41e936036976eac6ae5d4c21a0f294d2c0cd",
+    "validationDigest": "b8b462253169d16715d3970c5622306aa7ba6c3488f1b21e134e35087f7ff882",
     "laneCount": 1,
-    "validatedMessageCount": 3107,
+    "validatedMessageCount": 3114,
     "validatedModuleCount": 31,
-    "highRiskMessageCount": 1383,
-    "highRiskMessageDigest": "8040e7c73965f644e0d0d592ff4de3476d0ff83ce6db175003e6524274cedebd",
+    "highRiskMessageCount": 1390,
+    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635",
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "51a6eda54257f88f6ab76d9372808c88590c46cc844100418bd15deeb123052c"
+  "qualityDigest": "7c46407185cff54c6fdbda22bc73b412119d6712bde78bd74abaab95169e1694"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "863ddedfc01a4dac3be5369d0d6115ead307bed96cd385a05b427a2fcad15b7d",
-    "validatedMessageCount": 3107,
+    "auditedInputDigest": "87f3df83f41836dd1f32b5e25335ff71b23cc831bd0fa7c944d490cdb9345d6a",
+    "validatedMessageCount": 3114,
     "validatedModules": [
       "$entry",
       "component",
@@ -38,12 +38,12 @@
       "settings",
       "validator"
     ],
-    "highRiskMessageCount": 1383,
-    "highRiskMessageDigest": "8040e7c73965f644e0d0d592ff4de3476d0ff83ce6db175003e6524274cedebd",
-    "catalogDigest": "b3b9dd4af0e0c8ec81f8a46c3c072095eb9a58959db437900aee1206f293b60f",
-    "dossierDigest": "d7f19b4096fcd215fe69780ca5da4b041f0431464592324bf84f52ddb1c97d0f",
+    "highRiskMessageCount": 1390,
+    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
+    "catalogDigest": "aa8b61be8b056c7640170905371ff7564d95a4b3c11b2dd6dfbb0c43faf71a29",
+    "dossierDigest": "78fa368841d6d6e672bb2ea8a3624564d6d0600f6994247403c6f0ef532df0e6",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "0fe9fde9469f5c4c22c71f2fdaa50fd1d399b662a5c84940b48ea85519fa42a1",
+    "routeEvidenceDigest": "41c96657d29d1e29e7abf90448aaf3ccb2c30445cd39ce5357a3e3459f6b4953",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -92,11 +92,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3107,
-        "messageDigest": "04efe4411b2ca0b7d67feed52332b657e75801779cd43bac15e3a8bd0b832b6c",
-        "highRiskMessageCount": 1383,
-        "highRiskMessageDigest": "8040e7c73965f644e0d0d592ff4de3476d0ff83ce6db175003e6524274cedebd",
-        "dossierDigest": "d7f19b4096fcd215fe69780ca5da4b041f0431464592324bf84f52ddb1c97d0f",
+        "messageCount": 3114,
+        "messageDigest": "7e7b1cc9be2d7f7c8b74f069bddc34a36f242da8b1e5626f00a289473cc58ef2",
+        "highRiskMessageCount": 1390,
+        "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
+        "dossierDigest": "78fa368841d6d6e672bb2ea8a3624564d6d0600f6994247403c6f0ef532df0e6",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "ddf5136d71958149e194887fbf7c3f8db5fbfe812141acb39be4b6650be0c5c9"
+  "validationDigest": "b8b462253169d16715d3970c5622306aa7ba6c3488f1b21e134e35087f7ff882"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "4f27bcf3501430f5928d5aedb722795ce73ce53f899d0898648e11db3c4603ab",
-    "auditedInputDigest": "863ddedfc01a4dac3be5369d0d6115ead307bed96cd385a05b427a2fcad15b7d"
+    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723",
+    "auditedInputDigest": "87f3df83f41836dd1f32b5e25335ff71b23cc831bd0fa7c944d490cdb9345d6a"
   },
   "inventory": {
-    "sourceMessageCount": 3107,
-    "localeMessageCount": 3107,
+    "sourceMessageCount": 3114,
+    "localeMessageCount": 3114,
     "leafModuleCount": 30,
     "dynamicFamilyCount": 17,
     "dynamicCallsiteCount": 39,
@@ -44,36 +44,36 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3107,
-    "completeCount": 3107,
+    "messageCount": 3114,
+    "completeCount": 3114,
     "blockedCount": 0,
-    "dossierDigest": "eb512c1dbf93b9ddf5b90d2d82dfbda97594ba608eca77275a3aaca3c3ecb12f",
-    "catalogDigest": "85e41a13054efa933957b71731315f26ea8d34c527baaf3a900d9c2f43467a5d",
+    "dossierDigest": "1249b80a71a45a750a3ff6e642640ab24ee446abe9ed52a7d2ca59bb321c4802",
+    "catalogDigest": "e9ab3d4f080335169cdc43db7cf7fb93ba04129e9a94b7c30aa4548f725218d2",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
     "roleCounts": {
-      "error-or-validation": 362,
+      "error-or-validation": 363,
       "explanatory-copy": 110,
       "field-guidance": 49,
-      "label-or-body-copy": 1252,
+      "label-or-body-copy": 1255,
       "navigation-or-tab": 226,
       "reserved-catalog-copy": 277,
       "status-or-empty-state": 100,
-      "success-notification": 181,
+      "success-notification": 182,
       "title-or-heading": 239,
-      "user-action": 311
+      "user-action": 313
     },
     "stateCounts": {
-      "destructive-or-rejecting-action": 45,
-      "failure-or-invalid-input": 362,
-      "interactive-ready": 521,
+      "destructive-or-rejecting-action": 47,
+      "failure-or-invalid-input": 363,
+      "interactive-ready": 522,
       "retained-not-currently-reachable": 356,
-      "successful-completion": 181,
-      "visible": 1642
+      "successful-completion": 182,
+      "visible": 1644
     },
-    "riskCounts": { "high": 1383, "low": 1501, "medium": 223 },
-    "highRiskMessageCount": 1383,
-    "highRiskMessageDigest": "8040e7c73965f644e0d0d592ff4de3476d0ff83ce6db175003e6524274cedebd"
+    "riskCounts": { "high": 1390, "low": 1501, "medium": 223 },
+    "highRiskMessageCount": 1390,
+    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0"
   },
   "typedContentDossiers": {
     "sourcePath": "src/components/ImportTidasPackage/reportContent.ts",
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4114,
+    "literalReferenceCount": 4124,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale fr-FR --message <MESSAGE_ID>"
@@ -503,7 +503,7 @@
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "b1442ddd3a928a5a99c5020c2dceee3994fcd8744aa2e03c62f980625d38446b",
-          "focusedTestDigest": "855881c8dffba21d074a43c3b4c41a03c4270e7792a43ba4799a7b0ee4313f1c",
+          "focusedTestDigest": "e71ebdedaa744976d65be9341bae9fae3658e2158c6360f623c1260225b59854",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "0fe9fde9469f5c4c22c71f2fdaa50fd1d399b662a5c84940b48ea85519fa42a1",
+      "rowEvidenceDigest": "41c96657d29d1e29e7abf90448aaf3ccb2c30445cd39ce5357a3e3459f6b4953",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "c3c81c9caffe43a679a3f85e0532594810b2adffb62918d8d309cba0be6c95c7"
+  "contextDigest": "5a56a69bfbe51f37673fe3ac04fe25334a4e6f07e0e437cd4222bf52db7c72e7"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "4f27bcf3501430f5928d5aedb722795ce73ce53f899d0898648e11db3c4603ab"
+    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "c3c81c9caffe43a679a3f85e0532594810b2adffb62918d8d309cba0be6c95c7",
-    "qualityDigest": "c91b6df5b038854dd395c27238f61b8a68cdff905d2453d0477d34e5132cd075",
+    "contextDigest": "5a56a69bfbe51f37673fe3ac04fe25334a4e6f07e0e437cd4222bf52db7c72e7",
+    "qualityDigest": "395a92b7a83944109bea1935b036ed9bbf39a7c4edfadd4dfe6063ddc583553d",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "f0f5690aba343ceba2bcd26647355ddb59a537619ddafe9a8990f93cb5b7e2c7"
+  "activationDigest": "e93a9cd366976619edd6c5287ff4171e6891767b394998df62e48bf33d963c29"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,12 +3,12 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "4f27bcf3501430f5928d5aedb722795ce73ce53f899d0898648e11db3c4603ab",
-    "contextDigest": "c3c81c9caffe43a679a3f85e0532594810b2adffb62918d8d309cba0be6c95c7"
+    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723",
+    "contextDigest": "5a56a69bfbe51f37673fe3ac04fe25334a4e6f07e0e437cd4222bf52db7c72e7"
   },
   "catalog": {
-    "messageCount": 3107,
-    "catalogDigest": "85e41a13054efa933957b71731315f26ea8d34c527baaf3a900d9c2f43467a5d",
+    "messageCount": 3114,
+    "catalogDigest": "e9ab3d4f080335169cdc43db7cf7fb93ba04129e9a94b7c30aa4548f725218d2",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
@@ -41,16 +41,16 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "6d0a38e0397b18b938dcfbefa3bfdd1bb2144922612d3998ed3402b30acf5a58",
-    "validationDigest": "c0ec972b2e5288c92ae5caaac456a0a3d549d1ca771a28279ec6d1d68a4fb414",
+    "digest": "9e52ff06e83c8342ae58a159e27d476375730ac7efe3a1a1501f0764c8cb6624",
+    "validationDigest": "15903e0e6985b5a90568100dd3c9234d4d4dbd1cb10da41a5b6c9db1472d1c8b",
     "laneCount": 1,
-    "validatedMessageCount": 3107,
+    "validatedMessageCount": 3114,
     "validatedModuleCount": 31,
-    "highRiskMessageCount": 1383,
-    "highRiskMessageDigest": "8040e7c73965f644e0d0d592ff4de3476d0ff83ce6db175003e6524274cedebd",
+    "highRiskMessageCount": 1390,
+    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635",
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "c91b6df5b038854dd395c27238f61b8a68cdff905d2453d0477d34e5132cd075"
+  "qualityDigest": "395a92b7a83944109bea1935b036ed9bbf39a7c4edfadd4dfe6063ddc583553d"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "863ddedfc01a4dac3be5369d0d6115ead307bed96cd385a05b427a2fcad15b7d",
-    "validatedMessageCount": 3107,
+    "auditedInputDigest": "87f3df83f41836dd1f32b5e25335ff71b23cc831bd0fa7c944d490cdb9345d6a",
+    "validatedMessageCount": 3114,
     "validatedModules": [
       "$entry",
       "component",
@@ -38,12 +38,12 @@
       "settings",
       "validator"
     ],
-    "highRiskMessageCount": 1383,
-    "highRiskMessageDigest": "8040e7c73965f644e0d0d592ff4de3476d0ff83ce6db175003e6524274cedebd",
-    "catalogDigest": "85e41a13054efa933957b71731315f26ea8d34c527baaf3a900d9c2f43467a5d",
-    "dossierDigest": "eb512c1dbf93b9ddf5b90d2d82dfbda97594ba608eca77275a3aaca3c3ecb12f",
+    "highRiskMessageCount": 1390,
+    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
+    "catalogDigest": "e9ab3d4f080335169cdc43db7cf7fb93ba04129e9a94b7c30aa4548f725218d2",
+    "dossierDigest": "1249b80a71a45a750a3ff6e642640ab24ee446abe9ed52a7d2ca59bb321c4802",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "0fe9fde9469f5c4c22c71f2fdaa50fd1d399b662a5c84940b48ea85519fa42a1",
+    "routeEvidenceDigest": "41c96657d29d1e29e7abf90448aaf3ccb2c30445cd39ce5357a3e3459f6b4953",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -92,11 +92,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3107,
-        "messageDigest": "04efe4411b2ca0b7d67feed52332b657e75801779cd43bac15e3a8bd0b832b6c",
-        "highRiskMessageCount": 1383,
-        "highRiskMessageDigest": "8040e7c73965f644e0d0d592ff4de3476d0ff83ce6db175003e6524274cedebd",
-        "dossierDigest": "eb512c1dbf93b9ddf5b90d2d82dfbda97594ba608eca77275a3aaca3c3ecb12f",
+        "messageCount": 3114,
+        "messageDigest": "7e7b1cc9be2d7f7c8b74f069bddc34a36f242da8b1e5626f00a289473cc58ef2",
+        "highRiskMessageCount": 1390,
+        "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
+        "dossierDigest": "1249b80a71a45a750a3ff6e642640ab24ee446abe9ed52a7d2ca59bb321c4802",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "c0ec972b2e5288c92ae5caaac456a0a3d549d1ca771a28279ec6d1d68a4fb414"
+  "validationDigest": "15903e0e6985b5a90568100dd3c9234d4d4dbd1cb10da41a5b6c9db1472d1c8b"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "4f27bcf3501430f5928d5aedb722795ce73ce53f899d0898648e11db3c4603ab",
-    "auditedInputDigest": "863ddedfc01a4dac3be5369d0d6115ead307bed96cd385a05b427a2fcad15b7d"
+    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723",
+    "auditedInputDigest": "87f3df83f41836dd1f32b5e25335ff71b23cc831bd0fa7c944d490cdb9345d6a"
   },
   "inventory": {
-    "sourceMessageCount": 3107,
-    "localeMessageCount": 3107,
+    "sourceMessageCount": 3114,
+    "localeMessageCount": 3114,
     "leafModuleCount": 30,
     "dynamicFamilyCount": 17,
     "dynamicCallsiteCount": 39,
@@ -44,36 +44,36 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3107,
-    "completeCount": 3107,
+    "messageCount": 3114,
+    "completeCount": 3114,
     "blockedCount": 0,
-    "dossierDigest": "156ea78a8053c59acec02a0c68c8d399c39bb0fe8a3fd1c64c35700877a3e8aa",
-    "catalogDigest": "37af2ebcc85e0eb3f134b5e8ead8bccc20de3868e479218df23a9830bc7f603f",
+    "dossierDigest": "6793fa192e1db7d59fbc383d08b4ad71546d20562641484703b77c5ef1da52f0",
+    "catalogDigest": "ff6938d40f9eaf1179a1deae1da9474d2bc42478773be577c9fe4b97b98afd88",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
     "roleCounts": {
-      "error-or-validation": 362,
+      "error-or-validation": 363,
       "explanatory-copy": 110,
       "field-guidance": 49,
-      "label-or-body-copy": 1252,
+      "label-or-body-copy": 1255,
       "navigation-or-tab": 226,
       "reserved-catalog-copy": 277,
       "status-or-empty-state": 100,
-      "success-notification": 181,
+      "success-notification": 182,
       "title-or-heading": 239,
-      "user-action": 311
+      "user-action": 313
     },
     "stateCounts": {
-      "destructive-or-rejecting-action": 45,
-      "failure-or-invalid-input": 362,
-      "interactive-ready": 521,
+      "destructive-or-rejecting-action": 47,
+      "failure-or-invalid-input": 363,
+      "interactive-ready": 522,
       "retained-not-currently-reachable": 356,
-      "successful-completion": 181,
-      "visible": 1642
+      "successful-completion": 182,
+      "visible": 1644
     },
-    "riskCounts": { "high": 1383, "low": 1556, "medium": 168 },
-    "highRiskMessageCount": 1383,
-    "highRiskMessageDigest": "8040e7c73965f644e0d0d592ff4de3476d0ff83ce6db175003e6524274cedebd"
+    "riskCounts": { "high": 1390, "low": 1556, "medium": 168 },
+    "highRiskMessageCount": 1390,
+    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0"
   },
   "typedContentDossiers": {
     "sourcePath": "src/components/ImportTidasPackage/reportContent.ts",
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4114,
+    "literalReferenceCount": 4124,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale zh-CN --message <MESSAGE_ID>"
@@ -503,7 +503,7 @@
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "b1442ddd3a928a5a99c5020c2dceee3994fcd8744aa2e03c62f980625d38446b",
-          "focusedTestDigest": "855881c8dffba21d074a43c3b4c41a03c4270e7792a43ba4799a7b0ee4313f1c",
+          "focusedTestDigest": "e71ebdedaa744976d65be9341bae9fae3658e2158c6360f623c1260225b59854",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "0fe9fde9469f5c4c22c71f2fdaa50fd1d399b662a5c84940b48ea85519fa42a1",
+      "rowEvidenceDigest": "41c96657d29d1e29e7abf90448aaf3ccb2c30445cd39ce5357a3e3459f6b4953",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "e390e3303841a57fe32bfd32dcca5d34b42e17cb95c6459cd7067bd2e69f4058"
+  "contextDigest": "ac6f9e6c129a6e9679e183a45bbefc0ff07bc69a9b27db7635f990edaa5e081b"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "4f27bcf3501430f5928d5aedb722795ce73ce53f899d0898648e11db3c4603ab"
+    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "e390e3303841a57fe32bfd32dcca5d34b42e17cb95c6459cd7067bd2e69f4058",
-    "qualityDigest": "20de784ad4c3821e13c9f23f7c5f7410d9890d97d8ae6b23471ef4a5c3de9f38",
+    "contextDigest": "ac6f9e6c129a6e9679e183a45bbefc0ff07bc69a9b27db7635f990edaa5e081b",
+    "qualityDigest": "5002265938bbe25ba35e6b459515dc5fd307feabf9f7bb75f6dbdd7aab99c5a8",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "37d6ad2da80ccc69ade7144a6ed599c5cf1635aebf5d6e0dd45d6f51879c5729"
+  "activationDigest": "56d4e47e709d3e8d9acf47771bcfcd188efa9c5c3d96f62308ca6dc8452281f1"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,12 +3,12 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "4f27bcf3501430f5928d5aedb722795ce73ce53f899d0898648e11db3c4603ab",
-    "contextDigest": "e390e3303841a57fe32bfd32dcca5d34b42e17cb95c6459cd7067bd2e69f4058"
+    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723",
+    "contextDigest": "ac6f9e6c129a6e9679e183a45bbefc0ff07bc69a9b27db7635f990edaa5e081b"
   },
   "catalog": {
-    "messageCount": 3107,
-    "catalogDigest": "37af2ebcc85e0eb3f134b5e8ead8bccc20de3868e479218df23a9830bc7f603f",
+    "messageCount": 3114,
+    "catalogDigest": "ff6938d40f9eaf1179a1deae1da9474d2bc42478773be577c9fe4b97b98afd88",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
@@ -41,16 +41,16 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "d6fd966eb83dd47ee4b8cac89f4e4b660987c37f9efe8d0e140a89295928bd63",
-    "validationDigest": "eafa82cef0b03400d044d41b0a85b2ca0b1e42de70b669de428484ae86db8c4d",
+    "digest": "d9755b3b0a0aa7317ca989179f076072cd0aa23de4893d74bd979b5645c8c121",
+    "validationDigest": "4f09df5149a5fc0399a0ffffcde51d26e8abec2f380c1fd34d5f94d6830ab159",
     "laneCount": 1,
-    "validatedMessageCount": 3107,
+    "validatedMessageCount": 3114,
     "validatedModuleCount": 31,
-    "highRiskMessageCount": 1383,
-    "highRiskMessageDigest": "8040e7c73965f644e0d0d592ff4de3476d0ff83ce6db175003e6524274cedebd",
+    "highRiskMessageCount": 1390,
+    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635",
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "20de784ad4c3821e13c9f23f7c5f7410d9890d97d8ae6b23471ef4a5c3de9f38"
+  "qualityDigest": "5002265938bbe25ba35e6b459515dc5fd307feabf9f7bb75f6dbdd7aab99c5a8"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "863ddedfc01a4dac3be5369d0d6115ead307bed96cd385a05b427a2fcad15b7d",
-    "validatedMessageCount": 3107,
+    "auditedInputDigest": "87f3df83f41836dd1f32b5e25335ff71b23cc831bd0fa7c944d490cdb9345d6a",
+    "validatedMessageCount": 3114,
     "validatedModules": [
       "$entry",
       "component",
@@ -38,12 +38,12 @@
       "settings",
       "validator"
     ],
-    "highRiskMessageCount": 1383,
-    "highRiskMessageDigest": "8040e7c73965f644e0d0d592ff4de3476d0ff83ce6db175003e6524274cedebd",
-    "catalogDigest": "37af2ebcc85e0eb3f134b5e8ead8bccc20de3868e479218df23a9830bc7f603f",
-    "dossierDigest": "156ea78a8053c59acec02a0c68c8d399c39bb0fe8a3fd1c64c35700877a3e8aa",
+    "highRiskMessageCount": 1390,
+    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
+    "catalogDigest": "ff6938d40f9eaf1179a1deae1da9474d2bc42478773be577c9fe4b97b98afd88",
+    "dossierDigest": "6793fa192e1db7d59fbc383d08b4ad71546d20562641484703b77c5ef1da52f0",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "0fe9fde9469f5c4c22c71f2fdaa50fd1d399b662a5c84940b48ea85519fa42a1",
+    "routeEvidenceDigest": "41c96657d29d1e29e7abf90448aaf3ccb2c30445cd39ce5357a3e3459f6b4953",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -92,11 +92,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3107,
-        "messageDigest": "04efe4411b2ca0b7d67feed52332b657e75801779cd43bac15e3a8bd0b832b6c",
-        "highRiskMessageCount": 1383,
-        "highRiskMessageDigest": "8040e7c73965f644e0d0d592ff4de3476d0ff83ce6db175003e6524274cedebd",
-        "dossierDigest": "156ea78a8053c59acec02a0c68c8d399c39bb0fe8a3fd1c64c35700877a3e8aa",
+        "messageCount": 3114,
+        "messageDigest": "7e7b1cc9be2d7f7c8b74f069bddc34a36f242da8b1e5626f00a289473cc58ef2",
+        "highRiskMessageCount": 1390,
+        "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
+        "dossierDigest": "6793fa192e1db7d59fbc383d08b4ad71546d20562641484703b77c5ef1da52f0",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "eafa82cef0b03400d044d41b0a85b2ca0b1e42de70b669de428484ae86db8c4d"
+  "validationDigest": "4f09df5149a5fc0399a0ffffcde51d26e8abec2f380c1fd34d5f94d6830ab159"
 }

--- a/src/locales/de-DE/pages_review.ts
+++ b/src/locales/de-DE/pages_review.ts
@@ -66,6 +66,13 @@ export default {
   'pages.review.filters.displayMode.other': 'Andere Prüfungen',
   'pages.review.filters.dataType.label': 'Datentyp',
   'pages.review.filters.dataType.all': 'Alle Datentypen',
+  'pages.review.batch.approve': 'Auswahl genehmigen',
+  'pages.review.batch.reject': 'Auswahl ablehnen',
+  'pages.review.batch.approve.confirm': '{count} ausgewählte Prüfungen genehmigen?',
+  'pages.review.batch.reject.confirm': '{count} ausgewählte Prüfungen ablehnen',
+  'pages.review.batch.success': '{count} Prüfungen wurden erfolgreich verarbeitet.',
+  'pages.review.batch.partial': '{succeeded} erfolgreich, {failed} fehlgeschlagen.',
+  'pages.review.batch.error': 'Die ausgewählten Prüfungen konnten nicht verarbeitet werden.',
 
   'pages.review.progress.button': 'Prüfungsfortschritt',
   'pages.review.progress.editReviewer': 'Prüfende verwalten',

--- a/src/locales/en-US/pages_review.ts
+++ b/src/locales/en-US/pages_review.ts
@@ -66,6 +66,13 @@ export default {
   'pages.review.filters.displayMode.other': 'Other reviews',
   'pages.review.filters.dataType.label': 'Data type',
   'pages.review.filters.dataType.all': 'All data types',
+  'pages.review.batch.approve': 'Batch approve',
+  'pages.review.batch.reject': 'Batch reject',
+  'pages.review.batch.approve.confirm': 'Approve {count} selected reviews?',
+  'pages.review.batch.reject.confirm': 'Reject {count} selected reviews',
+  'pages.review.batch.success': '{count} reviews processed successfully.',
+  'pages.review.batch.partial': '{succeeded} succeeded and {failed} failed.',
+  'pages.review.batch.error': 'Unable to process the selected reviews.',
 
   'pages.review.progress.button': 'Review Progress',
   'pages.review.progress.editReviewer': 'Edit Reviewer',

--- a/src/locales/fr-FR/pages_review.ts
+++ b/src/locales/fr-FR/pages_review.ts
@@ -66,6 +66,13 @@ export default {
   'pages.review.filters.displayMode.other': 'Autres évaluations',
   'pages.review.filters.dataType.label': 'Type de données',
   'pages.review.filters.dataType.all': 'Tous les types de données',
+  'pages.review.batch.approve': 'Approuver la sélection',
+  'pages.review.batch.reject': 'Rejeter la sélection',
+  'pages.review.batch.approve.confirm': 'Approuver les {count} revues sélectionnées ?',
+  'pages.review.batch.reject.confirm': 'Rejeter les {count} revues sélectionnées',
+  'pages.review.batch.success': '{count} revues ont été traitées avec succès.',
+  'pages.review.batch.partial': '{succeeded} réussies et {failed} échouées.',
+  'pages.review.batch.error': 'Impossible de traiter les revues sélectionnées.',
 
   'pages.review.progress.button': 'Avancement de la revue',
   'pages.review.progress.editReviewer': "Modifier l'évaluateur",

--- a/src/locales/zh-CN/pages_review.ts
+++ b/src/locales/zh-CN/pages_review.ts
@@ -65,6 +65,13 @@ export default {
   'pages.review.filters.displayMode.other': '其他类型审核',
   'pages.review.filters.dataType.label': '数据类型',
   'pages.review.filters.dataType.all': '全部数据类型',
+  'pages.review.batch.approve': '批量通过',
+  'pages.review.batch.reject': '批量驳回',
+  'pages.review.batch.approve.confirm': '确定通过已选择的 {count} 个审核任务吗？',
+  'pages.review.batch.reject.confirm': '驳回已选择的 {count} 个审核任务',
+  'pages.review.batch.success': '已成功处理 {count} 个审核任务。',
+  'pages.review.batch.partial': '成功 {succeeded} 个，失败 {failed} 个。',
+  'pages.review.batch.error': '无法处理已选择的审核任务。',
 
   'pages.review.progress.button': '审核进度',
   'pages.review.progress.editReviewer': '编辑审核员',

--- a/src/pages/Review/Components/AssignmentReview.tsx
+++ b/src/pages/Review/Components/AssignmentReview.tsx
@@ -27,6 +27,7 @@ import { Card, Col, Input, Row, Select, Space, Spin, Table, Tag, theme } from 'a
 import { SearchProps } from 'antd/es/input/Search';
 import { SortOrder } from 'antd/es/table/interface';
 import { useEffect, useRef, useState } from 'react';
+import BatchReviewActions from './BatchReviewActions';
 import RejectReview from './RejectReview';
 import ReviewLifeCycleModelsDetail from './reviewLifeCycleModels';
 import ReviewProcessDetail from './reviewProcess';
@@ -152,6 +153,7 @@ const AssignmentReview = ({
 
   const isReferenceMatchingCurrentTab = (record: RootReviewReferenceProgress) =>
     isReferenceMatchingReviewTab(record, tableType);
+  const supportsBatchSelection = ['unassigned', 'assigned', 'pending'].includes(tableType);
 
   const renderDatasetViewButton = (
     targetTable: ReviewSubmitDatasetTable | undefined,
@@ -1073,7 +1075,7 @@ const AssignmentReview = ({
                 pagination={false}
                 rowKey='reference_review_id'
                 rowSelection={
-                  tableType === 'unassigned'
+                  supportsBatchSelection
                     ? {
                         selectedRowKeys: (subTableData[record.id] ?? [])
                           .map((item) => item.reference_review_id)
@@ -1114,7 +1116,7 @@ const AssignmentReview = ({
               />
             </Space>
           );
-          if (selectedReviewIds.length > 0 && tableType === 'unassigned') {
+          if (selectedReviewIds.length > 0 && supportsBatchSelection) {
             return [
               filterControls,
               <Space key='batch-assignment-selection'>
@@ -1144,11 +1146,22 @@ const AssignmentReview = ({
                     />
                   </span>
                 )}
-                <SelectReviewer
-                  tabType='unassigned'
-                  actionRef={actionRef}
+                {tableType === 'unassigned' && (
+                  <SelectReviewer
+                    tabType='unassigned'
+                    actionRef={actionRef}
+                    reviewIds={selectedReviewIds}
+                    disabled={
+                      selectionLoadingRootIds.length > 0 || selectionFailedRootIds.length > 0
+                    }
+                  />
+                )}
+                <BatchReviewActions
+                  role={tableType === 'pending' ? 'reviewer' : 'admin'}
                   reviewIds={selectedReviewIds}
+                  allowApprove={tableType === 'assigned' || tableType === 'pending'}
                   disabled={selectionLoadingRootIds.length > 0 || selectionFailedRootIds.length > 0}
+                  onFinished={reloadAfterChildAction}
                 />
               </Space>,
             ];
@@ -1201,7 +1214,7 @@ const AssignmentReview = ({
         actionRef={actionRef}
         tableAlertOptionRender={tableAlertOptionRender}
         rowSelection={
-          tableType === 'unassigned'
+          supportsBatchSelection
             ? {
                 selectedRowKeys: selectedReviewIds,
                 preserveSelectedRowKeys: true,

--- a/src/pages/Review/Components/BatchReviewActions.tsx
+++ b/src/pages/Review/Components/BatchReviewActions.tsx
@@ -1,0 +1,167 @@
+import {
+  submitAdminReviewBatchDecision,
+  submitReviewerBatchDecision,
+  type ReviewBatchDecision,
+  type ReviewBatchDecisionResult,
+} from '@/services/reviews/api';
+import { useIntl } from '@umijs/max';
+import { Button, Form, Input, message, Modal, Space } from 'antd';
+import { useState } from 'react';
+
+type BatchReviewActionsProps = {
+  role: 'admin' | 'reviewer';
+  reviewIds: React.Key[];
+  allowApprove: boolean;
+  disabled?: boolean;
+  onFinished: () => void;
+};
+
+const BatchReviewActions = ({
+  role,
+  reviewIds,
+  allowApprove,
+  disabled = false,
+  onFinished,
+}: BatchReviewActionsProps) => {
+  const intl = useIntl();
+  const [form] = Form.useForm<{ reason: string }>();
+  const [modal, modalContextHolder] = Modal.useModal();
+  const [rejectOpen, setRejectOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const submit = async (decision: ReviewBatchDecision, reason?: string) => {
+    setLoading(true);
+    try {
+      const result =
+        role === 'admin'
+          ? await submitAdminReviewBatchDecision(reviewIds, decision, reason)
+          : await submitReviewerBatchDecision(reviewIds, decision, reason);
+      if (result.error) throw result.error;
+
+      const payload = result.data?.[0] as ReviewBatchDecisionResult | undefined;
+      if (!payload) throw new Error('Missing batch result');
+
+      if (payload.summary.failed > 0) {
+        message.warning(
+          intl.formatMessage(
+            {
+              id: 'pages.review.batch.partial',
+              defaultMessage: '{succeeded} succeeded and {failed} failed.',
+            },
+            payload.summary,
+          ),
+        );
+      } else {
+        message.success(
+          intl.formatMessage(
+            {
+              id: 'pages.review.batch.success',
+              defaultMessage: '{count} reviews processed successfully.',
+            },
+            { count: payload.summary.succeeded },
+          ),
+        );
+      }
+
+      setRejectOpen(false);
+      form.resetFields();
+      onFinished();
+    } catch {
+      message.error(
+        intl.formatMessage({
+          id: 'pages.review.batch.error',
+          defaultMessage: 'Unable to process the selected reviews.',
+        }),
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const submitReject = async () => {
+    const { reason } = await form.validateFields();
+    await submit('reject', reason);
+  };
+
+  const confirmApprove = () => {
+    modal.confirm({
+      title: intl.formatMessage(
+        {
+          id: 'pages.review.batch.approve.confirm',
+          defaultMessage: 'Approve {count} selected reviews?',
+        },
+        { count: reviewIds.length },
+      ),
+      okText: intl.formatMessage({
+        id: 'pages.review.batch.approve',
+        defaultMessage: 'Batch approve',
+      }),
+      onOk: () => submit('approve'),
+    });
+  };
+
+  return (
+    <>
+      {modalContextHolder}
+      <Space>
+        {allowApprove && (
+          <Button
+            type='primary'
+            loading={loading}
+            disabled={disabled || reviewIds.length === 0}
+            onClick={confirmApprove}
+          >
+            {intl.formatMessage({
+              id: 'pages.review.batch.approve',
+              defaultMessage: 'Batch approve',
+            })}
+          </Button>
+        )}
+        <Button
+          danger
+          loading={loading}
+          disabled={disabled || reviewIds.length === 0}
+          onClick={() => setRejectOpen(true)}
+        >
+          {intl.formatMessage({
+            id: 'pages.review.batch.reject',
+            defaultMessage: 'Batch reject',
+          })}
+        </Button>
+      </Space>
+      <Modal
+        open={rejectOpen}
+        title={intl.formatMessage(
+          {
+            id: 'pages.review.batch.reject.confirm',
+            defaultMessage: 'Reject {count} selected reviews',
+          },
+          { count: reviewIds.length },
+        )}
+        okText={intl.formatMessage({
+          id: 'pages.review.batch.reject',
+          defaultMessage: 'Batch reject',
+        })}
+        okButtonProps={{ danger: true }}
+        confirmLoading={loading}
+        onCancel={() => setRejectOpen(false)}
+        onOk={submitReject}
+      >
+        <Form form={form} layout='vertical'>
+          <Form.Item
+            name='reason'
+            label={intl.formatMessage({
+              id: 'component.rejectReview.reason.label',
+              defaultMessage: 'Reject Reason',
+            })}
+            rules={[{ required: true, whitespace: true }]}
+          >
+            <Input.TextArea rows={4} maxLength={1000} showCount />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </>
+  );
+};
+
+export default BatchReviewActions;

--- a/src/services/reviews/api.ts
+++ b/src/services/reviews/api.ts
@@ -144,6 +144,26 @@ type ReviewWorkflowCommandFunctionName =
   | 'admin_review_approve'
   | 'admin_review_reject';
 
+export type ReviewBatchDecision = 'approve' | 'reject';
+
+export type ReviewBatchDecisionResult = {
+  ok: boolean;
+  command: 'admin_review_batch_decision' | 'reviewer_review_batch_decision';
+  batchId: string;
+  summary: {
+    total: number;
+    succeeded: number;
+    failed: number;
+  };
+  results: Array<{
+    reviewId: string;
+    ok: boolean;
+    code?: string;
+    message?: string;
+    status?: number;
+  }>;
+};
+
 const STABLE_HASH_KEY_ENCODER = new TextEncoder();
 
 type DataNotificationRpcRow = {
@@ -732,6 +752,35 @@ export async function rejectReviewApi<
     table,
     reason,
   });
+}
+
+async function submitReviewBatchDecision(
+  functionName: 'admin_review_batch_decision' | 'app_review_batch_decision',
+  reviewIds: React.Key[],
+  decision: ReviewBatchDecision,
+  reason?: string,
+) {
+  return invokeDatasetCommand<ReviewBatchDecisionResult>(functionName as never, {
+    reviewIds: Array.from(new Set(reviewIds.map(String))),
+    decision,
+    ...(decision === 'reject' ? { reason: reason?.trim() } : {}),
+  });
+}
+
+export async function submitAdminReviewBatchDecision(
+  reviewIds: React.Key[],
+  decision: ReviewBatchDecision,
+  reason?: string,
+) {
+  return submitReviewBatchDecision('admin_review_batch_decision', reviewIds, decision, reason);
+}
+
+export async function submitReviewerBatchDecision(
+  reviewIds: React.Key[],
+  decision: ReviewBatchDecision,
+  reason?: string,
+) {
+  return submitReviewBatchDecision('app_review_batch_decision', reviewIds, decision, reason);
 }
 
 export async function updateReviewApi(reviewIds: React.Key[], data: any) {

--- a/tests/unit/pages/Review/BatchReviewActions.test.tsx
+++ b/tests/unit/pages/Review/BatchReviewActions.test.tsx
@@ -1,0 +1,232 @@
+import BatchReviewActions from '@/pages/Review/Components/BatchReviewActions';
+import {
+  submitAdminReviewBatchDecision,
+  submitReviewerBatchDecision,
+} from '@/services/reviews/api';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const mockConfirm = jest.fn();
+const mockResetFields = jest.fn();
+const mockValidateFields = jest.fn();
+const mockSuccess = jest.fn();
+const mockWarning = jest.fn();
+const mockError = jest.fn();
+
+jest.mock('@/services/reviews/api', () => ({
+  submitAdminReviewBatchDecision: jest.fn(),
+  submitReviewerBatchDecision: jest.fn(),
+}));
+
+jest.mock('@umijs/max', () => ({
+  useIntl: () => ({
+    formatMessage: (
+      { defaultMessage }: { defaultMessage: string },
+      values?: Record<string, number>,
+    ) =>
+      Object.entries(values ?? {}).reduce(
+        (message, [key, value]) => message.replace(`{${key}}`, String(value)),
+        defaultMessage,
+      ),
+  }),
+}));
+
+jest.mock('antd', () => {
+  const Form = ({ children }: { children: import('react').ReactNode }) => <form>{children}</form>;
+  Form.useForm = () => [
+    {
+      validateFields: mockValidateFields,
+      resetFields: mockResetFields,
+    },
+  ];
+  Form.Item = ({ children, label }: { children: import('react').ReactNode; label?: string }) => (
+    <label>
+      {label}
+      {children}
+    </label>
+  );
+
+  const Modal = ({
+    children,
+    open,
+    title,
+    onCancel,
+    onOk,
+  }: {
+    children: import('react').ReactNode;
+    open?: boolean;
+    title?: string;
+    onCancel?: () => void;
+    onOk?: () => void;
+  }) =>
+    open ? (
+      <section aria-label={title}>
+        {children}
+        <button type='button' onClick={onCancel}>
+          cancel
+        </button>
+        <button type='button' onClick={onOk}>
+          confirm reject
+        </button>
+      </section>
+    ) : null;
+  Modal.useModal = () => [
+    { confirm: (options: { onOk?: () => void }) => mockConfirm(options) },
+    <span key='modal-context' data-testid='modal-context' />,
+  ];
+
+  return {
+    Button: ({
+      children,
+      disabled,
+      onClick,
+    }: {
+      children: import('react').ReactNode;
+      disabled?: boolean;
+      onClick?: () => void;
+    }) => (
+      <button type='button' disabled={disabled} onClick={onClick}>
+        {children}
+      </button>
+    ),
+    Form,
+    Input: { TextArea: () => <textarea aria-label='review-reason' /> },
+    message: {
+      success: (...args: unknown[]) => mockSuccess(...args),
+      warning: (...args: unknown[]) => mockWarning(...args),
+      error: (...args: unknown[]) => mockError(...args),
+    },
+    Modal,
+    Space: ({ children }: { children: import('react').ReactNode }) => <div>{children}</div>,
+  };
+});
+
+const adminDecisionMock = jest.mocked(submitAdminReviewBatchDecision);
+const reviewerDecisionMock = jest.mocked(submitReviewerBatchDecision);
+
+describe('BatchReviewActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConfirm.mockImplementation(({ onOk }: { onOk?: () => void }) => onOk?.());
+    mockValidateFields.mockResolvedValue({ reason: 'insufficient evidence' });
+  });
+
+  it('submits a successful admin batch approval and refreshes the table', async () => {
+    const onFinished = jest.fn();
+    adminDecisionMock.mockResolvedValue({
+      data: [{ summary: { succeeded: 2, failed: 0 }, items: [] }],
+      error: null,
+    } as never);
+
+    render(
+      <BatchReviewActions
+        role='admin'
+        reviewIds={['review-1', 'review-2']}
+        allowApprove
+        onFinished={onFinished}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Batch approve' }));
+
+    await waitFor(() =>
+      expect(adminDecisionMock).toHaveBeenCalledWith(
+        ['review-1', 'review-2'],
+        'approve',
+        undefined,
+      ),
+    );
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ onOk: expect.any(Function) }),
+    );
+    expect(mockSuccess).toHaveBeenCalledWith('2 reviews processed successfully.');
+    expect(mockResetFields).toHaveBeenCalled();
+    expect(onFinished).toHaveBeenCalled();
+    expect(screen.getByTestId('modal-context')).toBeInTheDocument();
+  });
+
+  it('submits a reviewer rejection as an advisory opinion and reports partial results', async () => {
+    const onFinished = jest.fn();
+    reviewerDecisionMock.mockResolvedValue({
+      data: [{ summary: { succeeded: 1, failed: 1 }, items: [] }],
+      error: null,
+    } as never);
+
+    render(
+      <BatchReviewActions
+        role='reviewer'
+        reviewIds={['review-1', 'review-2']}
+        allowApprove={false}
+        disabled={false}
+        onFinished={onFinished}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'Batch approve' })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Batch reject' }));
+    expect(screen.getByRole('region', { name: 'Reject 2 selected reviews' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'cancel' }));
+    expect(screen.queryByRole('region')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Batch reject' }));
+    fireEvent.click(screen.getByRole('button', { name: 'confirm reject' }));
+
+    await waitFor(() =>
+      expect(reviewerDecisionMock).toHaveBeenCalledWith(
+        ['review-1', 'review-2'],
+        'reject',
+        'insufficient evidence',
+      ),
+    );
+    expect(mockWarning).toHaveBeenCalledWith('1 succeeded and 1 failed.');
+    expect(onFinished).toHaveBeenCalled();
+  });
+
+  it('reports command and malformed-response failures without refreshing', async () => {
+    const onFinished = jest.fn();
+    adminDecisionMock.mockResolvedValue({ data: null, error: new Error('denied') } as never);
+    reviewerDecisionMock.mockResolvedValue({ data: [], error: null } as never);
+
+    const { rerender } = render(
+      <BatchReviewActions
+        role='admin'
+        reviewIds={['review-1']}
+        allowApprove
+        disabled={false}
+        onFinished={onFinished}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Batch approve' }));
+    await waitFor(() => expect(mockError).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <BatchReviewActions
+        role='reviewer'
+        reviewIds={['review-2']}
+        allowApprove
+        disabled={false}
+        onFinished={onFinished}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Batch approve' }));
+    await waitFor(() => expect(mockError).toHaveBeenCalledTimes(2));
+    expect(onFinished).not.toHaveBeenCalled();
+  });
+
+  it('disables actions for explicit disablement and empty selections', () => {
+    const { rerender } = render(
+      <BatchReviewActions
+        role='admin'
+        reviewIds={['review-1']}
+        allowApprove
+        disabled
+        onFinished={jest.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Batch approve' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Batch reject' })).toBeDisabled();
+
+    rerender(
+      <BatchReviewActions role='admin' reviewIds={[]} allowApprove onFinished={jest.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: 'Batch approve' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Batch reject' })).toBeDisabled();
+  });
+});

--- a/tests/unit/pages/Review/Components/AssignmentReview.test.tsx
+++ b/tests/unit/pages/Review/Components/AssignmentReview.test.tsx
@@ -115,6 +115,15 @@ jest.mock('@/pages/Review/Components/SelectReviewer', () => ({
   ),
 }));
 
+jest.mock('@/pages/Review/Components/BatchReviewActions', () => ({
+  __esModule: true,
+  default: ({ role, reviewIds, allowApprove, disabled }: any) => (
+    <div data-testid='batch-review-actions' data-disabled={String(!!disabled)}>
+      {`${role}:${String(allowApprove)}:${JSON.stringify(reviewIds)}`}
+    </div>
+  ),
+}));
+
 jest.mock('@/pages/Review/Components/SimpleReviewActions', () => ({
   __esModule: true,
   default: ({ reviewId, role, targetTable, actionRef }: any) => (
@@ -550,6 +559,9 @@ describe('AssignmentReview', () => {
       ),
     );
     expect(screen.getByText('Selected 1 root reviews and 1 reference reviews')).toBeInTheDocument();
+    expect(screen.getByTestId('batch-review-actions')).toHaveTextContent(
+      'admin:false:["review-1","reference-review-1"]',
+    );
 
     await userEvent.click(screen.getByRole('button', { name: 'expand-review-1' }));
     await waitFor(() =>
@@ -674,6 +686,39 @@ describe('AssignmentReview', () => {
       screen.queryByRole('button', { name: 'expand-flat-reference-review' }),
     ).not.toBeInTheDocument();
     expect(mockGetRootReviewReferenceProgress).not.toHaveBeenCalled();
+  });
+
+  it('shows review-admin batch approve and reject actions for assigned selections', async () => {
+    render(
+      <AssignmentReview
+        userData={{ user_id: 'admin-1', role: 'review-admin' }}
+        tableType='assigned'
+        actionRef={{ current: { reload: jest.fn() } }}
+      />,
+    );
+
+    await userEvent.click(await screen.findByRole('button', { name: 'select-review-1' }));
+
+    expect(await screen.findByTestId('batch-review-actions')).toHaveTextContent(
+      'admin:true:["review-1"]',
+    );
+    expect(screen.queryByTestId('select-reviewer')).not.toBeInTheDocument();
+  });
+
+  it('shows reviewer opinion batch actions for pending selections', async () => {
+    render(
+      <AssignmentReview
+        userData={{ user_id: 'member-1', role: 'review-member' }}
+        tableType='pending'
+        actionRef={{ current: { reload: jest.fn() } }}
+      />,
+    );
+
+    await userEvent.click(await screen.findByRole('button', { name: 'select-review-2' }));
+
+    expect(await screen.findByTestId('batch-review-actions')).toHaveTextContent(
+      'reviewer:true:["review-2"]',
+    );
   });
 
   it('clears the unified root and reference selection from the table alert', async () => {

--- a/tests/unit/services/reviews/api.test.ts
+++ b/tests/unit/services/reviews/api.test.ts
@@ -1225,6 +1225,28 @@ describe('review workflow command wrappers', () => {
     expect(approve).toEqual(approveResult);
     expect(reject).toEqual(rejectResult);
   });
+
+  it('keeps admin finalization and reviewer opinions on separate batch endpoints', async () => {
+    const commandResult = { data: { ok: true }, error: null };
+    mockInvokeDatasetCommand.mockResolvedValue(commandResult);
+
+    await reviewsApi.submitAdminReviewBatchDecision(
+      ['review-1', 'review-1', 'review-2'],
+      'reject',
+      '  Needs fixes  ',
+    );
+    await reviewsApi.submitReviewerBatchDecision(['review-3'], 'approve');
+
+    expect(mockInvokeDatasetCommand).toHaveBeenNthCalledWith(1, 'admin_review_batch_decision', {
+      reviewIds: ['review-1', 'review-2'],
+      decision: 'reject',
+      reason: 'Needs fixes',
+    });
+    expect(mockInvokeDatasetCommand).toHaveBeenNthCalledWith(2, 'app_review_batch_decision', {
+      reviewIds: ['review-3'],
+      decision: 'approve',
+    });
+  });
 });
 
 describe('updateReviewApi', () => {


### PR DESCRIPTION
## Summary
- add batch reject for administrator unassigned tasks
- add batch approve/reject for administrator assigned tasks
- add batch advisory approve/reject for reviewer pending tasks
- route administrator final decisions and reviewer opinions through distinct services and endpoints
- add four-locale copy, generated locale artifacts, and full component/service coverage

## Validation
- full pre-push gate passed
- 411 test suites and 5,668 tests passed
- 462/462 tracked source files reached 100% statements, branches, functions, and lines
- lint, TypeScript, build, i18n checks, generated-artifact idempotence, and staged Docpact gate passed

Closes #809

Depends on linancn/tiangong-lca-edge-functions#283 and tiangong-lca/database-engine#469
Parent: tiangong-lca/workspace#572