### PR TITLE
Polish batch review queue toolbar layout

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-08-11'
-lastReviewedCommit: '5400b798ea4ff948c2776b0d66fb2e52489e4066'
-lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: canonical artifacts and 100%-branch-covered unit/integration tests cover server-backed filters, intersection behavior, and the 50-row default.'
+lastReviewedCommit: '6677a2f6e4a3b860c71e81c52d80d443841be1e2'
+lastReviewedNote: 'Reviewed for Next Issue #811: review-queue toolbar presentation stays within the existing frontend, review-management, and validation routing contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
-lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: review queues add server-backed filters and a 50-row default with 100% AssignmentReview branch coverage, while preserving Database-owned authorization and totals.'
+lastReviewedCommit: 6677a2f6e4a3b860c71e81c52d80d443841be1e2
+lastReviewedNote: 'Reviewed for Next Issue #811: compact review-queue toolbar styling does not change repository ownership, service boundaries, branch policy, or delivery rules.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
-lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: Node 24, deterministic artifacts, 100%-branch-covered review tests, TypeScript, build, and managed checked-push remain the delivery path.'
+lastReviewedCommit: 6677a2f6e4a3b860c71e81c52d80d443841be1e2
+lastReviewedNote: 'Reviewed for Next Issue #811: toolbar-only review UI changes preserve the Node 24 bootstrap, focused validation loop, build requirement, and managed checked-push delivery path.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/data_audit_instruction.md
+++ b/docs/agents/data_audit_instruction.md
@@ -19,8 +19,8 @@ checkPaths:
   - src/pages/Review/**
   - src/pages/ManageSystem/**
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
-lastReviewedNote: 'Reviewed for Issue #807: flat Root/Reference queues add display-mode and exact data-type controls with server-owned filtering and a 50-row default; Process/Lifecycle Model relationship child tables remain unfiltered.'
+lastReviewedCommit: 6677a2f6e4a3b860c71e81c52d80d443841be1e2
+lastReviewedNote: 'Reviewed for Issue #811: toolbar presentation changes do not alter Root/Reference state codes, transition rules, or the Admin-versus-Member batch decision boundary.'
 ---
 
 # Audit Status Reference

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
-lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: review-filter unit/integration tests close all AssignmentReview branches and continue through the unchanged checked-push policy.'
+lastReviewedCommit: 6677a2f6e4a3b860c71e81c52d80d443841be1e2
+lastReviewedNote: 'Reviewed for Next Issue #811: review-toolbar unit coverage continues through the unchanged Docpact-first and full-gate-last checked-push policy.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
-lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: flat review queues expose display-mode and exact data-type controls, delegate filtering/counts to Database, default to 50 rows, and retain unfiltered relationship child tables.'
+lastReviewedCommit: 6677a2f6e4a3b860c71e81c52d80d443841be1e2
+lastReviewedNote: 'Reviewed for Next Issue #811: selection summaries, icon spacing, action-column rings, and fixed filter widths remain presentation details inside the existing unified Root/Reference Review UI.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
-lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: review queue proof covers forwarding, compatibility/intersections, reset, 50-row defaults, deterministic artifacts, integration rendering, and 100% AssignmentReview branches.'
+lastReviewedCommit: 6677a2f6e4a3b860c71e81c52d80d443841be1e2
+lastReviewedNote: 'Reviewed for Next Issue #811: focused AssignmentReview and BatchReviewActions proof plus the unchanged managed pre-push gate remain the correct validation path for toolbar-only UI refinements.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/team_management.md
+++ b/docs/agents/team_management.md
@@ -20,8 +20,8 @@ checkPaths:
   - src/pages/Review/**
   - src/pages/ManageSystem/**
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
-lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: review display/type filters and the 50-row default do not change team roles, review authority, or membership-constrained visibility.'
+lastReviewedCommit: 6677a2f6e4a3b860c71e81c52d80d443841be1e2
+lastReviewedNote: 'Reviewed for Next Issue #811: review-toolbar styling does not change team roles, review authority, or membership-constrained visibility.'
 ---
 
 # Team Management Reference

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,8 +28,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
-lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: filter contracts, integration rendering, and explicit all/member filter branches preserve the 100% coverage maintenance strategy.'
+lastReviewedCommit: 6677a2f6e4a3b860c71e81c52d80d443841be1e2
+lastReviewedNote: 'Reviewed for Next Issue #811: focused toolbar presentation assertions preserve the existing full-closure maintenance strategy without opening a new testing workstream.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
-lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: AssignmentReview filters/default pagination have canonical artifacts, integration proof, and explicit 100% branch closure.'
+lastReviewedCommit: 6677a2f6e4a3b860c71e81c52d80d443841be1e2
+lastReviewedNote: 'Reviewed for Next Issue #811: the added review-toolbar presentation assertions preserve full closure and create no active coverage queue.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,8 +31,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
-lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: flat-queue tests cover controls, forwarding, reset, 50-row defaults, integration mocks, and both sides of every new branch.'
+lastReviewedCommit: 6677a2f6e4a3b860c71e81c52d80d443841be1e2
+lastReviewedNote: 'Reviewed for Next Issue #811: existing component-mock and behavior-assertion patterns cover toolbar icons, spacing, selection summaries, and fixed localized filter labels.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,8 +28,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 5400b798ea4ff948c2776b0d66fb2e52489e4066
-lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: keep integration mocks aligned and exercise both all/type and Admin/Member filter branches before rerunning the strict 100% coverage gate.'
+lastReviewedCommit: 6677a2f6e4a3b860c71e81c52d80d443841be1e2
+lastReviewedNote: 'Reviewed for Next Issue #811: no new troubleshooting path is required; toolbar regressions remain covered by focused serial component tests before the managed full gate.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723",
-    "auditedInputDigest": "87f3df83f41836dd1f32b5e25335ff71b23cc831bd0fa7c944d490cdb9345d6a"
+    "sourceManifestDigest": "8c936f619cae14da2c617dadd73960d72c1e1b559d9c2805c6c08da2449d226f",
+    "auditedInputDigest": "080859aeb4d45b26df1cc45e87a010ed0360e3c40de1f45b80867a1aa2168a45"
   },
   "inventory": {
     "sourceMessageCount": 3114,
@@ -47,7 +47,7 @@
     "messageCount": 3114,
     "completeCount": 3114,
     "blockedCount": 0,
-    "dossierDigest": "9f05dfc8fafbc61c6362e009df503bc35bec74738f2eb0e743590d61abc3a9e2",
+    "dossierDigest": "40eeb06fbcbd6d8117990936d5c05df76e548704745c6bdb5e2b1a61ca3cc6bd",
     "catalogDigest": "05d9ac48d37d0eafb48ec463e6b33e2be831295ef25d4afba5dfce8ff96ff832",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -67,9 +67,9 @@
       "destructive-or-rejecting-action": 47,
       "failure-or-invalid-input": 363,
       "interactive-ready": 522,
-      "retained-not-currently-reachable": 356,
+      "retained-not-currently-reachable": 357,
       "successful-completion": 182,
-      "visible": 1644
+      "visible": 1643
     },
     "riskCounts": { "high": 1390, "low": 1502, "medium": 222 },
     "highRiskMessageCount": 1390,
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4124,
+    "literalReferenceCount": 4125,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale de-DE --message <MESSAGE_ID>"
@@ -503,7 +503,7 @@
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "b1442ddd3a928a5a99c5020c2dceee3994fcd8744aa2e03c62f980625d38446b",
-          "focusedTestDigest": "e71ebdedaa744976d65be9341bae9fae3658e2158c6360f623c1260225b59854",
+          "focusedTestDigest": "d7b32fccdc173f64ec403b234a4a6b317b7472e0433e20b560e8cd608a03461f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "41c96657d29d1e29e7abf90448aaf3ccb2c30445cd39ce5357a3e3459f6b4953",
+      "rowEvidenceDigest": "6241a103e7340fe5a95f20eac992a8991988ae78b237c46df8b6daddf1da94de",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "4f2bbb9a6d3183c3b3b4ffafabea01b2830cedff0eb49d622240d894ad61cb10"
+  "contextDigest": "4ce868c49399c7d65f0c2653bace718ce6347b74205318960c1cd5f30f0839b2"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -503,7 +503,7 @@
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "b1442ddd3a928a5a99c5020c2dceee3994fcd8744aa2e03c62f980625d38446b",
-          "focusedTestDigest": "d7b32fccdc173f64ec403b234a4a6b317b7472e0433e20b560e8cd608a03461f",
+          "focusedTestDigest": "c07876b4fdfe48fd401a12db522d50582a7f1af3f6285d3192ad8a90a25d072f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "6241a103e7340fe5a95f20eac992a8991988ae78b237c46df8b6daddf1da94de",
+      "rowEvidenceDigest": "9a8bd81d545e15cd030fc875b986073d3b48ef980af1635b8e7fa94931ec44f3",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "4ce868c49399c7d65f0c2653bace718ce6347b74205318960c1cd5f30f0839b2"
+  "contextDigest": "6ef02af7559c214a81ad272287c2588c9b9373ebda00ef631048604431e3492c"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4ce868c49399c7d65f0c2653bace718ce6347b74205318960c1cd5f30f0839b2",
-    "qualityDigest": "beb2bced63aed5d76dcaf6a3fd9ff6ff9b7b32f5d9d1c6b499e60ff27553cc25",
+    "contextDigest": "6ef02af7559c214a81ad272287c2588c9b9373ebda00ef631048604431e3492c",
+    "qualityDigest": "1b2e671d2c6055478fe3b97403eb0f2a2eae1c20cb2151232c536ab08b9a090e",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "9bc13848feca4ba85eb4fa28bd9a33ef6f52fb0f35bf14f6233308919b7cb44c"
+  "activationDigest": "8f7edaa41eead7113b04fd41cb4cc24ddadfc813ef0c5852a8fc38948167fafa"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723"
+    "sourceManifestDigest": "8c936f619cae14da2c617dadd73960d72c1e1b559d9c2805c6c08da2449d226f"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4f2bbb9a6d3183c3b3b4ffafabea01b2830cedff0eb49d622240d894ad61cb10",
-    "qualityDigest": "7467d11c191ba948d4be726d5a3598251c9088c0c332831c6e98f29dd47d3d1b",
+    "contextDigest": "4ce868c49399c7d65f0c2653bace718ce6347b74205318960c1cd5f30f0839b2",
+    "qualityDigest": "beb2bced63aed5d76dcaf6a3fd9ff6ff9b7b32f5d9d1c6b499e60ff27553cc25",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "4fe5f7ea4e1c081feaee41b4b587b839f93d6b71b59e3c76e28af3d5150e391b"
+  "activationDigest": "9bc13848feca4ba85eb4fa28bd9a33ef6f52fb0f35bf14f6233308919b7cb44c"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "87f3df83f41836dd1f32b5e25335ff71b23cc831bd0fa7c944d490cdb9345d6a",
+    "auditedInputDigest": "080859aeb4d45b26df1cc45e87a010ed0360e3c40de1f45b80867a1aa2168a45",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -71,11 +71,11 @@
     "localeLeafModuleCounts": { "en-US": 30, "zh-CN": 30, "de-DE": 30, "fr-FR": 30 },
     "localeUniqueKeyCounts": { "en-US": 3114, "zh-CN": 3114, "de-DE": 3114, "fr-FR": 3114 },
     "canonicalCandidateKeyCount": 3114,
-    "activeStaticKeyCount": 2116,
+    "activeStaticKeyCount": 2115,
     "activeDynamicKeyCount": 367,
-    "reservedKeyCount": 631,
+    "reservedKeyCount": 632,
     "productionSourceFileCount": 437,
-    "literalReferenceCount": 4124,
+    "literalReferenceCount": 4125,
     "dynamicCallsiteCount": 39,
     "dynamicCallsiteSummaryCount": 39,
     "registeredDynamicCallsiteCount": 39,
@@ -16405,7 +16405,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-          "line": 153,
+          "line": 181,
           "column": 20,
           "symbol": "BatchReviewActions",
           "defaultMessage": "Reject Reason",
@@ -16438,7 +16438,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-              "line": 153,
+              "line": 181,
               "column": 20,
               "kind": "formatMessage"
             },
@@ -26449,7 +26449,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 315,
+          "line": 340,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -27381,7 +27381,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 335,
+          "line": 360,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -27450,7 +27450,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 323,
+          "line": 348,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -27519,7 +27519,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 319,
+          "line": 344,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -27824,7 +27824,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 331,
+          "line": 356,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -27893,7 +27893,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 327,
+          "line": 352,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -28045,7 +28045,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 311,
+          "line": 336,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -28586,7 +28586,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1175,
+          "line": 1188,
           "column": 17,
           "symbol": "AssignmentReview",
           "defaultMessage": "Review Management",
@@ -28610,7 +28610,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1175,
+              "line": 1188,
               "column": 17,
               "kind": "FormattedMessage"
             },
@@ -206899,7 +206899,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 610,
+          "line": 634,
           "column": 14,
           "symbol": "AssignmentReview",
           "defaultMessage": "Actions",
@@ -206908,7 +206908,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 730,
+          "line": 755,
           "column": 14,
           "symbol": "AssignmentReview",
           "defaultMessage": "Actions",
@@ -206917,7 +206917,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 779,
+          "line": 805,
           "column": 18,
           "symbol": "AssignmentReview",
           "defaultMessage": "Actions",
@@ -206926,7 +206926,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 847,
+          "line": 874,
           "column": 18,
           "symbol": "AssignmentReview",
           "defaultMessage": "Actions",
@@ -206935,7 +206935,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 937,
+          "line": 965,
           "column": 18,
           "symbol": "AssignmentReview",
           "defaultMessage": "Actions",
@@ -206959,31 +206959,31 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 610,
+              "line": 634,
               "column": 14,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 730,
+              "line": 755,
               "column": 14,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 779,
+              "line": 805,
               "column": 18,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 847,
+              "line": 874,
               "column": 18,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 937,
+              "line": 965,
               "column": 18,
               "kind": "FormattedMessage"
             },
@@ -207253,7 +207253,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-          "line": 95,
+          "line": 97,
           "column": 15,
           "symbol": "confirmApprove",
           "defaultMessage": "Batch approve",
@@ -207262,8 +207262,17 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-          "line": 114,
-          "column": 14,
+          "line": 111,
+          "column": 20,
+          "symbol": "BatchReviewActions",
+          "defaultMessage": "Batch approve",
+          "defaultMessageExpression": null
+        },
+        {
+          "kind": "formatMessage",
+          "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+          "line": 124,
+          "column": 27,
           "symbol": "BatchReviewActions",
           "defaultMessage": "Batch approve",
           "defaultMessageExpression": null
@@ -207277,14 +207286,20 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-              "line": 95,
+              "line": 97,
               "column": 15,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-              "line": 114,
-              "column": 14,
+              "line": 111,
+              "column": 20,
+              "kind": "formatMessage"
+            },
+            {
+              "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+              "line": 124,
+              "column": 27,
               "kind": "formatMessage"
             }
           ]
@@ -207351,7 +207366,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-          "line": 88,
+          "line": 90,
           "column": 14,
           "symbol": "confirmApprove",
           "defaultMessage": "Approve {count} selected reviews?",
@@ -207366,7 +207381,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-              "line": 88,
+              "line": 90,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -207434,7 +207449,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-          "line": 71,
+          "line": 73,
           "column": 9,
           "symbol": "submit",
           "defaultMessage": "Unable to process the selected reviews.",
@@ -207449,7 +207464,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-              "line": 71,
+              "line": 73,
               "column": 9,
               "kind": "formatMessage"
             }
@@ -207529,7 +207544,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-          "line": 46,
+          "line": 48,
           "column": 11,
           "symbol": "submit",
           "defaultMessage": "{succeeded} succeeded and {failed} failed.",
@@ -207547,7 +207562,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-              "line": 46,
+              "line": 48,
               "column": 11,
               "kind": "formatMessage"
             }
@@ -207615,8 +207630,8 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-          "line": 126,
-          "column": 12,
+          "line": 136,
+          "column": 18,
           "symbol": "BatchReviewActions",
           "defaultMessage": "Batch reject",
           "defaultMessageExpression": null
@@ -207624,7 +207639,16 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-          "line": 141,
+          "line": 149,
+          "column": 25,
+          "symbol": "BatchReviewActions",
+          "defaultMessage": "Batch reject",
+          "defaultMessageExpression": null
+        },
+        {
+          "kind": "formatMessage",
+          "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+          "line": 169,
           "column": 17,
           "symbol": "BatchReviewActions",
           "defaultMessage": "Batch reject",
@@ -207639,13 +207663,19 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-              "line": 126,
-              "column": 12,
+              "line": 136,
+              "column": 18,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-              "line": 141,
+              "line": 149,
+              "column": 25,
+              "kind": "formatMessage"
+            },
+            {
+              "path": "src/pages/Review/Components/BatchReviewActions.tsx",
+              "line": 169,
               "column": 17,
               "kind": "formatMessage"
             }
@@ -207713,7 +207743,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-          "line": 134,
+          "line": 162,
           "column": 16,
           "symbol": "BatchReviewActions",
           "defaultMessage": "Reject {count} selected reviews",
@@ -207728,7 +207758,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-              "line": 134,
+              "line": 162,
               "column": 16,
               "kind": "formatMessage"
             }
@@ -207796,7 +207826,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-          "line": 56,
+          "line": 58,
           "column": 11,
           "symbol": "submit",
           "defaultMessage": "{count} reviews processed successfully.",
@@ -207811,7 +207841,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/BatchReviewActions.tsx",
-              "line": 56,
+              "line": 58,
               "column": 11,
               "kind": "formatMessage"
             }
@@ -208460,7 +208490,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 342,
+          "line": 367,
           "column": 14,
           "symbol": "targetTableOptions",
           "defaultMessage": "All data types",
@@ -208475,7 +208505,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 342,
+              "line": 367,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -208543,7 +208573,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1108,
+          "line": 1138,
           "column": 29,
           "symbol": "filterControls",
           "defaultMessage": "Data type",
@@ -208558,7 +208588,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1108,
+              "line": 1138,
               "column": 29,
               "kind": "formatMessage"
             }
@@ -208626,7 +208656,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 284,
+          "line": 309,
           "column": 14,
           "symbol": "displayModeOptions",
           "defaultMessage": "All reviews",
@@ -208641,7 +208671,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 284,
+              "line": 309,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -208709,7 +208739,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1098,
+          "line": 1127,
           "column": 29,
           "symbol": "filterControls",
           "defaultMessage": "Display mode",
@@ -208724,7 +208754,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1098,
+              "line": 1127,
               "column": 29,
               "kind": "formatMessage"
             }
@@ -208792,7 +208822,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 291,
+          "line": 316,
           "column": 14,
           "symbol": "displayModeOptions",
           "defaultMessage": "Process and model reviews",
@@ -208807,7 +208837,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 291,
+              "line": 316,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -208875,7 +208905,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 298,
+          "line": 323,
           "column": 14,
           "symbol": "displayModeOptions",
           "defaultMessage": "Other reviews",
@@ -208890,7 +208920,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 298,
+              "line": 323,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -212332,7 +212362,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 600,
+          "line": 624,
           "column": 9,
           "symbol": "subColumns",
           "defaultMessage": "Review Progress",
@@ -212341,7 +212371,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 763,
+          "line": 789,
           "column": 13,
           "symbol": "AssignmentReview",
           "defaultMessage": "Review Progress",
@@ -212356,13 +212386,13 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 600,
+              "line": 624,
               "column": 9,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 763,
+              "line": 789,
               "column": 13,
               "kind": "FormattedMessage"
             }
@@ -213817,7 +213847,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 567,
+          "line": 591,
           "column": 23,
           "symbol": "status",
           "defaultMessage": "Approved",
@@ -213832,7 +213862,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 567,
+              "line": 591,
               "column": 23,
               "kind": "formatMessage"
             }
@@ -213900,7 +213930,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 583,
+          "line": 607,
           "column": 27,
           "symbol": "status",
           "defaultMessage": "In review",
@@ -213915,7 +213945,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 583,
+              "line": 607,
               "column": 27,
               "kind": "formatMessage"
             }
@@ -213983,7 +214013,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 575,
+          "line": 599,
           "column": 25,
           "symbol": "status",
           "defaultMessage": "Rejected",
@@ -213998,7 +214028,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 575,
+              "line": 599,
               "column": 25,
               "kind": "formatMessage"
             }
@@ -214066,7 +214096,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 590,
+          "line": 614,
           "column": 27,
           "symbol": "status",
           "defaultMessage": "Unassigned",
@@ -214081,7 +214111,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 590,
+              "line": 614,
               "column": 27,
               "kind": "formatMessage"
             }
@@ -214149,7 +214179,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 549,
+          "line": 573,
           "column": 14,
           "symbol": "subColumns",
           "defaultMessage": "Data type",
@@ -214164,7 +214194,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 549,
+              "line": 573,
               "column": 14,
               "kind": "FormattedMessage"
             }
@@ -214232,7 +214262,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 554,
+          "line": 578,
           "column": 14,
           "symbol": "subColumns",
           "defaultMessage": "Data version",
@@ -214247,7 +214277,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 554,
+              "line": 578,
               "column": 14,
               "kind": "FormattedMessage"
             }
@@ -214564,7 +214594,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1143,
+          "line": 1156,
           "column": 21,
           "symbol": "AssignmentReview",
           "defaultMessage": "Failed to load referenced reviews. Reselect the root review to retry.",
@@ -214579,7 +214609,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1143,
+              "line": 1156,
               "column": 21,
               "kind": "FormattedMessage"
             }
@@ -214589,7 +214619,7 @@
     },
     {
       "id": "pages.review.selection.loading",
-      "category": "active-static",
+      "category": "reserved",
       "dynamicFamilies": [],
       "moduleOwnership": {
         "en-US": ["pages_review"],
@@ -214643,32 +214673,8 @@
           }
         }
       },
-      "references": [
-        {
-          "kind": "FormattedMessage",
-          "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1135,
-          "column": 21,
-          "symbol": "AssignmentReview",
-          "defaultMessage": "Loading referenced reviews...",
-          "defaultMessageExpression": null
-        }
-      ],
-      "defaultMessages": [
-        {
-          "value": "Loading referenced reviews...",
-          "argumentSignature": [],
-          "placeholders": [],
-          "locations": [
-            {
-              "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1135,
-              "column": 21,
-              "kind": "FormattedMessage"
-            }
-          ]
-        }
-      ]
+      "references": [],
+      "defaultMessages": []
     },
     {
       "id": "pages.review.selection.summary",
@@ -214742,8 +214748,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1124,
-          "column": 19,
+          "line": 1235,
+          "column": 15,
           "symbol": "AssignmentReview",
           "defaultMessage": "Selected {rootCount} root reviews and {referenceCount} reference reviews",
           "defaultMessageExpression": null
@@ -214760,8 +214766,8 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1124,
-              "column": 19,
+              "line": 1235,
+              "column": 15,
               "kind": "FormattedMessage"
             }
           ]
@@ -215605,7 +215611,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 719,
+          "line": 744,
           "column": 9,
           "symbol": "columns",
           "defaultMessage": "Submitted at",
@@ -215620,7 +215626,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 719,
+              "line": 744,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -215688,7 +215694,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 537,
+          "line": 561,
           "column": 9,
           "symbol": "subColumns",
           "defaultMessage": "Data name",
@@ -215697,7 +215703,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 683,
+          "line": 708,
           "column": 9,
           "symbol": "columns",
           "defaultMessage": "Data name",
@@ -215712,13 +215718,13 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 537,
+              "line": 561,
               "column": 9,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 683,
+              "line": 708,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -215786,7 +215792,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 754,
+          "line": 780,
           "column": 13,
           "symbol": "AssignmentReview",
           "defaultMessage": "Deadline",
@@ -215795,7 +215801,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 839,
+          "line": 866,
           "column": 13,
           "symbol": "AssignmentReview",
           "defaultMessage": "Deadline",
@@ -215804,7 +215810,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 929,
+          "line": 957,
           "column": 13,
           "symbol": "AssignmentReview",
           "defaultMessage": "Deadline",
@@ -215819,19 +215825,19 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 754,
+              "line": 780,
               "column": 13,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 839,
+              "line": 866,
               "column": 13,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 929,
+              "line": 957,
               "column": 13,
               "kind": "FormattedMessage"
             }
@@ -216076,7 +216082,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 703,
+          "line": 728,
           "column": 9,
           "symbol": "columns",
           "defaultMessage": "User Name",
@@ -216091,7 +216097,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 703,
+              "line": 728,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -216349,7 +216355,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 559,
+          "line": 583,
           "column": 14,
           "symbol": "subColumns",
           "defaultMessage": "Status",
@@ -216370,7 +216376,7 @@
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 559,
+              "line": 583,
               "column": 14,
               "kind": "FormattedMessage"
             }
@@ -216914,7 +216920,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 982,
+          "line": 1011,
           "column": 16,
           "symbol": "getSubTitle",
           "defaultMessage": "Assigned Task",
@@ -216938,7 +216944,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 982,
+              "line": 1011,
               "column": 16,
               "kind": "FormattedMessage"
             }
@@ -217098,7 +217104,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 986,
+          "line": 1015,
           "column": 16,
           "symbol": "getSubTitle",
           "defaultMessage": "Pending Review",
@@ -217122,7 +217128,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 986,
+              "line": 1015,
               "column": 16,
               "kind": "FormattedMessage"
             }
@@ -217190,7 +217196,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 988,
+          "line": 1017,
           "column": 16,
           "symbol": "getSubTitle",
           "defaultMessage": "Rejected",
@@ -217214,7 +217220,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 988,
+              "line": 1017,
               "column": 16,
               "kind": "FormattedMessage"
             }
@@ -217282,7 +217288,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 991,
+          "line": 1020,
           "column": 11,
           "symbol": "getSubTitle",
           "defaultMessage": "Rejected Task",
@@ -217306,7 +217312,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 991,
+              "line": 1020,
               "column": 11,
               "kind": "FormattedMessage"
             }
@@ -217374,7 +217380,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 984,
+          "line": 1013,
           "column": 16,
           "symbol": "getSubTitle",
           "defaultMessage": "Reviewed",
@@ -217398,7 +217404,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 984,
+              "line": 1013,
               "column": 16,
               "kind": "FormattedMessage"
             }
@@ -217466,7 +217472,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 979,
+          "line": 1008,
           "column": 11,
           "symbol": "getSubTitle",
           "defaultMessage": "Unassigned Task",
@@ -217490,7 +217496,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 979,
+              "line": 1008,
               "column": 11,
               "kind": "FormattedMessage"
             }
@@ -219256,7 +219262,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1040,
+          "line": 1069,
           "column": 30,
           "symbol": "AssignmentReview",
           "defaultMessage": null,
@@ -220411,7 +220417,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 135,
+          "line": 160,
           "column": 5,
           "symbol": "defaultTableAlertOptionRender",
           "defaultMessage": "Clear selection",
@@ -220522,7 +220528,7 @@
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 135,
+              "line": 160,
               "column": 5,
               "kind": "FormattedMessage"
             },
@@ -231211,7 +231217,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 676,
+          "line": 701,
           "column": 14,
           "symbol": "columns",
           "defaultMessage": "Index",
@@ -231436,7 +231442,7 @@
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 676,
+              "line": 701,
               "column": 14,
               "kind": "FormattedMessage"
             },

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723",
-    "contextDigest": "4f2bbb9a6d3183c3b3b4ffafabea01b2830cedff0eb49d622240d894ad61cb10"
+    "sourceManifestDigest": "8c936f619cae14da2c617dadd73960d72c1e1b559d9c2805c6c08da2449d226f",
+    "contextDigest": "4ce868c49399c7d65f0c2653bace718ce6347b74205318960c1cd5f30f0839b2"
   },
   "catalog": {
     "messageCount": 3114,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "8e4cc4140b6c9bef7de3ae2dbfb80b10a2e6b571dfe907907ff1b8860d3e9d74",
-    "validationDigest": "6118ee8339b197b381515b19fe022e72b1bf4f434b62e1fded88e574df90c4fc",
+    "digest": "73124cc84fa8d4cb4c6848bcdf9e415f35069ebd134244bcbe49fe086efa5394",
+    "validationDigest": "f1e817b4427c7031d871607f63f630ac29eb6c258a3641adc171940fc3175e8c",
     "laneCount": 1,
     "validatedMessageCount": 3114,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "7467d11c191ba948d4be726d5a3598251c9088c0c332831c6e98f29dd47d3d1b"
+  "qualityDigest": "beb2bced63aed5d76dcaf6a3fd9ff6ff9b7b32f5d9d1c6b499e60ff27553cc25"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "8c936f619cae14da2c617dadd73960d72c1e1b559d9c2805c6c08da2449d226f",
-    "contextDigest": "4ce868c49399c7d65f0c2653bace718ce6347b74205318960c1cd5f30f0839b2"
+    "contextDigest": "6ef02af7559c214a81ad272287c2588c9b9373ebda00ef631048604431e3492c"
   },
   "catalog": {
     "messageCount": 3114,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "73124cc84fa8d4cb4c6848bcdf9e415f35069ebd134244bcbe49fe086efa5394",
-    "validationDigest": "f1e817b4427c7031d871607f63f630ac29eb6c258a3641adc171940fc3175e8c",
+    "digest": "832f2f135630fe9ecdac4addf88ff5a67802ec3804f169ff1b09658bac0c9a94",
+    "validationDigest": "72c9db167063da4db62888dbe0e41f3918b6cb6b6e2449c211a1234735530272",
     "laneCount": 1,
     "validatedMessageCount": 3114,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "beb2bced63aed5d76dcaf6a3fd9ff6ff9b7b32f5d9d1c6b499e60ff27553cc25"
+  "qualityDigest": "1b2e671d2c6055478fe3b97403eb0f2a2eae1c20cb2151232c536ab08b9a090e"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "05d9ac48d37d0eafb48ec463e6b33e2be831295ef25d4afba5dfce8ff96ff832",
     "dossierDigest": "40eeb06fbcbd6d8117990936d5c05df76e548704745c6bdb5e2b1a61ca3cc6bd",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "6241a103e7340fe5a95f20eac992a8991988ae78b237c46df8b6daddf1da94de",
+    "routeEvidenceDigest": "9a8bd81d545e15cd030fc875b986073d3b48ef980af1635b8e7fa94931ec44f3",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "f1e817b4427c7031d871607f63f630ac29eb6c258a3641adc171940fc3175e8c"
+  "validationDigest": "72c9db167063da4db62888dbe0e41f3918b6cb6b6e2449c211a1234735530272"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "87f3df83f41836dd1f32b5e25335ff71b23cc831bd0fa7c944d490cdb9345d6a",
+    "auditedInputDigest": "080859aeb4d45b26df1cc45e87a010ed0360e3c40de1f45b80867a1aa2168a45",
     "validatedMessageCount": 3114,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1390,
     "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
     "catalogDigest": "05d9ac48d37d0eafb48ec463e6b33e2be831295ef25d4afba5dfce8ff96ff832",
-    "dossierDigest": "9f05dfc8fafbc61c6362e009df503bc35bec74738f2eb0e743590d61abc3a9e2",
+    "dossierDigest": "40eeb06fbcbd6d8117990936d5c05df76e548704745c6bdb5e2b1a61ca3cc6bd",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "41c96657d29d1e29e7abf90448aaf3ccb2c30445cd39ce5357a3e3459f6b4953",
+    "routeEvidenceDigest": "6241a103e7340fe5a95f20eac992a8991988ae78b237c46df8b6daddf1da94de",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "7e7b1cc9be2d7f7c8b74f069bddc34a36f242da8b1e5626f00a289473cc58ef2",
         "highRiskMessageCount": 1390,
         "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
-        "dossierDigest": "9f05dfc8fafbc61c6362e009df503bc35bec74738f2eb0e743590d61abc3a9e2",
+        "dossierDigest": "40eeb06fbcbd6d8117990936d5c05df76e548704745c6bdb5e2b1a61ca3cc6bd",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "6118ee8339b197b381515b19fe022e72b1bf4f434b62e1fded88e574df90c4fc"
+  "validationDigest": "f1e817b4427c7031d871607f63f630ac29eb6c258a3641adc171940fc3175e8c"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723",
-    "auditedInputDigest": "87f3df83f41836dd1f32b5e25335ff71b23cc831bd0fa7c944d490cdb9345d6a"
+    "sourceManifestDigest": "8c936f619cae14da2c617dadd73960d72c1e1b559d9c2805c6c08da2449d226f",
+    "auditedInputDigest": "080859aeb4d45b26df1cc45e87a010ed0360e3c40de1f45b80867a1aa2168a45"
   },
   "inventory": {
     "sourceMessageCount": 3114,
@@ -47,7 +47,7 @@
     "messageCount": 3114,
     "completeCount": 3114,
     "blockedCount": 0,
-    "dossierDigest": "78fa368841d6d6e672bb2ea8a3624564d6d0600f6994247403c6f0ef532df0e6",
+    "dossierDigest": "c0ebcceb1366f775242128d9ff02b8b9b433cad1d0740a8975d2b5db743d62d3",
     "catalogDigest": "aa8b61be8b056c7640170905371ff7564d95a4b3c11b2dd6dfbb0c43faf71a29",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -67,9 +67,9 @@
       "destructive-or-rejecting-action": 47,
       "failure-or-invalid-input": 363,
       "interactive-ready": 522,
-      "retained-not-currently-reachable": 356,
+      "retained-not-currently-reachable": 357,
       "successful-completion": 182,
-      "visible": 1644
+      "visible": 1643
     },
     "riskCounts": { "high": 1390, "low": 1523, "medium": 201 },
     "highRiskMessageCount": 1390,
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4124,
+    "literalReferenceCount": 4125,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale en-US --message <MESSAGE_ID>"
@@ -503,7 +503,7 @@
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "b1442ddd3a928a5a99c5020c2dceee3994fcd8744aa2e03c62f980625d38446b",
-          "focusedTestDigest": "e71ebdedaa744976d65be9341bae9fae3658e2158c6360f623c1260225b59854",
+          "focusedTestDigest": "d7b32fccdc173f64ec403b234a4a6b317b7472e0433e20b560e8cd608a03461f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "41c96657d29d1e29e7abf90448aaf3ccb2c30445cd39ce5357a3e3459f6b4953",
+      "rowEvidenceDigest": "6241a103e7340fe5a95f20eac992a8991988ae78b237c46df8b6daddf1da94de",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "401c245b48eb1ab7c0973cb7bc69ab24c537b76662d893a1e3b2e8313adafa91"
+  "contextDigest": "21609aa07e365a8374e4fa8b839b590264273238cee70a18a818f2d0ef2a5d55"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -503,7 +503,7 @@
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "b1442ddd3a928a5a99c5020c2dceee3994fcd8744aa2e03c62f980625d38446b",
-          "focusedTestDigest": "d7b32fccdc173f64ec403b234a4a6b317b7472e0433e20b560e8cd608a03461f",
+          "focusedTestDigest": "c07876b4fdfe48fd401a12db522d50582a7f1af3f6285d3192ad8a90a25d072f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "6241a103e7340fe5a95f20eac992a8991988ae78b237c46df8b6daddf1da94de",
+      "rowEvidenceDigest": "9a8bd81d545e15cd030fc875b986073d3b48ef980af1635b8e7fa94931ec44f3",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "21609aa07e365a8374e4fa8b839b590264273238cee70a18a818f2d0ef2a5d55"
+  "contextDigest": "3ebb23cb64636b3366d8569b9b8eef140c088c78459b60646c3622606939563b"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "21609aa07e365a8374e4fa8b839b590264273238cee70a18a818f2d0ef2a5d55",
-    "qualityDigest": "96ba9fab9ad490996fd9cfa3e69a620ef7b949c5a62b3184709c9f4dc12bcf72",
+    "contextDigest": "3ebb23cb64636b3366d8569b9b8eef140c088c78459b60646c3622606939563b",
+    "qualityDigest": "cda6743bd96febf0cf04caf3c399157a36110483a3d3c3a025dc865e12e0bbad",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "9d8f9745b3432f86e49c3ba5cebac09d7d51ad989bcf0a79d92abb6372304e21"
+  "activationDigest": "8e30285132ad7100b4ca0ec3c9c3b0e76695e7679d614883e69f47e2ffcd1636"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723"
+    "sourceManifestDigest": "8c936f619cae14da2c617dadd73960d72c1e1b559d9c2805c6c08da2449d226f"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "401c245b48eb1ab7c0973cb7bc69ab24c537b76662d893a1e3b2e8313adafa91",
-    "qualityDigest": "7c46407185cff54c6fdbda22bc73b412119d6712bde78bd74abaab95169e1694",
+    "contextDigest": "21609aa07e365a8374e4fa8b839b590264273238cee70a18a818f2d0ef2a5d55",
+    "qualityDigest": "96ba9fab9ad490996fd9cfa3e69a620ef7b949c5a62b3184709c9f4dc12bcf72",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "4c38e5b3c6ede8c07dc35191ae901c69eeff837b3ccb7236a4a4fe2e8179097e"
+  "activationDigest": "9d8f9745b3432f86e49c3ba5cebac09d7d51ad989bcf0a79d92abb6372304e21"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723",
-    "contextDigest": "401c245b48eb1ab7c0973cb7bc69ab24c537b76662d893a1e3b2e8313adafa91"
+    "sourceManifestDigest": "8c936f619cae14da2c617dadd73960d72c1e1b559d9c2805c6c08da2449d226f",
+    "contextDigest": "21609aa07e365a8374e4fa8b839b590264273238cee70a18a818f2d0ef2a5d55"
   },
   "catalog": {
     "messageCount": 3114,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "63e947a0addb2fa1b8f2f2b7967a41e936036976eac6ae5d4c21a0f294d2c0cd",
-    "validationDigest": "b8b462253169d16715d3970c5622306aa7ba6c3488f1b21e134e35087f7ff882",
+    "digest": "1f02e32e15dfe209bb35ab56ad025373c12fe47e4a178f80f2c2dd8b8738687a",
+    "validationDigest": "4d9337d3be9fa3cfd2a35822d8b46c69b7e75c35dccce1e996812c4cd09b6685",
     "laneCount": 1,
     "validatedMessageCount": 3114,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "7c46407185cff54c6fdbda22bc73b412119d6712bde78bd74abaab95169e1694"
+  "qualityDigest": "96ba9fab9ad490996fd9cfa3e69a620ef7b949c5a62b3184709c9f4dc12bcf72"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "8c936f619cae14da2c617dadd73960d72c1e1b559d9c2805c6c08da2449d226f",
-    "contextDigest": "21609aa07e365a8374e4fa8b839b590264273238cee70a18a818f2d0ef2a5d55"
+    "contextDigest": "3ebb23cb64636b3366d8569b9b8eef140c088c78459b60646c3622606939563b"
   },
   "catalog": {
     "messageCount": 3114,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "1f02e32e15dfe209bb35ab56ad025373c12fe47e4a178f80f2c2dd8b8738687a",
-    "validationDigest": "4d9337d3be9fa3cfd2a35822d8b46c69b7e75c35dccce1e996812c4cd09b6685",
+    "digest": "3fa940d18c5fc42d02442f74b5ae06729a80521c5cd3896dcd13d6af95f872ff",
+    "validationDigest": "e769c34db641a0bb6ba561d13856ac22406b2a1fd45fbde924114bd12a241e31",
     "laneCount": 1,
     "validatedMessageCount": 3114,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "96ba9fab9ad490996fd9cfa3e69a620ef7b949c5a62b3184709c9f4dc12bcf72"
+  "qualityDigest": "cda6743bd96febf0cf04caf3c399157a36110483a3d3c3a025dc865e12e0bbad"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "87f3df83f41836dd1f32b5e25335ff71b23cc831bd0fa7c944d490cdb9345d6a",
+    "auditedInputDigest": "080859aeb4d45b26df1cc45e87a010ed0360e3c40de1f45b80867a1aa2168a45",
     "validatedMessageCount": 3114,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1390,
     "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
     "catalogDigest": "aa8b61be8b056c7640170905371ff7564d95a4b3c11b2dd6dfbb0c43faf71a29",
-    "dossierDigest": "78fa368841d6d6e672bb2ea8a3624564d6d0600f6994247403c6f0ef532df0e6",
+    "dossierDigest": "c0ebcceb1366f775242128d9ff02b8b9b433cad1d0740a8975d2b5db743d62d3",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "41c96657d29d1e29e7abf90448aaf3ccb2c30445cd39ce5357a3e3459f6b4953",
+    "routeEvidenceDigest": "6241a103e7340fe5a95f20eac992a8991988ae78b237c46df8b6daddf1da94de",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "7e7b1cc9be2d7f7c8b74f069bddc34a36f242da8b1e5626f00a289473cc58ef2",
         "highRiskMessageCount": 1390,
         "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
-        "dossierDigest": "78fa368841d6d6e672bb2ea8a3624564d6d0600f6994247403c6f0ef532df0e6",
+        "dossierDigest": "c0ebcceb1366f775242128d9ff02b8b9b433cad1d0740a8975d2b5db743d62d3",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "b8b462253169d16715d3970c5622306aa7ba6c3488f1b21e134e35087f7ff882"
+  "validationDigest": "4d9337d3be9fa3cfd2a35822d8b46c69b7e75c35dccce1e996812c4cd09b6685"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "aa8b61be8b056c7640170905371ff7564d95a4b3c11b2dd6dfbb0c43faf71a29",
     "dossierDigest": "c0ebcceb1366f775242128d9ff02b8b9b433cad1d0740a8975d2b5db743d62d3",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "6241a103e7340fe5a95f20eac992a8991988ae78b237c46df8b6daddf1da94de",
+    "routeEvidenceDigest": "9a8bd81d545e15cd030fc875b986073d3b48ef980af1635b8e7fa94931ec44f3",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "4d9337d3be9fa3cfd2a35822d8b46c69b7e75c35dccce1e996812c4cd09b6685"
+  "validationDigest": "e769c34db641a0bb6ba561d13856ac22406b2a1fd45fbde924114bd12a241e31"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723",
-    "auditedInputDigest": "87f3df83f41836dd1f32b5e25335ff71b23cc831bd0fa7c944d490cdb9345d6a"
+    "sourceManifestDigest": "8c936f619cae14da2c617dadd73960d72c1e1b559d9c2805c6c08da2449d226f",
+    "auditedInputDigest": "080859aeb4d45b26df1cc45e87a010ed0360e3c40de1f45b80867a1aa2168a45"
   },
   "inventory": {
     "sourceMessageCount": 3114,
@@ -47,7 +47,7 @@
     "messageCount": 3114,
     "completeCount": 3114,
     "blockedCount": 0,
-    "dossierDigest": "1249b80a71a45a750a3ff6e642640ab24ee446abe9ed52a7d2ca59bb321c4802",
+    "dossierDigest": "d69181d296ef505ec96fb58969d7010fe9538f605f0ec4ec6deee9ccafd982da",
     "catalogDigest": "e9ab3d4f080335169cdc43db7cf7fb93ba04129e9a94b7c30aa4548f725218d2",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -67,9 +67,9 @@
       "destructive-or-rejecting-action": 47,
       "failure-or-invalid-input": 363,
       "interactive-ready": 522,
-      "retained-not-currently-reachable": 356,
+      "retained-not-currently-reachable": 357,
       "successful-completion": 182,
-      "visible": 1644
+      "visible": 1643
     },
     "riskCounts": { "high": 1390, "low": 1501, "medium": 223 },
     "highRiskMessageCount": 1390,
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4124,
+    "literalReferenceCount": 4125,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale fr-FR --message <MESSAGE_ID>"
@@ -503,7 +503,7 @@
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "b1442ddd3a928a5a99c5020c2dceee3994fcd8744aa2e03c62f980625d38446b",
-          "focusedTestDigest": "e71ebdedaa744976d65be9341bae9fae3658e2158c6360f623c1260225b59854",
+          "focusedTestDigest": "d7b32fccdc173f64ec403b234a4a6b317b7472e0433e20b560e8cd608a03461f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "41c96657d29d1e29e7abf90448aaf3ccb2c30445cd39ce5357a3e3459f6b4953",
+      "rowEvidenceDigest": "6241a103e7340fe5a95f20eac992a8991988ae78b237c46df8b6daddf1da94de",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "5a56a69bfbe51f37673fe3ac04fe25334a4e6f07e0e437cd4222bf52db7c72e7"
+  "contextDigest": "f288c80de7a9de95ab05b52425ef7f2427faec59a308f10d0c821ebad47abe00"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -503,7 +503,7 @@
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "b1442ddd3a928a5a99c5020c2dceee3994fcd8744aa2e03c62f980625d38446b",
-          "focusedTestDigest": "d7b32fccdc173f64ec403b234a4a6b317b7472e0433e20b560e8cd608a03461f",
+          "focusedTestDigest": "c07876b4fdfe48fd401a12db522d50582a7f1af3f6285d3192ad8a90a25d072f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "6241a103e7340fe5a95f20eac992a8991988ae78b237c46df8b6daddf1da94de",
+      "rowEvidenceDigest": "9a8bd81d545e15cd030fc875b986073d3b48ef980af1635b8e7fa94931ec44f3",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "f288c80de7a9de95ab05b52425ef7f2427faec59a308f10d0c821ebad47abe00"
+  "contextDigest": "0427a768f38082bd7887227ed85920003adb759fb83fc4aea95dab3dd99442d4"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "f288c80de7a9de95ab05b52425ef7f2427faec59a308f10d0c821ebad47abe00",
-    "qualityDigest": "e43bd647184f279d35ebffc789e5831c885fdf51dcf83ae6be12e68cc962b32f",
+    "contextDigest": "0427a768f38082bd7887227ed85920003adb759fb83fc4aea95dab3dd99442d4",
+    "qualityDigest": "4995c507aa9ce2414d19c0097ecbc96f2595c6887cf1690fdb043793ea11ca50",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "c5622850026bacdf394a638b3f6e237ed41bd53402fdba72594443698cb3b71e"
+  "activationDigest": "43bc98c7e4f762c1049eceacb70dbc86f9c05f307461a4c42c1563ffd0ea0b9d"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723"
+    "sourceManifestDigest": "8c936f619cae14da2c617dadd73960d72c1e1b559d9c2805c6c08da2449d226f"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "5a56a69bfbe51f37673fe3ac04fe25334a4e6f07e0e437cd4222bf52db7c72e7",
-    "qualityDigest": "395a92b7a83944109bea1935b036ed9bbf39a7c4edfadd4dfe6063ddc583553d",
+    "contextDigest": "f288c80de7a9de95ab05b52425ef7f2427faec59a308f10d0c821ebad47abe00",
+    "qualityDigest": "e43bd647184f279d35ebffc789e5831c885fdf51dcf83ae6be12e68cc962b32f",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "e93a9cd366976619edd6c5287ff4171e6891767b394998df62e48bf33d963c29"
+  "activationDigest": "c5622850026bacdf394a638b3f6e237ed41bd53402fdba72594443698cb3b71e"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "8c936f619cae14da2c617dadd73960d72c1e1b559d9c2805c6c08da2449d226f",
-    "contextDigest": "f288c80de7a9de95ab05b52425ef7f2427faec59a308f10d0c821ebad47abe00"
+    "contextDigest": "0427a768f38082bd7887227ed85920003adb759fb83fc4aea95dab3dd99442d4"
   },
   "catalog": {
     "messageCount": 3114,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "865d4c849a13fa1f1be439ee51dc585ae72dd72644abb67ebef5917515c41573",
-    "validationDigest": "95c24a716645e67683e6aa69abe07b02bc0c28a9f17bdf7cb31058f2b8c093bc",
+    "digest": "ee3e6c5fa7c2db8b02584c826bdb960c2b2b39cf4db3a986181baa8071d8b091",
+    "validationDigest": "5d455034d05ce4eef7cccfab448311fdeee069b24e58ca1b15af28861a5c4ae5",
     "laneCount": 1,
     "validatedMessageCount": 3114,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "e43bd647184f279d35ebffc789e5831c885fdf51dcf83ae6be12e68cc962b32f"
+  "qualityDigest": "4995c507aa9ce2414d19c0097ecbc96f2595c6887cf1690fdb043793ea11ca50"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723",
-    "contextDigest": "5a56a69bfbe51f37673fe3ac04fe25334a4e6f07e0e437cd4222bf52db7c72e7"
+    "sourceManifestDigest": "8c936f619cae14da2c617dadd73960d72c1e1b559d9c2805c6c08da2449d226f",
+    "contextDigest": "f288c80de7a9de95ab05b52425ef7f2427faec59a308f10d0c821ebad47abe00"
   },
   "catalog": {
     "messageCount": 3114,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "9e52ff06e83c8342ae58a159e27d476375730ac7efe3a1a1501f0764c8cb6624",
-    "validationDigest": "15903e0e6985b5a90568100dd3c9234d4d4dbd1cb10da41a5b6c9db1472d1c8b",
+    "digest": "865d4c849a13fa1f1be439ee51dc585ae72dd72644abb67ebef5917515c41573",
+    "validationDigest": "95c24a716645e67683e6aa69abe07b02bc0c28a9f17bdf7cb31058f2b8c093bc",
     "laneCount": 1,
     "validatedMessageCount": 3114,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "395a92b7a83944109bea1935b036ed9bbf39a7c4edfadd4dfe6063ddc583553d"
+  "qualityDigest": "e43bd647184f279d35ebffc789e5831c885fdf51dcf83ae6be12e68cc962b32f"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "e9ab3d4f080335169cdc43db7cf7fb93ba04129e9a94b7c30aa4548f725218d2",
     "dossierDigest": "d69181d296ef505ec96fb58969d7010fe9538f605f0ec4ec6deee9ccafd982da",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "6241a103e7340fe5a95f20eac992a8991988ae78b237c46df8b6daddf1da94de",
+    "routeEvidenceDigest": "9a8bd81d545e15cd030fc875b986073d3b48ef980af1635b8e7fa94931ec44f3",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "95c24a716645e67683e6aa69abe07b02bc0c28a9f17bdf7cb31058f2b8c093bc"
+  "validationDigest": "5d455034d05ce4eef7cccfab448311fdeee069b24e58ca1b15af28861a5c4ae5"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "87f3df83f41836dd1f32b5e25335ff71b23cc831bd0fa7c944d490cdb9345d6a",
+    "auditedInputDigest": "080859aeb4d45b26df1cc45e87a010ed0360e3c40de1f45b80867a1aa2168a45",
     "validatedMessageCount": 3114,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1390,
     "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
     "catalogDigest": "e9ab3d4f080335169cdc43db7cf7fb93ba04129e9a94b7c30aa4548f725218d2",
-    "dossierDigest": "1249b80a71a45a750a3ff6e642640ab24ee446abe9ed52a7d2ca59bb321c4802",
+    "dossierDigest": "d69181d296ef505ec96fb58969d7010fe9538f605f0ec4ec6deee9ccafd982da",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "41c96657d29d1e29e7abf90448aaf3ccb2c30445cd39ce5357a3e3459f6b4953",
+    "routeEvidenceDigest": "6241a103e7340fe5a95f20eac992a8991988ae78b237c46df8b6daddf1da94de",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "7e7b1cc9be2d7f7c8b74f069bddc34a36f242da8b1e5626f00a289473cc58ef2",
         "highRiskMessageCount": 1390,
         "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
-        "dossierDigest": "1249b80a71a45a750a3ff6e642640ab24ee446abe9ed52a7d2ca59bb321c4802",
+        "dossierDigest": "d69181d296ef505ec96fb58969d7010fe9538f605f0ec4ec6deee9ccafd982da",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "15903e0e6985b5a90568100dd3c9234d4d4dbd1cb10da41a5b6c9db1472d1c8b"
+  "validationDigest": "95c24a716645e67683e6aa69abe07b02bc0c28a9f17bdf7cb31058f2b8c093bc"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723",
-    "auditedInputDigest": "87f3df83f41836dd1f32b5e25335ff71b23cc831bd0fa7c944d490cdb9345d6a"
+    "sourceManifestDigest": "8c936f619cae14da2c617dadd73960d72c1e1b559d9c2805c6c08da2449d226f",
+    "auditedInputDigest": "080859aeb4d45b26df1cc45e87a010ed0360e3c40de1f45b80867a1aa2168a45"
   },
   "inventory": {
     "sourceMessageCount": 3114,
@@ -47,7 +47,7 @@
     "messageCount": 3114,
     "completeCount": 3114,
     "blockedCount": 0,
-    "dossierDigest": "6793fa192e1db7d59fbc383d08b4ad71546d20562641484703b77c5ef1da52f0",
+    "dossierDigest": "d3b7a085387db948900bb12b4f1ae604c3de6a354f198cb5310b4ee7191add28",
     "catalogDigest": "ff6938d40f9eaf1179a1deae1da9474d2bc42478773be577c9fe4b97b98afd88",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
@@ -67,9 +67,9 @@
       "destructive-or-rejecting-action": 47,
       "failure-or-invalid-input": 363,
       "interactive-ready": 522,
-      "retained-not-currently-reachable": 356,
+      "retained-not-currently-reachable": 357,
       "successful-completion": 182,
-      "visible": 1644
+      "visible": 1643
     },
     "riskCounts": { "high": 1390, "low": 1556, "medium": 168 },
     "highRiskMessageCount": 1390,
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4124,
+    "literalReferenceCount": 4125,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale zh-CN --message <MESSAGE_ID>"
@@ -503,7 +503,7 @@
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "b1442ddd3a928a5a99c5020c2dceee3994fcd8744aa2e03c62f980625d38446b",
-          "focusedTestDigest": "e71ebdedaa744976d65be9341bae9fae3658e2158c6360f623c1260225b59854",
+          "focusedTestDigest": "d7b32fccdc173f64ec403b234a4a6b317b7472e0433e20b560e8cd608a03461f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "41c96657d29d1e29e7abf90448aaf3ccb2c30445cd39ce5357a3e3459f6b4953",
+      "rowEvidenceDigest": "6241a103e7340fe5a95f20eac992a8991988ae78b237c46df8b6daddf1da94de",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "ac6f9e6c129a6e9679e183a45bbefc0ff07bc69a9b27db7635f990edaa5e081b"
+  "contextDigest": "371ac2bb1db545c5efa3088fcc58ad42ca1f64389588e79554da2f2fe22e05c0"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -503,7 +503,7 @@
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "b1442ddd3a928a5a99c5020c2dceee3994fcd8744aa2e03c62f980625d38446b",
-          "focusedTestDigest": "d7b32fccdc173f64ec403b234a4a6b317b7472e0433e20b560e8cd608a03461f",
+          "focusedTestDigest": "c07876b4fdfe48fd401a12db522d50582a7f1af3f6285d3192ad8a90a25d072f",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "6241a103e7340fe5a95f20eac992a8991988ae78b237c46df8b6daddf1da94de",
+      "rowEvidenceDigest": "9a8bd81d545e15cd030fc875b986073d3b48ef980af1635b8e7fa94931ec44f3",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "371ac2bb1db545c5efa3088fcc58ad42ca1f64389588e79554da2f2fe22e05c0"
+  "contextDigest": "90af18b08ec8448f33324dc5e64d5d2dc67f6b48e0235a11c4a9398fb7d4e548"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "371ac2bb1db545c5efa3088fcc58ad42ca1f64389588e79554da2f2fe22e05c0",
-    "qualityDigest": "95c409ace1a7402f0d39640e9667fdb46e4f95635a7f4a669a5d8775063e4a08",
+    "contextDigest": "90af18b08ec8448f33324dc5e64d5d2dc67f6b48e0235a11c4a9398fb7d4e548",
+    "qualityDigest": "8b4a5f9517eca0eae607c5b43d4dc234b2c45dac35c560262119bd2cde1d5359",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "906d5ea7b8f1bbcdea5a759fd108a6edec0741a5d3c4ee5382bd6622b641fded"
+  "activationDigest": "36ecfb99581785c85f170e870ae507738e3dcc04c8c9294fec491ced6578c72b"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723"
+    "sourceManifestDigest": "8c936f619cae14da2c617dadd73960d72c1e1b559d9c2805c6c08da2449d226f"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "ac6f9e6c129a6e9679e183a45bbefc0ff07bc69a9b27db7635f990edaa5e081b",
-    "qualityDigest": "5002265938bbe25ba35e6b459515dc5fd307feabf9f7bb75f6dbdd7aab99c5a8",
+    "contextDigest": "371ac2bb1db545c5efa3088fcc58ad42ca1f64389588e79554da2f2fe22e05c0",
+    "qualityDigest": "95c409ace1a7402f0d39640e9667fdb46e4f95635a7f4a669a5d8775063e4a08",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "f4080350c1c62a4d4c31328fffa32f004e0f166322373fef102046e747fe4910",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "56d4e47e709d3e8d9acf47771bcfcd188efa9c5c3d96f62308ca6dc8452281f1"
+  "activationDigest": "906d5ea7b8f1bbcdea5a759fd108a6edec0741a5d3c4ee5382bd6622b641fded"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "8c936f619cae14da2c617dadd73960d72c1e1b559d9c2805c6c08da2449d226f",
-    "contextDigest": "371ac2bb1db545c5efa3088fcc58ad42ca1f64389588e79554da2f2fe22e05c0"
+    "contextDigest": "90af18b08ec8448f33324dc5e64d5d2dc67f6b48e0235a11c4a9398fb7d4e548"
   },
   "catalog": {
     "messageCount": 3114,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "0aa5c5b03bc9fc807ac553e7d291d89e6b51648c451b80cb5cfeea5bc3b4b1e1",
-    "validationDigest": "85e84d460579deca2989783804c09ff1743d36ae718b1672931ad4c5cf0795de",
+    "digest": "886a34e190a41266151e03438880531fc7d6893288b49c5ad8b1dd1af23d3444",
+    "validationDigest": "1665f5915dd329055514454540afa809bb2c6f7f9186056137fe2b6da64ee503",
     "laneCount": 1,
     "validatedMessageCount": 3114,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "95c409ace1a7402f0d39640e9667fdb46e4f95635a7f4a669a5d8775063e4a08"
+  "qualityDigest": "8b4a5f9517eca0eae607c5b43d4dc234b2c45dac35c560262119bd2cde1d5359"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6c5f1a53ab8226b8d29727d0d051942560873f5fe4321aa6e25614dd16ea4723",
-    "contextDigest": "ac6f9e6c129a6e9679e183a45bbefc0ff07bc69a9b27db7635f990edaa5e081b"
+    "sourceManifestDigest": "8c936f619cae14da2c617dadd73960d72c1e1b559d9c2805c6c08da2449d226f",
+    "contextDigest": "371ac2bb1db545c5efa3088fcc58ad42ca1f64389588e79554da2f2fe22e05c0"
   },
   "catalog": {
     "messageCount": 3114,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "d9755b3b0a0aa7317ca989179f076072cd0aa23de4893d74bd979b5645c8c121",
-    "validationDigest": "4f09df5149a5fc0399a0ffffcde51d26e8abec2f380c1fd34d5f94d6830ab159",
+    "digest": "0aa5c5b03bc9fc807ac553e7d291d89e6b51648c451b80cb5cfeea5bc3b4b1e1",
+    "validationDigest": "85e84d460579deca2989783804c09ff1743d36ae718b1672931ad4c5cf0795de",
     "laneCount": 1,
     "validatedMessageCount": 3114,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "5002265938bbe25ba35e6b459515dc5fd307feabf9f7bb75f6dbdd7aab99c5a8"
+  "qualityDigest": "95c409ace1a7402f0d39640e9667fdb46e4f95635a7f4a669a5d8775063e4a08"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "ff6938d40f9eaf1179a1deae1da9474d2bc42478773be577c9fe4b97b98afd88",
     "dossierDigest": "d3b7a085387db948900bb12b4f1ae604c3de6a354f198cb5310b4ee7191add28",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "6241a103e7340fe5a95f20eac992a8991988ae78b237c46df8b6daddf1da94de",
+    "routeEvidenceDigest": "9a8bd81d545e15cd030fc875b986073d3b48ef980af1635b8e7fa94931ec44f3",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "85e84d460579deca2989783804c09ff1743d36ae718b1672931ad4c5cf0795de"
+  "validationDigest": "1665f5915dd329055514454540afa809bb2c6f7f9186056137fe2b6da64ee503"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "87f3df83f41836dd1f32b5e25335ff71b23cc831bd0fa7c944d490cdb9345d6a",
+    "auditedInputDigest": "080859aeb4d45b26df1cc45e87a010ed0360e3c40de1f45b80867a1aa2168a45",
     "validatedMessageCount": 3114,
     "validatedModules": [
       "$entry",
@@ -41,9 +41,9 @@
     "highRiskMessageCount": 1390,
     "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
     "catalogDigest": "ff6938d40f9eaf1179a1deae1da9474d2bc42478773be577c9fe4b97b98afd88",
-    "dossierDigest": "6793fa192e1db7d59fbc383d08b4ad71546d20562641484703b77c5ef1da52f0",
+    "dossierDigest": "d3b7a085387db948900bb12b4f1ae604c3de6a354f198cb5310b4ee7191add28",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "41c96657d29d1e29e7abf90448aaf3ccb2c30445cd39ce5357a3e3459f6b4953",
+    "routeEvidenceDigest": "6241a103e7340fe5a95f20eac992a8991988ae78b237c46df8b6daddf1da94de",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -96,7 +96,7 @@
         "messageDigest": "7e7b1cc9be2d7f7c8b74f069bddc34a36f242da8b1e5626f00a289473cc58ef2",
         "highRiskMessageCount": 1390,
         "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
-        "dossierDigest": "6793fa192e1db7d59fbc383d08b4ad71546d20562641484703b77c5ef1da52f0",
+        "dossierDigest": "d3b7a085387db948900bb12b4f1ae604c3de6a354f198cb5310b4ee7191add28",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "4f09df5149a5fc0399a0ffffcde51d26e8abec2f380c1fd34d5f94d6830ab159"
+  "validationDigest": "85e84d460579deca2989783804c09ff1743d36ae718b1672931ad4c5cf0795de"
 }

--- a/src/pages/Review/Components/AssignmentReview.tsx
+++ b/src/pages/Review/Components/AssignmentReview.tsx
@@ -23,7 +23,7 @@ import { ReviewsTable } from '@/services/reviews/data';
 import { isCurrentAssignedReviewerCommentState } from '@/services/reviews/util';
 import { ProColumns, ProTable } from '@ant-design/pro-components';
 import { FormattedMessage, useIntl } from '@umijs/max';
-import { Card, Col, Input, Row, Select, Space, Spin, Table, Tag, theme } from 'antd';
+import { Card, Col, Input, Row, Select, Space, Spin, Table, Tag, theme, Tooltip } from 'antd';
 import { SearchProps } from 'antd/es/input/Search';
 import { SortOrder } from 'antd/es/table/interface';
 import { useEffect, useRef, useState } from 'react';
@@ -38,12 +38,32 @@ import SimpleReviewActions from './SimpleReviewActions';
 const { Search } = Input;
 
 export const SELECTED_REVIEW_ROW_BUTTON_STYLE = `
-  .review-table-with-expand-icon .ant-table-row-selected .ant-btn {
+  .review-table-with-expand-icon
+    .ant-table-cell:not(.review-action-column)
+    .ant-btn {
     background: transparent !important;
     border-color: transparent !important;
     box-shadow: none;
   }
 `;
+
+export const REVIEW_DISPLAY_MODE_FILTER_WIDTH = '10.5em';
+export const REVIEW_DATA_TYPE_FILTER_WIDTH = '9.5em';
+
+const ReviewFilterLabel = ({ label }: { label: React.ReactNode }) => (
+  <Tooltip title={label}>
+    <span
+      style={{
+        display: 'block',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {label}
+    </span>
+  </Tooltip>
+);
 
 type AssignmentReviewProps = {
   userData: { user_id: string; role: string } | null;
@@ -105,6 +125,11 @@ const ExpandIconStyle = () => {
         color: ${token.colorPrimary} !important;
       }
       ${SELECTED_REVIEW_ROW_BUTTON_STYLE}
+      .review-table-with-expand-icon .review-action-column .ant-btn {
+        background: ${token.colorBgContainer} !important;
+        border-color: ${token.colorBorder} !important;
+        border-radius: 50%;
+      }
     `}</style>
   );
 };
@@ -348,7 +373,6 @@ const AssignmentReview = ({
       isReviewTargetTableCompatible(displayMode, value),
     ),
   ];
-
   const onSearch: SearchProps['onSearch'] = () => {
     // setKeyWord(value);
     // actionRef.current?.setPageInfo?.({ current: 1 });
@@ -609,6 +633,7 @@ const AssignmentReview = ({
     subColumns.push({
       title: <FormattedMessage id='pages.review.actions' defaultMessage='Actions' />,
       key: 'actions',
+      className: 'review-action-column',
       render: (_: unknown, record: RootReviewReferenceProgress) => {
         if (tableType === 'unassigned') {
           return [
@@ -729,6 +754,7 @@ const AssignmentReview = ({
     columns.push({
       title: <FormattedMessage id='pages.review.actions' defaultMessage='Actions' />,
       dataIndex: 'actions',
+      className: 'review-action-column',
       search: false,
       render: (_, record) => {
         if (record.rootMatchesStatus === false) return [];
@@ -778,6 +804,7 @@ const AssignmentReview = ({
         {
           title: <FormattedMessage id='pages.review.actions' defaultMessage='Actions' />,
           dataIndex: 'actions',
+          className: 'review-action-column',
           search: false,
           render: (_: any, record: ReviewsTable) => {
             if (record.rootMatchesStatus === false) return [];
@@ -846,6 +873,7 @@ const AssignmentReview = ({
         {
           title: <FormattedMessage id='pages.review.actions' defaultMessage='Actions' />,
           dataIndex: 'actions',
+          className: 'review-action-column',
           search: false,
           render: (_: any, record: ReviewsTable) => {
             if (record.rootMatchesStatus === false) return [];
@@ -936,6 +964,7 @@ const AssignmentReview = ({
         {
           title: <FormattedMessage id='pages.review.actions' defaultMessage='Actions' />,
           dataIndex: 'actions',
+          className: 'review-action-column',
           search: false,
           render: (_: any, record: ReviewsTable) => {
             if (record.rootMatchesStatus === false) return [];
@@ -1101,8 +1130,9 @@ const AssignmentReview = ({
                 })}
                 value={displayMode}
                 options={displayModeOptions}
+                labelRender={({ label }) => <ReviewFilterLabel label={label} />}
                 onChange={handleDisplayModeChange}
-                style={{ minWidth: 200 }}
+                style={{ width: REVIEW_DISPLAY_MODE_FILTER_WIDTH }}
               />
               <Select<ReviewSubmitDatasetTable | 'all'>
                 aria-label={intl.formatMessage({
@@ -1111,8 +1141,9 @@ const AssignmentReview = ({
                 })}
                 value={targetTable ?? 'all'}
                 options={targetTableOptions}
+                labelRender={({ label }) => <ReviewFilterLabel label={label} />}
                 onChange={handleTargetTableChange}
-                style={{ minWidth: 180 }}
+                style={{ width: REVIEW_DATA_TYPE_FILTER_WIDTH }}
               />
             </Space>
           );
@@ -1120,24 +1151,6 @@ const AssignmentReview = ({
             return [
               filterControls,
               <Space key='batch-assignment-selection'>
-                <span>
-                  <FormattedMessage
-                    id='pages.review.selection.summary'
-                    defaultMessage='Selected {rootCount} root reviews and {referenceCount} reference reviews'
-                    values={{
-                      rootCount: selectedRootReviewIds.length,
-                      referenceCount: effectiveSelectedReferenceIds.length,
-                    }}
-                  />
-                </span>
-                {selectionLoadingRootIds.length > 0 && (
-                  <span>
-                    <FormattedMessage
-                      id='pages.review.selection.loading'
-                      defaultMessage='Loading referenced reviews...'
-                    />
-                  </span>
-                )}
                 {selectionFailedRootIds.length > 0 && (
                   <span>
                     <FormattedMessage
@@ -1212,6 +1225,24 @@ const AssignmentReview = ({
           }
         }}
         actionRef={actionRef}
+        tableAlertRender={({ intl: tableIntl, selectedRowKeys = [] }) => (
+          <Space>
+            <span>
+              {tableIntl.getMessage('alert.selected', 'Selected')} {selectedRowKeys.length}{' '}
+              {tableIntl.getMessage('alert.item', 'items')}
+            </span>
+            <span>
+              <FormattedMessage
+                id='pages.review.selection.summary'
+                defaultMessage='Selected {rootCount} root reviews and {referenceCount} reference reviews'
+                values={{
+                  rootCount: selectedRootReviewIds.length,
+                  referenceCount: effectiveSelectedReferenceIds.length,
+                }}
+              />
+            </span>
+          </Space>
+        )}
         tableAlertOptionRender={tableAlertOptionRender}
         rowSelection={
           supportsBatchSelection

--- a/src/pages/Review/Components/BatchReviewActions.tsx
+++ b/src/pages/Review/Components/BatchReviewActions.tsx
@@ -4,8 +4,9 @@ import {
   type ReviewBatchDecision,
   type ReviewBatchDecisionResult,
 } from '@/services/reviews/api';
+import { FileExcelOutlined, SafetyCertificateOutlined } from '@ant-design/icons';
 import { useIntl } from '@umijs/max';
-import { Button, Form, Input, message, Modal, Space } from 'antd';
+import { Button, Form, Input, message, Modal, Space, theme, Tooltip } from 'antd';
 import { useState } from 'react';
 
 type BatchReviewActionsProps = {
@@ -24,6 +25,7 @@ const BatchReviewActions = ({
   onFinished,
 }: BatchReviewActionsProps) => {
   const intl = useIntl();
+  const { token } = theme.useToken();
   const [form] = Form.useForm<{ reason: string }>();
   const [modal, modalContextHolder] = Modal.useModal();
   const [rejectOpen, setRejectOpen] = useState(false);
@@ -103,31 +105,57 @@ const BatchReviewActions = ({
   return (
     <>
       {modalContextHolder}
-      <Space>
+      <Space size={token.marginXS}>
         {allowApprove && (
-          <Button
-            type='primary'
-            loading={loading}
-            disabled={disabled || reviewIds.length === 0}
-            onClick={confirmApprove}
-          >
-            {intl.formatMessage({
+          <Tooltip
+            title={intl.formatMessage({
               id: 'pages.review.batch.approve',
               defaultMessage: 'Batch approve',
             })}
-          </Button>
+          >
+            <Button
+              type='text'
+              size='large'
+              style={{
+                width: token.controlHeightSM,
+                height: token.controlHeight,
+                paddingInline: 0,
+              }}
+              aria-label={intl.formatMessage({
+                id: 'pages.review.batch.approve',
+                defaultMessage: 'Batch approve',
+              })}
+              icon={<SafetyCertificateOutlined />}
+              loading={loading}
+              disabled={disabled || reviewIds.length === 0}
+              onClick={confirmApprove}
+            />
+          </Tooltip>
         )}
-        <Button
-          danger
-          loading={loading}
-          disabled={disabled || reviewIds.length === 0}
-          onClick={() => setRejectOpen(true)}
-        >
-          {intl.formatMessage({
+        <Tooltip
+          title={intl.formatMessage({
             id: 'pages.review.batch.reject',
             defaultMessage: 'Batch reject',
           })}
-        </Button>
+        >
+          <Button
+            type='text'
+            size='large'
+            style={{
+              width: token.controlHeightSM,
+              height: token.controlHeight,
+              paddingInline: 0,
+            }}
+            aria-label={intl.formatMessage({
+              id: 'pages.review.batch.reject',
+              defaultMessage: 'Batch reject',
+            })}
+            icon={<FileExcelOutlined />}
+            loading={loading}
+            disabled={disabled || reviewIds.length === 0}
+            onClick={() => setRejectOpen(true)}
+          />
+        </Tooltip>
       </Space>
       <Modal
         open={rejectOpen}

--- a/tests/unit/pages/Review/BatchReviewActions.test.tsx
+++ b/tests/unit/pages/Review/BatchReviewActions.test.tsx
@@ -12,6 +12,11 @@ const mockSuccess = jest.fn();
 const mockWarning = jest.fn();
 const mockError = jest.fn();
 
+jest.mock('@ant-design/icons', () => ({
+  FileExcelOutlined: () => <span data-testid='batch-reject-icon' />,
+  SafetyCertificateOutlined: () => <span data-testid='batch-approve-icon' />,
+}));
+
 jest.mock('@/services/reviews/api', () => ({
   submitAdminReviewBatchDecision: jest.fn(),
   submitReviewerBatchDecision: jest.fn(),
@@ -78,13 +83,38 @@ jest.mock('antd', () => {
     Button: ({
       children,
       disabled,
+      icon,
       onClick,
+      type,
+      size,
+      shape,
+      style,
+      danger,
+      'aria-label': ariaLabel,
     }: {
       children: import('react').ReactNode;
       disabled?: boolean;
+      icon?: import('react').ReactNode;
       onClick?: () => void;
+      type?: string;
+      size?: string;
+      shape?: string;
+      style?: import('react').CSSProperties;
+      danger?: boolean;
+      'aria-label'?: string;
     }) => (
-      <button type='button' disabled={disabled} onClick={onClick}>
+      <button
+        type='button'
+        disabled={disabled}
+        onClick={onClick}
+        aria-label={ariaLabel}
+        data-button-type={type}
+        data-button-size={size}
+        data-button-shape={shape}
+        data-button-danger={danger ? 'true' : 'false'}
+        style={style}
+      >
+        {icon}
         {children}
       </button>
     ),
@@ -96,7 +126,21 @@ jest.mock('antd', () => {
       error: (...args: unknown[]) => mockError(...args),
     },
     Modal,
-    Space: ({ children }: { children: import('react').ReactNode }) => <div>{children}</div>,
+    Space: ({ children, size }: { children: import('react').ReactNode; size?: number }) => (
+      <div data-space-size={size}>{children}</div>
+    ),
+    theme: {
+      useToken: () => ({
+        token: {
+          marginXS: 8,
+          controlHeightSM: 24,
+          controlHeight: 32,
+        },
+      }),
+    },
+    Tooltip: ({ children, title }: { children: import('react').ReactNode; title?: string }) => (
+      <span title={title}>{children}</span>
+    ),
   };
 });
 
@@ -125,7 +169,15 @@ describe('BatchReviewActions', () => {
         onFinished={onFinished}
       />,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Batch approve' }));
+    const approveButton = screen.getByRole('button', { name: 'Batch approve' });
+    expect(screen.getByTestId('batch-approve-icon')).toBeInTheDocument();
+    expect(approveButton).toHaveAttribute('data-button-type', 'text');
+    expect(approveButton).toHaveAttribute('data-button-size', 'large');
+    expect(approveButton).not.toHaveAttribute('data-button-shape');
+    expect(approveButton).toHaveAttribute('data-button-danger', 'false');
+    expect(approveButton).toHaveStyle({ width: '24px', height: '32px', paddingInline: 0 });
+    expect(approveButton.parentElement?.parentElement).toHaveAttribute('data-space-size', '8');
+    fireEvent.click(approveButton);
 
     await waitFor(() =>
       expect(adminDecisionMock).toHaveBeenCalledWith(
@@ -160,7 +212,14 @@ describe('BatchReviewActions', () => {
       />,
     );
     expect(screen.queryByRole('button', { name: 'Batch approve' })).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Batch reject' }));
+    expect(screen.getByTestId('batch-reject-icon')).toBeInTheDocument();
+    const rejectButton = screen.getByRole('button', { name: 'Batch reject' });
+    expect(rejectButton).toHaveAttribute('data-button-type', 'text');
+    expect(rejectButton).toHaveAttribute('data-button-size', 'large');
+    expect(rejectButton).not.toHaveAttribute('data-button-shape');
+    expect(rejectButton).toHaveAttribute('data-button-danger', 'false');
+    expect(rejectButton).toHaveStyle({ width: '24px', height: '32px', paddingInline: 0 });
+    fireEvent.click(rejectButton);
     expect(screen.getByRole('region', { name: 'Reject 2 selected reviews' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'cancel' }));
     expect(screen.queryByRole('region')).not.toBeInTheDocument();

--- a/tests/unit/pages/Review/Components/AssignmentReview.test.tsx
+++ b/tests/unit/pages/Review/Components/AssignmentReview.test.tsx
@@ -150,15 +150,26 @@ jest.mock('antd', () => {
   );
   const Col = ({ children }: any) => <div>{children}</div>;
   const Row = ({ children }: any) => <div>{children}</div>;
-  const Select = ({ value, onChange, options = [], 'aria-label': ariaLabel }: any) => (
-    <select aria-label={ariaLabel} value={value} onChange={(event) => onChange(event.target.value)}>
-      {options.map((option: any) => (
-        <option key={option.value} value={option.value}>
-          {option.label}
-        </option>
-      ))}
-    </select>
-  );
+  const Select = ({ value, onChange, options = [], labelRender, 'aria-label': ariaLabel }: any) => {
+    const selectedOption = options.find((option: any) => option.value === value);
+
+    return (
+      <div>
+        {labelRender?.({ label: selectedOption?.label })}
+        <select
+          aria-label={ariaLabel}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+        >
+          {options.map((option: any) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+  };
   const Space = ({ children }: any) => <div>{children}</div>;
   const Spin = ({ children }: any) => <div data-testid='spin'>{children}</div>;
   const Table = ({ columns = [], dataSource = [], rowSelection }: any) => (
@@ -265,6 +276,13 @@ const MockProTable = ({
 
     reload();
   }, []);
+
+  tableAlertRender?.({
+    intl: {
+      getMessage: (_id: string, defaultMessage: string) => defaultMessage,
+    },
+    selectedRowKeys: undefined,
+  });
 
   return (
     <section data-testid='protable'>

--- a/tests/unit/pages/Review/Components/AssignmentReview.test.tsx
+++ b/tests/unit/pages/Review/Components/AssignmentReview.test.tsx
@@ -1,5 +1,7 @@
 // @ts-nocheck
 import AssignmentReview, {
+  REVIEW_DATA_TYPE_FILTER_WIDTH,
+  REVIEW_DISPLAY_MODE_FILTER_WIDTH,
   SELECTED_REVIEW_ROW_BUTTON_STYLE,
   isExpandableRootReview,
   isReferenceMatchingReviewTab,
@@ -208,6 +210,7 @@ jest.mock('antd', () => {
     useToken: () => ({ token: { colorPrimary: '#1677ff', fontSize: 14 } }),
   };
   const Tag = ({ children, color }: any) => <span data-color={color}>{children}</span>;
+  const Tooltip = ({ children, title }: any) => <span title={title}>{children}</span>;
 
   return {
     __esModule: true,
@@ -222,6 +225,7 @@ jest.mock('antd', () => {
     Table,
     Tag,
     theme,
+    Tooltip,
   };
 });
 
@@ -233,6 +237,7 @@ const MockProTable = ({
   headerTitle,
   columns,
   expandable,
+  tableAlertRender,
   tableAlertOptionRender,
   pagination,
 }: any) => {
@@ -266,6 +271,13 @@ const MockProTable = ({
       <div data-testid='header-title'>{headerTitle}</div>
       <div data-testid='toolbar'>{toolBarRender?.()}</div>
       <div data-testid='table-alert'>
+        {(rowSelection?.selectedRowKeys?.length ?? 0) > 0 &&
+          tableAlertRender?.({
+            selectedRowKeys: rowSelection?.selectedRowKeys ?? [],
+            intl: {
+              getMessage: (id: string, defaultMessage: string) => defaultMessage,
+            },
+          })}
         {tableAlertOptionRender?.({
           selectedRowKeys: rowSelection?.selectedRowKeys ?? [],
           onCleanSelected: () => rowSelection?.onChange?.([]),
@@ -351,9 +363,14 @@ jest.mock('@/services/reviews/api', () => ({
 }));
 
 describe('AssignmentReview', () => {
-  it('keeps icon buttons transparent only inside selected review rows', () => {
+  it('keeps review filters at their Chinese-option widths across locales', () => {
+    expect(REVIEW_DISPLAY_MODE_FILTER_WIDTH).toBe('10.5em');
+    expect(REVIEW_DATA_TYPE_FILTER_WIDTH).toBe('9.5em');
+  });
+
+  it('removes button rings outside action columns', () => {
     expect(SELECTED_REVIEW_ROW_BUTTON_STYLE).toContain(
-      '.review-table-with-expand-icon .ant-table-row-selected .ant-btn',
+      '.ant-table-cell:not(.review-action-column)',
     );
     expect(SELECTED_REVIEW_ROW_BUTTON_STYLE).toContain('background: transparent !important');
     expect(SELECTED_REVIEW_ROW_BUTTON_STYLE).toContain('border-color: transparent !important');
@@ -559,6 +576,12 @@ describe('AssignmentReview', () => {
       ),
     );
     expect(screen.getByText('Selected 1 root reviews and 1 reference reviews')).toBeInTheDocument();
+    expect(screen.getByTestId('toolbar')).not.toHaveTextContent(
+      'Selected 1 root reviews and 1 reference reviews',
+    );
+    expect(screen.getByTestId('table-alert')).toHaveTextContent(
+      'Selected 2 itemsSelected 1 root reviews and 1 reference reviews',
+    );
     expect(screen.getByTestId('batch-review-actions')).toHaveTextContent(
       'admin:false:["review-1","reference-review-1"]',
     );
@@ -761,7 +784,7 @@ describe('AssignmentReview', () => {
     );
 
     await userEvent.click(await screen.findByRole('button', { name: 'select-duplicate-review-1' }));
-    expect(screen.getByText('Loading referenced reviews...')).toBeInTheDocument();
+    expect(screen.queryByText('Loading referenced reviews...')).not.toBeInTheDocument();
     expect(mockGetRootReviewReferenceProgress).toHaveBeenCalledTimes(1);
 
     resolveReferences({ data: [], error: new Error('duplicate selection load failed') });
@@ -816,7 +839,7 @@ describe('AssignmentReview', () => {
 
     const rootSelection = await screen.findByRole('button', { name: 'select-review-1' });
     await userEvent.click(rootSelection);
-    expect(screen.getByText('Loading referenced reviews...')).toBeInTheDocument();
+    expect(screen.queryByText('Loading referenced reviews...')).not.toBeInTheDocument();
     await userEvent.click(rootSelection);
 
     resolveReferences({
@@ -870,7 +893,7 @@ describe('AssignmentReview', () => {
     );
 
     await userEvent.click(await screen.findByRole('button', { name: 'select-review-1' }));
-    expect(screen.getByText('Loading referenced reviews...')).toBeInTheDocument();
+    expect(screen.queryByText('Loading referenced reviews...')).not.toBeInTheDocument();
     expect(screen.getByTestId('select-reviewer')).toHaveAttribute('data-disabled', 'true');
 
     resolveReferences({


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#811

## Summary
- Move the root/reference review selection summary next to the selected-item count across review queues.
- Use icon-only approve/reject batch actions with consistent toolbar color and spacing, while keeping circular rings only in table action columns.
- Hide referenced-review loading copy and constrain localized filter labels to fixed Chinese-sized widths with ellipsis and hover tooltips.

## Key Decisions
- Keep review-admin final approve/reject commands separate from reviewer advisory approve/reject opinions; this PR changes presentation only and preserves role-specific service routing.

## Validation
- npx jest tests/unit/pages/Review/Components/AssignmentReview.test.tsx tests/unit/pages/Review/BatchReviewActions.test.tsx --runInBand (74 tests passed).
- npx eslint on changed review source/tests and npx tsc --noEmit passed.
- npm run i18n:locale:artifacts:idempotence passed with two canonical generations for all four locales.
- npm run push:checked -- fork codex/fix-issue-811-review-toolbar-ui passed: 5,669 tests and 412 suites passed; 462/462 tracked source files reached 100/100/100/100 coverage.
- No authenticated browser smoke test was run; the change is covered by unit and review-workflow integration tests.

## Risks / Rollback
- Low UI-only risk; rollback by reverting the feature commit. Review role boundaries and command routing are unchanged.

## Follow-ups
- After merge to dev, promote through the repository's dev-to-main release workflow before root workspace integration.

## Workspace Integration
- Workspace integration remains pending under workspace issue #572; root main must only consume a release-semantic commit promoted to child main.