### PR TITLE
fix: stabilize v0.0.70 release gate fixtures

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-13"
-lastReviewedCommit: "3ef10317dac87831f48c728ae92e54bdb98c4433"
+lastReviewedCommit: "fcb03cca5d67941f63b2ebb382e43f19a9588a0d"
 lastReviewedNote: 'Reviewed for Next Issues #823 and #832: the v0.0.70 evidence refresh and tracked porcelain parser repair remain within the existing release, test, and documentation ownership domains.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 1f1cdcb238368518fc98c4117eeeba63902e8462
+lastReviewedCommit: fcb03cca5d67941f63b2ebb382e43f19a9588a0d
 lastReviewedNote: 'Reviewed for Next Issues #823 and #832: the v0.0.70 evidence refresh and release-parser repair preserve the existing repo contract, quality gate, and delivery boundaries.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 1f1cdcb238368518fc98c4117eeeba63902e8462
+lastReviewedCommit: fcb03cca5d67941f63b2ebb382e43f19a9588a0d
 lastReviewedNote: 'Reviewed for Next Issues #823 and #832: bootstrap and managed delivery remain unchanged after the v0.0.70 evidence refresh and release-parser repair.'
 ---
 

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -56,9 +56,9 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - .github/workflows/build.yml
   - package.json
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: 9fc83b97055c88c87d2e76e9b644fb5860bdb63b
-lastReviewedNote: 'Reviewed for Next Issue #823: the v0.0.70 authenticated production proof, regenerated locale artifacts, and final credential-free qualification preserve the existing evidence-binding and production-data authorization boundaries.'
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: 5114e834
+lastReviewedNote: 'Reviewed for Next Issue #836: the time-independent unit fixture and refreshed v0.0.70 proof preserve the existing evidence-binding and production-data authorization boundaries.'
 baselineObservedAt: 2026-07-18
 related:
   - ../../AGENTS.md

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 3ef10317dac87831f48c728ae92e54bdb98c4433
+lastReviewedCommit: fcb03cca5d67941f63b2ebb382e43f19a9588a0d
 lastReviewedNote: 'Reviewed for Next Issues #823 and #832: the v0.0.70 release proof and tracked porcelain parser repair preserve the existing full-gate trigger and release policy.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 3ef10317dac87831f48c728ae92e54bdb98c4433
+lastReviewedCommit: fcb03cca5d67941f63b2ebb382e43f19a9588a0d
 lastReviewedNote: 'Reviewed for Next Issues #823 and #832: the current validation matrix already covers the v0.0.70 evidence refresh and tracked release-parser regression proof.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 3ef10317dac87831f48c728ae92e54bdb98c4433
+lastReviewedCommit: fcb03cca5d67941f63b2ebb382e43f19a9588a0d
 lastReviewedNote: 'Reviewed for Next Issues #823 and #832: release evidence refresh and the parser regression test preserve the existing full-closure strategy.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 3ef10317dac87831f48c728ae92e54bdb98c4433
+lastReviewedCommit: fcb03cca5d67941f63b2ebb382e43f19a9588a0d
 lastReviewedNote: 'Reviewed for Next Issues #823 and #832: the v0.0.70 candidate and parser regression retain the closed 413-suite, 5,690-test coverage baseline.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 3ef10317dac87831f48c728ae92e54bdb98c4433
+lastReviewedCommit: fcb03cca5d67941f63b2ebb382e43f19a9588a0d
 lastReviewedNote: 'Reviewed for Next Issues #823 and #832: release evidence refresh and porcelain parsing use the existing release-contract and focused unit-test patterns.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-13
-lastReviewedCommit: 3ef10317dac87831f48c728ae92e54bdb98c4433
+lastReviewedCommit: fcb03cca5d67941f63b2ebb382e43f19a9588a0d
 lastReviewedNote: 'Reviewed for Next Issues #823 and #832: existing qualification, preflight, and managed-push recovery guidance remains correct after the parser repair.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
+    "digest": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "f19e6a354051055e604f733d627c5a632bf0c9168275145b3998d728925cc2e9",
+          "sha256": "124d07d113b614a6b9d5fa9337b21a8d060cc7ef19b885193568d4b2c948e013",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
+    "docs/plans/i18n/route-view-coverage.json": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-de-DE/glossary.json": "a5fd4e759af2713fbec83f2b95171c7b32206d7218da0401d28d2eecefccce3a",
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "1e2d7b9f7e50a717429beb75c8d0ad8a5f3829568af505b2974cd983dc4d7a5b"
+  "contextDigest": "8eff9352147c28702db5cdb73ac2bcef2d30832c6d4fb87a829106f5447c30fb"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "1e2d7b9f7e50a717429beb75c8d0ad8a5f3829568af505b2974cd983dc4d7a5b",
-    "qualityDigest": "9add58322ab5e081e1b048db37e5b7d30326cf870dae8a7eb8a152f7ac009a73",
+    "contextDigest": "8eff9352147c28702db5cdb73ac2bcef2d30832c6d4fb87a829106f5447c30fb",
+    "qualityDigest": "1eabb56f944c8fa21dda7aee78950601949f29003b667892f9959db45af742f3",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
+    "routeViewCoverageDigest": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "ef4369e03b26ccc015f155fb5687641b617835420e305db4944362170a0a0a68"
+  "activationDigest": "a712538f9251b2fad28a237cb6bf7b337579e4dc103e3b72c34c74420dbe49d2"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "e6c47a648303f385c3db0d271584b0047417aa9a1544bd8a2984ce80ce8ebd7a",
-    "contextDigest": "1e2d7b9f7e50a717429beb75c8d0ad8a5f3829568af505b2974cd983dc4d7a5b"
+    "contextDigest": "8eff9352147c28702db5cdb73ac2bcef2d30832c6d4fb87a829106f5447c30fb"
   },
   "catalog": {
     "messageCount": 3119,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "9add58322ab5e081e1b048db37e5b7d30326cf870dae8a7eb8a152f7ac009a73"
+  "qualityDigest": "1eabb56f944c8fa21dda7aee78950601949f29003b667892f9959db45af742f3"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
+    "digest": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "f19e6a354051055e604f733d627c5a632bf0c9168275145b3998d728925cc2e9",
+          "sha256": "124d07d113b614a6b9d5fa9337b21a8d060cc7ef19b885193568d4b2c948e013",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
+    "docs/plans/i18n/route-view-coverage.json": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-en-US/glossary.json": "4b8443ea3f91f15383683e9ece6221e40e24ceb75442ea830964b06c12559970",
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "aca0e88810e966f27333088216fdd678618a3bbe7bb769c4844188c1976956a2"
+  "contextDigest": "2855bf0660e2229a732547a79615c9dd82c72144ad1aec8cedef14060aa932ba"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "aca0e88810e966f27333088216fdd678618a3bbe7bb769c4844188c1976956a2",
-    "qualityDigest": "04c8d835334735bf832e8a64829a9af1fdb569f04426010559dece7e4da8fc94",
+    "contextDigest": "2855bf0660e2229a732547a79615c9dd82c72144ad1aec8cedef14060aa932ba",
+    "qualityDigest": "f22095ea0b771fe89e267fe22e038f429eda0ac1c10f11603ee5a57229232ce5",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
+    "routeViewCoverageDigest": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "51fa0a0621a35c1ca0780e2449137f805fae3ed097cbacf7fb7bd8bf47f7f496"
+  "activationDigest": "04ea26cbdaf22aa2946bf4274b1dfa9c753eb022ad391b482aafa0c1c780047a"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "e6c47a648303f385c3db0d271584b0047417aa9a1544bd8a2984ce80ce8ebd7a",
-    "contextDigest": "aca0e88810e966f27333088216fdd678618a3bbe7bb769c4844188c1976956a2"
+    "contextDigest": "2855bf0660e2229a732547a79615c9dd82c72144ad1aec8cedef14060aa932ba"
   },
   "catalog": {
     "messageCount": 3119,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "04c8d835334735bf832e8a64829a9af1fdb569f04426010559dece7e4da8fc94"
+  "qualityDigest": "f22095ea0b771fe89e267fe22e038f429eda0ac1c10f11603ee5a57229232ce5"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
+    "digest": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "f19e6a354051055e604f733d627c5a632bf0c9168275145b3998d728925cc2e9",
+          "sha256": "124d07d113b614a6b9d5fa9337b21a8d060cc7ef19b885193568d4b2c948e013",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
+    "docs/plans/i18n/route-view-coverage.json": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-fr-FR/glossary.json": "057cb494f02d980106469f6a16befc102d26db5ac362b9777cd5f97c7729c91b",
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "3348c4d8fea07588f08caecc60cc936f808b918aefb8c644a03d4a265f27e06d"
+  "contextDigest": "d274af5ea3c6522e391d2e32109c4d8cbc85ca4fb84b7a82a94e3b2c63a4b132"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "3348c4d8fea07588f08caecc60cc936f808b918aefb8c644a03d4a265f27e06d",
-    "qualityDigest": "186ed940fa00da063ad7abc264bf8a484bdbe896062be71d31f68206b2fffa7d",
+    "contextDigest": "d274af5ea3c6522e391d2e32109c4d8cbc85ca4fb84b7a82a94e3b2c63a4b132",
+    "qualityDigest": "15a9f48ee97af273c2a1f05921274cd3e930b8a2c3f14725d49a8c2be628b725",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
+    "routeViewCoverageDigest": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "2edbade7b57c90d4d79ea6ef65e4dcd17d37a19b686ce37ed85069c90514793e"
+  "activationDigest": "15f889b01e0f1ce014db54508f086bb228e97b0582c7b5af4905b0dd641bc876"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "e6c47a648303f385c3db0d271584b0047417aa9a1544bd8a2984ce80ce8ebd7a",
-    "contextDigest": "3348c4d8fea07588f08caecc60cc936f808b918aefb8c644a03d4a265f27e06d"
+    "contextDigest": "d274af5ea3c6522e391d2e32109c4d8cbc85ca4fb84b7a82a94e3b2c63a4b132"
   },
   "catalog": {
     "messageCount": 3119,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "186ed940fa00da063ad7abc264bf8a484bdbe896062be71d31f68206b2fffa7d"
+  "qualityDigest": "15a9f48ee97af273c2a1f05921274cd3e930b8a2c3f14725d49a8c2be628b725"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
+    "digest": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "f19e6a354051055e604f733d627c5a632bf0c9168275145b3998d728925cc2e9",
+          "sha256": "124d07d113b614a6b9d5fa9337b21a8d060cc7ef19b885193568d4b2c948e013",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "55e442639615bcf45bcd7ef29996638f366c9614136e8a06df6c85410a99ff67",
-    "docs/plans/i18n/route-view-coverage.json": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
+    "docs/plans/i18n/route-view-coverage.json": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-zh-CN/glossary.json": "c891add0ee4bd6d24c0213d0c839474e145d85867426df796763b8e038053d9b",
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "31f31a464a2a3ecfa1f2b39617847f91d6c567c48a17ba1ab858be483170962f"
+  "contextDigest": "5f3ae8341fc84dcb9a030b4ceb2ff2fde358a2689070258a9a242f54d5497990"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "31f31a464a2a3ecfa1f2b39617847f91d6c567c48a17ba1ab858be483170962f",
-    "qualityDigest": "cf6812d7699fdd33d98465212a2aecbee9c11bdc7039321dd9a8df6d3ae8d960",
+    "contextDigest": "5f3ae8341fc84dcb9a030b4ceb2ff2fde358a2689070258a9a242f54d5497990",
+    "qualityDigest": "9aef839f2b6cc5ca5b2edb1bd22069058c63c5f34e5d820d48d273c8bc4df3cd",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "3c3dae8fc0c49eca75815956b6c3e1d1722e62ec1a9a7dd1988ab6d96b5e012e",
+    "routeViewCoverageDigest": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "7b5bc5c4465b1900ba7cd2d2704c54e34718b7ca4790a4521f7a51aa91a95265"
+  "activationDigest": "e44e907628677bb95e1fd23b42d9567e5fcacbee6315f7227462b14988e5f485"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "e6c47a648303f385c3db0d271584b0047417aa9a1544bd8a2984ce80ce8ebd7a",
-    "contextDigest": "31f31a464a2a3ecfa1f2b39617847f91d6c567c48a17ba1ab858be483170962f"
+    "contextDigest": "5f3ae8341fc84dcb9a030b4ceb2ff2fde358a2689070258a9a242f54d5497990"
   },
   "catalog": {
     "messageCount": 3119,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "cf6812d7699fdd33d98465212a2aecbee9c11bdc7039321dd9a8df6d3ae8d960"
+  "qualityDigest": "9aef839f2b6cc5ca5b2edb1bd22069058c63c5f34e5d820d48d273c8bc4df3cd"
 }

--- a/docs/plans/i18n/route-view-coverage.json
+++ b/docs/plans/i18n/route-view-coverage.json
@@ -353,7 +353,7 @@
       "executedEvidence": [
         {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "f19e6a354051055e604f733d627c5a632bf0c9168275145b3998d728925cc2e9"
+          "sha256": "124d07d113b614a6b9d5fa9337b21a8d060cc7ef19b885193568d4b2c948e013"
         }
       ]
     }

--- a/docs/plans/i18n/semantic-e2e-evidence.json
+++ b/docs/plans/i18n/semantic-e2e-evidence.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": "tiangong.i18n-semantic-e2e-evidence.v1",
   "status": "verified",
-  "generatedAt": "2026-08-13T14:45:11.991Z",
-  "runId": "local-c5507a8c-9302-4e74-853a-836be04db33e",
+  "generatedAt": "2026-08-13T16:03:03.669Z",
+  "runId": "local-e1ccecf8-011c-4dae-b4da-ff4731b2a2bf",
   "candidate": {
     "configTreeDigest": "c79878bbed6dfb7becc3cedae0fdd08e0926b674293a6f9656469ac8682cc804",
-    "observedHeadCommit": "bc7aaf34f7ce78f206c33562f6460ffc1580ae7b",
+    "observedHeadCommit": "b918c68480ac67de3ab66e332c0e5a62272963c9",
     "packageManifestDigest": "2b78dea75572169f5a945913cc1d3b8b9ed3b9ecbb65c4fc0dc45b4126150437",
     "sourceTreeDigest": "5e5430988c519280325dd6d71189e8651780c4b3eb1d78616b4a2121ddb523a9",
-    "unitTestTreeDigest": "f16debd5fcaebcc64f9f9b59370bfba863784dd190f9c90c6ed02200a2ffb7b0"
+    "unitTestTreeDigest": "40d09c6a1e13df8a901f7c6d5f34c2464247b49d06d5381cbfc980ac89a0bab0"
   },
   "target": {
     "frontend": "candidate-local",

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "d78733b23f20c1d981d526c77998f7bb497a79a7bbc2bafdd2692ae8926b5765"
+    "runResultSha256": "713ea5ee978229a81c5b5a6b9ddba9590238aa01bde676cde89110016690b8b3"
   },
-  "environmentManifestSha256": "903138591b7d02564f1bb8bb603857765b670c0c4e6296bb047625078f5bc6ae",
+  "environmentManifestSha256": "e1c99a5bf228f5f00582072acab1c62b2a59968cba1c24fd62808c71832c47ae",
   "externalRequests": 0,
-  "generatedAt": "2026-08-13T16:15:10.495Z",
+  "generatedAt": "2026-08-13T16:28:10.441Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "0f466a41d97b74d86c71d48996b529c54d5066b47cbc5592a933e64f939c7b0b",
-  "qualifiedCommit": "062eaa6cb501447c00d1b63405b3fb1d7eb884a8",
-  "qualifiedTree": "1ed33268d248fa16e360eefe135a6c81c093b688",
+  "qualificationInputSha256": "1fb6497e2cc9b11b625a45c85cfacffc9312aa9f9e0208a6bbc7a81bbe4fcc76",
+  "qualifiedCommit": "320543506f5bcfcdc1c6d475f313e05a2f43ebae",
+  "qualifiedTree": "1c8ff68902bd6e12e6862e98f8a441e53ddb7cfb",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "90417b1d8555463c53bb69e18acaaf8612a85e7afde2de6491e954f8bec5a813"
+    "runResultSha256": "d78733b23f20c1d981d526c77998f7bb497a79a7bbc2bafdd2692ae8926b5765"
   },
-  "environmentManifestSha256": "efb77228c60d3134130c4aee437396892f997de1c2deaa88f0d3cc2c1bfbfdaa",
+  "environmentManifestSha256": "903138591b7d02564f1bb8bb603857765b670c0c4e6296bb047625078f5bc6ae",
   "externalRequests": 0,
-  "generatedAt": "2026-08-13T14:59:34.206Z",
+  "generatedAt": "2026-08-13T16:15:10.495Z",
   "productionWrites": 0,
   "qualificationInputSha256": "0f466a41d97b74d86c71d48996b529c54d5066b47cbc5592a933e64f939c7b0b",
-  "qualifiedCommit": "c2ed3f2e2e17834d3182c83912c5963ca2d9ad65",
-  "qualifiedTree": "aec76b78ed28cee2e0d227880f9ae8ff33943cd5",
+  "qualifiedCommit": "062eaa6cb501447c00d1b63405b3fb1d7eb884a8",
+  "qualifiedTree": "1ed33268d248fa16e360eefe135a6c81c093b688",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }

--- a/tests/unit/services/tidasPackage/taskCenter.test.ts
+++ b/tests/unit/services/tidasPackage/taskCenter.test.ts
@@ -709,7 +709,7 @@ describe('tidasPackage/taskCenter', () => {
       STORAGE_KEY,
       JSON.stringify({
         version: 1,
-        savedAt: '2026-08-10T15:20:00.000Z',
+        savedAt: new Date().toISOString(),
         tasks: [
           {
             id: 'original-local-task',

--- a/tests/unit/services/unitgroups/util.test.ts
+++ b/tests/unit/services/unitgroups/util.test.ts
@@ -9,11 +9,11 @@ import {
   genUnitTableData,
 } from '@/services/unitgroups/util';
 
-jest.mock('@tiangong-lca/tidas-sdk', () => ({
+jest.mock('@tiangong-lca/tidas-sdk/core', () => ({
   createUnitGroup: jest.fn((data) => data),
 }));
 
-const mockCreateUnitGroup = jest.requireMock('@tiangong-lca/tidas-sdk')
+const mockCreateUnitGroup = jest.requireMock('@tiangong-lca/tidas-sdk/core')
   .createUnitGroup as jest.Mock;
 
 const baseUnitGroupData = {


### PR DESCRIPTION
## Summary

- make the persisted Task Center alias fixture time-independent while retaining fixed backend timestamps for reconciliation assertions
- bind the Unit Group factory spy to the exact `@tiangong-lca/tidas-sdk/core` entry imported by production code
- refresh the v0.0.70 authenticated semantic evidence, locale artifacts, final qualification receipt, and governed review evidence

## Key decisions

- The Task Center fixture uses the current save time because the product contract intentionally expires persisted snapshots after 72 hours; changing the product TTL would hide the test defect.
- The Unit Group test mocks the actual SDK entry point instead of depending on the Jest mapper to bridge a root-package mock into `/core`.
- No production source behavior changes. The existing production-data safety boundary was used for authenticated evidence: one exact UUID-scoped fixture was created and cleaned, with `created=1`, `cleaned=1`, and `leaked=0`.

## Validation

- `npm run test:ci -- --runInBand tests/unit/services/tidasPackage/taskCenter.test.ts --no-coverage` — 35 passed
- `npm run test:ci -- --runInBand tests/unit/services/unitgroups/util.test.ts --no-coverage` — 11 passed
- authenticated `npm run e2e:release` — 60 passed, 33 designed skips; exact production fixture cleaned
- `npm run i18n:locale:artifacts:write` and `npm run i18n:locale:artifacts:idempotence`
- final `npm run e2e:qualify` — 63 passed, 30 designed skips; zero external requests and zero production writes
- `npm run release:preflight`
- managed `npm run push:checked` — Docpact pass; 413 suites / 5691 tests passed; statements, branches, functions, and lines all 100%

## Release handoff

This PR restores a valid exact `dev` candidate for the v0.0.70 promote recovery. After merge, promotion must use the exact resulting `dev` SHA; the existing PR #835 lacks the release-automation identity marker and must not be retroactively marked.

Closes #836
Closes #837
Related: #823