### PR TITLE
fix: preserve tracked release receipt status columns

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-13"
-lastReviewedCommit: "c498d0f5e777555f99a56685160596a66b54c2eb"
+lastReviewedCommit: "41e3617f6c9e987ebd478fc5a529ab449991de99"
 lastReviewedNote: 'Reviewed for Next Issue #828: owner-draft scope and adjacent coverage repairs stay within existing runtime, test, and documentation ownership domains.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c498d0f5e777555f99a56685160596a66b54c2eb
+lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
 lastReviewedNote: 'Reviewed for Next Issue #828: owner-draft scope and focused coverage repairs preserve the existing repo contract, quality gate, and delivery boundaries.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c498d0f5e777555f99a56685160596a66b54c2eb
+lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
 lastReviewedNote: 'Reviewed for Next Issue #828: bootstrap and managed delivery remain unchanged; focused proof precedes one hook-owned full gate.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c498d0f5e777555f99a56685160596a66b54c2eb
+lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
 lastReviewedNote: 'Reviewed for Next Issue #828: focused branch coverage repairs restore the unchanged 100% gate without changing trigger or release policy.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c498d0f5e777555f99a56685160596a66b54c2eb
+lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
 lastReviewedNote: 'Reviewed for Next Issue #828: the Process LCA picker proof and focused coverage recovery remain correctly described by the existing matrix.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c498d0f5e777555f99a56685160596a66b54c2eb
+lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
 lastReviewedNote: 'Reviewed for Next Issue #828: adding behavior-level tests for real calculation branches preserves the existing full-closure strategy.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c498d0f5e777555f99a56685160596a66b54c2eb
+lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
 lastReviewedNote: 'Reviewed for Next Issue #828: owner-draft scope adds two behavior tests and closes the adjacent baseline coverage gaps without opening a queue.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c498d0f5e777555f99a56685160596a66b54c2eb
+lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
 lastReviewedNote: 'Reviewed for Next Issue #828: the new tests follow existing unit and behavior-level component patterns for real calculation branches.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c498d0f5e777555f99a56685160596a66b54c2eb
+lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
 lastReviewedNote: 'Reviewed for Next Issue #828: the focused coverage-gap playbook remains the correct recovery path; no troubleshooting rule changes.'
 ---
 

--- a/scripts/release/release-workflow.cjs
+++ b/scripts/release/release-workflow.cjs
@@ -12,8 +12,7 @@ const DEFAULT_CANONICAL_REMOTE = 'origin';
 const DEFAULT_PUSH_REMOTE = 'fork';
 const DEFAULT_LOG_DIRECTORY = '.local/release-automation';
 const TRANSPORT_RECEIPT_PATH = '.local/prepush-gate/failed-transport-receipt.json';
-const QUALIFICATION_RECEIPT_PATH =
-  'docs/plans/i18n/semantic-harness-qualification-receipt.json';
+const QUALIFICATION_RECEIPT_PATH = 'docs/plans/i18n/semantic-harness-qualification-receipt.json';
 const RELEASE_MARKER_PREFIX = 'tiangong-next-release-automation:v1';
 const MAX_CAPTURE_BYTES = 64 * 1024 * 1024;
 const MAIN_SEMANTIC_BRANCH_PATTERN = /^(?:codex\/)?(?:hotfix|promote|release)(?:\/|-)/u;
@@ -165,7 +164,10 @@ function assertClean(root) {
 }
 
 function worktreeStatus(root) {
-  return git(root, ['status', '--porcelain=v1', '--untracked-files=all']).stdout.trim();
+  return git(root, ['status', '--porcelain=v1', '--untracked-files=all']).stdout.replace(
+    /\r?\n$/u,
+    '',
+  );
 }
 
 function branchHasMainSemantics(branch) {
@@ -496,10 +498,7 @@ function reviewCommitFromDocument(source) {
 }
 
 function assertQualificationReceiptProvenance(root, baseRef) {
-  const receipt = readJson(
-    path.join(root, QUALIFICATION_RECEIPT_PATH),
-    QUALIFICATION_RECEIPT_PATH,
-  );
+  const receipt = readJson(path.join(root, QUALIFICATION_RECEIPT_PATH), QUALIFICATION_RECEIPT_PATH);
   if (
     receipt.schemaVersion !== 'tiangong.semantic-harness-qualification.v1' ||
     !/^[0-9a-f]{40}$/u.test(receipt.qualifiedCommit || '') ||
@@ -710,10 +709,7 @@ function generateQualification(root, logFile) {
     .split(/\r?\n/u)
     .filter(Boolean)
     .map((line) => line.slice(3));
-  if (
-    changed.length !== 1 ||
-    changed[0] !== QUALIFICATION_RECEIPT_PATH
-  ) {
+  if (changed.length !== 1 || changed[0] !== QUALIFICATION_RECEIPT_PATH) {
     throw new ReleaseAutomationError(
       'semantic_qualification_scope_invalid',
       'Qualification changed files outside its one generated receipt.',
@@ -724,10 +720,7 @@ function generateQualification(root, logFile) {
     );
   }
   const provenance = assertQualificationReceiptProvenance(root, sourceCommit);
-  if (
-    provenance.qualified_commit !== sourceCommit ||
-    provenance.qualified_tree !== sourceTree
-  ) {
+  if (provenance.qualified_commit !== sourceCommit || provenance.qualified_tree !== sourceTree) {
     throw new ReleaseAutomationError(
       'semantic_qualification_source_mismatch',
       'Qualification did not bind the exact clean source commit and tree.',

--- a/tests/unit/scripts/releaseWorkflow.test.ts
+++ b/tests/unit/scripts/releaseWorkflow.test.ts
@@ -148,7 +148,11 @@ const args = process.argv.slice(2);
 if (process.env.FAKE_NPM_LOG) fs.appendFileSync(process.env.FAKE_NPM_LOG, JSON.stringify(args) + '\\n');
 const qualificationReceipt = 'docs/plans/i18n/semantic-harness-qualification-receipt.json';
 if (args[0] === 'run' && args[1] === 'e2e:qualification:check') {
-  const mustRegenerate = process.env.FAKE_QUALIFICATION_STATUS === 'invalid' && !fs.existsSync(qualificationReceipt);
+  const currentReceipt = fs.existsSync(qualificationReceipt)
+    ? fs.readFileSync(qualificationReceipt, 'utf8')
+    : '';
+  const mustRegenerate = process.env.FAKE_QUALIFICATION_STATUS === 'invalid'
+    && (!currentReceipt || currentReceipt.includes('"stale": true'));
   process.exitCode = mustRegenerate ? 10 : 0;
 } else if (args[0] === 'run' && args[1] === 'e2e:qualify') {
   if (process.env.FAKE_QUALIFICATION_FAIL === '1') {
@@ -557,6 +561,52 @@ describe('release automation public contracts', () => {
       ]),
     ).toContain(`"qualifiedCommit": "${fixture.devSha}"`);
     expect(fs.readFileSync(npmLog, 'utf8')).toContain('e2e:qualify');
+  });
+
+  it('regenerates an already tracked stale qualification receipt', () => {
+    const fixture = createFixture();
+    git(fixture.root, ['switch', 'dev']);
+    writeJson(
+      path.join(fixture.root, 'docs/plans/i18n/semantic-harness-qualification-receipt.json'),
+      {
+        schemaVersion: 'tiangong.semantic-harness-qualification.v1',
+        stale: true,
+      },
+    );
+    git(fixture.root, ['add', 'docs/plans/i18n/semantic-harness-qualification-receipt.json']);
+    git(fixture.root, ['commit', '-m', 'track stale qualification receipt']);
+    fixture.devSha = git(fixture.root, ['rev-parse', 'HEAD']);
+    git(fixture.root, ['push', '--no-verify', 'origin', 'dev']);
+    git(fixture.root, ['switch', 'main']);
+    git(fixture.root, ['fetch', 'origin', 'dev']);
+
+    const result = runCli(
+      fixture,
+      releaseScript,
+      ['--version', '1.0.1', '--issue', '778', '--head-owner', 'fixture', '--apply'],
+      {
+        FAKE_QUALIFICATION_STATUS: 'invalid',
+        FAKE_GH_CREATED_URL: 'https://example.test/pull/55',
+      },
+    );
+
+    expect(result.status).toBe(0);
+    const output = JSON.parse(result.stdout);
+    expect(output).toMatchObject({
+      status: 'ready_for_review',
+      qualification: {
+        status: 'generated',
+        action: 'included_in_release_pr',
+        qualified_commit: fixture.devSha,
+      },
+      pull_request: { url: 'https://example.test/pull/55' },
+    });
+    expect(
+      git(fixture.root, [
+        'show',
+        'HEAD:docs/plans/i18n/semantic-harness-qualification-receipt.json',
+      ]),
+    ).not.toContain('"stale": true');
   });
 
   it('fails before push when semantic qualification cannot be generated', () => {


### PR DESCRIPTION
Closes #832

## Summary
- preserve the leading two-column `git status --porcelain=v1` status field when release automation inspects qualification output
- correctly recognize an already tracked, regenerated semantic qualification receipt
- add an isolated release-workflow regression test for the tracked stale-receipt path
- record the required Docpact review evidence without changing release policy

## Root cause
`worktreeStatus()` used `.trim()`, so an unstaged tracked receipt line beginning with ` M ` lost its first status-column space. The later fixed-width path extraction then turned `docs/...` into `ocs/...` and failed with `semantic_qualification_scope_invalid`.

## Validation
- `npm run test:release-workflow` (20/20)
- `npm run lint`
- Docpact worktree lint: pass
- managed `push:checked` gate: pass
- full coverage: 462/462 tracked source files at 100% statements, branches, functions, and lines

## Delivery context
This repairs the repository-managed v0.0.70 release path needed to promote the owner-draft scope from #828. No workspace pointer update is required for this blocker fix by itself; the subsequent v0.0.70 promote commit will be integrated through tiangong-lca/workspace#578.