### PR TITLE
test: bind SDK mocks to runtime core entry

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-13"
-lastReviewedCommit: "fcb03cca5d67941f63b2ebb382e43f19a9588a0d"
-lastReviewedNote: 'Reviewed for Next Issues #823 and #832: the v0.0.70 evidence refresh and tracked porcelain parser repair remain within the existing release, test, and documentation ownership domains.'
+lastReviewedAt: "2026-08-14"
+lastReviewedCommit: "018bd8e1c932c307b1e024a02928c65c06d60048"
+lastReviewedNote: 'Reviewed for Next Issue #839: direct runtime-entry SDK mocks remain within the existing test, release, and documentation ownership domains.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,9 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: fcb03cca5d67941f63b2ebb382e43f19a9588a0d
-lastReviewedNote: 'Reviewed for Next Issues #823 and #832: the v0.0.70 evidence refresh and release-parser repair preserve the existing repo contract, quality gate, and delivery boundaries.'
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: 018bd8e1c932c307b1e024a02928c65c06d60048
+lastReviewedNote: 'Reviewed for Next Issue #839: direct runtime-entry SDK mocks preserve the existing repo contract, quality gate, and delivery boundaries.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -29,9 +29,9 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - .nvmrc
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: fcb03cca5d67941f63b2ebb382e43f19a9588a0d
-lastReviewedNote: 'Reviewed for Next Issues #823 and #832: bootstrap and managed delivery remain unchanged after the v0.0.70 evidence refresh and release-parser repair.'
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: 018bd8e1c932c307b1e024a02928c65c06d60048
+lastReviewedNote: 'Reviewed for Next Issue #839: bootstrap and managed delivery remain unchanged by the SDK mock-entry alignment.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -30,9 +30,9 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: fcb03cca5d67941f63b2ebb382e43f19a9588a0d
-lastReviewedNote: 'Reviewed for Next Issues #823 and #832: the v0.0.70 release proof and tracked porcelain parser repair preserve the existing full-gate trigger and release policy.'
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: 018bd8e1c932c307b1e024a02928c65c06d60048
+lastReviewedNote: 'Reviewed for Next Issue #839: the SDK mock-entry alignment preserves the existing full-gate trigger and release policy.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,9 +30,9 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: fcb03cca5d67941f63b2ebb382e43f19a9588a0d
-lastReviewedNote: 'Reviewed for Next Issues #823 and #832: the current validation matrix already covers the v0.0.70 evidence refresh and tracked release-parser regression proof.'
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: 018bd8e1c932c307b1e024a02928c65c06d60048
+lastReviewedNote: 'Reviewed for Next Issue #839: the current tests-and-gates validation row covers the SDK mock-entry alignment and focused regression proof.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -27,9 +27,9 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - package.json
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: fcb03cca5d67941f63b2ebb382e43f19a9588a0d
-lastReviewedNote: 'Reviewed for Next Issues #823 and #832: release evidence refresh and the parser regression test preserve the existing full-closure strategy.'
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: 018bd8e1c932c307b1e024a02928c65c06d60048
+lastReviewedNote: 'Reviewed for Next Issue #839: direct runtime-entry SDK mocks preserve the existing focused-first, full-closure strategy.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -29,9 +29,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: fcb03cca5d67941f63b2ebb382e43f19a9588a0d
-lastReviewedNote: 'Reviewed for Next Issues #823 and #832: the v0.0.70 candidate and parser regression retain the closed 413-suite, 5,690-test coverage baseline.'
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: 018bd8e1c932c307b1e024a02928c65c06d60048
+lastReviewedNote: 'Reviewed for Next Issue #839: the SDK mock-entry alignment adds no test or queue item and preserves the checked-in reference baseline.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -30,9 +30,9 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: fcb03cca5d67941f63b2ebb382e43f19a9588a0d
-lastReviewedNote: 'Reviewed for Next Issues #823 and #832: release evidence refresh and porcelain parsing use the existing release-contract and focused unit-test patterns.'
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: 018bd8e1c932c307b1e024a02928c65c06d60048
+lastReviewedNote: 'Reviewed for Next Issue #839: direct runtime-entry SDK mocks follow the existing focused unit-test and external-boundary mock patterns.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -27,9 +27,9 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: fcb03cca5d67941f63b2ebb382e43f19a9588a0d
-lastReviewedNote: 'Reviewed for Next Issues #823 and #832: existing qualification, preflight, and managed-push recovery guidance remains correct after the parser repair.'
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: 018bd8e1c932c307b1e024a02928c65c06d60048
+lastReviewedNote: 'Reviewed for Next Issue #839: existing wrong-import-path diagnosis and focused-to-full-gate recovery guidance remains correct.'
 ---
 
 # Testing Troubleshooting

--- a/tests/unit/pages/Processes/Components/edit.test.tsx
+++ b/tests/unit/pages/Processes/Components/edit.test.tsx
@@ -239,7 +239,7 @@ jest.mock('@/components/RefsOfNewVersionDrawer', () => ({
 
 const mockValidateEnhanced = jest.fn();
 
-jest.mock('@tiangong-lca/tidas-sdk', () => ({
+jest.mock('@tiangong-lca/tidas-sdk/core', () => ({
   __esModule: true,
   createProcess: jest.fn(() => ({
     validateEnhanced: (...args: any[]) => mockValidateEnhanced(...args),

--- a/tests/unit/services/contacts/api.test.ts
+++ b/tests/unit/services/contacts/api.test.ts
@@ -4,7 +4,7 @@
 import '@testing-library/jest-dom';
 
 // Mock TIDAS SDK
-jest.mock('@tiangong-lca/tidas-sdk', () => ({
+jest.mock('@tiangong-lca/tidas-sdk/core', () => ({
   __esModule: true,
   createContact: jest.fn().mockReturnValue({
     validateEnhanced: jest.fn().mockReturnValue({ success: true }),

--- a/tests/unit/services/contacts/util.cleanup.test.ts
+++ b/tests/unit/services/contacts/util.cleanup.test.ts
@@ -4,7 +4,7 @@
 
 import { genContactFromData, genContactJsonOrdered } from '@/services/contacts/util';
 
-jest.mock('@tiangong-lca/tidas-sdk', () => ({
+jest.mock('@tiangong-lca/tidas-sdk/core', () => ({
   __esModule: true,
   createContact: jest.fn((data: any) => data),
 }));

--- a/tests/unit/services/contacts/util.test.ts
+++ b/tests/unit/services/contacts/util.test.ts
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom';
 
 // Mock dependencies
 jest.mock('@/services/general/util');
-jest.mock('@tiangong-lca/tidas-sdk');
+jest.mock('@tiangong-lca/tidas-sdk/core');
 
 describe('Contacts Util Service', () => {
   const {
@@ -17,7 +17,7 @@ describe('Contacts Util Service', () => {
     removeEmptyObjects,
     formatDateTime,
   } = jest.requireMock('@/services/general/util');
-  const { createContact: createTidasContact } = jest.requireMock('@tiangong-lca/tidas-sdk');
+  const { createContact: createTidasContact } = jest.requireMock('@tiangong-lca/tidas-sdk/core');
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/tests/unit/services/flowproperties/api.test.ts
+++ b/tests/unit/services/flowproperties/api.test.ts
@@ -10,7 +10,7 @@
  * - getFlowpropertyTablePgroongaSearch: Full-text search for flow properties
  */
 
-jest.mock('@tiangong-lca/tidas-sdk', () => ({
+jest.mock('@tiangong-lca/tidas-sdk/core', () => ({
   __esModule: true,
   createFlowProperty: jest.fn(),
 }));
@@ -89,7 +89,9 @@ const {
   invokeDatasetCreateVersion,
   normalizeLangPayloadForSave,
 } = jest.requireMock('@/services/general/api');
-const { createFlowProperty: mockCreateFlowProperty } = jest.requireMock('@tiangong-lca/tidas-sdk');
+const { createFlowProperty: mockCreateFlowProperty } = jest.requireMock(
+  '@tiangong-lca/tidas-sdk/core',
+);
 
 describe('FlowProperties API Service (src/services/flowproperties/api.ts)', () => {
   const mockSession = createMockSession('user-123', 'test-token');

--- a/tests/unit/services/flowproperties/util.test.ts
+++ b/tests/unit/services/flowproperties/util.test.ts
@@ -21,7 +21,7 @@ jest.mock('@/services/general/util', () => ({
   removeEmptyObjects: jest.fn(),
 }));
 
-jest.mock('@tiangong-lca/tidas-sdk', () => ({
+jest.mock('@tiangong-lca/tidas-sdk/core', () => ({
   createFlowProperty: jest.fn((data) => data),
 }));
 
@@ -34,7 +34,7 @@ const {
   getLangList,
   removeEmptyObjects,
 } = jest.requireMock('@/services/general/util');
-const mockCreateFlowProperty = jest.requireMock('@tiangong-lca/tidas-sdk')
+const mockCreateFlowProperty = jest.requireMock('@tiangong-lca/tidas-sdk/core')
   .createFlowProperty as jest.Mock;
 
 describe('FlowProperties Utility Functions (src/services/flowproperties/util.ts)', () => {

--- a/tests/unit/services/flows/util.test.ts
+++ b/tests/unit/services/flows/util.test.ts
@@ -33,7 +33,7 @@ jest.mock('@/services/general/util', () => ({
 }));
 
 // Mock tidas-sdk module
-jest.mock('@tiangong-lca/tidas-sdk', () => ({
+jest.mock('@tiangong-lca/tidas-sdk/core', () => ({
   createFlow: jest.fn((data) => data),
 }));
 

--- a/tests/unit/services/lifeCycleModels/api.test.ts
+++ b/tests/unit/services/lifeCycleModels/api.test.ts
@@ -4,7 +4,7 @@
 
 jest.mock('@/pages/LifeCycleModels/lifecyclemodels.json', () => ({}), { virtual: true });
 
-jest.mock('@tiangong-lca/tidas-sdk', () => ({
+jest.mock('@tiangong-lca/tidas-sdk/core', () => ({
   __esModule: true,
   createLifeCycleModel: jest.fn().mockReturnValue({
     validateEnhanced: jest.fn().mockReturnValue({ success: true }),
@@ -17,7 +17,7 @@ jest.mock('@tiangong-lca/tidas-sdk', () => ({
 const {
   createLifeCycleModel: mockCreateTidasLifeCycleModel,
   createProcess: mockCreateTidasProcess,
-} = jest.requireMock('@tiangong-lca/tidas-sdk');
+} = jest.requireMock('@tiangong-lca/tidas-sdk/core');
 
 const mockFrom = jest.fn();
 const mockAuthGetSession = jest.fn();

--- a/tests/unit/services/lifeCycleModels/persistencePlan.test.ts
+++ b/tests/unit/services/lifeCycleModels/persistencePlan.test.ts
@@ -1,4 +1,4 @@
-jest.mock('@tiangong-lca/tidas-sdk', () => ({
+jest.mock('@tiangong-lca/tidas-sdk/core', () => ({
   __esModule: true,
   createLifeCycleModel: jest.fn(),
   createProcess: jest.fn(),
@@ -7,7 +7,7 @@ jest.mock('@tiangong-lca/tidas-sdk', () => ({
 const {
   createLifeCycleModel: mockCreateTidasLifeCycleModel,
   createProcess: mockCreateTidasProcess,
-} = jest.requireMock('@tiangong-lca/tidas-sdk');
+} = jest.requireMock('@tiangong-lca/tidas-sdk/core');
 
 const mockNormalizeLangPayloadForSave = jest.fn();
 const mockJsonToList = jest.fn();

--- a/tests/unit/services/processes/api.test.ts
+++ b/tests/unit/services/processes/api.test.ts
@@ -6,13 +6,13 @@
 import * as processesApi from '@/services/processes/api';
 import { FunctionRegion } from '@supabase/supabase-js';
 
-jest.mock('@tiangong-lca/tidas-sdk', () => ({
+jest.mock('@tiangong-lca/tidas-sdk/core', () => ({
   __esModule: true,
   createProcess: jest.fn().mockReturnValue({
     validateEnhanced: jest.fn().mockReturnValue({ success: true }),
   }),
 }));
-const { createProcess: mockCreateTidasProcess } = jest.requireMock('@tiangong-lca/tidas-sdk');
+const { createProcess: mockCreateTidasProcess } = jest.requireMock('@tiangong-lca/tidas-sdk/core');
 
 const mockFrom = jest.fn();
 const mockAuthGetSession = jest.fn();

--- a/tests/unit/services/processes/util.test.ts
+++ b/tests/unit/services/processes/util.test.ts
@@ -65,7 +65,7 @@ jest.mock('@/services/general/util', () => ({
 }));
 
 // Mock tidas-sdk module
-jest.mock('@tiangong-lca/tidas-sdk', () => ({
+jest.mock('@tiangong-lca/tidas-sdk/core', () => ({
   createProcess: jest.fn((data) => data),
 }));
 

--- a/tests/unit/services/sources/api.test.ts
+++ b/tests/unit/services/sources/api.test.ts
@@ -12,7 +12,7 @@
  * - getSourcesByIdsAndVersions: Fetch multiple sources by ID-version pairs (used in Utils/review.tsx)
  */
 
-jest.mock('@tiangong-lca/tidas-sdk', () => ({
+jest.mock('@tiangong-lca/tidas-sdk/core', () => ({
   __esModule: true,
   createSource: jest.fn(),
 }));
@@ -102,7 +102,7 @@ const {
   normalizeLangPayloadForSave,
 } = jest.requireMock('@/services/general/api');
 const { genSourceJsonOrdered } = jest.requireMock('@/services/sources/util');
-const { createSource: mockCreateSource } = jest.requireMock('@tiangong-lca/tidas-sdk');
+const { createSource: mockCreateSource } = jest.requireMock('@tiangong-lca/tidas-sdk/core');
 
 describe('Sources API Service (src/services/sources/api.ts)', () => {
   const mockSession = createMockSession('user-123', 'test-token');

--- a/tests/unit/services/sources/util.test.ts
+++ b/tests/unit/services/sources/util.test.ts
@@ -39,11 +39,11 @@ const {
   removeEmptyObjects: jest.Mock;
 };
 
-jest.mock('@tiangong-lca/tidas-sdk', () => ({
+jest.mock('@tiangong-lca/tidas-sdk/core', () => ({
   createSource: jest.fn(),
 }));
 
-const mockCreateSource = jest.requireMock('@tiangong-lca/tidas-sdk').createSource as jest.Mock;
+const mockCreateSource = jest.requireMock('@tiangong-lca/tidas-sdk/core').createSource as jest.Mock;
 
 describe('Source Utility Functions', () => {
   beforeEach(() => {

--- a/tests/unit/services/unitgroups/api.test.ts
+++ b/tests/unit/services/unitgroups/api.test.ts
@@ -17,7 +17,7 @@ import {
   updateUnitGroup,
 } from '@/services/unitgroups/api';
 
-jest.mock('@tiangong-lca/tidas-sdk', () => ({
+jest.mock('@tiangong-lca/tidas-sdk/core', () => ({
   __esModule: true,
   createUnitGroup: jest.fn().mockReturnValue({
     validateEnhanced: jest.fn().mockReturnValue({ success: true }),

--- a/tests/unit/utils/review.test.ts
+++ b/tests/unit/utils/review.test.ts
@@ -57,7 +57,7 @@ const mockCreateUnitGroup = jest.fn(() => ({
   }),
 }));
 
-jest.mock('@tiangong-lca/tidas-sdk', () => ({
+jest.mock('@tiangong-lca/tidas-sdk/core', () => ({
   __esModule: true,
   createContact: (...args: any[]) => mockCreateContact(...args),
   createFlow: (...args: any[]) => mockCreateFlow(...args),

--- a/tests/unit/utils/review.validation.test.ts
+++ b/tests/unit/utils/review.validation.test.ts
@@ -26,7 +26,7 @@ const mockGetRefDataByIds = jest.fn();
 const mockGetReviewsOfData = jest.fn();
 const mockUpdateDateToReviewState = jest.fn();
 
-jest.mock('@tiangong-lca/tidas-sdk', () => ({
+jest.mock('@tiangong-lca/tidas-sdk/core', () => ({
   __esModule: true,
   createContact: (...args: any[]) => mockCreateContact(...args),
   createFlow: (...args: any[]) => mockCreateFlow(...args),


### PR DESCRIPTION
## Summary

- bind all affected Jest SDK factories and requireMock lookups to `@tiangong-lca/tidas-sdk/core`, matching the runtime imports
- remove the implicit root-package-to-core mapper bridge that let the full suite load the real SDK in shared-module order
- record the required testing-contract and bootstrap document reviews without changing their policies

## Why

The v0.0.70 promote gate exposed 25 false-negative assertions across three suites. Focused reruns passed because their root-package mocks happened to bridge into the mapped core entry, while the complete suite could load the real SDK first. Using the runtime import specifier directly makes the test double deterministic in both focused and complete inventory runs.

## Validation

- 16 affected suites: 773 tests passed
- Docpact worktree lint: passed, 0 findings, coverage/freshness OK
- `npm run release:preflight`: passed before the test-only change; `tests/unit/**` is execution provenance and not a production-evidence invalidation input
- managed `npm run push:checked -- fork-https codex/issue-839-tidas-sdk-core-mocks:refs/heads/codex/issue-839-tidas-sdk-core-mocks`: passed
  - Docpact gate passed
  - LCIA cache and reference-data checks passed
  - ESLint, Prettier, and TypeScript passed
  - 413 suites / 5691 tests passed
  - 462/462 tracked source files at 100% statements, branches, functions, and lines
- environment: macOS arm64, Node 24.16.0, npm 11.13.0, clean `npm ci` dependency tree

No authenticated production E2E rerun was required or performed. The existing v0.0.70 evidence remains current with `created=1`, `cleaned=1`, `leaked=0`.

Closes #839
Related to #823