### PR TITLE
fix: keep Ant Design form mocks stable across rerenders

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-14"
-lastReviewedCommit: "018bd8e1c932c307b1e024a02928c65c06d60048"
-lastReviewedNote: 'Reviewed for Next Issue #839: direct runtime-entry SDK mocks remain within the existing test, release, and documentation ownership domains.'
+lastReviewedCommit: "69c286c45e34645d3768c7943b62df9f9665dec9"
+lastReviewedNote: 'Reviewed for Next Issue #842: stable stateful-hook mock identity remains within the existing test, release, and documentation ownership domains.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 018bd8e1c932c307b1e024a02928c65c06d60048
-lastReviewedNote: 'Reviewed for Next Issue #839: direct runtime-entry SDK mocks preserve the existing repo contract, quality gate, and delivery boundaries.'
+lastReviewedCommit: 69c286c45e34645d3768c7943b62df9f9665dec9
+lastReviewedNote: 'Reviewed for Next Issue #842: the shared form-mock lifecycle repair preserves the existing repo contract, quality gate, and delivery boundaries.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 018bd8e1c932c307b1e024a02928c65c06d60048
-lastReviewedNote: 'Reviewed for Next Issue #839: bootstrap and managed delivery remain unchanged by the SDK mock-entry alignment.'
+lastReviewedCommit: 69c286c45e34645d3768c7943b62df9f9665dec9
+lastReviewedNote: 'Reviewed for Next Issue #842: bootstrap and managed delivery remain unchanged by the shared form-mock lifecycle repair.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 018bd8e1c932c307b1e024a02928c65c06d60048
-lastReviewedNote: 'Reviewed for Next Issue #839: the SDK mock-entry alignment preserves the existing full-gate trigger and release policy.'
+lastReviewedCommit: 69c286c45e34645d3768c7943b62df9f9665dec9
+lastReviewedNote: 'Reviewed for Next Issue #842: the shared form-mock lifecycle repair preserves the existing full-gate trigger and release policy.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 018bd8e1c932c307b1e024a02928c65c06d60048
-lastReviewedNote: 'Reviewed for Next Issue #839: the current tests-and-gates validation row covers the SDK mock-entry alignment and focused regression proof.'
+lastReviewedCommit: 69c286c45e34645d3768c7943b62df9f9665dec9
+lastReviewedNote: 'Reviewed for Next Issue #842: the tests-and-gates validation row covers the shared form-mock lifecycle repair and focused rerender proof.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,8 +28,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 018bd8e1c932c307b1e024a02928c65c06d60048
-lastReviewedNote: 'Reviewed for Next Issue #839: direct runtime-entry SDK mocks preserve the existing focused-first, full-closure strategy.'
+lastReviewedCommit: 69c286c45e34645d3768c7943b62df9f9665dec9
+lastReviewedNote: 'Reviewed for Next Issue #842: stable shared hook mocks preserve the existing focused-first, full-closure strategy.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 018bd8e1c932c307b1e024a02928c65c06d60048
-lastReviewedNote: 'Reviewed for Next Issue #839: the SDK mock-entry alignment adds no test or queue item and preserves the checked-in reference baseline.'
+lastReviewedCommit: 69c286c45e34645d3768c7943b62df9f9665dec9
+lastReviewedNote: 'Reviewed for Next Issue #842: the shared form-mock regression adds no queue item and preserves the checked-in reference baseline policy.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,8 +31,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 018bd8e1c932c307b1e024a02928c65c06d60048
-lastReviewedNote: 'Reviewed for Next Issue #839: direct runtime-entry SDK mocks follow the existing focused unit-test and external-boundary mock patterns.'
+lastReviewedCommit: 69c286c45e34645d3768c7943b62df9f9665dec9
+lastReviewedNote: 'Reviewed for Next Issue #842: stateful hook mocks now explicitly preserve API identity across parent rerenders.'
 ---
 
 # Testing Patterns Reference
@@ -54,6 +54,8 @@ lastReviewedNote: 'Reviewed for Next Issue #839: direct runtime-entry SDK mocks 
 - keep test setup close to the behavior being proved
 - prefer existing helpers over one-off fixtures
 - do not add snapshots when explicit assertions are clearer
+- make mocks for stateful hooks preserve the identity of returned API objects across parent rerenders; update methods on the stable object instead of returning a fresh placeholder on each render
+- pair shared hook mocks with a direct rerender regression that proves both object identity and the callable API the consumer relies on
 - test release workflow policy at the contract boundary: parse or inspect the reusable gate and caller workflows, assert exact base/head wiring, and prove publication dependencies rather than invoking production actions
 - test branch-sensitive push gates with isolated temporary Git remotes so `dev`, `main`, and main-semantic source branches prove their different command sequences without contacting a real repository
 - test release-orchestration commands with temporary Git repositories plus fake `gh`/`npm`/Docpact executables: assert one JSON stdout document, exact remote/base/head/version identities, independent candidate and cumulative `main`-to-`dev` path evaluation, bounded review-only fixed-point behavior, branch-sensitive checked-push delegation, idempotent PR reuse, and stable fail-closed drift codes without creating real GitHub resources; additionally run a real Docpact canary in an isolated exact-`dev` clone to prove the current governed-document closure and metadata-only mutation boundary

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,8 +28,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 018bd8e1c932c307b1e024a02928c65c06d60048
-lastReviewedNote: 'Reviewed for Next Issue #839: existing wrong-import-path diagnosis and focused-to-full-gate recovery guidance remains correct.'
+lastReviewedCommit: 69c286c45e34645d3768c7943b62df9f9665dec9
+lastReviewedNote: 'Reviewed for Next Issue #842: rerender-only missing mock APIs now route to stable hook identity and focused regression proof.'
 ---
 
 # Testing Troubleshooting
@@ -58,6 +58,7 @@ Canonical baseline and proof ownership stays with `DEV.md` and `docs/agents/repo
 | element not found | query too early, wrong role/text, render path not reached | assert the prerequisite state first, then switch to semantic query |
 | a visible action exists but the expected request never starts | the control is present but still disabled while prerequisite data loads | wait for the control to become enabled, then interact; do not replace the product guard with an arbitrary delay |
 | mock not hit | wrong import path or mock order | verify module path and set mocks before importing the subject |
+| a mocked hook API method is missing only after a state-driven rerender | the hook mock returns a new placeholder object on every render before its child can attach the API | preserve the hook result with a ref, update methods on that stable object, and add a direct parent-rerender identity regression before rerunning the affected flow |
 | Task Center shows duplicate TIDAS exports or keeps an old completion timestamp after a new request | local submission/persisted aliases were treated as separate facts instead of reconciling the backend worker/package identity | run the focused `tests/unit/services/tidasPackage/taskCenter.test.ts` suite, compare `workerJobId` and `jobId`, and verify hydration, queue, polling, and Worker refresh all retain one canonical task with backend timestamps |
 | provider or context error | missing wrapper or wrong test utility | use the repo helper that already provides the required wrapper |
 | data workflow smoke assertion mismatch | `fixtures/data/**`, `fixtures/result/**`, workflow default path, or last-run artifact drifted apart | compare the case in `tests/data-workflows/fixtures/result/README.md`, then update the paired input fixture, expected-result Markdown, workflow lib default, and unit proof together |

--- a/tests/mocks/antd.tsx
+++ b/tests/mocks/antd.tsx
@@ -766,11 +766,15 @@ export const createAntdMock = () => {
     );
   };
 
-  (Form as any).Item = FormItem;
-  (Form as any).useForm = () => {
-    const api: any = {};
-    return [api];
+  const useMockForm = () => {
+    const apiRef = React.useRef<any>(null);
+    if (apiRef.current === null) {
+      apiRef.current = {};
+    }
+    return [apiRef.current];
   };
+  (Form as any).Item = FormItem;
+  (Form as any).useForm = useMockForm;
 
   const Layout = ({ children, style }: any) => (
     <div data-testid='layout' style={style}>

--- a/tests/unit/mocks/antd.test.tsx
+++ b/tests/unit/mocks/antd.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { createAntdMock } from '../../mocks/antd';
+
+const { Form } = createAntdMock();
+const MockForm = Form as any;
+
+describe('Ant Design test mock', () => {
+  it('keeps useForm instances stable across parent rerenders', async () => {
+    const observedInstances = new Set<any>();
+
+    const Harness = () => {
+      const [renderCount, setRenderCount] = React.useState(0);
+      const [form] = MockForm.useForm();
+      observedInstances.add(form);
+
+      return (
+        <>
+          <MockForm form={form}>
+            <MockForm.Item name='name'>
+              <input aria-label='Name' />
+            </MockForm.Item>
+          </MockForm>
+          <span data-testid='render-count'>{renderCount}</span>
+          <button type='button' onClick={() => setRenderCount((count: number) => count + 1)}>
+            Rerender parent
+          </button>
+        </>
+      );
+    };
+
+    render(<Harness />);
+
+    await waitFor(() =>
+      expect(typeof Array.from(observedInstances)[0]?.validateFields).toBe('function'),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Rerender parent' }));
+
+    expect(screen.getByTestId('render-count')).toHaveTextContent('1');
+    expect(observedInstances.size).toBe(1);
+    await expect(Array.from(observedInstances)[0].validateFields()).resolves.toEqual({});
+  });
+});

--- a/tests/unit/mocks/dataProcessingFormFallback.test.tsx
+++ b/tests/unit/mocks/dataProcessingFormFallback.test.tsx
@@ -1,0 +1,127 @@
+import DataProcessing from '@/pages/DataProcessing';
+import { render, waitFor } from '@testing-library/react';
+import { useRef } from 'react';
+
+jest.mock('antd', () => require('../../mocks/antd').createAntdMock());
+jest.mock('@ant-design/pro-components', () =>
+  require('../../mocks/proComponents').createProComponentsMock(),
+);
+jest.mock('@ant-design/icons', () =>
+  require('../../mocks/antDesignIcons').createAntDesignIconsMock(),
+);
+
+jest.mock('@/components/AccessDenied', () => ({
+  __esModule: true,
+  default: () => <div>Access denied</div>,
+}));
+jest.mock('@/components/ClosureTaskDetail', () => ({
+  ClosureArtifactList: () => null,
+  closureCheckNeedsPolling: () => false,
+  closureCheckPollIntervalMs: 1,
+  closureCheckPollMaxAttempts: 1,
+}));
+jest.mock('@/components/LcaReleaseReadPanel', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('@/pages/DataProcessing/CalculationBundlePanel', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const mockGetClosureCheck = jest.fn();
+const mockDataProductTasks: any[] = [];
+const mockListDataProductTasks = jest.fn(() => mockDataProductTasks);
+const mockSubscribeDataProductTasks = jest.fn((listener: () => void) => {
+  void listener;
+  return () => undefined;
+});
+
+jest.mock('@umijs/max', () => ({
+  __esModule: true,
+  FormattedMessage: ({ defaultMessage, id }: any) => defaultMessage ?? id,
+  history: { replace: jest.fn() },
+  useIntl: () => ({
+    formatMessage: ({ defaultMessage, id }: any) => defaultMessage ?? id,
+    locale: 'en-US',
+  }),
+  useLocation: () => ({
+    pathname: '/data-processing',
+    search: '?closureCheckId=closure-valid',
+  }),
+}));
+
+jest.mock('@/services/roles/api', () => ({
+  getSystemUserRoleApi: jest.fn(async () => ({ role: 'data_product_manager' })),
+}));
+
+jest.mock('@/services/dataProducts', () => ({
+  createClosureCheck: jest.fn(),
+  createLciaResultBuildRequest: jest.fn(),
+  getClosureCheck: (...args: any[]) => Reflect.apply(mockGetClosureCheck, undefined, args),
+  listClosureCheckIssues: jest.fn(async () => ({ data: { issues: [] }, error: null })),
+  listLciaResultPublications: jest.fn(async () => ({ data: [], error: null })),
+  previewLciaResultPackage: jest.fn(),
+  publishLciaResultPackage: jest.fn(),
+  unpublishLciaResultPublication: jest.fn(),
+}));
+
+jest.mock('@/services/dataProducts/taskCenter', () => ({
+  listDataProductTasks: () => mockListDataProductTasks(),
+  refreshDataProductTasks: jest.fn(async () => []),
+  subscribeDataProductTasks: (listener: () => void) => mockSubscribeDataProductTasks(listener),
+  upsertDataProductTasks: jest.fn(),
+}));
+
+describe('DataProcessing form compatibility fallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ files: [] }),
+    })) as any;
+    mockGetClosureCheck.mockResolvedValue({
+      data: {
+        schemaVersion: 'lcia.scope-closure-check.v1',
+        closureCheckId: 'closure-valid',
+        runStatus: 'passed',
+        certificateValidity: 'valid',
+        scanCompleteness: 'complete',
+        requestedScopeHash: 'scope-hash-valid',
+        policyFingerprint: 'policy-valid',
+        artifacts: [],
+      },
+      error: null,
+    });
+  });
+
+  it('uses an empty selection when the form API omits current-value access', async () => {
+    const { Form } = jest.requireMock('antd');
+    const originalUseForm = Form.useForm;
+
+    function useFormWithoutCurrentValues() {
+      const [form] = originalUseForm();
+      const proxyRef = useRef<object>();
+      if (!proxyRef.current) {
+        proxyRef.current = new Proxy(form, {
+          get(target, property, receiver) {
+            if (property === 'getFieldsValue') return undefined;
+            return Reflect.get(target, property, receiver);
+          },
+        });
+      }
+      return [proxyRef.current];
+    }
+
+    Form.useForm = useFormWithoutCurrentValues;
+    const view = render(<DataProcessing />);
+
+    try {
+      await waitFor(() => expect(mockGetClosureCheck).toHaveBeenCalledWith('closure-valid'));
+      await waitFor(() => expect(mockGetClosureCheck).toHaveBeenCalledTimes(1));
+    } finally {
+      view.unmount();
+      Form.useForm = originalUseForm;
+    }
+  });
+});


### PR DESCRIPTION
Closes #842

## Summary
- keep each mocked `Form.useForm()` API stable across parent rerenders, matching the real Ant Design hook contract
- add a direct rerender regression test for form API identity and delayed method attachment
- cover the DataProcessing compatibility fallback in an isolated test without changing its release-bound semantic evidence input
- record the durable testing rule and troubleshooting guidance in governed docs

## Root cause
The shared Ant Design mock returned a fresh plain object on every parent rerender. A child effect attached `validateFields` after render, so a subsequent parent rerender could replace that API with a new method-less object. Release Gate exposed the race in `DataProcessing`.

## Validation
- `npm run lint`
- focused DataProcessing and Ant Design mock tests: 58 passed
- targeted DataProcessing coverage: 100% statements, branches, functions, and lines
- `npm run i18n:locale:artifacts:idempotence`
- `npm run release:preflight`
- managed `npm run push:checked -- fork codex/issue-842-stable-antd-form`
  - Docpact coverage and freshness: passed
  - 414 suites / 5693 tests: passed
  - 462/462 tracked source files at 100/100/100/100 coverage
  - transport completed through the exact receipt-bound `npm run push:retry`

## Release evidence boundary
The release-bound `tests/unit/pages/DataProcessing/index.test.tsx` and generated locale evidence artifacts remain unchanged. This repair changes test infrastructure, isolated regression coverage, and governed documentation only.