### PR TITLE
test: qualify v0.0.71 release harness

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-08-14'
-lastReviewedCommit: '8c735ca300f4505f436df2d1f2db4f7adc830e39'
+lastReviewedAt: "2026-08-14"
+lastReviewedCommit: "6d45b13a55b178ec33094d2bb021659350a2dee9"
 lastReviewedNote: 'Next routing covers explicit proof-reuse publication dependencies and deterministic release-line validation for direct ancestry or an exact tree-identical two-parent promotion.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 8c735ca300f4505f436df2d1f2db4f7adc830e39
+lastReviewedCommit: 4d133b0fe25ce991e585e08cc58b36602be65ede
 lastReviewedNote: 'Release publication now carries exact reused proof through explicit dependency results, and deterministic release commands recognize the normal tree-identical two-parent promotion topology without accepting main-only drift.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 8c735ca300f4505f436df2d1f2db4f7adc830e39
+lastReviewedCommit: 4d133b0fe25ce991e585e08cc58b36602be65ede
 lastReviewedNote: 'The normal release commands preserve exact qualification and managed-push proof while accepting only direct ancestry or a tree-identical two-parent promotion as a safe release line.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 8c735ca300f4505f436df2d1f2db4f7adc830e39
+lastReviewedCommit: 6d45b13a55b178ec33094d2bb021659350a2dee9
 lastReviewedNote: 'Deterministic release commands preserve Docpact-first managed gates and validate direct ancestry or only an exact tree-identical two-parent promotion before transport.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 8c735ca300f4505f436df2d1f2db4f7adc830e39
+lastReviewedCommit: 6d45b13a55b178ec33094d2bb021659350a2dee9
 lastReviewedNote: 'Release proof covers explicit proof-reuse publication dependencies plus direct-ancestry, exact two-parent promotion, and changed-tree rejection fixtures before the managed full gate.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 8c735ca300f4505f436df2d1f2db4f7adc830e39
+lastReviewedCommit: 6d45b13a55b178ec33094d2bb021659350a2dee9
 lastReviewedNote: 'Release orchestration remains fail closed before transport while recognizing only direct ancestry or an exact tree-identical two-parent promotion as aligned.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 8c735ca300f4505f436df2d1f2db4f7adc830e39
+lastReviewedCommit: 6d45b13a55b178ec33094d2bb021659350a2dee9
 lastReviewedNote: 'Issue #845 adds proof-reuse publication and exact promotion-topology coverage with no exception queue; the checked-in bounded full-coverage baseline remains authoritative.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 8c735ca300f4505f436df2d1f2db4f7adc830e39
+lastReviewedCommit: 6d45b13a55b178ec33094d2bb021659350a2dee9
 lastReviewedNote: 'Release tests bind proof-reuse continuation to explicit successful prerequisites and exercise both accepted and rejected promotion topology in hermetic repositories.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 8c735ca300f4505f436df2d1f2db4f7adc830e39
+lastReviewedCommit: 6d45b13a55b178ec33094d2bb021659350a2dee9
 lastReviewedNote: 'Release diagnosis now distinguishes an exact promoted lineage from true main/dev drift and preserves explicit prerequisite checks after proof reuse.'
 ---
 

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "713ea5ee978229a81c5b5a6b9ddba9590238aa01bde676cde89110016690b8b3"
+    "runResultSha256": "c6fe99aa4e212fa3a8425ae93629237a307bbd7fbfa8e9f0e2a4a45621c1e363"
   },
-  "environmentManifestSha256": "e1c99a5bf228f5f00582072acab1c62b2a59968cba1c24fd62808c71832c47ae",
+  "environmentManifestSha256": "8ef2de062ad20f69085cee7598f5bcf97b7379b832b14d968473f85cb67a5e15",
   "externalRequests": 0,
-  "generatedAt": "2026-08-13T16:28:10.441Z",
+  "generatedAt": "2026-08-14T03:08:36.440Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "1fb6497e2cc9b11b625a45c85cfacffc9312aa9f9e0208a6bbc7a81bbe4fcc76",
-  "qualifiedCommit": "320543506f5bcfcdc1c6d475f313e05a2f43ebae",
-  "qualifiedTree": "1c8ff68902bd6e12e6862e98f8a441e53ddb7cfb",
+  "qualificationInputSha256": "63b0735ce1cab9b4368c61a90bec47f3cefc419148ccb8b6fa43683bea59950d",
+  "qualifiedCommit": "8354e00092eeb83762bccc436e2694c3cab08546",
+  "qualifiedTree": "c85f3dcbb9b0420eeb5d04a3b12feef49225e672",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }


### PR DESCRIPTION
## Summary

- refresh the credential-free semantic-harness qualification receipt for exact `dev@8354e00092eeb83762bccc436e2694c3cab08546`
- retain the generated receipt's zero-external-request, zero-production-write, zero-cleanup-residue provenance
- record the required Docpact review evidence without changing governed document bodies

## Validation

- semantic qualification: 63 passed, 30 designed skips, 0 failures across Chromium, Firefox, and WebKit
- `npm run e2e:qualification:check`: passed
- Docpact strict validation and enforced lint: passed with zero findings
- repository-managed checked push: 417 suites and 5,734 tests passed; 462/462 tracked source files at 100% statements, branches, functions, and lines

## Release Follow-up

This PR does not manufacture or replace authenticated production evidence. After it merges into `dev`, run the explicitly authorized authenticated semantic E2E closure from the clean merged candidate and land only its generated evidence plus regenerated locale artifacts through a separate reviewed `dev` PR. Then restart the deterministic v0.0.71 release command from the resulting `dev` head.

Refs #845
