### PR TITLE
chore: prepare v0.0.70 on current dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-13"
-lastReviewedCommit: "c498d0f5e777555f99a56685160596a66b54c2eb"
+lastReviewedCommit: "41e3617f6c9e987ebd478fc5a529ab449991de99"
 lastReviewedNote: 'Reviewed for Next Issue #828: owner-draft scope and adjacent coverage repairs stay within existing runtime, test, and documentation ownership domains.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-13"
-lastReviewedCommit: "41e3617f6c9e987ebd478fc5a529ab449991de99"
-lastReviewedNote: 'Reviewed for Next Issue #828: owner-draft scope and adjacent coverage repairs stay within existing runtime, test, and documentation ownership domains.'
+lastReviewedCommit: "3ef10317dac87831f48c728ae92e54bdb98c4433"
+lastReviewedNote: 'Reviewed for Next Issues #823 and #832: the v0.0.70 evidence refresh and tracked porcelain parser repair remain within the existing release, test, and documentation ownership domains.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c498d0f5e777555f99a56685160596a66b54c2eb
+lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
 lastReviewedNote: 'Reviewed for Next Issue #828: owner-draft scope and focused coverage repairs preserve the existing repo contract, quality gate, and delivery boundaries.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
-lastReviewedNote: 'Reviewed for Next Issue #828: owner-draft scope and focused coverage repairs preserve the existing repo contract, quality gate, and delivery boundaries.'
+lastReviewedCommit: 1f1cdcb238368518fc98c4117eeeba63902e8462
+lastReviewedNote: 'Reviewed for Next Issues #823 and #832: the v0.0.70 evidence refresh and release-parser repair preserve the existing repo contract, quality gate, and delivery boundaries.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
-lastReviewedNote: 'Reviewed for Next Issue #828: bootstrap and managed delivery remain unchanged; focused proof precedes one hook-owned full gate.'
+lastReviewedCommit: 1f1cdcb238368518fc98c4117eeeba63902e8462
+lastReviewedNote: 'Reviewed for Next Issues #823 and #832: bootstrap and managed delivery remain unchanged after the v0.0.70 evidence refresh and release-parser repair.'
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c498d0f5e777555f99a56685160596a66b54c2eb
+lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
 lastReviewedNote: 'Reviewed for Next Issue #828: bootstrap and managed delivery remain unchanged; focused proof precedes one hook-owned full gate.'
 ---
 

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -57,8 +57,8 @@ checkPaths:
   - .github/workflows/build.yml
   - package.json
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 7a5e0a1b7a5811a745bd1b305730ad3a46a63124
-lastReviewedNote: 'Reviewed for Next Issue #807 / workspace Issue #521: regenerating deterministic locale artifacts after the final flat-queue interaction closure does not change locale delivery or production-data authorization boundaries.'
+lastReviewedCommit: 9fc83b97055c88c87d2e76e9b644fb5860bdb63b
+lastReviewedNote: 'Reviewed for Next Issue #823: the v0.0.70 authenticated production proof, regenerated locale artifacts, and final credential-free qualification preserve the existing evidence-binding and production-data authorization boundaries.'
 baselineObservedAt: 2026-07-18
 related:
   - ../../AGENTS.md

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c498d0f5e777555f99a56685160596a66b54c2eb
+lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
 lastReviewedNote: 'Reviewed for Next Issue #828: focused branch coverage repairs restore the unchanged 100% gate without changing trigger or release policy.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
-lastReviewedNote: 'Reviewed for Next Issue #828: focused branch coverage repairs restore the unchanged 100% gate without changing trigger or release policy.'
+lastReviewedCommit: 3ef10317dac87831f48c728ae92e54bdb98c4433
+lastReviewedNote: 'Reviewed for Next Issues #823 and #832: the v0.0.70 release proof and tracked porcelain parser repair preserve the existing full-gate trigger and release policy.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c498d0f5e777555f99a56685160596a66b54c2eb
+lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
 lastReviewedNote: 'Reviewed for Next Issue #828: the Process LCA picker proof and focused coverage recovery remain correctly described by the existing matrix.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
-lastReviewedNote: 'Reviewed for Next Issue #828: the Process LCA picker proof and focused coverage recovery remain correctly described by the existing matrix.'
+lastReviewedCommit: 3ef10317dac87831f48c728ae92e54bdb98c4433
+lastReviewedNote: 'Reviewed for Next Issues #823 and #832: the current validation matrix already covers the v0.0.70 evidence refresh and tracked release-parser regression proof.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,8 +28,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
-lastReviewedNote: 'Reviewed for Next Issue #828: adding behavior-level tests for real calculation branches preserves the existing full-closure strategy.'
+lastReviewedCommit: 3ef10317dac87831f48c728ae92e54bdb98c4433
+lastReviewedNote: 'Reviewed for Next Issues #823 and #832: release evidence refresh and the parser regression test preserve the existing full-closure strategy.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c498d0f5e777555f99a56685160596a66b54c2eb
+lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
 lastReviewedNote: 'Reviewed for Next Issue #828: adding behavior-level tests for real calculation branches preserves the existing full-closure strategy.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c498d0f5e777555f99a56685160596a66b54c2eb
+lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
 lastReviewedNote: 'Reviewed for Next Issue #828: owner-draft scope adds two behavior tests and closes the adjacent baseline coverage gaps without opening a queue.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
-lastReviewedNote: 'Reviewed for Next Issue #828: owner-draft scope adds two behavior tests and closes the adjacent baseline coverage gaps without opening a queue.'
+lastReviewedCommit: 3ef10317dac87831f48c728ae92e54bdb98c4433
+lastReviewedNote: 'Reviewed for Next Issues #823 and #832: the v0.0.70 candidate and parser regression retain the closed 413-suite, 5,690-test coverage baseline.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c498d0f5e777555f99a56685160596a66b54c2eb
+lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
 lastReviewedNote: 'Reviewed for Next Issue #828: the new tests follow existing unit and behavior-level component patterns for real calculation branches.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,8 +31,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
-lastReviewedNote: 'Reviewed for Next Issue #828: the new tests follow existing unit and behavior-level component patterns for real calculation branches.'
+lastReviewedCommit: 3ef10317dac87831f48c728ae92e54bdb98c4433
+lastReviewedNote: 'Reviewed for Next Issues #823 and #832: release evidence refresh and porcelain parsing use the existing release-contract and focused unit-test patterns.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,8 +28,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
-lastReviewedNote: 'Reviewed for Next Issue #828: the focused coverage-gap playbook remains the correct recovery path; no troubleshooting rule changes.'
+lastReviewedCommit: 3ef10317dac87831f48c728ae92e54bdb98c4433
+lastReviewedNote: 'Reviewed for Next Issues #823 and #832: existing qualification, preflight, and managed-push recovery guidance remains correct after the parser repair.'
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: c498d0f5e777555f99a56685160596a66b54c2eb
+lastReviewedCommit: 41e3617f6c9e987ebd478fc5a529ab449991de99
 lastReviewedNote: 'Reviewed for Next Issue #828: the focused coverage-gap playbook remains the correct recovery path; no troubleshooting rule changes.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "digest": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "76cdd16a44d8d73d710f0b5c3da4e02dade38f27402995f0d0c4f6ddbe1645b5",
+          "sha256": "f19e6a354051055e604f733d627c5a632bf0c9168275145b3998d728925cc2e9",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "docs/plans/i18n/route-view-coverage.json": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-de-DE/glossary.json": "a5fd4e759af2713fbec83f2b95171c7b32206d7218da0401d28d2eecefccce3a",
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "85776b135ae473500b9cd4ca6ee324fb6628c376c4211f10a1168bfb9e99b247"
+  "contextDigest": "1e2d7b9f7e50a717429beb75c8d0ad8a5f3829568af505b2974cd983dc4d7a5b"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "85776b135ae473500b9cd4ca6ee324fb6628c376c4211f10a1168bfb9e99b247",
-    "qualityDigest": "8331baa67e8e24f9dd4e3518943b7ffef056e84f61e9e12b2021f39bb3b6b046",
+    "contextDigest": "1e2d7b9f7e50a717429beb75c8d0ad8a5f3829568af505b2974cd983dc4d7a5b",
+    "qualityDigest": "9add58322ab5e081e1b048db37e5b7d30326cf870dae8a7eb8a152f7ac009a73",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "routeViewCoverageDigest": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "c312fca51c8c02aa436635129db3037dee19d723e863f5fad37e2f3f3b884860"
+  "activationDigest": "ef4369e03b26ccc015f155fb5687641b617835420e305db4944362170a0a0a68"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "e6c47a648303f385c3db0d271584b0047417aa9a1544bd8a2984ce80ce8ebd7a",
-    "contextDigest": "85776b135ae473500b9cd4ca6ee324fb6628c376c4211f10a1168bfb9e99b247"
+    "contextDigest": "1e2d7b9f7e50a717429beb75c8d0ad8a5f3829568af505b2974cd983dc4d7a5b"
   },
   "catalog": {
     "messageCount": 3119,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "8331baa67e8e24f9dd4e3518943b7ffef056e84f61e9e12b2021f39bb3b6b046"
+  "qualityDigest": "9add58322ab5e081e1b048db37e5b7d30326cf870dae8a7eb8a152f7ac009a73"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "digest": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "76cdd16a44d8d73d710f0b5c3da4e02dade38f27402995f0d0c4f6ddbe1645b5",
+          "sha256": "f19e6a354051055e604f733d627c5a632bf0c9168275145b3998d728925cc2e9",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "docs/plans/i18n/route-view-coverage.json": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-en-US/glossary.json": "4b8443ea3f91f15383683e9ece6221e40e24ceb75442ea830964b06c12559970",
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "b7cbc5c720fecc72a8369da78a7888332ec56a123586bc61bdd8b43f8a989665"
+  "contextDigest": "aca0e88810e966f27333088216fdd678618a3bbe7bb769c4844188c1976956a2"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "b7cbc5c720fecc72a8369da78a7888332ec56a123586bc61bdd8b43f8a989665",
-    "qualityDigest": "3552a07f6d350e505c6817030c9c5b7a2112156c651cced81db2ca0bcf9e7d72",
+    "contextDigest": "aca0e88810e966f27333088216fdd678618a3bbe7bb769c4844188c1976956a2",
+    "qualityDigest": "04c8d835334735bf832e8a64829a9af1fdb569f04426010559dece7e4da8fc94",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "routeViewCoverageDigest": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "2afabf0e281cf45914414efe6fcaf3ddcf8bf40c3a867ca1a02d1c87c61e5f7f"
+  "activationDigest": "51fa0a0621a35c1ca0780e2449137f805fae3ed097cbacf7fb7bd8bf47f7f496"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "e6c47a648303f385c3db0d271584b0047417aa9a1544bd8a2984ce80ce8ebd7a",
-    "contextDigest": "b7cbc5c720fecc72a8369da78a7888332ec56a123586bc61bdd8b43f8a989665"
+    "contextDigest": "aca0e88810e966f27333088216fdd678618a3bbe7bb769c4844188c1976956a2"
   },
   "catalog": {
     "messageCount": 3119,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "3552a07f6d350e505c6817030c9c5b7a2112156c651cced81db2ca0bcf9e7d72"
+  "qualityDigest": "04c8d835334735bf832e8a64829a9af1fdb569f04426010559dece7e4da8fc94"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "digest": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "76cdd16a44d8d73d710f0b5c3da4e02dade38f27402995f0d0c4f6ddbe1645b5",
+          "sha256": "f19e6a354051055e604f733d627c5a632bf0c9168275145b3998d728925cc2e9",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "docs/plans/i18n/route-view-coverage.json": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-fr-FR/glossary.json": "057cb494f02d980106469f6a16befc102d26db5ac362b9777cd5f97c7729c91b",
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "7488b3d39c71c0ade5de4a630bec0662a7986e9b49200f6763baf7cfe96bdf94"
+  "contextDigest": "3348c4d8fea07588f08caecc60cc936f808b918aefb8c644a03d4a265f27e06d"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "7488b3d39c71c0ade5de4a630bec0662a7986e9b49200f6763baf7cfe96bdf94",
-    "qualityDigest": "e7cdd11b4227906dfe8a6f151f08c163d3baf9d5ef931d9decd2c4066e45c083",
+    "contextDigest": "3348c4d8fea07588f08caecc60cc936f808b918aefb8c644a03d4a265f27e06d",
+    "qualityDigest": "186ed940fa00da063ad7abc264bf8a484bdbe896062be71d31f68206b2fffa7d",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "routeViewCoverageDigest": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "f8a636a8c0e44ea12f4ba638739cb7386c4ec668f3531e9ba2d1e7a81e81a8a1"
+  "activationDigest": "2edbade7b57c90d4d79ea6ef65e4dcd17d37a19b686ce37ed85069c90514793e"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "e6c47a648303f385c3db0d271584b0047417aa9a1544bd8a2984ce80ce8ebd7a",
-    "contextDigest": "7488b3d39c71c0ade5de4a630bec0662a7986e9b49200f6763baf7cfe96bdf94"
+    "contextDigest": "3348c4d8fea07588f08caecc60cc936f808b918aefb8c644a03d4a265f27e06d"
   },
   "catalog": {
     "messageCount": 3119,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "e7cdd11b4227906dfe8a6f151f08c163d3baf9d5ef931d9decd2c4066e45c083"
+  "qualityDigest": "186ed940fa00da063ad7abc264bf8a484bdbe896062be71d31f68206b2fffa7d"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "digest": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "76cdd16a44d8d73d710f0b5c3da4e02dade38f27402995f0d0c4f6ddbe1645b5",
+          "sha256": "f19e6a354051055e604f733d627c5a632bf0c9168275145b3998d728925cc2e9",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "docs/plans/i18n/route-view-coverage.json": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-zh-CN/glossary.json": "c891add0ee4bd6d24c0213d0c839474e145d85867426df796763b8e038053d9b",
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "d1db04c7297e07afe06ca81b30826f7142f4b9ecc48174d3de1d8ecaf62ae7bb"
+  "contextDigest": "31f31a464a2a3ecfa1f2b39617847f91d6c567c48a17ba1ab858be483170962f"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "d1db04c7297e07afe06ca81b30826f7142f4b9ecc48174d3de1d8ecaf62ae7bb",
-    "qualityDigest": "7882536340eed8292f370bec5f9acc37f9fc83a5d810b76a45f1d50f3cc3e42c",
+    "contextDigest": "31f31a464a2a3ecfa1f2b39617847f91d6c567c48a17ba1ab858be483170962f",
+    "qualityDigest": "cf6812d7699fdd33d98465212a2aecbee9c11bdc7039321dd9a8df6d3ae8d960",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "4cb5341e8964b51ca78dc2816ad3ad477ee6c6c85c4c92382605240e762c2e7c",
+    "routeViewCoverageDigest": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "88ddb016960805c94a6aea6281af34002f179e7b9f15436d9c78af3e2cf9e788"
+  "activationDigest": "7b5bc5c4465b1900ba7cd2d2704c54e34718b7ca4790a4521f7a51aa91a95265"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "e6c47a648303f385c3db0d271584b0047417aa9a1544bd8a2984ce80ce8ebd7a",
-    "contextDigest": "d1db04c7297e07afe06ca81b30826f7142f4b9ecc48174d3de1d8ecaf62ae7bb"
+    "contextDigest": "31f31a464a2a3ecfa1f2b39617847f91d6c567c48a17ba1ab858be483170962f"
   },
   "catalog": {
     "messageCount": 3119,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "7882536340eed8292f370bec5f9acc37f9fc83a5d810b76a45f1d50f3cc3e42c"
+  "qualityDigest": "cf6812d7699fdd33d98465212a2aecbee9c11bdc7039321dd9a8df6d3ae8d960"
 }

--- a/docs/plans/i18n/route-view-coverage.json
+++ b/docs/plans/i18n/route-view-coverage.json
@@ -353,7 +353,7 @@
       "executedEvidence": [
         {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "76cdd16a44d8d73d710f0b5c3da4e02dade38f27402995f0d0c4f6ddbe1645b5"
+          "sha256": "f19e6a354051055e604f733d627c5a632bf0c9168275145b3998d728925cc2e9"
         }
       ]
     }

--- a/docs/plans/i18n/semantic-e2e-evidence.json
+++ b/docs/plans/i18n/semantic-e2e-evidence.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": "tiangong.i18n-semantic-e2e-evidence.v1",
   "status": "verified",
-  "generatedAt": "2026-08-13T04:43:11.480Z",
-  "runId": "local-b77e55ac-7ccf-40f3-9eb6-ec51ae13dc05",
+  "generatedAt": "2026-08-13T14:45:11.991Z",
+  "runId": "local-c5507a8c-9302-4e74-853a-836be04db33e",
   "candidate": {
     "configTreeDigest": "c79878bbed6dfb7becc3cedae0fdd08e0926b674293a6f9656469ac8682cc804",
-    "observedHeadCommit": "42b7e37ad3334e69bad22932677e61f9dfb31774",
-    "packageManifestDigest": "4edda913c2d75c266e5ef803b7d0171f019ed5494ad8cbef10d8d0b7e7ecc2b0",
-    "sourceTreeDigest": "7eb7f23eaa1bc802da8a594c8609c7005fd02a3b2b7bdc623a7df5cac295aedf",
-    "unitTestTreeDigest": "4902252cde9a2d5764f73a9fa42990b2c164d7e9b4aff6e4ec8141fabcbab218"
+    "observedHeadCommit": "bc7aaf34f7ce78f206c33562f6460ffc1580ae7b",
+    "packageManifestDigest": "2b78dea75572169f5a945913cc1d3b8b9ed3b9ecbb65c4fc0dc45b4126150437",
+    "sourceTreeDigest": "5e5430988c519280325dd6d71189e8651780c4b3eb1d78616b4a2121ddb523a9",
+    "unitTestTreeDigest": "f16debd5fcaebcc64f9f9b59370bfba863784dd190f9c90c6ed02200a2ffb7b0"
   },
   "target": {
     "frontend": "candidate-local",
@@ -34,7 +34,7 @@
   "digests": {
     "packageLock": {
       "path": "package-lock.json",
-      "sha256": "b46fc0f92f5cdd34853fa71c7238a15bcefde446d6795893ea650f2490496931"
+      "sha256": "9fd2ed1e848cbdbc78d612167f5672ab034a3b5445d5e9a391d113a1fe1f6d69"
     },
     "runtimeAssets": [
       {
@@ -377,7 +377,7 @@
       },
       {
         "path": "tests/unit/pages/DataProcessing/index.test.tsx",
-        "sha256": "718feff487151b71ad19ad0a508bb56b46bfd8531af05b60477c678b479ade2a"
+        "sha256": "d1930ddaf4817eb4dec31668565b1b3d52103dbeca3cb515066594807e0d0198"
       },
       {
         "path": "tests/unit/pages/Flowproperties/index.test.tsx",
@@ -519,7 +519,7 @@
       },
       {
         "path": "src/locales/en-US/pages.ts",
-        "sha256": "287a5f3f589b5e3138ba05891b6259da4c6da452c800e22456fab4273909b74e"
+        "sha256": "a593dba3f0843b5ff53f4739953702d7608c9e6134ee4f33db2d7533339d72a4"
       },
       {
         "path": "src/locales/en-US/pages_general.ts",
@@ -543,7 +543,7 @@
       },
       {
         "path": "src/pages/DataProcessing/index.tsx",
-        "sha256": "e395d4baee0870648b3d832bcbc2af3e5449a19dd9bba07d1cbae1ec149e619e"
+        "sha256": "940f8843458a176296cfb41b824204bedd203b45981657b409dc1d38734d50da"
       },
       {
         "path": "src/pages/Flowproperties/index.tsx",

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "a948e3ebaf6fd1f616d8a37855deaf4f999d4ffc1ac176d9c8fb576ea5a62a81"
+    "runResultSha256": "4ce427d093f19ee570db9d3673ca2031e8da3ee3446c617ab9ae464762131bef"
   },
-  "environmentManifestSha256": "94fe11a04b87b84ed66feb20903ee7984dd9579b0b60776561202eb29fc94a99",
+  "environmentManifestSha256": "5ba5ed1ebba6b8a7b949b9f78ed0ad10e327bcdd6cf293a48d535ab9b8e0db61",
   "externalRequests": 0,
-  "generatedAt": "2026-08-13T05:05:13.997Z",
+  "generatedAt": "2026-08-13T14:27:27.932Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "7e988b5d275477358055ad204a0afff8dc5aba34d53d0fa736cd2574e4273e0f",
-  "qualifiedCommit": "39542f077a598ee9386a57c9d82ca375cf4b03b3",
-  "qualifiedTree": "49002deee38e129b52d03921989b63793e451925",
+  "qualificationInputSha256": "4a611da0aeee33db772a55ed67da45130a8f0860226c0571f63806244df1176d",
+  "qualifiedCommit": "41e3617f6c9e987ebd478fc5a529ab449991de99",
+  "qualifiedTree": "cdca4f4b37446c0b8ac065f43e70480559274c99",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "4ce427d093f19ee570db9d3673ca2031e8da3ee3446c617ab9ae464762131bef"
+    "runResultSha256": "90417b1d8555463c53bb69e18acaaf8612a85e7afde2de6491e954f8bec5a813"
   },
-  "environmentManifestSha256": "5ba5ed1ebba6b8a7b949b9f78ed0ad10e327bcdd6cf293a48d535ab9b8e0db61",
+  "environmentManifestSha256": "efb77228c60d3134130c4aee437396892f997de1c2deaa88f0d3cc2c1bfbfdaa",
   "externalRequests": 0,
-  "generatedAt": "2026-08-13T14:27:27.932Z",
+  "generatedAt": "2026-08-13T14:59:34.206Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "4a611da0aeee33db772a55ed67da45130a8f0860226c0571f63806244df1176d",
-  "qualifiedCommit": "41e3617f6c9e987ebd478fc5a529ab449991de99",
-  "qualifiedTree": "cdca4f4b37446c0b8ac065f43e70480559274c99",
+  "qualificationInputSha256": "0f466a41d97b74d86c71d48996b529c54d5066b47cbc5592a933e64f939c7b0b",
+  "qualifiedCommit": "c2ed3f2e2e17834d3182c83912c5963ca2d9ad65",
+  "qualifiedTree": "aec76b78ed28cee2e0d227880f9ae8ff33943cd5",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.69",
+      "version": "0.0.70",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
Closes #823

## Summary

- prepare Next version `0.0.70` from current `dev` after the merged calculation product fixes
- bind fresh authenticated production semantic evidence to the current calculation tests and sources
- regenerate all four locale delivery artifacts and the final credential-free qualification receipt
- record the required i18n delivery contract review
- include the merged release-status parser regression fix from #832 / #833

## Candidate

- base `dev` SHA: `0b8a8874`
- candidate SHA: `16d4badcf0d937c94fee0fa7a370ab2554955507`
- version: `0.0.70`

## Validation

- authenticated production semantic E2E: 60 passed, 33 designed skips
- controlled production fixture cleanup: created=1, cleaned=1, leaked=0
- final credential-free semantic qualification: 63 passed, 30 designed skips
- full local gate on the final candidate: 413 suites, 5691 tests, 0 failures
- coverage: 462/462 tracked files at 100/100/100/100
- release preflight: passed on the final candidate
- locale artifacts: canonical, double-generation idempotent, production-ready for 4 locales
- reference-resource production check: 5 resources across 4 languages
- Docpact strict config and enforce lint: passed

## Notes

- supersedes the conflict-stale release PR #831
- the independently discovered release-status parsing defect in #834 is resolved by #832 / merged PR #833
- after merge to `dev`, promote this exact Release PR through the deterministic `dev -> main` workflow
- root workspace integration remains pending until the child `main` release completes