### PR TITLE
chore: prepare v0.0.69 on dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-08-13'
-lastReviewedCommit: '7a5e0a1b7a5811a745bd1b305730ad3a46a63124'
+lastReviewedAt: "2026-08-13"
+lastReviewedCommit: "a1f5f75640cb64e01f681a2336f12d2d1def3717"
 lastReviewedNote: 'Reviewed for Next Issue #813: dataset search-mode routing stays within the existing frontend runtime, service boundary, and validation contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 7a2829ba9bd3cd628a4f2ec82924955fc692bbd1
+lastReviewedCommit: a1f5f75640cb64e01f681a2336f12d2d1def3717
 lastReviewedNote: 'Reviewed for Next Issue #813: dataset search-mode routing does not change repository ownership, service boundaries, branch policy, or delivery rules.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 7a2829ba9bd3cd628a4f2ec82924955fc692bbd1
+lastReviewedCommit: a1f5f75640cb64e01f681a2336f12d2d1def3717
 lastReviewedNote: 'Reviewed for Next Issue #813: dataset search-mode routing preserves the Node 24 bootstrap, focused validation loop, build requirement, and managed checked-push delivery path.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 7a5e0a1b7a5811a745bd1b305730ad3a46a63124
+lastReviewedCommit: a1f5f75640cb64e01f681a2336f12d2d1def3717
 lastReviewedNote: 'Reviewed for Next Issue #813: search-mode page and service coverage continues through the unchanged Docpact-first and full-gate-last checked-push policy.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 7a5e0a1b7a5811a745bd1b305730ad3a46a63124
+lastReviewedCommit: a1f5f75640cb64e01f681a2336f12d2d1def3717
 lastReviewedNote: 'Reviewed for Next Issue #813: the existing hybrid-search page, service, picker, locale, request-guard, lint, and build proof remains the correct validation path.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 7a5e0a1b7a5811a745bd1b305730ad3a46a63124
+lastReviewedCommit: a1f5f75640cb64e01f681a2336f12d2d1def3717
 lastReviewedNote: 'Reviewed for Next Issue #813: focused three-mode routing assertions preserve the existing full-closure maintenance strategy without opening a new testing workstream.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 7a5e0a1b7a5811a745bd1b305730ad3a46a63124
+lastReviewedCommit: a1f5f75640cb64e01f681a2336f12d2d1def3717
 lastReviewedNote: 'Reviewed for Next Issue #813: the added three-mode routing assertions preserve full closure and create no active coverage queue.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 7a5e0a1b7a5811a745bd1b305730ad3a46a63124
+lastReviewedCommit: a1f5f75640cb64e01f681a2336f12d2d1def3717
 lastReviewedNote: 'Reviewed for Next Issue #813: existing controlled-component mocks and behavior assertions cover search-mode routing, prompts, and mutual exclusion.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 7a5e0a1b7a5811a745bd1b305730ad3a46a63124
+lastReviewedCommit: a1f5f75640cb64e01f681a2336f12d2d1def3717
 lastReviewedNote: 'Reviewed for Next Issue #813: no new troubleshooting path is required; search-mode regressions remain covered by focused serial tests before the managed full gate.'
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.68",
+      "version": "0.0.69",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
<!-- tiangong-next-release-automation:v1 issue=780 version=0.0.69 base=a1f5f75640cb64e01f681a2336f12d2d1def3717 candidate=b6602a159875535f89a0b5ff4320adce82105346 -->

## Branch Contract

- base branch: `dev`
- validated environment: repository-managed dev gate
- back-merge required after merge: No
- root workspace integration expected: after later dev-to-main promotion

## Linked Issue

Refs #780

## Change Facts

- Prepare version `0.0.69` from exact dev base `a1f5f75640cb64e01f681a2336f12d2d1def3717`.
- Keep package.json and both package-lock root version fields aligned.
- Reuse the current credential-free semantic qualification receipt.
- Record Docpact review evidence only after the command proves the candidate has no other semantic change.
- Reviewed paths:
  - `.docpact/config.yaml`
  - `AGENTS.md`
  - `DEV.md`
  - `docs/agents/prepush-gate-policy.md`
  - `docs/agents/repo-validation.md`
  - `docs/agents/test_improvement_plan.md`
  - `docs/agents/test_todo_list.md`
  - `docs/agents/testing-patterns.md`
  - `docs/agents/testing-troubleshooting.md`

## Validation Facts

- Candidate: `b6602a159875535f89a0b5ff4320adce82105346`
- Main baseline: `8dba6c8944f8c3acb1b4047529130f6216a75228`
- Semantic qualification: `reused`; composed-candidate preflight: `passed`
- Docpact automatic-review status: `completed`
- Docpact checked the complete main-to-candidate promotion range before the dev PR was created.
- Final push used the repository-managed dev gate; full logs remain local and are not copied into the PR.

## Risks And Follow-Up

- Merge this PR into dev, then run the deterministic dev-to-main promotion command with this PR number.
