### PR TITLE
chore: prepare v0.0.70 on dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-13"
-lastReviewedCommit: "88758d0cd1f1e8fd021c6b963674ee5f08e873b2"
+lastReviewedCommit: "3af9c5bce57706fd1dd23d2502c96841210695db"
 lastReviewedNote: 'Reviewed for Next Issue #819: release-proof reuse and the 512MB-bounded two-worker coverage gate stay within existing release, workflow, test, and documentation ownership domains.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-13"
-lastReviewedCommit: "c14e2d92bdbda1c2704c5b852e74ad99f191d3f7"
+lastReviewedCommit: "9e24439ded1686ed7a54eb9317c2e352ed5b7c95"
 lastReviewedNote: 'Reviewed for Next Issue #819: release-proof reuse and the 512MB-bounded two-worker coverage gate stay within existing release, workflow, test, and documentation ownership domains.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-13"
-lastReviewedCommit: "4fbdfcf63da97ed128a452d61f4272d3ee02781a"
+lastReviewedCommit: "02848777b35b74dd8d02faffc68632013b903310"
 lastReviewedNote: 'Reviewed for Next Issue #819: release-proof reuse and the 512MB-bounded two-worker coverage gate stay within existing release, workflow, test, and documentation ownership domains.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-13"
-lastReviewedCommit: "3af9c5bce57706fd1dd23d2502c96841210695db"
+lastReviewedCommit: "69564f9d16e28e55d7e7eb89c3488cc286651bc9"
 lastReviewedNote: 'Reviewed for Next Issue #819: release-proof reuse and the 512MB-bounded two-worker coverage gate stay within existing release, workflow, test, and documentation ownership domains.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-13"
-lastReviewedCommit: "9e24439ded1686ed7a54eb9317c2e352ed5b7c95"
+lastReviewedCommit: "4fbdfcf63da97ed128a452d61f4272d3ee02781a"
 lastReviewedNote: 'Reviewed for Next Issue #819: release-proof reuse and the 512MB-bounded two-worker coverage gate stay within existing release, workflow, test, and documentation ownership domains.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-08-13'
-lastReviewedCommit: 'c7e6ac3364a0ebb0cc11b717550a9c0afaa20311'
+lastReviewedAt: "2026-08-13"
+lastReviewedCommit: "794fef603798d03c3dd8f4692a53563074b09d63"
 lastReviewedNote: 'Reviewed for Next Issue #819: release-proof reuse and the 512MB-bounded two-worker coverage gate stay within existing release, workflow, test, and documentation ownership domains.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-13"
-lastReviewedCommit: "69564f9d16e28e55d7e7eb89c3488cc286651bc9"
+lastReviewedCommit: "c14e2d92bdbda1c2704c5b852e74ad99f191d3f7"
 lastReviewedNote: 'Reviewed for Next Issue #819: release-proof reuse and the 512MB-bounded two-worker coverage gate stay within existing release, workflow, test, and documentation ownership domains.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-13"
-lastReviewedCommit: "794fef603798d03c3dd8f4692a53563074b09d63"
+lastReviewedCommit: "88758d0cd1f1e8fd021c6b963674ee5f08e873b2"
 lastReviewedNote: 'Reviewed for Next Issue #819: release-proof reuse and the 512MB-bounded two-worker coverage gate stay within existing release, workflow, test, and documentation ownership domains.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 794fef603798d03c3dd8f4692a53563074b09d63
+lastReviewedCommit: 88758d0cd1f1e8fd021c6b963674ee5f08e873b2
 lastReviewedNote: 'Reviewed for Next Issue #819: exact PR proof reuse and the two-worker, 512MB-recycle coverage gate preserve the complete repository quality boundary without excessive GC churn.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c7e6ac3364a0ebb0cc11b717550a9c0afaa20311
+lastReviewedCommit: 794fef603798d03c3dd8f4692a53563074b09d63
 lastReviewedNote: 'Reviewed for Next Issue #819: exact PR proof reuse and the two-worker, 512MB-recycle coverage gate preserve the complete repository quality boundary without excessive GC churn.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 794fef603798d03c3dd8f4692a53563074b09d63
+lastReviewedCommit: 88758d0cd1f1e8fd021c6b963674ee5f08e873b2
 lastReviewedNote: 'Reviewed for Next Issue #819: bootstrap and managed delivery remain unchanged while the full coverage command uses two workers with a 512MB recycle boundary.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c7e6ac3364a0ebb0cc11b717550a9c0afaa20311
+lastReviewedCommit: 794fef603798d03c3dd8f4692a53563074b09d63
 lastReviewedNote: 'Reviewed for Next Issue #819: bootstrap and managed delivery remain unchanged while the full coverage command uses two workers with a 512MB recycle boundary.'
 ---
 

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -57,7 +57,7 @@ checkPaths:
   - .github/workflows/build.yml
   - package.json
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 88758d0cd1f1e8fd021c6b963674ee5f08e873b2
+lastReviewedCommit: c14e2d92bdbda1c2704c5b852e74ad99f191d3f7
 lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: regenerating deterministic locale artifacts after the final flat-queue interaction closure does not change locale delivery or production-data authorization boundaries.'
 baselineObservedAt: 2026-07-18
 related:

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -57,7 +57,7 @@ checkPaths:
   - .github/workflows/build.yml
   - package.json
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 7a5e0a1b7a5811a745bd1b305730ad3a46a63124
+lastReviewedCommit: 88758d0cd1f1e8fd021c6b963674ee5f08e873b2
 lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: regenerating deterministic locale artifacts after the final flat-queue interaction closure does not change locale delivery or production-data authorization boundaries.'
 baselineObservedAt: 2026-07-18
 related:

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -57,7 +57,7 @@ checkPaths:
   - .github/workflows/build.yml
   - package.json
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c14e2d92bdbda1c2704c5b852e74ad99f191d3f7
+lastReviewedCommit: 4fbdfcf63da97ed128a452d61f4272d3ee02781a
 lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: regenerating deterministic locale artifacts after the final flat-queue interaction closure does not change locale delivery or production-data authorization boundaries.'
 baselineObservedAt: 2026-07-18
 related:

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 4fbdfcf63da97ed128a452d61f4272d3ee02781a
+lastReviewedCommit: 02848777b35b74dd8d02faffc68632013b903310
 lastReviewedNote: 'Reviewed for Next Issue #819: canonical releases reuse exact proof or run the complete fallback through the two-worker, 512MB-recycle coverage pool.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 88758d0cd1f1e8fd021c6b963674ee5f08e873b2
+lastReviewedCommit: 3af9c5bce57706fd1dd23d2502c96841210695db
 lastReviewedNote: 'Reviewed for Next Issue #819: canonical releases reuse exact proof or run the complete fallback through the two-worker, 512MB-recycle coverage pool.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c14e2d92bdbda1c2704c5b852e74ad99f191d3f7
+lastReviewedCommit: 9e24439ded1686ed7a54eb9317c2e352ed5b7c95
 lastReviewedNote: 'Reviewed for Next Issue #819: canonical releases reuse exact proof or run the complete fallback through the two-worker, 512MB-recycle coverage pool.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 794fef603798d03c3dd8f4692a53563074b09d63
+lastReviewedCommit: 88758d0cd1f1e8fd021c6b963674ee5f08e873b2
 lastReviewedNote: 'Reviewed for Next Issue #819: canonical releases reuse exact proof or run the complete fallback through the two-worker, 512MB-recycle coverage pool.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 9e24439ded1686ed7a54eb9317c2e352ed5b7c95
+lastReviewedCommit: 4fbdfcf63da97ed128a452d61f4272d3ee02781a
 lastReviewedNote: 'Reviewed for Next Issue #819: canonical releases reuse exact proof or run the complete fallback through the two-worker, 512MB-recycle coverage pool.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 3af9c5bce57706fd1dd23d2502c96841210695db
+lastReviewedCommit: 69564f9d16e28e55d7e7eb89c3488cc286651bc9
 lastReviewedNote: 'Reviewed for Next Issue #819: canonical releases reuse exact proof or run the complete fallback through the two-worker, 512MB-recycle coverage pool.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c7e6ac3364a0ebb0cc11b717550a9c0afaa20311
+lastReviewedCommit: 794fef603798d03c3dd8f4692a53563074b09d63
 lastReviewedNote: 'Reviewed for Next Issue #819: canonical releases reuse exact proof or run the complete fallback through the two-worker, 512MB-recycle coverage pool.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 69564f9d16e28e55d7e7eb89c3488cc286651bc9
+lastReviewedCommit: c14e2d92bdbda1c2704c5b852e74ad99f191d3f7
 lastReviewedNote: 'Reviewed for Next Issue #819: canonical releases reuse exact proof or run the complete fallback through the two-worker, 512MB-recycle coverage pool.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 88758d0cd1f1e8fd021c6b963674ee5f08e873b2
+lastReviewedCommit: 3af9c5bce57706fd1dd23d2502c96841210695db
 lastReviewedNote: 'Reviewed for Next Issue #819: release validation distinguishes reusable proof from fallback and runs the complete coverage inventory through two workers with a 512MB recycle boundary.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c7e6ac3364a0ebb0cc11b717550a9c0afaa20311
+lastReviewedCommit: 794fef603798d03c3dd8f4692a53563074b09d63
 lastReviewedNote: 'Reviewed for Next Issue #819: release validation distinguishes reusable proof from fallback and runs the complete coverage inventory through two workers with a 512MB recycle boundary.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c14e2d92bdbda1c2704c5b852e74ad99f191d3f7
+lastReviewedCommit: 9e24439ded1686ed7a54eb9317c2e352ed5b7c95
 lastReviewedNote: 'Reviewed for Next Issue #819: release validation distinguishes reusable proof from fallback and runs the complete coverage inventory through two workers with a 512MB recycle boundary.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 3af9c5bce57706fd1dd23d2502c96841210695db
+lastReviewedCommit: 69564f9d16e28e55d7e7eb89c3488cc286651bc9
 lastReviewedNote: 'Reviewed for Next Issue #819: release validation distinguishes reusable proof from fallback and runs the complete coverage inventory through two workers with a 512MB recycle boundary.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 794fef603798d03c3dd8f4692a53563074b09d63
+lastReviewedCommit: 88758d0cd1f1e8fd021c6b963674ee5f08e873b2
 lastReviewedNote: 'Reviewed for Next Issue #819: release validation distinguishes reusable proof from fallback and runs the complete coverage inventory through two workers with a 512MB recycle boundary.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 9e24439ded1686ed7a54eb9317c2e352ed5b7c95
+lastReviewedCommit: 4fbdfcf63da97ed128a452d61f4272d3ee02781a
 lastReviewedNote: 'Reviewed for Next Issue #819: release validation distinguishes reusable proof from fallback and runs the complete coverage inventory through two workers with a 512MB recycle boundary.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 69564f9d16e28e55d7e7eb89c3488cc286651bc9
+lastReviewedCommit: c14e2d92bdbda1c2704c5b852e74ad99f191d3f7
 lastReviewedNote: 'Reviewed for Next Issue #819: release validation distinguishes reusable proof from fallback and runs the complete coverage inventory through two workers with a 512MB recycle boundary.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 4fbdfcf63da97ed128a452d61f4272d3ee02781a
+lastReviewedCommit: 02848777b35b74dd8d02faffc68632013b903310
 lastReviewedNote: 'Reviewed for Next Issue #819: release validation distinguishes reusable proof from fallback and runs the complete coverage inventory through two workers with a 512MB recycle boundary.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 9e24439ded1686ed7a54eb9317c2e352ed5b7c95
+lastReviewedCommit: 4fbdfcf63da97ed128a452d61f4272d3ee02781a
 lastReviewedNote: 'Reviewed for Next Issue #819: the strategy removes exact duplicate execution and bounds a two-worker pool at 512MB without weakening full closure.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 794fef603798d03c3dd8f4692a53563074b09d63
+lastReviewedCommit: 88758d0cd1f1e8fd021c6b963674ee5f08e873b2
 lastReviewedNote: 'Reviewed for Next Issue #819: the strategy removes exact duplicate execution and bounds a two-worker pool at 512MB without weakening full closure.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c14e2d92bdbda1c2704c5b852e74ad99f191d3f7
+lastReviewedCommit: 9e24439ded1686ed7a54eb9317c2e352ed5b7c95
 lastReviewedNote: 'Reviewed for Next Issue #819: the strategy removes exact duplicate execution and bounds a two-worker pool at 512MB without weakening full closure.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 4fbdfcf63da97ed128a452d61f4272d3ee02781a
+lastReviewedCommit: 02848777b35b74dd8d02faffc68632013b903310
 lastReviewedNote: 'Reviewed for Next Issue #819: the strategy removes exact duplicate execution and bounds a two-worker pool at 512MB without weakening full closure.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 69564f9d16e28e55d7e7eb89c3488cc286651bc9
+lastReviewedCommit: c14e2d92bdbda1c2704c5b852e74ad99f191d3f7
 lastReviewedNote: 'Reviewed for Next Issue #819: the strategy removes exact duplicate execution and bounds a two-worker pool at 512MB without weakening full closure.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c7e6ac3364a0ebb0cc11b717550a9c0afaa20311
+lastReviewedCommit: 794fef603798d03c3dd8f4692a53563074b09d63
 lastReviewedNote: 'Reviewed for Next Issue #819: the strategy removes exact duplicate execution and bounds a two-worker pool at 512MB without weakening full closure.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 88758d0cd1f1e8fd021c6b963674ee5f08e873b2
+lastReviewedCommit: 3af9c5bce57706fd1dd23d2502c96841210695db
 lastReviewedNote: 'Reviewed for Next Issue #819: the strategy removes exact duplicate execution and bounds a two-worker pool at 512MB without weakening full closure.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 3af9c5bce57706fd1dd23d2502c96841210695db
+lastReviewedCommit: 69564f9d16e28e55d7e7eb89c3488cc286651bc9
 lastReviewedNote: 'Reviewed for Next Issue #819: the strategy removes exact duplicate execution and bounds a two-worker pool at 512MB without weakening full closure.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 69564f9d16e28e55d7e7eb89c3488cc286651bc9
+lastReviewedCommit: c14e2d92bdbda1c2704c5b852e74ad99f191d3f7
 lastReviewedNote: 'Reviewed for Next Issue #819: current execution state records exact proof reuse and requalification of the two-worker full-coverage inventory at a 512MB recycle boundary.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c14e2d92bdbda1c2704c5b852e74ad99f191d3f7
+lastReviewedCommit: 9e24439ded1686ed7a54eb9317c2e352ed5b7c95
 lastReviewedNote: 'Reviewed for Next Issue #819: current execution state records exact proof reuse and requalification of the two-worker full-coverage inventory at a 512MB recycle boundary.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 794fef603798d03c3dd8f4692a53563074b09d63
+lastReviewedCommit: 88758d0cd1f1e8fd021c6b963674ee5f08e873b2
 lastReviewedNote: 'Reviewed for Next Issue #819: current execution state records exact proof reuse and requalification of the two-worker full-coverage inventory at a 512MB recycle boundary.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c7e6ac3364a0ebb0cc11b717550a9c0afaa20311
+lastReviewedCommit: 794fef603798d03c3dd8f4692a53563074b09d63
 lastReviewedNote: 'Reviewed for Next Issue #819: current execution state records exact proof reuse and requalification of the two-worker full-coverage inventory at a 512MB recycle boundary.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 3af9c5bce57706fd1dd23d2502c96841210695db
+lastReviewedCommit: 69564f9d16e28e55d7e7eb89c3488cc286651bc9
 lastReviewedNote: 'Reviewed for Next Issue #819: current execution state records exact proof reuse and requalification of the two-worker full-coverage inventory at a 512MB recycle boundary.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 88758d0cd1f1e8fd021c6b963674ee5f08e873b2
+lastReviewedCommit: 3af9c5bce57706fd1dd23d2502c96841210695db
 lastReviewedNote: 'Reviewed for Next Issue #819: current execution state records exact proof reuse and requalification of the two-worker full-coverage inventory at a 512MB recycle boundary.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 4fbdfcf63da97ed128a452d61f4272d3ee02781a
+lastReviewedCommit: 02848777b35b74dd8d02faffc68632013b903310
 lastReviewedNote: 'Reviewed for Next Issue #819: current execution state records exact proof reuse and requalification of the two-worker full-coverage inventory at a 512MB recycle boundary.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 9e24439ded1686ed7a54eb9317c2e352ed5b7c95
+lastReviewedCommit: 4fbdfcf63da97ed128a452d61f4272d3ee02781a
 lastReviewedNote: 'Reviewed for Next Issue #819: current execution state records exact proof reuse and requalification of the two-worker full-coverage inventory at a 512MB recycle boundary.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 3af9c5bce57706fd1dd23d2502c96841210695db
+lastReviewedCommit: 69564f9d16e28e55d7e7eb89c3488cc286651bc9
 lastReviewedNote: 'Reviewed for Next Issue #819: exact proof reuse and heap-aware bounded worker pools are reusable Release Gate patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c7e6ac3364a0ebb0cc11b717550a9c0afaa20311
+lastReviewedCommit: 794fef603798d03c3dd8f4692a53563074b09d63
 lastReviewedNote: 'Reviewed for Next Issue #819: exact proof reuse and heap-aware bounded worker pools are reusable Release Gate patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 9e24439ded1686ed7a54eb9317c2e352ed5b7c95
+lastReviewedCommit: 4fbdfcf63da97ed128a452d61f4272d3ee02781a
 lastReviewedNote: 'Reviewed for Next Issue #819: exact proof reuse and heap-aware bounded worker pools are reusable Release Gate patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 88758d0cd1f1e8fd021c6b963674ee5f08e873b2
+lastReviewedCommit: 3af9c5bce57706fd1dd23d2502c96841210695db
 lastReviewedNote: 'Reviewed for Next Issue #819: exact proof reuse and heap-aware bounded worker pools are reusable Release Gate patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 4fbdfcf63da97ed128a452d61f4272d3ee02781a
+lastReviewedCommit: 02848777b35b74dd8d02faffc68632013b903310
 lastReviewedNote: 'Reviewed for Next Issue #819: exact proof reuse and heap-aware bounded worker pools are reusable Release Gate patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 69564f9d16e28e55d7e7eb89c3488cc286651bc9
+lastReviewedCommit: c14e2d92bdbda1c2704c5b852e74ad99f191d3f7
 lastReviewedNote: 'Reviewed for Next Issue #819: exact proof reuse and heap-aware bounded worker pools are reusable Release Gate patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c14e2d92bdbda1c2704c5b852e74ad99f191d3f7
+lastReviewedCommit: 9e24439ded1686ed7a54eb9317c2e352ed5b7c95
 lastReviewedNote: 'Reviewed for Next Issue #819: exact proof reuse and heap-aware bounded worker pools are reusable Release Gate patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 794fef603798d03c3dd8f4692a53563074b09d63
+lastReviewedCommit: 88758d0cd1f1e8fd021c6b963674ee5f08e873b2
 lastReviewedNote: 'Reviewed for Next Issue #819: exact proof reuse and heap-aware bounded worker pools are reusable Release Gate patterns.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 9e24439ded1686ed7a54eb9317c2e352ed5b7c95
+lastReviewedCommit: 4fbdfcf63da97ed128a452d61f4272d3ee02781a
 lastReviewedNote: 'Reviewed for Next Issue #819: full-gate fallback and two-worker native-crash diagnosis use a heap-aware 512MB recycle boundary.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c14e2d92bdbda1c2704c5b852e74ad99f191d3f7
+lastReviewedCommit: 9e24439ded1686ed7a54eb9317c2e352ed5b7c95
 lastReviewedNote: 'Reviewed for Next Issue #819: full-gate fallback and two-worker native-crash diagnosis use a heap-aware 512MB recycle boundary.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 69564f9d16e28e55d7e7eb89c3488cc286651bc9
+lastReviewedCommit: c14e2d92bdbda1c2704c5b852e74ad99f191d3f7
 lastReviewedNote: 'Reviewed for Next Issue #819: full-gate fallback and two-worker native-crash diagnosis use a heap-aware 512MB recycle boundary.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c7e6ac3364a0ebb0cc11b717550a9c0afaa20311
+lastReviewedCommit: 794fef603798d03c3dd8f4692a53563074b09d63
 lastReviewedNote: 'Reviewed for Next Issue #819: full-gate fallback and two-worker native-crash diagnosis use a heap-aware 512MB recycle boundary.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 794fef603798d03c3dd8f4692a53563074b09d63
+lastReviewedCommit: 88758d0cd1f1e8fd021c6b963674ee5f08e873b2
 lastReviewedNote: 'Reviewed for Next Issue #819: full-gate fallback and two-worker native-crash diagnosis use a heap-aware 512MB recycle boundary.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 4fbdfcf63da97ed128a452d61f4272d3ee02781a
+lastReviewedCommit: 02848777b35b74dd8d02faffc68632013b903310
 lastReviewedNote: 'Reviewed for Next Issue #819: full-gate fallback and two-worker native-crash diagnosis use a heap-aware 512MB recycle boundary.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 3af9c5bce57706fd1dd23d2502c96841210695db
+lastReviewedCommit: 69564f9d16e28e55d7e7eb89c3488cc286651bc9
 lastReviewedNote: 'Reviewed for Next Issue #819: full-gate fallback and two-worker native-crash diagnosis use a heap-aware 512MB recycle boundary.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 88758d0cd1f1e8fd021c6b963674ee5f08e873b2
+lastReviewedCommit: 3af9c5bce57706fd1dd23d2502c96841210695db
 lastReviewedNote: 'Reviewed for Next Issue #819: full-gate fallback and two-worker native-crash diagnosis use a heap-aware 512MB recycle boundary.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
+    "digest": "39d31311c22e08e6ba5f5b59cb82959e9ff5127cfaf497c4160a0317a22ed6ad",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "11b27a2a3e20215b2e796519a0dbe3fd937940b4e88f4261d615780a4e3e824e",
+          "sha256": "abd50e20572034e698d43c1592d2ad3bc79242bd9ce50f566e923b2d7d0c4800",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
+    "docs/plans/i18n/route-view-coverage.json": "39d31311c22e08e6ba5f5b59cb82959e9ff5127cfaf497c4160a0317a22ed6ad",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-de-DE/glossary.json": "a5fd4e759af2713fbec83f2b95171c7b32206d7218da0401d28d2eecefccce3a",
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "67d35a48d2e65424b8d5eb67c0f165080662c87c95a1610674791a05425af736"
+  "contextDigest": "049cfbdf820e1112b9e8f79900280ea8904d33e586c498cc834b26304b07973b"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
+    "digest": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "9dcff21b8caea698f67dd0c899cf2b007d34bda442f00702967e09ca8fdc55dd",
+          "sha256": "11b27a2a3e20215b2e796519a0dbe3fd937940b4e88f4261d615780a4e3e824e",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1043,7 +1043,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "32fe106473e04bf5f0cb7101c0e01258a74037dbe436b6168fd3cec645ad25ee",
-          "focusedTestDigest": "ac2a7911150bdf0d092b41037817f85caf3618c853dc4bec9f391fbc883e4a8d",
+          "focusedTestDigest": "fc41b8aa33910cdfc8bd350b7fa66d037e9f4fa5c0073b2ff5856044aa2974ac",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "5a1a477972b0b0ca71d25f149ae0ac4f561dd1f9ffcd64486efe941ae5f881a4",
+      "rowEvidenceDigest": "997a00ea7a96230491788656a5323ee3e0f8213690b70fc2a63333e7fc06c19f",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
+    "docs/plans/i18n/route-view-coverage.json": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-de-DE/glossary.json": "a5fd4e759af2713fbec83f2b95171c7b32206d7218da0401d28d2eecefccce3a",
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "c984e30b8a2dff926bd8ad2c336c20ef80e7f27930af38b0848b46c67fd7c8d9"
+  "contextDigest": "67d35a48d2e65424b8d5eb67c0f165080662c87c95a1610674791a05425af736"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "4dbaff8f99ec34385c3d76bdfe68a5fc1590f481b84efd9dace708db4be7633b",
-    "auditedInputDigest": "1657b2b1efa3385624a8ec837f40e2f0650b79ae2986865593fed797741d494f"
+    "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296",
+    "auditedInputDigest": "9d886b4500d7cebd1365547d0439b6a508bcc25aabe085e7cc9ccd15a592f238"
   },
   "inventory": {
-    "sourceMessageCount": 3114,
-    "localeMessageCount": 3114,
+    "sourceMessageCount": 3119,
+    "localeMessageCount": 3119,
     "leafModuleCount": 30,
     "dynamicFamilyCount": 17,
     "dynamicCallsiteCount": 39,
@@ -44,18 +44,18 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3114,
-    "completeCount": 3114,
+    "messageCount": 3119,
+    "completeCount": 3119,
     "blockedCount": 0,
-    "dossierDigest": "06a7dbdba0db74f82cedbc8f776e66292b9cc6dc4af26ae8132fc8d886ea5a77",
-    "catalogDigest": "05d9ac48d37d0eafb48ec463e6b33e2be831295ef25d4afba5dfce8ff96ff832",
+    "dossierDigest": "63e35cf47082f64566dcd51b330db1e1a20119b1625712c0dadb063fe8d07210",
+    "catalogDigest": "50e3a72dc8865ec46d5a8e3c607a4b762942de3886a7a46b90b124c5f93776a5",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
     "roleCounts": {
       "error-or-validation": 363,
       "explanatory-copy": 110,
       "field-guidance": 49,
-      "label-or-body-copy": 1255,
+      "label-or-body-copy": 1260,
       "navigation-or-tab": 226,
       "reserved-catalog-copy": 277,
       "status-or-empty-state": 100,
@@ -69,11 +69,11 @@
       "interactive-ready": 522,
       "retained-not-currently-reachable": 357,
       "successful-completion": 182,
-      "visible": 1643
+      "visible": 1648
     },
-    "riskCounts": { "high": 1390, "low": 1502, "medium": 222 },
-    "highRiskMessageCount": 1390,
-    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0"
+    "riskCounts": { "high": 1391, "low": 1506, "medium": 222 },
+    "highRiskMessageCount": 1391,
+    "highRiskMessageDigest": "803ebcc8320e7f5a792c522a7c5b69a4f24b672308a12b1feaeaa94b4df3aa5f"
   },
   "typedContentDossiers": {
     "sourcePath": "src/components/ImportTidasPackage/reportContent.ts",
@@ -88,14 +88,14 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4133,
+    "literalReferenceCount": 4138,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale de-DE --message <MESSAGE_ID>"
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "digest": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "76cdd16a44d8d73d710f0b5c3da4e02dade38f27402995f0d0c4f6ddbe1645b5",
+          "sha256": "9dcff21b8caea698f67dd0c899cf2b007d34bda442f00702967e09ca8fdc55dd",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "a2cd3077c993f0767ab41166d4f3997d830d9dd0e13b808f126d5240a9076096",
+      "sourceEvidenceDigest": "14f9bc3d2fd84b277b87e196b3d545f115edfbda0a6bdd6d502556e95011ac97",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "81cdf5260f0628c68834ad7480fcf22f0362b8d22d446806bc40a08393622d47",
+          "sourceDigest": "faec100f15f715c8b5683e2787dcb8533ac9cc8dd55e6d244f3c4cc138a84441",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "d4437736c255556fa6c1a335125b456d8ba89ecb5a0a9a4603cf6a253724c117",
+          "sourceDigest": "682631477c3b35bd011a997e724e95095641b47977c380ae76fe963dd68fad6b",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "0f64fed1ff2725b709b8b3e31f6d8af67336805bf2d5efdec932fb666c78f76c",
+          "sourceDigest": "4eddb7365c887a97b19bfcf1712b8a03f85b99f2f96cf2f5a1f71cb14ba45f51",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -367,7 +367,7 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "54fde5a5b291c98c7c8119ac5d565c3d547fdeca44b44dd5ada6833bcf70c4c2",
+          "sourceDigest": "3b059d1541b24fc98b97e61410447284a1c9edfb0d20bb56843346610ef2f2dc",
           "focusedTestDigest": "d847dd197b921ae4e91f7b23627490186c3c4fc51a15caa788684f61e1e26e68",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
@@ -1042,12 +1042,12 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "302ccc4ae35fa69d5b4a27ff2abcfa38db8218ecb49218ead4007f2a12e5f174",
-          "focusedTestDigest": "b13bc3461ea49d945a22b38ed816e8c5535f30e9188b367186ee9dadc31f0a11",
+          "sourceDigest": "32fe106473e04bf5f0cb7101c0e01258a74037dbe436b6168fd3cec645ad25ee",
+          "focusedTestDigest": "ac2a7911150bdf0d092b41037817f85caf3618c853dc4bec9f391fbc883e4a8d",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
-          "derivedMessageDigest": "f3f53e78726b3875411fb46e70f2c863dad1fe7cd30bc2a3337e9d040dd7ef16",
+          "derivedMessageDigest": "239595ff0d771df59ecbaec630c05cb2baaca2eba21b26c8e27dcd33491b4c5b",
           "stateSignals": ["empty", "error", "loading", "success", "unavailable"],
           "queryParameters": ["tid"],
           "navigationTargets": [
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "8c46fc18019f45c8f9fa5bbd9bd9562ef12260bc36c909752364048eb514949e",
+      "rowEvidenceDigest": "5a1a477972b0b0ca71d25f149ae0ac4f561dd1f9ffcd64486efe941ae5f881a4",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "docs/plans/i18n/route-view-coverage.json": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-de-DE/glossary.json": "a5fd4e759af2713fbec83f2b95171c7b32206d7218da0401d28d2eecefccce3a",
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "0e9e670c2fc8620837387415c3d06237bb485ea6da86afa454a4f3973ec0ea4e"
+  "contextDigest": "c984e30b8a2dff926bd8ad2c336c20ef80e7f27930af38b0848b46c67fd7c8d9"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "67d35a48d2e65424b8d5eb67c0f165080662c87c95a1610674791a05425af736",
-    "qualityDigest": "ce36fa4687fe29f7607b8d9614229deb7022d1363e4a0c582da4e42666c30ffe",
+    "contextDigest": "049cfbdf820e1112b9e8f79900280ea8904d33e586c498cc834b26304b07973b",
+    "qualityDigest": "b51f92287994924132da2749c0a994f507298e51ac2278d18ac922dfce55c33e",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
+    "routeViewCoverageDigest": "39d31311c22e08e6ba5f5b59cb82959e9ff5127cfaf497c4160a0317a22ed6ad",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "e476fdf95d44af1cce6292e44adbe22a6f6e465ab011942ca72e282adadaedb4"
+  "activationDigest": "379e4648ebf2193f6fa101be220ba999fd0ce65581bbf865adcbef10204f0f2e"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "4dbaff8f99ec34385c3d76bdfe68a5fc1590f481b84efd9dace708db4be7633b"
+    "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "0e9e670c2fc8620837387415c3d06237bb485ea6da86afa454a4f3973ec0ea4e",
-    "qualityDigest": "ea2ae1a2e0f81170f2fe1d048336594494f3eb7ad4d89bd0acbc358398db5aad",
+    "contextDigest": "c984e30b8a2dff926bd8ad2c336c20ef80e7f27930af38b0848b46c67fd7c8d9",
+    "qualityDigest": "91f1ec7dc597f3b2c7af360683eb1ba71c71777cb020e0c2965d1224ceae5fb8",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "routeViewCoverageDigest": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "47a675b4d35f37f374bcb3b90aa71d6ecc0bb10902920ec781bbeba3db810c4e"
+  "activationDigest": "840d5e3a915540ea00886be5db6b9eae1ffc941e00adfb43dd58a47d9b27b90b"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "c984e30b8a2dff926bd8ad2c336c20ef80e7f27930af38b0848b46c67fd7c8d9",
-    "qualityDigest": "91f1ec7dc597f3b2c7af360683eb1ba71c71777cb020e0c2965d1224ceae5fb8",
+    "contextDigest": "67d35a48d2e65424b8d5eb67c0f165080662c87c95a1610674791a05425af736",
+    "qualityDigest": "ce36fa4687fe29f7607b8d9614229deb7022d1363e4a0c582da4e42666c30ffe",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
+    "routeViewCoverageDigest": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "840d5e3a915540ea00886be5db6b9eae1ffc941e00adfb43dd58a47d9b27b90b"
+  "activationDigest": "e476fdf95d44af1cce6292e44adbe22a6f6e465ab011942ca72e282adadaedb4"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": "tiangong.i18n-manifest.v1",
   "source": {
-    "baseRef": "origin/dev",
-    "baseCommit": "2d50fb1e425750274d5a1e03c67980a87bfae26c",
+    "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
+    "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "auditedInputDigest": "9d886b4500d7cebd1365547d0439b6a508bcc25aabe085e7cc9ccd15a592f238",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296",
-    "contextDigest": "c984e30b8a2dff926bd8ad2c336c20ef80e7f27930af38b0848b46c67fd7c8d9"
+    "contextDigest": "67d35a48d2e65424b8d5eb67c0f165080662c87c95a1610674791a05425af736"
   },
   "catalog": {
     "messageCount": 3119,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "8d73793355f96bf12782bff7de72c7b459776163435a3e6cde46dd1a8aecb631",
-    "validationDigest": "d64bf5d9fbf1740d6d9d4a875a4e8ba83de76ccb03ca30911099546deb6fa6d1",
+    "digest": "4c3e6d603d21ddf7d2b9a77708fc4b517daa58142210b94513f904f8f10fd59a",
+    "validationDigest": "0a2a2a443d5f39c0e00591bbeec876f22657446fa8142e0eca5fa84c44515d3a",
     "laneCount": 1,
     "validatedMessageCount": 3119,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "91f1ec7dc597f3b2c7af360683eb1ba71c71777cb020e0c2965d1224ceae5fb8"
+  "qualityDigest": "ce36fa4687fe29f7607b8d9614229deb7022d1363e4a0c582da4e42666c30ffe"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296",
-    "contextDigest": "67d35a48d2e65424b8d5eb67c0f165080662c87c95a1610674791a05425af736"
+    "contextDigest": "049cfbdf820e1112b9e8f79900280ea8904d33e586c498cc834b26304b07973b"
   },
   "catalog": {
     "messageCount": 3119,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "ce36fa4687fe29f7607b8d9614229deb7022d1363e4a0c582da4e42666c30ffe"
+  "qualityDigest": "b51f92287994924132da2749c0a994f507298e51ac2278d18ac922dfce55c33e"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,12 +3,12 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "4dbaff8f99ec34385c3d76bdfe68a5fc1590f481b84efd9dace708db4be7633b",
-    "contextDigest": "0e9e670c2fc8620837387415c3d06237bb485ea6da86afa454a4f3973ec0ea4e"
+    "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296",
+    "contextDigest": "c984e30b8a2dff926bd8ad2c336c20ef80e7f27930af38b0848b46c67fd7c8d9"
   },
   "catalog": {
-    "messageCount": 3114,
-    "catalogDigest": "05d9ac48d37d0eafb48ec463e6b33e2be831295ef25d4afba5dfce8ff96ff832",
+    "messageCount": 3119,
+    "catalogDigest": "50e3a72dc8865ec46d5a8e3c607a4b762942de3886a7a46b90b124c5f93776a5",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
@@ -21,7 +21,7 @@
     "acceptedDeclaredSourceEqualityDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
     "forbiddenGlossaryMatchCount": 0,
     "forbiddenGlossaryMatchDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
-    "suspiciousSourceEqualityRatio": 0.01123956326268465,
+    "suspiciousSourceEqualityRatio": 0.01122154536710484,
     "maxSuspiciousSourceEqualityRatio": 0.02
   },
   "automatedChecks": {
@@ -41,16 +41,16 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "f30bf368b0011ddce55136b4e558b09f70fa0de0ddc64ef874de0576eaa79935",
-    "validationDigest": "494aee435c43337882b1030ffd0dd63d4aa5e501d42984f7c0b9d6318ae7876b",
+    "digest": "8d73793355f96bf12782bff7de72c7b459776163435a3e6cde46dd1a8aecb631",
+    "validationDigest": "d64bf5d9fbf1740d6d9d4a875a4e8ba83de76ccb03ca30911099546deb6fa6d1",
     "laneCount": 1,
-    "validatedMessageCount": 3114,
+    "validatedMessageCount": 3119,
     "validatedModuleCount": 31,
-    "highRiskMessageCount": 1390,
-    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
+    "highRiskMessageCount": 1391,
+    "highRiskMessageDigest": "803ebcc8320e7f5a792c522a7c5b69a4f24b672308a12b1feaeaa94b4df3aa5f",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635",
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "ea2ae1a2e0f81170f2fe1d048336594494f3eb7ad4d89bd0acbc358398db5aad"
+  "qualityDigest": "91f1ec7dc597f3b2c7af360683eb1ba71c71777cb020e0c2965d1224ceae5fb8"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "50e3a72dc8865ec46d5a8e3c607a4b762942de3886a7a46b90b124c5f93776a5",
     "dossierDigest": "63e35cf47082f64566dcd51b330db1e1a20119b1625712c0dadb063fe8d07210",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "5a1a477972b0b0ca71d25f149ae0ac4f561dd1f9ffcd64486efe941ae5f881a4",
+    "routeEvidenceDigest": "997a00ea7a96230491788656a5323ee3e0f8213690b70fc2a63333e7fc06c19f",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "d64bf5d9fbf1740d6d9d4a875a4e8ba83de76ccb03ca30911099546deb6fa6d1"
+  "validationDigest": "0a2a2a443d5f39c0e00591bbeec876f22657446fa8142e0eca5fa84c44515d3a"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "1657b2b1efa3385624a8ec837f40e2f0650b79ae2986865593fed797741d494f",
-    "validatedMessageCount": 3114,
+    "auditedInputDigest": "9d886b4500d7cebd1365547d0439b6a508bcc25aabe085e7cc9ccd15a592f238",
+    "validatedMessageCount": 3119,
     "validatedModules": [
       "$entry",
       "component",
@@ -38,12 +38,12 @@
       "settings",
       "validator"
     ],
-    "highRiskMessageCount": 1390,
-    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
-    "catalogDigest": "05d9ac48d37d0eafb48ec463e6b33e2be831295ef25d4afba5dfce8ff96ff832",
-    "dossierDigest": "06a7dbdba0db74f82cedbc8f776e66292b9cc6dc4af26ae8132fc8d886ea5a77",
+    "highRiskMessageCount": 1391,
+    "highRiskMessageDigest": "803ebcc8320e7f5a792c522a7c5b69a4f24b672308a12b1feaeaa94b4df3aa5f",
+    "catalogDigest": "50e3a72dc8865ec46d5a8e3c607a4b762942de3886a7a46b90b124c5f93776a5",
+    "dossierDigest": "63e35cf47082f64566dcd51b330db1e1a20119b1625712c0dadb063fe8d07210",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "8c46fc18019f45c8f9fa5bbd9bd9562ef12260bc36c909752364048eb514949e",
+    "routeEvidenceDigest": "5a1a477972b0b0ca71d25f149ae0ac4f561dd1f9ffcd64486efe941ae5f881a4",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -92,11 +92,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3114,
-        "messageDigest": "7e7b1cc9be2d7f7c8b74f069bddc34a36f242da8b1e5626f00a289473cc58ef2",
-        "highRiskMessageCount": 1390,
-        "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
-        "dossierDigest": "06a7dbdba0db74f82cedbc8f776e66292b9cc6dc4af26ae8132fc8d886ea5a77",
+        "messageCount": 3119,
+        "messageDigest": "a85893ebd5e961b8e5d716263510cfa5c38544c7dc8e0c106a070667d0906dab",
+        "highRiskMessageCount": 1391,
+        "highRiskMessageDigest": "803ebcc8320e7f5a792c522a7c5b69a4f24b672308a12b1feaeaa94b4df3aa5f",
+        "dossierDigest": "63e35cf47082f64566dcd51b330db1e1a20119b1625712c0dadb063fe8d07210",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "494aee435c43337882b1030ffd0dd63d4aa5e501d42984f7c0b9d6318ae7876b"
+  "validationDigest": "d64bf5d9fbf1740d6d9d4a875a4e8ba83de76ccb03ca30911099546deb6fa6d1"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
+    "digest": "39d31311c22e08e6ba5f5b59cb82959e9ff5127cfaf497c4160a0317a22ed6ad",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "11b27a2a3e20215b2e796519a0dbe3fd937940b4e88f4261d615780a4e3e824e",
+          "sha256": "abd50e20572034e698d43c1592d2ad3bc79242bd9ce50f566e923b2d7d0c4800",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
+    "docs/plans/i18n/route-view-coverage.json": "39d31311c22e08e6ba5f5b59cb82959e9ff5127cfaf497c4160a0317a22ed6ad",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-en-US/glossary.json": "4b8443ea3f91f15383683e9ece6221e40e24ceb75442ea830964b06c12559970",
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "024296b123940d3c84299bb1d1d4548bd30850a8b58d0afd506c156eac2c75df"
+  "contextDigest": "1b60c8958572280e2d75005fdae205c6dd0834ca5a9233b4daa89db9b454f951"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
+    "digest": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "9dcff21b8caea698f67dd0c899cf2b007d34bda442f00702967e09ca8fdc55dd",
+          "sha256": "11b27a2a3e20215b2e796519a0dbe3fd937940b4e88f4261d615780a4e3e824e",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1043,7 +1043,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "32fe106473e04bf5f0cb7101c0e01258a74037dbe436b6168fd3cec645ad25ee",
-          "focusedTestDigest": "ac2a7911150bdf0d092b41037817f85caf3618c853dc4bec9f391fbc883e4a8d",
+          "focusedTestDigest": "fc41b8aa33910cdfc8bd350b7fa66d037e9f4fa5c0073b2ff5856044aa2974ac",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "5a1a477972b0b0ca71d25f149ae0ac4f561dd1f9ffcd64486efe941ae5f881a4",
+      "rowEvidenceDigest": "997a00ea7a96230491788656a5323ee3e0f8213690b70fc2a63333e7fc06c19f",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
+    "docs/plans/i18n/route-view-coverage.json": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-en-US/glossary.json": "4b8443ea3f91f15383683e9ece6221e40e24ceb75442ea830964b06c12559970",
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "72568041eec7577f4cd94ebddf4ca2e941cfcc83d136fd601b21e94c514817ff"
+  "contextDigest": "024296b123940d3c84299bb1d1d4548bd30850a8b58d0afd506c156eac2c75df"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "4dbaff8f99ec34385c3d76bdfe68a5fc1590f481b84efd9dace708db4be7633b",
-    "auditedInputDigest": "1657b2b1efa3385624a8ec837f40e2f0650b79ae2986865593fed797741d494f"
+    "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296",
+    "auditedInputDigest": "9d886b4500d7cebd1365547d0439b6a508bcc25aabe085e7cc9ccd15a592f238"
   },
   "inventory": {
-    "sourceMessageCount": 3114,
-    "localeMessageCount": 3114,
+    "sourceMessageCount": 3119,
+    "localeMessageCount": 3119,
     "leafModuleCount": 30,
     "dynamicFamilyCount": 17,
     "dynamicCallsiteCount": 39,
@@ -44,18 +44,18 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3114,
-    "completeCount": 3114,
+    "messageCount": 3119,
+    "completeCount": 3119,
     "blockedCount": 0,
-    "dossierDigest": "89f239cc6278c116368b1436aebcf40fcb81850cd75da12382421f161cd918b9",
-    "catalogDigest": "aa8b61be8b056c7640170905371ff7564d95a4b3c11b2dd6dfbb0c43faf71a29",
+    "dossierDigest": "820795a5444230a1625bb89e83d858f6445dd613d7a7ce2fc74d7db9b3e9e5d3",
+    "catalogDigest": "ab1d1262388c2a5376f03d52cf7c376dccb0b9b8d3bb1f927c140e95b1002454",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
     "roleCounts": {
       "error-or-validation": 363,
       "explanatory-copy": 110,
       "field-guidance": 49,
-      "label-or-body-copy": 1255,
+      "label-or-body-copy": 1260,
       "navigation-or-tab": 226,
       "reserved-catalog-copy": 277,
       "status-or-empty-state": 100,
@@ -69,11 +69,11 @@
       "interactive-ready": 522,
       "retained-not-currently-reachable": 357,
       "successful-completion": 182,
-      "visible": 1643
+      "visible": 1648
     },
-    "riskCounts": { "high": 1390, "low": 1523, "medium": 201 },
-    "highRiskMessageCount": 1390,
-    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0"
+    "riskCounts": { "high": 1391, "low": 1527, "medium": 201 },
+    "highRiskMessageCount": 1391,
+    "highRiskMessageDigest": "803ebcc8320e7f5a792c522a7c5b69a4f24b672308a12b1feaeaa94b4df3aa5f"
   },
   "typedContentDossiers": {
     "sourcePath": "src/components/ImportTidasPackage/reportContent.ts",
@@ -88,14 +88,14 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4133,
+    "literalReferenceCount": 4138,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale en-US --message <MESSAGE_ID>"
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "digest": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "76cdd16a44d8d73d710f0b5c3da4e02dade38f27402995f0d0c4f6ddbe1645b5",
+          "sha256": "9dcff21b8caea698f67dd0c899cf2b007d34bda442f00702967e09ca8fdc55dd",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "a2cd3077c993f0767ab41166d4f3997d830d9dd0e13b808f126d5240a9076096",
+      "sourceEvidenceDigest": "14f9bc3d2fd84b277b87e196b3d545f115edfbda0a6bdd6d502556e95011ac97",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "81cdf5260f0628c68834ad7480fcf22f0362b8d22d446806bc40a08393622d47",
+          "sourceDigest": "faec100f15f715c8b5683e2787dcb8533ac9cc8dd55e6d244f3c4cc138a84441",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "d4437736c255556fa6c1a335125b456d8ba89ecb5a0a9a4603cf6a253724c117",
+          "sourceDigest": "682631477c3b35bd011a997e724e95095641b47977c380ae76fe963dd68fad6b",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "0f64fed1ff2725b709b8b3e31f6d8af67336805bf2d5efdec932fb666c78f76c",
+          "sourceDigest": "4eddb7365c887a97b19bfcf1712b8a03f85b99f2f96cf2f5a1f71cb14ba45f51",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -367,7 +367,7 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "54fde5a5b291c98c7c8119ac5d565c3d547fdeca44b44dd5ada6833bcf70c4c2",
+          "sourceDigest": "3b059d1541b24fc98b97e61410447284a1c9edfb0d20bb56843346610ef2f2dc",
           "focusedTestDigest": "d847dd197b921ae4e91f7b23627490186c3c4fc51a15caa788684f61e1e26e68",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
@@ -1042,12 +1042,12 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "302ccc4ae35fa69d5b4a27ff2abcfa38db8218ecb49218ead4007f2a12e5f174",
-          "focusedTestDigest": "b13bc3461ea49d945a22b38ed816e8c5535f30e9188b367186ee9dadc31f0a11",
+          "sourceDigest": "32fe106473e04bf5f0cb7101c0e01258a74037dbe436b6168fd3cec645ad25ee",
+          "focusedTestDigest": "ac2a7911150bdf0d092b41037817f85caf3618c853dc4bec9f391fbc883e4a8d",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
-          "derivedMessageDigest": "f3f53e78726b3875411fb46e70f2c863dad1fe7cd30bc2a3337e9d040dd7ef16",
+          "derivedMessageDigest": "239595ff0d771df59ecbaec630c05cb2baaca2eba21b26c8e27dcd33491b4c5b",
           "stateSignals": ["empty", "error", "loading", "success", "unavailable"],
           "queryParameters": ["tid"],
           "navigationTargets": [
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "8c46fc18019f45c8f9fa5bbd9bd9562ef12260bc36c909752364048eb514949e",
+      "rowEvidenceDigest": "5a1a477972b0b0ca71d25f149ae0ac4f561dd1f9ffcd64486efe941ae5f881a4",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "docs/plans/i18n/route-view-coverage.json": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-en-US/glossary.json": "4b8443ea3f91f15383683e9ece6221e40e24ceb75442ea830964b06c12559970",
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "92290ee415bf1cc14b16a2878f7286363bb509c4ab6c16999d8b426d061dfed7"
+  "contextDigest": "72568041eec7577f4cd94ebddf4ca2e941cfcc83d136fd601b21e94c514817ff"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "024296b123940d3c84299bb1d1d4548bd30850a8b58d0afd506c156eac2c75df",
-    "qualityDigest": "53ca2a3cdf44fe7f16d87a966415b21f32c411fb07bde6c0760348fc0a7f3023",
+    "contextDigest": "1b60c8958572280e2d75005fdae205c6dd0834ca5a9233b4daa89db9b454f951",
+    "qualityDigest": "5ae0c0e4c2c68c4034cc8b924582bfd117e7de90a6c892e034b642fcaaf3f683",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
+    "routeViewCoverageDigest": "39d31311c22e08e6ba5f5b59cb82959e9ff5127cfaf497c4160a0317a22ed6ad",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "93dc5d6b585634de729729cfbcc09ffb6139f5e52b3674f5116a0a3f058d93c1"
+  "activationDigest": "696a97c6bfd6173b5492746d3f5550bb90c36c9f806c00b3ba7d2310b13e315b"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "4dbaff8f99ec34385c3d76bdfe68a5fc1590f481b84efd9dace708db4be7633b"
+    "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "92290ee415bf1cc14b16a2878f7286363bb509c4ab6c16999d8b426d061dfed7",
-    "qualityDigest": "c55deac7fa2ea84abc77e4be9fd9b0bb12151dc0b26cfaa5380862c3a441e4cd",
+    "contextDigest": "72568041eec7577f4cd94ebddf4ca2e941cfcc83d136fd601b21e94c514817ff",
+    "qualityDigest": "87dd02578ce4170624d6a516927ca065f6aaf7b2c3775a654d81ae54fc3eb4f2",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "routeViewCoverageDigest": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "2db9b4b9b2c2b2cda0095a7ebdda8538a1ce4a347909ef3c7d16997c05e12871"
+  "activationDigest": "8e26ab3fda632623e95fd7d12655cf8fb3c02740f7eb6eddb1ecd6931977d3c0"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "72568041eec7577f4cd94ebddf4ca2e941cfcc83d136fd601b21e94c514817ff",
-    "qualityDigest": "87dd02578ce4170624d6a516927ca065f6aaf7b2c3775a654d81ae54fc3eb4f2",
+    "contextDigest": "024296b123940d3c84299bb1d1d4548bd30850a8b58d0afd506c156eac2c75df",
+    "qualityDigest": "53ca2a3cdf44fe7f16d87a966415b21f32c411fb07bde6c0760348fc0a7f3023",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
+    "routeViewCoverageDigest": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "8e26ab3fda632623e95fd7d12655cf8fb3c02740f7eb6eddb1ecd6931977d3c0"
+  "activationDigest": "93dc5d6b585634de729729cfbcc09ffb6139f5e52b3674f5116a0a3f058d93c1"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,25 +3,25 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "4dbaff8f99ec34385c3d76bdfe68a5fc1590f481b84efd9dace708db4be7633b",
-    "contextDigest": "92290ee415bf1cc14b16a2878f7286363bb509c4ab6c16999d8b426d061dfed7"
+    "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296",
+    "contextDigest": "72568041eec7577f4cd94ebddf4ca2e941cfcc83d136fd601b21e94c514817ff"
   },
   "catalog": {
-    "messageCount": 3114,
-    "catalogDigest": "aa8b61be8b056c7640170905371ff7564d95a4b3c11b2dd6dfbb0c43faf71a29",
+    "messageCount": 3119,
+    "catalogDigest": "ab1d1262388c2a5376f03d52cf7c376dccb0b9b8d3bb1f927c140e95b1002454",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
     "cjkLeakCount": 0,
-    "suspiciousSourceEqualityCount": 3036,
-    "suspiciousSourceEqualityDigest": "c8c8ce3199775178ecb508e500154d3d28445e1070af7ecade31a6be036bd4a7",
+    "suspiciousSourceEqualityCount": 3041,
+    "suspiciousSourceEqualityDigest": "f1fb93c7911ce9439c28b8e2ed7b2efbe55e1634064931b59231d88c3f72b6bf",
     "acceptedTechnicalSourceEqualityCount": 77,
     "acceptedTechnicalSourceEqualityDigest": "2c498f32e45a368d8f4ddb6987df879250152a55da7babd4f4dbeb717b3d0583",
     "acceptedDeclaredSourceEqualityCount": 0,
     "acceptedDeclaredSourceEqualityDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
     "forbiddenGlossaryMatchCount": 0,
     "forbiddenGlossaryMatchDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
-    "suspiciousSourceEqualityRatio": 0.9749518304431599,
+    "suspiciousSourceEqualityRatio": 0.9749919846104521,
     "maxSuspiciousSourceEqualityRatio": 1
   },
   "automatedChecks": {
@@ -41,16 +41,16 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "3121dc5f569a60114f029c6009c82eecc0bf9eb59c4282661f80443b410ae224",
-    "validationDigest": "f074e3910cf5e9d2d79793f3b3f6432510d724f370c9fef798d1cb220704f52c",
+    "digest": "a1880851c161deed1fa4f6a66c2aca305776876a1b3ef6fa1d05b61acf0a331d",
+    "validationDigest": "24934cb3ecab37717b193a7339d69c8b815d3ef276c3f26a2563152b802c0ef5",
     "laneCount": 1,
-    "validatedMessageCount": 3114,
+    "validatedMessageCount": 3119,
     "validatedModuleCount": 31,
-    "highRiskMessageCount": 1390,
-    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
+    "highRiskMessageCount": 1391,
+    "highRiskMessageDigest": "803ebcc8320e7f5a792c522a7c5b69a4f24b672308a12b1feaeaa94b4df3aa5f",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635",
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "c55deac7fa2ea84abc77e4be9fd9b0bb12151dc0b26cfaa5380862c3a441e4cd"
+  "qualityDigest": "87dd02578ce4170624d6a516927ca065f6aaf7b2c3775a654d81ae54fc3eb4f2"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296",
-    "contextDigest": "72568041eec7577f4cd94ebddf4ca2e941cfcc83d136fd601b21e94c514817ff"
+    "contextDigest": "024296b123940d3c84299bb1d1d4548bd30850a8b58d0afd506c156eac2c75df"
   },
   "catalog": {
     "messageCount": 3119,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "a1880851c161deed1fa4f6a66c2aca305776876a1b3ef6fa1d05b61acf0a331d",
-    "validationDigest": "24934cb3ecab37717b193a7339d69c8b815d3ef276c3f26a2563152b802c0ef5",
+    "digest": "0a129fa4ec0e82397473154847e1d565e17edb2271c05ed4262867519f763c20",
+    "validationDigest": "b12e84caeda42a1fe7965abcb716894e49d48556d603c156ea69a49c56fb77fc",
     "laneCount": 1,
     "validatedMessageCount": 3119,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "87dd02578ce4170624d6a516927ca065f6aaf7b2c3775a654d81ae54fc3eb4f2"
+  "qualityDigest": "53ca2a3cdf44fe7f16d87a966415b21f32c411fb07bde6c0760348fc0a7f3023"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296",
-    "contextDigest": "024296b123940d3c84299bb1d1d4548bd30850a8b58d0afd506c156eac2c75df"
+    "contextDigest": "1b60c8958572280e2d75005fdae205c6dd0834ca5a9233b4daa89db9b454f951"
   },
   "catalog": {
     "messageCount": 3119,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "53ca2a3cdf44fe7f16d87a966415b21f32c411fb07bde6c0760348fc0a7f3023"
+  "qualityDigest": "5ae0c0e4c2c68c4034cc8b924582bfd117e7de90a6c892e034b642fcaaf3f683"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "ab1d1262388c2a5376f03d52cf7c376dccb0b9b8d3bb1f927c140e95b1002454",
     "dossierDigest": "820795a5444230a1625bb89e83d858f6445dd613d7a7ce2fc74d7db9b3e9e5d3",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "5a1a477972b0b0ca71d25f149ae0ac4f561dd1f9ffcd64486efe941ae5f881a4",
+    "routeEvidenceDigest": "997a00ea7a96230491788656a5323ee3e0f8213690b70fc2a63333e7fc06c19f",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "24934cb3ecab37717b193a7339d69c8b815d3ef276c3f26a2563152b802c0ef5"
+  "validationDigest": "b12e84caeda42a1fe7965abcb716894e49d48556d603c156ea69a49c56fb77fc"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "1657b2b1efa3385624a8ec837f40e2f0650b79ae2986865593fed797741d494f",
-    "validatedMessageCount": 3114,
+    "auditedInputDigest": "9d886b4500d7cebd1365547d0439b6a508bcc25aabe085e7cc9ccd15a592f238",
+    "validatedMessageCount": 3119,
     "validatedModules": [
       "$entry",
       "component",
@@ -38,12 +38,12 @@
       "settings",
       "validator"
     ],
-    "highRiskMessageCount": 1390,
-    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
-    "catalogDigest": "aa8b61be8b056c7640170905371ff7564d95a4b3c11b2dd6dfbb0c43faf71a29",
-    "dossierDigest": "89f239cc6278c116368b1436aebcf40fcb81850cd75da12382421f161cd918b9",
+    "highRiskMessageCount": 1391,
+    "highRiskMessageDigest": "803ebcc8320e7f5a792c522a7c5b69a4f24b672308a12b1feaeaa94b4df3aa5f",
+    "catalogDigest": "ab1d1262388c2a5376f03d52cf7c376dccb0b9b8d3bb1f927c140e95b1002454",
+    "dossierDigest": "820795a5444230a1625bb89e83d858f6445dd613d7a7ce2fc74d7db9b3e9e5d3",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "8c46fc18019f45c8f9fa5bbd9bd9562ef12260bc36c909752364048eb514949e",
+    "routeEvidenceDigest": "5a1a477972b0b0ca71d25f149ae0ac4f561dd1f9ffcd64486efe941ae5f881a4",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -92,11 +92,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3114,
-        "messageDigest": "7e7b1cc9be2d7f7c8b74f069bddc34a36f242da8b1e5626f00a289473cc58ef2",
-        "highRiskMessageCount": 1390,
-        "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
-        "dossierDigest": "89f239cc6278c116368b1436aebcf40fcb81850cd75da12382421f161cd918b9",
+        "messageCount": 3119,
+        "messageDigest": "a85893ebd5e961b8e5d716263510cfa5c38544c7dc8e0c106a070667d0906dab",
+        "highRiskMessageCount": 1391,
+        "highRiskMessageDigest": "803ebcc8320e7f5a792c522a7c5b69a4f24b672308a12b1feaeaa94b4df3aa5f",
+        "dossierDigest": "820795a5444230a1625bb89e83d858f6445dd613d7a7ce2fc74d7db9b3e9e5d3",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "f074e3910cf5e9d2d79793f3b3f6432510d724f370c9fef798d1cb220704f52c"
+  "validationDigest": "24934cb3ecab37717b193a7339d69c8b815d3ef276c3f26a2563152b802c0ef5"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
+    "digest": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "9dcff21b8caea698f67dd0c899cf2b007d34bda442f00702967e09ca8fdc55dd",
+          "sha256": "11b27a2a3e20215b2e796519a0dbe3fd937940b4e88f4261d615780a4e3e824e",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1043,7 +1043,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "32fe106473e04bf5f0cb7101c0e01258a74037dbe436b6168fd3cec645ad25ee",
-          "focusedTestDigest": "ac2a7911150bdf0d092b41037817f85caf3618c853dc4bec9f391fbc883e4a8d",
+          "focusedTestDigest": "fc41b8aa33910cdfc8bd350b7fa66d037e9f4fa5c0073b2ff5856044aa2974ac",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "5a1a477972b0b0ca71d25f149ae0ac4f561dd1f9ffcd64486efe941ae5f881a4",
+      "rowEvidenceDigest": "997a00ea7a96230491788656a5323ee3e0f8213690b70fc2a63333e7fc06c19f",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
+    "docs/plans/i18n/route-view-coverage.json": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-fr-FR/glossary.json": "057cb494f02d980106469f6a16befc102d26db5ac362b9777cd5f97c7729c91b",
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "f3b3903f89d22e472d65da4fc999eb1d80e9a47a71afedfe3845d2e0cd8350e2"
+  "contextDigest": "d079a3cd55574a34c853d7e6f0ec3c25c87927a10c093914acfb88f170c5a5e3"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "4dbaff8f99ec34385c3d76bdfe68a5fc1590f481b84efd9dace708db4be7633b",
-    "auditedInputDigest": "1657b2b1efa3385624a8ec837f40e2f0650b79ae2986865593fed797741d494f"
+    "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296",
+    "auditedInputDigest": "9d886b4500d7cebd1365547d0439b6a508bcc25aabe085e7cc9ccd15a592f238"
   },
   "inventory": {
-    "sourceMessageCount": 3114,
-    "localeMessageCount": 3114,
+    "sourceMessageCount": 3119,
+    "localeMessageCount": 3119,
     "leafModuleCount": 30,
     "dynamicFamilyCount": 17,
     "dynamicCallsiteCount": 39,
@@ -44,18 +44,18 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3114,
-    "completeCount": 3114,
+    "messageCount": 3119,
+    "completeCount": 3119,
     "blockedCount": 0,
-    "dossierDigest": "ae762548ef0aa4eb4ce5f43d320e141dd6a2f63e4938f3242adee10476dd7191",
-    "catalogDigest": "e9ab3d4f080335169cdc43db7cf7fb93ba04129e9a94b7c30aa4548f725218d2",
+    "dossierDigest": "db42f0c63951b04acc5c4f76e5abd1b690d40bb5c740b77f23ec079c2861dbf7",
+    "catalogDigest": "863ec5951debb9d5343d30fe702dfd57f2c452a60bf7a635cf18dcdeb262d9d8",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
     "roleCounts": {
       "error-or-validation": 363,
       "explanatory-copy": 110,
       "field-guidance": 49,
-      "label-or-body-copy": 1255,
+      "label-or-body-copy": 1260,
       "navigation-or-tab": 226,
       "reserved-catalog-copy": 277,
       "status-or-empty-state": 100,
@@ -69,11 +69,11 @@
       "interactive-ready": 522,
       "retained-not-currently-reachable": 357,
       "successful-completion": 182,
-      "visible": 1643
+      "visible": 1648
     },
-    "riskCounts": { "high": 1390, "low": 1501, "medium": 223 },
-    "highRiskMessageCount": 1390,
-    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0"
+    "riskCounts": { "high": 1391, "low": 1505, "medium": 223 },
+    "highRiskMessageCount": 1391,
+    "highRiskMessageDigest": "803ebcc8320e7f5a792c522a7c5b69a4f24b672308a12b1feaeaa94b4df3aa5f"
   },
   "typedContentDossiers": {
     "sourcePath": "src/components/ImportTidasPackage/reportContent.ts",
@@ -88,14 +88,14 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4133,
+    "literalReferenceCount": 4138,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale fr-FR --message <MESSAGE_ID>"
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "digest": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "76cdd16a44d8d73d710f0b5c3da4e02dade38f27402995f0d0c4f6ddbe1645b5",
+          "sha256": "9dcff21b8caea698f67dd0c899cf2b007d34bda442f00702967e09ca8fdc55dd",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "a2cd3077c993f0767ab41166d4f3997d830d9dd0e13b808f126d5240a9076096",
+      "sourceEvidenceDigest": "14f9bc3d2fd84b277b87e196b3d545f115edfbda0a6bdd6d502556e95011ac97",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "81cdf5260f0628c68834ad7480fcf22f0362b8d22d446806bc40a08393622d47",
+          "sourceDigest": "faec100f15f715c8b5683e2787dcb8533ac9cc8dd55e6d244f3c4cc138a84441",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "d4437736c255556fa6c1a335125b456d8ba89ecb5a0a9a4603cf6a253724c117",
+          "sourceDigest": "682631477c3b35bd011a997e724e95095641b47977c380ae76fe963dd68fad6b",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "0f64fed1ff2725b709b8b3e31f6d8af67336805bf2d5efdec932fb666c78f76c",
+          "sourceDigest": "4eddb7365c887a97b19bfcf1712b8a03f85b99f2f96cf2f5a1f71cb14ba45f51",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -367,7 +367,7 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "54fde5a5b291c98c7c8119ac5d565c3d547fdeca44b44dd5ada6833bcf70c4c2",
+          "sourceDigest": "3b059d1541b24fc98b97e61410447284a1c9edfb0d20bb56843346610ef2f2dc",
           "focusedTestDigest": "d847dd197b921ae4e91f7b23627490186c3c4fc51a15caa788684f61e1e26e68",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
@@ -1042,12 +1042,12 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "302ccc4ae35fa69d5b4a27ff2abcfa38db8218ecb49218ead4007f2a12e5f174",
-          "focusedTestDigest": "b13bc3461ea49d945a22b38ed816e8c5535f30e9188b367186ee9dadc31f0a11",
+          "sourceDigest": "32fe106473e04bf5f0cb7101c0e01258a74037dbe436b6168fd3cec645ad25ee",
+          "focusedTestDigest": "ac2a7911150bdf0d092b41037817f85caf3618c853dc4bec9f391fbc883e4a8d",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
-          "derivedMessageDigest": "f3f53e78726b3875411fb46e70f2c863dad1fe7cd30bc2a3337e9d040dd7ef16",
+          "derivedMessageDigest": "239595ff0d771df59ecbaec630c05cb2baaca2eba21b26c8e27dcd33491b4c5b",
           "stateSignals": ["empty", "error", "loading", "success", "unavailable"],
           "queryParameters": ["tid"],
           "navigationTargets": [
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "8c46fc18019f45c8f9fa5bbd9bd9562ef12260bc36c909752364048eb514949e",
+      "rowEvidenceDigest": "5a1a477972b0b0ca71d25f149ae0ac4f561dd1f9ffcd64486efe941ae5f881a4",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "docs/plans/i18n/route-view-coverage.json": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-fr-FR/glossary.json": "057cb494f02d980106469f6a16befc102d26db5ac362b9777cd5f97c7729c91b",
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "14f09fd13cd0a82e19a667f2efbc2ee807a0c510084a41df8bd6bd625974e8d1"
+  "contextDigest": "f3b3903f89d22e472d65da4fc999eb1d80e9a47a71afedfe3845d2e0cd8350e2"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
+    "digest": "39d31311c22e08e6ba5f5b59cb82959e9ff5127cfaf497c4160a0317a22ed6ad",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "11b27a2a3e20215b2e796519a0dbe3fd937940b4e88f4261d615780a4e3e824e",
+          "sha256": "abd50e20572034e698d43c1592d2ad3bc79242bd9ce50f566e923b2d7d0c4800",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
+    "docs/plans/i18n/route-view-coverage.json": "39d31311c22e08e6ba5f5b59cb82959e9ff5127cfaf497c4160a0317a22ed6ad",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-fr-FR/glossary.json": "057cb494f02d980106469f6a16befc102d26db5ac362b9777cd5f97c7729c91b",
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "d079a3cd55574a34c853d7e6f0ec3c25c87927a10c093914acfb88f170c5a5e3"
+  "contextDigest": "19fe05c03cc0edd3506c9db1ed1d0bf7d9717df3330213a8f0c20b7bfd2bb786"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "4dbaff8f99ec34385c3d76bdfe68a5fc1590f481b84efd9dace708db4be7633b"
+    "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "14f09fd13cd0a82e19a667f2efbc2ee807a0c510084a41df8bd6bd625974e8d1",
-    "qualityDigest": "c5d2cf3c16864d991419fd673da8f06896422fac68c8338377581451ad1a25cc",
+    "contextDigest": "f3b3903f89d22e472d65da4fc999eb1d80e9a47a71afedfe3845d2e0cd8350e2",
+    "qualityDigest": "b8e8e93857c75e5228f7e0f08b9480fe47d9b077c953ceae08b945d97e07c583",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "routeViewCoverageDigest": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "bb47e7d58fd6259a1477e9d5dccf6d00c3e15a9a270513c17cba35eaafcc9d51"
+  "activationDigest": "7e74ba5b5a79c32a8da9f218c0096eaa081f49b2d0e93351bbea74df197d9085"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "d079a3cd55574a34c853d7e6f0ec3c25c87927a10c093914acfb88f170c5a5e3",
-    "qualityDigest": "82fad8415aa79ce9e537e6751e74b130580f93ecb7cfa2be14ecc078c6511167",
+    "contextDigest": "19fe05c03cc0edd3506c9db1ed1d0bf7d9717df3330213a8f0c20b7bfd2bb786",
+    "qualityDigest": "18b85552e67502fa2b05a6b228a3f3b2f7ed2d9f9e7b9a29c161e9b19786476f",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
+    "routeViewCoverageDigest": "39d31311c22e08e6ba5f5b59cb82959e9ff5127cfaf497c4160a0317a22ed6ad",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "8debd9590eee2fdc8c912044d38312e8fddfea5a7fd1eded6ddb5bdd105e2918"
+  "activationDigest": "f03c3737eef35135c67ab2a704a5a847c3d5633937a16b4497a2a3f1695af5fb"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "f3b3903f89d22e472d65da4fc999eb1d80e9a47a71afedfe3845d2e0cd8350e2",
-    "qualityDigest": "b8e8e93857c75e5228f7e0f08b9480fe47d9b077c953ceae08b945d97e07c583",
+    "contextDigest": "d079a3cd55574a34c853d7e6f0ec3c25c87927a10c093914acfb88f170c5a5e3",
+    "qualityDigest": "82fad8415aa79ce9e537e6751e74b130580f93ecb7cfa2be14ecc078c6511167",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
+    "routeViewCoverageDigest": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "7e74ba5b5a79c32a8da9f218c0096eaa081f49b2d0e93351bbea74df197d9085"
+  "activationDigest": "8debd9590eee2fdc8c912044d38312e8fddfea5a7fd1eded6ddb5bdd105e2918"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296",
-    "contextDigest": "f3b3903f89d22e472d65da4fc999eb1d80e9a47a71afedfe3845d2e0cd8350e2"
+    "contextDigest": "d079a3cd55574a34c853d7e6f0ec3c25c87927a10c093914acfb88f170c5a5e3"
   },
   "catalog": {
     "messageCount": 3119,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "155cc327d86e7b41c8150ff93dc27e83832631d6c4d7ac5b61d5f2afe0f870a9",
-    "validationDigest": "13fa62bc398763dcb8e322b2a24715af2d45b0bc6a64eeb4399567126161b213",
+    "digest": "ffccd7ee768858097dfe23a279ee2debe74ab2daf38f674e2c229560b0ff2f01",
+    "validationDigest": "5dddf81d518d1b400c0b10440f016b8b21ea6e1f9613aded1302633ba62372af",
     "laneCount": 1,
     "validatedMessageCount": 3119,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "b8e8e93857c75e5228f7e0f08b9480fe47d9b077c953ceae08b945d97e07c583"
+  "qualityDigest": "82fad8415aa79ce9e537e6751e74b130580f93ecb7cfa2be14ecc078c6511167"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296",
-    "contextDigest": "d079a3cd55574a34c853d7e6f0ec3c25c87927a10c093914acfb88f170c5a5e3"
+    "contextDigest": "19fe05c03cc0edd3506c9db1ed1d0bf7d9717df3330213a8f0c20b7bfd2bb786"
   },
   "catalog": {
     "messageCount": 3119,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "82fad8415aa79ce9e537e6751e74b130580f93ecb7cfa2be14ecc078c6511167"
+  "qualityDigest": "18b85552e67502fa2b05a6b228a3f3b2f7ed2d9f9e7b9a29c161e9b19786476f"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,12 +3,12 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "4dbaff8f99ec34385c3d76bdfe68a5fc1590f481b84efd9dace708db4be7633b",
-    "contextDigest": "14f09fd13cd0a82e19a667f2efbc2ee807a0c510084a41df8bd6bd625974e8d1"
+    "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296",
+    "contextDigest": "f3b3903f89d22e472d65da4fc999eb1d80e9a47a71afedfe3845d2e0cd8350e2"
   },
   "catalog": {
-    "messageCount": 3114,
-    "catalogDigest": "e9ab3d4f080335169cdc43db7cf7fb93ba04129e9a94b7c30aa4548f725218d2",
+    "messageCount": 3119,
+    "catalogDigest": "863ec5951debb9d5343d30fe702dfd57f2c452a60bf7a635cf18dcdeb262d9d8",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
@@ -41,16 +41,16 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "4bb230ef93806d913e40b2e0ae72eddf9b7d35314b043c08a270c17e60b40f76",
-    "validationDigest": "7ae3d7f73c349e3f56c37a7b51e3aa056301450b0ee2bb4f58ec691537ef26b2",
+    "digest": "155cc327d86e7b41c8150ff93dc27e83832631d6c4d7ac5b61d5f2afe0f870a9",
+    "validationDigest": "13fa62bc398763dcb8e322b2a24715af2d45b0bc6a64eeb4399567126161b213",
     "laneCount": 1,
-    "validatedMessageCount": 3114,
+    "validatedMessageCount": 3119,
     "validatedModuleCount": 31,
-    "highRiskMessageCount": 1390,
-    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
+    "highRiskMessageCount": 1391,
+    "highRiskMessageDigest": "803ebcc8320e7f5a792c522a7c5b69a4f24b672308a12b1feaeaa94b4df3aa5f",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635",
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "c5d2cf3c16864d991419fd673da8f06896422fac68c8338377581451ad1a25cc"
+  "qualityDigest": "b8e8e93857c75e5228f7e0f08b9480fe47d9b077c953ceae08b945d97e07c583"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "863ec5951debb9d5343d30fe702dfd57f2c452a60bf7a635cf18dcdeb262d9d8",
     "dossierDigest": "db42f0c63951b04acc5c4f76e5abd1b690d40bb5c740b77f23ec079c2861dbf7",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "5a1a477972b0b0ca71d25f149ae0ac4f561dd1f9ffcd64486efe941ae5f881a4",
+    "routeEvidenceDigest": "997a00ea7a96230491788656a5323ee3e0f8213690b70fc2a63333e7fc06c19f",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "13fa62bc398763dcb8e322b2a24715af2d45b0bc6a64eeb4399567126161b213"
+  "validationDigest": "5dddf81d518d1b400c0b10440f016b8b21ea6e1f9613aded1302633ba62372af"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "1657b2b1efa3385624a8ec837f40e2f0650b79ae2986865593fed797741d494f",
-    "validatedMessageCount": 3114,
+    "auditedInputDigest": "9d886b4500d7cebd1365547d0439b6a508bcc25aabe085e7cc9ccd15a592f238",
+    "validatedMessageCount": 3119,
     "validatedModules": [
       "$entry",
       "component",
@@ -38,12 +38,12 @@
       "settings",
       "validator"
     ],
-    "highRiskMessageCount": 1390,
-    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
-    "catalogDigest": "e9ab3d4f080335169cdc43db7cf7fb93ba04129e9a94b7c30aa4548f725218d2",
-    "dossierDigest": "ae762548ef0aa4eb4ce5f43d320e141dd6a2f63e4938f3242adee10476dd7191",
+    "highRiskMessageCount": 1391,
+    "highRiskMessageDigest": "803ebcc8320e7f5a792c522a7c5b69a4f24b672308a12b1feaeaa94b4df3aa5f",
+    "catalogDigest": "863ec5951debb9d5343d30fe702dfd57f2c452a60bf7a635cf18dcdeb262d9d8",
+    "dossierDigest": "db42f0c63951b04acc5c4f76e5abd1b690d40bb5c740b77f23ec079c2861dbf7",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "8c46fc18019f45c8f9fa5bbd9bd9562ef12260bc36c909752364048eb514949e",
+    "routeEvidenceDigest": "5a1a477972b0b0ca71d25f149ae0ac4f561dd1f9ffcd64486efe941ae5f881a4",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -92,11 +92,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3114,
-        "messageDigest": "7e7b1cc9be2d7f7c8b74f069bddc34a36f242da8b1e5626f00a289473cc58ef2",
-        "highRiskMessageCount": 1390,
-        "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
-        "dossierDigest": "ae762548ef0aa4eb4ce5f43d320e141dd6a2f63e4938f3242adee10476dd7191",
+        "messageCount": 3119,
+        "messageDigest": "a85893ebd5e961b8e5d716263510cfa5c38544c7dc8e0c106a070667d0906dab",
+        "highRiskMessageCount": 1391,
+        "highRiskMessageDigest": "803ebcc8320e7f5a792c522a7c5b69a4f24b672308a12b1feaeaa94b4df3aa5f",
+        "dossierDigest": "db42f0c63951b04acc5c4f76e5abd1b690d40bb5c740b77f23ec079c2861dbf7",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "7ae3d7f73c349e3f56c37a7b51e3aa056301450b0ee2bb4f58ec691537ef26b2"
+  "validationDigest": "13fa62bc398763dcb8e322b2a24715af2d45b0bc6a64eeb4399567126161b213"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "4dbaff8f99ec34385c3d76bdfe68a5fc1590f481b84efd9dace708db4be7633b",
-    "auditedInputDigest": "1657b2b1efa3385624a8ec837f40e2f0650b79ae2986865593fed797741d494f"
+    "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296",
+    "auditedInputDigest": "9d886b4500d7cebd1365547d0439b6a508bcc25aabe085e7cc9ccd15a592f238"
   },
   "inventory": {
-    "sourceMessageCount": 3114,
-    "localeMessageCount": 3114,
+    "sourceMessageCount": 3119,
+    "localeMessageCount": 3119,
     "leafModuleCount": 30,
     "dynamicFamilyCount": 17,
     "dynamicCallsiteCount": 39,
@@ -44,18 +44,18 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3114,
-    "completeCount": 3114,
+    "messageCount": 3119,
+    "completeCount": 3119,
     "blockedCount": 0,
-    "dossierDigest": "e63b05251405c364a3a5d2907473c95194863109c0477738494639b5c52b6a7e",
-    "catalogDigest": "ff6938d40f9eaf1179a1deae1da9474d2bc42478773be577c9fe4b97b98afd88",
+    "dossierDigest": "0904aae78e8ef98e1785731c1729f09c575ecd0ae4c81386d6c0d05c5c5873b4",
+    "catalogDigest": "6827c943304f5ed82c6c9e7d2476db149798f2e17f4d9906a8e251baa8eaa68f",
     "moduleCount": 31,
     "moduleDigest": "46fb10d2d29c762e23a92a65d644a45d9f5e3cd5f2cd7c56e5a9c57ed428cd4f",
     "roleCounts": {
       "error-or-validation": 363,
       "explanatory-copy": 110,
       "field-guidance": 49,
-      "label-or-body-copy": 1255,
+      "label-or-body-copy": 1260,
       "navigation-or-tab": 226,
       "reserved-catalog-copy": 277,
       "status-or-empty-state": 100,
@@ -69,11 +69,11 @@
       "interactive-ready": 522,
       "retained-not-currently-reachable": 357,
       "successful-completion": 182,
-      "visible": 1643
+      "visible": 1648
     },
-    "riskCounts": { "high": 1390, "low": 1556, "medium": 168 },
-    "highRiskMessageCount": 1390,
-    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0"
+    "riskCounts": { "high": 1391, "low": 1560, "medium": 168 },
+    "highRiskMessageCount": 1391,
+    "highRiskMessageDigest": "803ebcc8320e7f5a792c522a7c5b69a4f24b672308a12b1feaeaa94b4df3aa5f"
   },
   "typedContentDossiers": {
     "sourcePath": "src/components/ImportTidasPackage/reportContent.ts",
@@ -88,14 +88,14 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4133,
+    "literalReferenceCount": 4138,
     "dynamicCallsiteCount": 39,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale zh-CN --message <MESSAGE_ID>"
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "digest": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "76cdd16a44d8d73d710f0b5c3da4e02dade38f27402995f0d0c4f6ddbe1645b5",
+          "sha256": "9dcff21b8caea698f67dd0c899cf2b007d34bda442f00702967e09ca8fdc55dd",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "a2cd3077c993f0767ab41166d4f3997d830d9dd0e13b808f126d5240a9076096",
+      "sourceEvidenceDigest": "14f9bc3d2fd84b277b87e196b3d545f115edfbda0a6bdd6d502556e95011ac97",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -229,7 +229,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "81cdf5260f0628c68834ad7480fcf22f0362b8d22d446806bc40a08393622d47",
+          "sourceDigest": "faec100f15f715c8b5683e2787dcb8533ac9cc8dd55e6d244f3c4cc138a84441",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -254,7 +254,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "d4437736c255556fa6c1a335125b456d8ba89ecb5a0a9a4603cf6a253724c117",
+          "sourceDigest": "682631477c3b35bd011a997e724e95095641b47977c380ae76fe963dd68fad6b",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -277,7 +277,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "0f64fed1ff2725b709b8b3e31f6d8af67336805bf2d5efdec932fb666c78f76c",
+          "sourceDigest": "4eddb7365c887a97b19bfcf1712b8a03f85b99f2f96cf2f5a1f71cb14ba45f51",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -367,7 +367,7 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "54fde5a5b291c98c7c8119ac5d565c3d547fdeca44b44dd5ada6833bcf70c4c2",
+          "sourceDigest": "3b059d1541b24fc98b97e61410447284a1c9edfb0d20bb56843346610ef2f2dc",
           "focusedTestDigest": "d847dd197b921ae4e91f7b23627490186c3c4fc51a15caa788684f61e1e26e68",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
@@ -1042,12 +1042,12 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "302ccc4ae35fa69d5b4a27ff2abcfa38db8218ecb49218ead4007f2a12e5f174",
-          "focusedTestDigest": "b13bc3461ea49d945a22b38ed816e8c5535f30e9188b367186ee9dadc31f0a11",
+          "sourceDigest": "32fe106473e04bf5f0cb7101c0e01258a74037dbe436b6168fd3cec645ad25ee",
+          "focusedTestDigest": "ac2a7911150bdf0d092b41037817f85caf3618c853dc4bec9f391fbc883e4a8d",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
-          "derivedMessageDigest": "f3f53e78726b3875411fb46e70f2c863dad1fe7cd30bc2a3337e9d040dd7ef16",
+          "derivedMessageDigest": "239595ff0d771df59ecbaec630c05cb2baaca2eba21b26c8e27dcd33491b4c5b",
           "stateSignals": ["empty", "error", "loading", "success", "unavailable"],
           "queryParameters": ["tid"],
           "navigationTargets": [
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "8c46fc18019f45c8f9fa5bbd9bd9562ef12260bc36c909752364048eb514949e",
+      "rowEvidenceDigest": "5a1a477972b0b0ca71d25f149ae0ac4f561dd1f9ffcd64486efe941ae5f881a4",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "docs/plans/i18n/route-view-coverage.json": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-zh-CN/glossary.json": "c891add0ee4bd6d24c0213d0c839474e145d85867426df796763b8e038053d9b",
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "119e9f9d8d0b7fba4ae1cbd8cbdc195b66024376c60ddf3f42e98d4f8fc2831e"
+  "contextDigest": "f1c0de50859e3e4a0cc7941529d56e03156c6a1e0facba1daef37de01297c6c9"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
+    "digest": "39d31311c22e08e6ba5f5b59cb82959e9ff5127cfaf497c4160a0317a22ed6ad",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "11b27a2a3e20215b2e796519a0dbe3fd937940b4e88f4261d615780a4e3e824e",
+          "sha256": "abd50e20572034e698d43c1592d2ad3bc79242bd9ce50f566e923b2d7d0c4800",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
+    "docs/plans/i18n/route-view-coverage.json": "39d31311c22e08e6ba5f5b59cb82959e9ff5127cfaf497c4160a0317a22ed6ad",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-zh-CN/glossary.json": "c891add0ee4bd6d24c0213d0c839474e145d85867426df796763b8e038053d9b",
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "311f281c4357b626caacfef1f0cefdb348cf315d7efc9c9fff95313367ce2954"
+  "contextDigest": "2947e46959355ed813d3867b915c88da2542e67942f0f33e14d771aab79134fe"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
+    "digest": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "9dcff21b8caea698f67dd0c899cf2b007d34bda442f00702967e09ca8fdc55dd",
+          "sha256": "11b27a2a3e20215b2e796519a0dbe3fd937940b4e88f4261d615780a4e3e824e",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1043,7 +1043,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "32fe106473e04bf5f0cb7101c0e01258a74037dbe436b6168fd3cec645ad25ee",
-          "focusedTestDigest": "ac2a7911150bdf0d092b41037817f85caf3618c853dc4bec9f391fbc883e4a8d",
+          "focusedTestDigest": "fc41b8aa33910cdfc8bd350b7fa66d037e9f4fa5c0073b2ff5856044aa2974ac",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "5a1a477972b0b0ca71d25f149ae0ac4f561dd1f9ffcd64486efe941ae5f881a4",
+      "rowEvidenceDigest": "997a00ea7a96230491788656a5323ee3e0f8213690b70fc2a63333e7fc06c19f",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
+    "docs/plans/i18n/route-view-coverage.json": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-zh-CN/glossary.json": "c891add0ee4bd6d24c0213d0c839474e145d85867426df796763b8e038053d9b",
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "f1c0de50859e3e4a0cc7941529d56e03156c6a1e0facba1daef37de01297c6c9"
+  "contextDigest": "311f281c4357b626caacfef1f0cefdb348cf315d7efc9c9fff95313367ce2954"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "4dbaff8f99ec34385c3d76bdfe68a5fc1590f481b84efd9dace708db4be7633b"
+    "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "119e9f9d8d0b7fba4ae1cbd8cbdc195b66024376c60ddf3f42e98d4f8fc2831e",
-    "qualityDigest": "ae75bd789a79147d2535f6df62389555213dcc8fe6e2ffa0025eccf7ec3ce361",
+    "contextDigest": "f1c0de50859e3e4a0cc7941529d56e03156c6a1e0facba1daef37de01297c6c9",
+    "qualityDigest": "1a64d835ab34f48e93cbafa644cd1e2865934ded36697bfff19e696690168aff",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "routeViewCoverageDigest": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "1f9449b25b0620052ebb220096136b91381a99ffbfff9752749f31a2895aadc7"
+  "activationDigest": "c8c5a1c43df41202416b6c020c5110ba92a477ea45f41fc8e372f2e15f07de67"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "f1c0de50859e3e4a0cc7941529d56e03156c6a1e0facba1daef37de01297c6c9",
-    "qualityDigest": "1a64d835ab34f48e93cbafa644cd1e2865934ded36697bfff19e696690168aff",
+    "contextDigest": "311f281c4357b626caacfef1f0cefdb348cf315d7efc9c9fff95313367ce2954",
+    "qualityDigest": "a1ca1a8803118d1a60acc9cd1eaa4bd295e4396db4561c7ab828513ebfbd1837",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "f36791e092d1e17f2ca0c1f3d08d4c967e12cbcc542192e3389ac58ebb1828bd",
+    "routeViewCoverageDigest": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "c8c5a1c43df41202416b6c020c5110ba92a477ea45f41fc8e372f2e15f07de67"
+  "activationDigest": "2652cc2a8c973193d8eace956db34599805d56547553c06a9c373fa452c86e03"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "311f281c4357b626caacfef1f0cefdb348cf315d7efc9c9fff95313367ce2954",
-    "qualityDigest": "a1ca1a8803118d1a60acc9cd1eaa4bd295e4396db4561c7ab828513ebfbd1837",
+    "contextDigest": "2947e46959355ed813d3867b915c88da2542e67942f0f33e14d771aab79134fe",
+    "qualityDigest": "3342d32c1f11a870526d2e6fb736a5d1a9bcf07bc65986eb2c276f4f163998d9",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "c1fb5b9f142e4e2e647b2ca08a6337334345bb62a19c2deb69ea76325b858393",
+    "routeViewCoverageDigest": "39d31311c22e08e6ba5f5b59cb82959e9ff5127cfaf497c4160a0317a22ed6ad",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "2652cc2a8c973193d8eace956db34599805d56547553c06a9c373fa452c86e03"
+  "activationDigest": "991a8a381c13331c54992fc013ef7c402d0462a2dab89f69f9153d8ac87e9245"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,12 +3,12 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "4dbaff8f99ec34385c3d76bdfe68a5fc1590f481b84efd9dace708db4be7633b",
-    "contextDigest": "119e9f9d8d0b7fba4ae1cbd8cbdc195b66024376c60ddf3f42e98d4f8fc2831e"
+    "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296",
+    "contextDigest": "f1c0de50859e3e4a0cc7941529d56e03156c6a1e0facba1daef37de01297c6c9"
   },
   "catalog": {
-    "messageCount": 3114,
-    "catalogDigest": "ff6938d40f9eaf1179a1deae1da9474d2bc42478773be577c9fe4b97b98afd88",
+    "messageCount": 3119,
+    "catalogDigest": "6827c943304f5ed82c6c9e7d2476db149798f2e17f4d9906a8e251baa8eaa68f",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
@@ -41,16 +41,16 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "8f09dd720fa7f7ac3641cc3f13cff226f155b5ed923af26ac3ba8e12f9e489cc",
-    "validationDigest": "a8897d00a606f18af23e4414e1d8c666109ef9aeaebd1ee271a2206277072959",
+    "digest": "cda2008df008935efd31b159ce6f1691bfc3d1f49b7c296087d601d1e38a4910",
+    "validationDigest": "40a20b88f97ff089fc826ae5250bd6876a402890527ef687d9cb07cf6881ecfd",
     "laneCount": 1,
-    "validatedMessageCount": 3114,
+    "validatedMessageCount": 3119,
     "validatedModuleCount": 31,
-    "highRiskMessageCount": 1390,
-    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
+    "highRiskMessageCount": 1391,
+    "highRiskMessageDigest": "803ebcc8320e7f5a792c522a7c5b69a4f24b672308a12b1feaeaa94b4df3aa5f",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635",
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "ae75bd789a79147d2535f6df62389555213dcc8fe6e2ffa0025eccf7ec3ce361"
+  "qualityDigest": "1a64d835ab34f48e93cbafa644cd1e2865934ded36697bfff19e696690168aff"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296",
-    "contextDigest": "311f281c4357b626caacfef1f0cefdb348cf315d7efc9c9fff95313367ce2954"
+    "contextDigest": "2947e46959355ed813d3867b915c88da2542e67942f0f33e14d771aab79134fe"
   },
   "catalog": {
     "messageCount": 3119,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "a1ca1a8803118d1a60acc9cd1eaa4bd295e4396db4561c7ab828513ebfbd1837"
+  "qualityDigest": "3342d32c1f11a870526d2e6fb736a5d1a9bcf07bc65986eb2c276f4f163998d9"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "8a204be4ad9e6d42394c3856686da1e41ead558a58e5d26b3ce9e029c32d3296",
-    "contextDigest": "f1c0de50859e3e4a0cc7941529d56e03156c6a1e0facba1daef37de01297c6c9"
+    "contextDigest": "311f281c4357b626caacfef1f0cefdb348cf315d7efc9c9fff95313367ce2954"
   },
   "catalog": {
     "messageCount": 3119,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "cda2008df008935efd31b159ce6f1691bfc3d1f49b7c296087d601d1e38a4910",
-    "validationDigest": "40a20b88f97ff089fc826ae5250bd6876a402890527ef687d9cb07cf6881ecfd",
+    "digest": "38c28ceacad576835962f8e7cca08b0499475c84d2d103cf527a2d9430a161fa",
+    "validationDigest": "2fd561aac756087e672b0996ca805c7ce7d90065809d454e16ee84af047b8175",
     "laneCount": 1,
     "validatedMessageCount": 3119,
     "validatedModuleCount": 31,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "1a64d835ab34f48e93cbafa644cd1e2865934ded36697bfff19e696690168aff"
+  "qualityDigest": "a1ca1a8803118d1a60acc9cd1eaa4bd295e4396db4561c7ab828513ebfbd1837"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "1657b2b1efa3385624a8ec837f40e2f0650b79ae2986865593fed797741d494f",
-    "validatedMessageCount": 3114,
+    "auditedInputDigest": "9d886b4500d7cebd1365547d0439b6a508bcc25aabe085e7cc9ccd15a592f238",
+    "validatedMessageCount": 3119,
     "validatedModules": [
       "$entry",
       "component",
@@ -38,12 +38,12 @@
       "settings",
       "validator"
     ],
-    "highRiskMessageCount": 1390,
-    "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
-    "catalogDigest": "ff6938d40f9eaf1179a1deae1da9474d2bc42478773be577c9fe4b97b98afd88",
-    "dossierDigest": "e63b05251405c364a3a5d2907473c95194863109c0477738494639b5c52b6a7e",
+    "highRiskMessageCount": 1391,
+    "highRiskMessageDigest": "803ebcc8320e7f5a792c522a7c5b69a4f24b672308a12b1feaeaa94b4df3aa5f",
+    "catalogDigest": "6827c943304f5ed82c6c9e7d2476db149798f2e17f4d9906a8e251baa8eaa68f",
+    "dossierDigest": "0904aae78e8ef98e1785731c1729f09c575ecd0ae4c81386d6c0d05c5c5873b4",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "8c46fc18019f45c8f9fa5bbd9bd9562ef12260bc36c909752364048eb514949e",
+    "routeEvidenceDigest": "5a1a477972b0b0ca71d25f149ae0ac4f561dd1f9ffcd64486efe941ae5f881a4",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -92,11 +92,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3114,
-        "messageDigest": "7e7b1cc9be2d7f7c8b74f069bddc34a36f242da8b1e5626f00a289473cc58ef2",
-        "highRiskMessageCount": 1390,
-        "highRiskMessageDigest": "af9c33a37e6517bfd6c9a539c8f06ad0ca010472b6f5f4d94183ad81c0103bd0",
-        "dossierDigest": "e63b05251405c364a3a5d2907473c95194863109c0477738494639b5c52b6a7e",
+        "messageCount": 3119,
+        "messageDigest": "a85893ebd5e961b8e5d716263510cfa5c38544c7dc8e0c106a070667d0906dab",
+        "highRiskMessageCount": 1391,
+        "highRiskMessageDigest": "803ebcc8320e7f5a792c522a7c5b69a4f24b672308a12b1feaeaa94b4df3aa5f",
+        "dossierDigest": "0904aae78e8ef98e1785731c1729f09c575ecd0ae4c81386d6c0d05c5c5873b4",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "a8897d00a606f18af23e4414e1d8c666109ef9aeaebd1ee271a2206277072959"
+  "validationDigest": "40a20b88f97ff089fc826ae5250bd6876a402890527ef687d9cb07cf6881ecfd"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -43,7 +43,7 @@
     "catalogDigest": "6827c943304f5ed82c6c9e7d2476db149798f2e17f4d9906a8e251baa8eaa68f",
     "dossierDigest": "0904aae78e8ef98e1785731c1729f09c575ecd0ae4c81386d6c0d05c5c5873b4",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "5a1a477972b0b0ca71d25f149ae0ac4f561dd1f9ffcd64486efe941ae5f881a4",
+    "routeEvidenceDigest": "997a00ea7a96230491788656a5323ee3e0f8213690b70fc2a63333e7fc06c19f",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -111,5 +111,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "40a20b88f97ff089fc826ae5250bd6876a402890527ef687d9cb07cf6881ecfd"
+  "validationDigest": "2fd561aac756087e672b0996ca805c7ce7d90065809d454e16ee84af047b8175"
 }

--- a/docs/plans/i18n/route-view-coverage.json
+++ b/docs/plans/i18n/route-view-coverage.json
@@ -353,7 +353,7 @@
       "executedEvidence": [
         {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "76cdd16a44d8d73d710f0b5c3da4e02dade38f27402995f0d0c4f6ddbe1645b5"
+          "sha256": "9dcff21b8caea698f67dd0c899cf2b007d34bda442f00702967e09ca8fdc55dd"
         }
       ]
     }

--- a/docs/plans/i18n/route-view-coverage.json
+++ b/docs/plans/i18n/route-view-coverage.json
@@ -353,7 +353,7 @@
       "executedEvidence": [
         {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "9dcff21b8caea698f67dd0c899cf2b007d34bda442f00702967e09ca8fdc55dd"
+          "sha256": "11b27a2a3e20215b2e796519a0dbe3fd937940b4e88f4261d615780a4e3e824e"
         }
       ]
     }

--- a/docs/plans/i18n/route-view-coverage.json
+++ b/docs/plans/i18n/route-view-coverage.json
@@ -353,7 +353,7 @@
       "executedEvidence": [
         {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "11b27a2a3e20215b2e796519a0dbe3fd937940b4e88f4261d615780a4e3e824e"
+          "sha256": "abd50e20572034e698d43c1592d2ad3bc79242bd9ce50f566e923b2d7d0c4800"
         }
       ]
     }

--- a/docs/plans/i18n/semantic-e2e-evidence.json
+++ b/docs/plans/i18n/semantic-e2e-evidence.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": "tiangong.i18n-semantic-e2e-evidence.v1",
   "status": "verified",
-  "generatedAt": "2026-08-13T11:30:47.633Z",
-  "runId": "local-b07d1c54-cc76-47b4-af7d-f6aa1768e5bc",
+  "generatedAt": "2026-08-13T12:51:15.997Z",
+  "runId": "local-3498953f-026f-4f2f-8b60-d9899e192048",
   "candidate": {
     "configTreeDigest": "c79878bbed6dfb7becc3cedae0fdd08e0926b674293a6f9656469ac8682cc804",
-    "observedHeadCommit": "88758d0cd1f1e8fd021c6b963674ee5f08e873b2",
+    "observedHeadCommit": "6d58c67027ef7f8e061455078feb8db760f5b518",
     "packageManifestDigest": "2b78dea75572169f5a945913cc1d3b8b9ed3b9ecbb65c4fc0dc45b4126150437",
     "sourceTreeDigest": "6bf3df96128a18ffde3658b99d6cb8cd36fd8322d92fdde59338c65c3d8530d6",
-    "unitTestTreeDigest": "0f9654a32892ad4404f2a9e2f5288acfaba27a4f2776cf2b6547c08e263d661c"
+    "unitTestTreeDigest": "21903c76065fd616469e1ab929d0fe5fde811f850c2a212dea6fce6aa7ea85a6"
   },
   "target": {
     "frontend": "candidate-local",
@@ -377,7 +377,7 @@
       },
       {
         "path": "tests/unit/pages/DataProcessing/index.test.tsx",
-        "sha256": "62e2fa228b3c006769e1053e91f6f027e7c301944f8365685ff3e74c243653be"
+        "sha256": "bb26a437e66f4e7018c6a1857b8f9a4b69087315d58da2d5dfd7448b94129fc2"
       },
       {
         "path": "tests/unit/pages/Flowproperties/index.test.tsx",

--- a/docs/plans/i18n/semantic-e2e-evidence.json
+++ b/docs/plans/i18n/semantic-e2e-evidence.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": "tiangong.i18n-semantic-e2e-evidence.v1",
   "status": "verified",
-  "generatedAt": "2026-08-13T12:51:15.997Z",
-  "runId": "local-3498953f-026f-4f2f-8b60-d9899e192048",
+  "generatedAt": "2026-08-13T13:24:51.739Z",
+  "runId": "local-83865de9-bafe-41e1-bab6-5d60d4eb7e81",
   "candidate": {
     "configTreeDigest": "c79878bbed6dfb7becc3cedae0fdd08e0926b674293a6f9656469ac8682cc804",
-    "observedHeadCommit": "6d58c67027ef7f8e061455078feb8db760f5b518",
+    "observedHeadCommit": "6f73e8f1593cdb2eecfa09c8ad1cef092c401cf9",
     "packageManifestDigest": "2b78dea75572169f5a945913cc1d3b8b9ed3b9ecbb65c4fc0dc45b4126150437",
     "sourceTreeDigest": "6bf3df96128a18ffde3658b99d6cb8cd36fd8322d92fdde59338c65c3d8530d6",
-    "unitTestTreeDigest": "21903c76065fd616469e1ab929d0fe5fde811f850c2a212dea6fce6aa7ea85a6"
+    "unitTestTreeDigest": "b9d484d98cbb5d54a32c909c6dbbc4d5f4d85468f2c53c720da49160861ab000"
   },
   "target": {
     "frontend": "candidate-local",

--- a/docs/plans/i18n/semantic-e2e-evidence.json
+++ b/docs/plans/i18n/semantic-e2e-evidence.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": "tiangong.i18n-semantic-e2e-evidence.v1",
   "status": "verified",
-  "generatedAt": "2026-08-13T04:43:11.480Z",
-  "runId": "local-b77e55ac-7ccf-40f3-9eb6-ec51ae13dc05",
+  "generatedAt": "2026-08-13T11:30:47.633Z",
+  "runId": "local-b07d1c54-cc76-47b4-af7d-f6aa1768e5bc",
   "candidate": {
     "configTreeDigest": "c79878bbed6dfb7becc3cedae0fdd08e0926b674293a6f9656469ac8682cc804",
-    "observedHeadCommit": "42b7e37ad3334e69bad22932677e61f9dfb31774",
-    "packageManifestDigest": "4edda913c2d75c266e5ef803b7d0171f019ed5494ad8cbef10d8d0b7e7ecc2b0",
-    "sourceTreeDigest": "7eb7f23eaa1bc802da8a594c8609c7005fd02a3b2b7bdc623a7df5cac295aedf",
-    "unitTestTreeDigest": "4902252cde9a2d5764f73a9fa42990b2c164d7e9b4aff6e4ec8141fabcbab218"
+    "observedHeadCommit": "88758d0cd1f1e8fd021c6b963674ee5f08e873b2",
+    "packageManifestDigest": "2b78dea75572169f5a945913cc1d3b8b9ed3b9ecbb65c4fc0dc45b4126150437",
+    "sourceTreeDigest": "6bf3df96128a18ffde3658b99d6cb8cd36fd8322d92fdde59338c65c3d8530d6",
+    "unitTestTreeDigest": "0f9654a32892ad4404f2a9e2f5288acfaba27a4f2776cf2b6547c08e263d661c"
   },
   "target": {
     "frontend": "candidate-local",
@@ -34,7 +34,7 @@
   "digests": {
     "packageLock": {
       "path": "package-lock.json",
-      "sha256": "b46fc0f92f5cdd34853fa71c7238a15bcefde446d6795893ea650f2490496931"
+      "sha256": "9fd2ed1e848cbdbc78d612167f5672ab034a3b5445d5e9a391d113a1fe1f6d69"
     },
     "runtimeAssets": [
       {
@@ -377,7 +377,7 @@
       },
       {
         "path": "tests/unit/pages/DataProcessing/index.test.tsx",
-        "sha256": "718feff487151b71ad19ad0a508bb56b46bfd8531af05b60477c678b479ade2a"
+        "sha256": "62e2fa228b3c006769e1053e91f6f027e7c301944f8365685ff3e74c243653be"
       },
       {
         "path": "tests/unit/pages/Flowproperties/index.test.tsx",
@@ -519,7 +519,7 @@
       },
       {
         "path": "src/locales/en-US/pages.ts",
-        "sha256": "287a5f3f589b5e3138ba05891b6259da4c6da452c800e22456fab4273909b74e"
+        "sha256": "a593dba3f0843b5ff53f4739953702d7608c9e6134ee4f33db2d7533339d72a4"
       },
       {
         "path": "src/locales/en-US/pages_general.ts",
@@ -543,7 +543,7 @@
       },
       {
         "path": "src/pages/DataProcessing/index.tsx",
-        "sha256": "e395d4baee0870648b3d832bcbc2af3e5449a19dd9bba07d1cbae1ec149e619e"
+        "sha256": "940f8843458a176296cfb41b824204bedd203b45981657b409dc1d38734d50da"
       },
       {
         "path": "src/pages/Flowproperties/index.tsx",

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "a948e3ebaf6fd1f616d8a37855deaf4f999d4ffc1ac176d9c8fb576ea5a62a81"
+    "runResultSha256": "591d51d6e16fc253375f70107584011a5c0f6921b81e5d2dddec8880e0c0ddb9"
   },
-  "environmentManifestSha256": "94fe11a04b87b84ed66feb20903ee7984dd9579b0b60776561202eb29fc94a99",
+  "environmentManifestSha256": "9b93b59da7a7f842ed8d9bed8f8ae05267ae0f7b1e50031ebf923778e0ab1231",
   "externalRequests": 0,
-  "generatedAt": "2026-08-13T05:05:13.997Z",
+  "generatedAt": "2026-08-13T11:03:08.640Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "7e988b5d275477358055ad204a0afff8dc5aba34d53d0fa736cd2574e4273e0f",
-  "qualifiedCommit": "39542f077a598ee9386a57c9d82ca375cf4b03b3",
-  "qualifiedTree": "49002deee38e129b52d03921989b63793e451925",
+  "qualificationInputSha256": "6c411712682a081343f3a9631e6b0fdd8f22eceaa7d2e7787a876f752e46dc63",
+  "qualifiedCommit": "794fef603798d03c3dd8f4692a53563074b09d63",
+  "qualifiedTree": "4f4f885aa12e358cb705841dbe2eab515f83e38b",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "f95f485bdd8ef1668ae177a9b4ee79a3efdc618e270d6616c7a22fa0144d23c7"
+    "runResultSha256": "c930dc17c3c991dc31e1b39f3b5660727fe36a56a49ca0ceb3a35a991785ae3d"
   },
-  "environmentManifestSha256": "5628305f037c8dd824f229d48ba138bdc21615d3b8cf80af7970374956886804",
+  "environmentManifestSha256": "da2e223834e1669ea2e615c24375e26571307c32efac335cb05628e3a1efeb7b",
   "externalRequests": 0,
-  "generatedAt": "2026-08-13T12:15:11.495Z",
+  "generatedAt": "2026-08-13T12:35:12.214Z",
   "productionWrites": 0,
   "qualificationInputSha256": "69f6b8b1afe9df878740a18a89e6f5ec5f9f2701349a4412c1261afc7a74d247",
-  "qualifiedCommit": "c603bac3f92d91d7309694ef26dcac98f67cc23c",
-  "qualifiedTree": "e9916d60a1d0f72fd9d5fd0c4669a9b4ee70c2d5",
+  "qualifiedCommit": "e37156cb2ff459ac54f098528a9a5e29cb7ad942",
+  "qualifiedTree": "05b2a88eb82ce9b80180ac3aafc4bf56af2d7557",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "591d51d6e16fc253375f70107584011a5c0f6921b81e5d2dddec8880e0c0ddb9"
+    "runResultSha256": "cb2a8609871e1663849bae650d270340d72f5896819ecbc2584e8ee2f927d542"
   },
-  "environmentManifestSha256": "9b93b59da7a7f842ed8d9bed8f8ae05267ae0f7b1e50031ebf923778e0ab1231",
+  "environmentManifestSha256": "aaece2daa1b76980ede55c205693dde261566cdb3b5b56f46914818181afc228",
   "externalRequests": 0,
-  "generatedAt": "2026-08-13T11:03:08.640Z",
+  "generatedAt": "2026-08-13T11:50:22.216Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "6c411712682a081343f3a9631e6b0fdd8f22eceaa7d2e7787a876f752e46dc63",
-  "qualifiedCommit": "794fef603798d03c3dd8f4692a53563074b09d63",
-  "qualifiedTree": "4f4f885aa12e358cb705841dbe2eab515f83e38b",
+  "qualificationInputSha256": "69f6b8b1afe9df878740a18a89e6f5ec5f9f2701349a4412c1261afc7a74d247",
+  "qualifiedCommit": "9e7214ce1aac2c92403484d4d338ba44c479dc0d",
+  "qualifiedTree": "0ca3d8aa4314fa0c6094d2af90c56474b15f8d3d",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "c930dc17c3c991dc31e1b39f3b5660727fe36a56a49ca0ceb3a35a991785ae3d"
+    "runResultSha256": "fe092b4831604886276294e39d226a0c6eee946d513c0c8edceae4ecea5e1f5f"
   },
-  "environmentManifestSha256": "da2e223834e1669ea2e615c24375e26571307c32efac335cb05628e3a1efeb7b",
+  "environmentManifestSha256": "1fc21c9be8f6f866ab6b31138a64c37ae2e3ecc672f22cf5cd84fca07afb4576",
   "externalRequests": 0,
-  "generatedAt": "2026-08-13T12:35:12.214Z",
+  "generatedAt": "2026-08-13T13:04:10.919Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "69f6b8b1afe9df878740a18a89e6f5ec5f9f2701349a4412c1261afc7a74d247",
-  "qualifiedCommit": "e37156cb2ff459ac54f098528a9a5e29cb7ad942",
-  "qualifiedTree": "05b2a88eb82ce9b80180ac3aafc4bf56af2d7557",
+  "qualificationInputSha256": "9ad2b325c3a334ba4dd34e83710599381bd0fccf507d63f601566167d6767aad",
+  "qualifiedCommit": "f49ba60ac3d916bf253bd7aefd59fbedc87c5803",
+  "qualifiedTree": "41b0807ac737c795be2ca8bf2385ff85c24980b6",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "cb2a8609871e1663849bae650d270340d72f5896819ecbc2584e8ee2f927d542"
+    "runResultSha256": "f95f485bdd8ef1668ae177a9b4ee79a3efdc618e270d6616c7a22fa0144d23c7"
   },
-  "environmentManifestSha256": "aaece2daa1b76980ede55c205693dde261566cdb3b5b56f46914818181afc228",
+  "environmentManifestSha256": "5628305f037c8dd824f229d48ba138bdc21615d3b8cf80af7970374956886804",
   "externalRequests": 0,
-  "generatedAt": "2026-08-13T11:50:22.216Z",
+  "generatedAt": "2026-08-13T12:15:11.495Z",
   "productionWrites": 0,
   "qualificationInputSha256": "69f6b8b1afe9df878740a18a89e6f5ec5f9f2701349a4412c1261afc7a74d247",
-  "qualifiedCommit": "9e7214ce1aac2c92403484d4d338ba44c479dc0d",
-  "qualifiedTree": "0ca3d8aa4314fa0c6094d2af90c56474b15f8d3d",
+  "qualifiedCommit": "c603bac3f92d91d7309694ef26dcac98f67cc23c",
+  "qualifiedTree": "e9916d60a1d0f72fd9d5fd0c4669a9b4ee70c2d5",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "fe092b4831604886276294e39d226a0c6eee946d513c0c8edceae4ecea5e1f5f"
+    "runResultSha256": "2fad57bac015eac3a1e6cb4c3f9ce02c79f3f21a221e4a1f5174892fb313f6eb"
   },
-  "environmentManifestSha256": "1fc21c9be8f6f866ab6b31138a64c37ae2e3ecc672f22cf5cd84fca07afb4576",
+  "environmentManifestSha256": "cab13e9591f2da07c864d377802bff975ac543cf5754eba97a164735d6b3faf4",
   "externalRequests": 0,
-  "generatedAt": "2026-08-13T13:04:10.919Z",
+  "generatedAt": "2026-08-13T13:37:10.200Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "9ad2b325c3a334ba4dd34e83710599381bd0fccf507d63f601566167d6767aad",
-  "qualifiedCommit": "f49ba60ac3d916bf253bd7aefd59fbedc87c5803",
-  "qualifiedTree": "41b0807ac737c795be2ca8bf2385ff85c24980b6",
+  "qualificationInputSha256": "bf78e38a35782873bfad26ab8f517b3a2b381cd6c44f81d7006c6b7eb36d06f8",
+  "qualifiedCommit": "6aa30d7919138af3fdf3be3d3a86aafe39933507",
+  "qualifiedTree": "71a2d19d12dd85becb910051cca7a2374dffc251",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.69",
+      "version": "0.0.70",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",

--- a/tests/unit/pages/DataProcessing/index.test.tsx
+++ b/tests/unit/pages/DataProcessing/index.test.tsx
@@ -472,7 +472,13 @@ describe('DataProcessing page', () => {
     expect(parseImpactCategoryOptionLabel('Legacy label without metadata')).toEqual({
       name: 'Legacy label without metadata',
     });
+    expect(selectedImpactCategoryIdentity(undefined, [])).toBeNull();
     expect(selectedImpactCategoryIdentity('missing-method', [])).toBeNull();
+    expect(
+      selectedImpactCategoryIdentity('method-a', [
+        { value: 'method-a', version: '01.00.000', label: 'Method A' },
+      ]),
+    ).toEqual({ id: 'method-a', version: '01.00.000' });
     expect(reviewedLciaMethodSet(buildImpactCategoryOptions(mockLciaMethodList, 'en-US'))).toEqual(
       expectedReviewedLciaMethods,
     );
@@ -1233,6 +1239,27 @@ describe('DataProcessing page', () => {
       await screen.findByText('The reviewed LCIA method catalog is unavailable.'),
     ).toBeInTheDocument();
     expect(mockCreateClosureCheck).not.toHaveBeenCalled();
+  });
+
+  it('does not submit a result build when the reviewed LCIA catalog is unavailable', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false });
+    render(<DataProcessing />);
+
+    expect(await screen.findByTestId('page-title')).toHaveTextContent('Data Processing');
+    fireEvent.change(screen.getByLabelText('Result set name'), {
+      target: { value: 'Missing LCIA method build' },
+    });
+    fireEvent.change(screen.getByLabelText('Default impact category'), {
+      target: { value: 'missing-method' },
+    });
+    const generateButton = screen.getByRole('button', { name: 'Generate result set' });
+    await waitFor(() => expect(generateButton).not.toBeDisabled());
+    fireEvent.click(generateButton);
+
+    expect(
+      await screen.findByText('The reviewed LCIA method catalog is unavailable.'),
+    ).toBeInTheDocument();
+    expect(mockCreateLciaResultBuildRequest).not.toHaveBeenCalled();
   });
 
   it('renders preview input scope and artifact verification details', async () => {

--- a/tests/unit/services/lcaReleases/api.test.ts
+++ b/tests/unit/services/lcaReleases/api.test.ts
@@ -395,6 +395,46 @@ describe('lcaReleases api', () => {
     });
   });
 
+  it('resolves named Calculation Bundle downloads through the refreshed projection', async () => {
+    const bytes = new Uint8Array([3, 3, 3]);
+    const expected = {
+      sha256: '03'.repeat(32),
+      byteSize: bytes.byteLength,
+      mediaType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    };
+    mockFunctionsInvoke.mockResolvedValueOnce({
+      data: {
+        ok: true,
+        data: {
+          calculationBundle: {
+            artifacts: [],
+            downloads: [
+              {
+                ...expected,
+                role: 'review_workbook',
+                signedDownloadUrl: 'https://download.example/review-workbook',
+              },
+            ],
+          },
+        },
+      },
+      error: null,
+    });
+    setCryptoDigest(3);
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      arrayBuffer: async () => bytes.buffer,
+    })) as any;
+
+    await expect(
+      fetchFreshCalculationBundleDownloadBlob('package', 'download:review_workbook', expected),
+    ).resolves.toMatchObject({ size: bytes.byteLength, type: expected.mediaType });
+    expect(global.fetch).toHaveBeenCalledWith('https://download.example/review-workbook', {
+      credentials: 'omit',
+    });
+  });
+
   it('rejects missing, denied, or drifted fresh Calculation Bundle downloads before saving', async () => {
     const expected = {
       sha256: '00'.repeat(32),

--- a/tests/unit/services/lcaReleases/api.test.ts
+++ b/tests/unit/services/lcaReleases/api.test.ts
@@ -456,6 +456,13 @@ describe('lcaReleases api', () => {
       .mockResolvedValueOnce({
         data: {
           ok: true,
+          data: { calculationBundle: { artifacts: [] } },
+        },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: {
+          ok: true,
           data: {
             calculationBundle: {
               manifestDownload: expected,
@@ -478,6 +485,9 @@ describe('lcaReleases api', () => {
     ).rejects.toThrow('Access denied');
     await expect(
       fetchFreshCalculationBundleDownloadBlob('package', 'missing.ndjson.gz', expected),
+    ).rejects.toThrow('no longer available');
+    await expect(
+      fetchFreshCalculationBundleDownloadBlob('package', 'download:missing', expected),
     ).rejects.toThrow('no longer available');
     await expect(
       fetchFreshCalculationBundleDownloadBlob('package', 'results/lci.ndjson.gz', expected),

--- a/tests/unit/services/tidasPackage/taskCenter.test.ts
+++ b/tests/unit/services/tidasPackage/taskCenter.test.ts
@@ -784,7 +784,7 @@ describe('tidasPackage/taskCenter', () => {
       STORAGE_KEY,
       JSON.stringify({
         version: 1,
-        savedAt: '2026-08-10T11:05:00.000Z',
+        savedAt: new Date().toISOString(),
         tasks: [
           {
             id: 'later-job-alias',


### PR DESCRIPTION
Closes #823\n\n## Summary\n\n- prepare Next version 0.0.70 from the merged dev baseline\n- include the merged calculation product fixes and exact release evidence\n- fix a date-sensitive task-center cache fixture discovered by the full release gate\n- close the new Calculation Bundle and Data Processing unit-test coverage paths\n\n## Candidate\n\n- base dev SHA: 794fef603798d03c3dd8f4692a53563074b09d63\n- candidate SHA: b920ffe464e60e0c51665d03ef0910fcd70d1b72\n- version: 0.0.70\n\n## Validation\n\n- authenticated production semantic E2E: 60 passed, 33 designed skips\n- controlled production fixture cleanup: created=1, cleaned=1, leaked=0\n- credential-free semantic qualification: 63 passed, 30 designed skips\n- full unit and integration coverage: 413 suites, 5690 tests, 100/100/100/100\n- release preflight: passed\n- four locale production artifacts: canonical, idempotent, production-ready\n- reference resource production check: 5 resources across 4 languages\n- Docpact enforce: 35 changed paths covered, freshness ok\n\n## Follow-up\n\nAfter this PR merges to dev, promote the exact merged Release PR SHA from dev to main using the repository release promotion workflow. Root workspace integration remains pending until the child main release is complete.