### PR TITLE
test: refresh v0.0.71 production semantic evidence

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-14"
-lastReviewedCommit: "6d45b13a55b178ec33094d2bb021659350a2dee9"
-lastReviewedNote: 'Next routing covers explicit proof-reuse publication dependencies and deterministic release-line validation for direct ancestry or an exact tree-identical two-parent promotion.'
+lastReviewedCommit: "04fa6b7539156a1d3585d228b7564fc08cf7b0c2"
+lastReviewedNote: 'Reviewed for Next Issue #845: refreshing provenance-bound production evidence and qualification artifacts does not change the repository routing contract.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 4d133b0fe25ce991e585e08cc58b36602be65ede
-lastReviewedNote: 'Release publication now carries exact reused proof through explicit dependency results, and deterministic release commands recognize the normal tree-identical two-parent promotion topology without accepting main-only drift.'
+lastReviewedCommit: 473aba11cf7c1b991e66c8241ef55c3c098904d4
+lastReviewedNote: 'Reviewed for Next Issue #845: refreshed v0.0.71 production evidence and qualification follow the existing explicit-authorization, exact-cleanup, and deterministic-release contract.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 4d133b0fe25ce991e585e08cc58b36602be65ede
-lastReviewedNote: 'The normal release commands preserve exact qualification and managed-push proof while accepting only direct ancestry or a tree-identical two-parent promotion as a safe release line.'
+lastReviewedCommit: 473aba11cf7c1b991e66c8241ef55c3c098904d4
+lastReviewedNote: 'Reviewed for Next Issue #845: the documented clean-candidate authenticated run and credential-free qualification commands produced the refreshed v0.0.71 evidence without changing bootstrap steps.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -57,8 +57,8 @@ checkPaths:
   - .github/workflows/build.yml
   - package.json
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 5114e834
-lastReviewedNote: 'Reviewed for Next Issue #836: the time-independent unit fixture and refreshed v0.0.70 proof preserve the existing evidence-binding and production-data authorization boundaries.'
+lastReviewedCommit: 04fa6b7539156a1d3585d228b7564fc08cf7b0c2
+lastReviewedNote: 'Reviewed for Next Issue #845: the refreshed v0.0.71 production proof preserves the existing evidence-binding, explicit authorization, and exact-cleanup boundaries.'
 baselineObservedAt: 2026-07-18
 related:
   - ../../AGENTS.md

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 6d45b13a55b178ec33094d2bb021659350a2dee9
-lastReviewedNote: 'Deterministic release commands preserve Docpact-first managed gates and validate direct ancestry or only an exact tree-identical two-parent promotion before transport.'
+lastReviewedCommit: 04fa6b7539156a1d3585d228b7564fc08cf7b0c2
+lastReviewedNote: 'Reviewed for Next Issue #845: refreshed production evidence and qualification continue to use the documented Docpact-first managed release gates.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 6d45b13a55b178ec33094d2bb021659350a2dee9
-lastReviewedNote: 'Release proof covers explicit proof-reuse publication dependencies plus direct-ancestry, exact two-parent promotion, and changed-tree rejection fixtures before the managed full gate.'
+lastReviewedCommit: 04fa6b7539156a1d3585d228b7564fc08cf7b0c2
+lastReviewedNote: 'Reviewed for Next Issue #845: authenticated production proof, exact cleanup, canonical artifacts, and credential-free qualification follow the documented validation order.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,8 +28,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 6d45b13a55b178ec33094d2bb021659350a2dee9
-lastReviewedNote: 'Release orchestration remains fail closed before transport while recognizing only direct ancestry or an exact tree-identical two-parent promotion as aligned.'
+lastReviewedCommit: 04fa6b7539156a1d3585d228b7564fc08cf7b0c2
+lastReviewedNote: 'Reviewed for Next Issue #845: the v0.0.71 evidence refresh closes the existing semantic proof contract without changing the test-improvement plan.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 6d45b13a55b178ec33094d2bb021659350a2dee9
-lastReviewedNote: 'Issue #845 adds proof-reuse publication and exact promotion-topology coverage with no exception queue; the checked-in bounded full-coverage baseline remains authoritative.'
+lastReviewedCommit: 04fa6b7539156a1d3585d228b7564fc08cf7b0c2
+lastReviewedNote: 'Reviewed for Next Issue #845: v0.0.71 now has fresh authenticated semantic evidence and credential-free qualification with no new exception queue.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,8 +31,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 6d45b13a55b178ec33094d2bb021659350a2dee9
-lastReviewedNote: 'Release tests bind proof-reuse continuation to explicit successful prerequisites and exercise both accepted and rejected promotion topology in hermetic repositories.'
+lastReviewedCommit: 04fa6b7539156a1d3585d228b7564fc08cf7b0c2
+lastReviewedNote: 'Reviewed for Next Issue #845: the refreshed run follows the existing clean-candidate, explicit-production-authorization, exact-cleanup, and qualification patterns.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,8 +28,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 6d45b13a55b178ec33094d2bb021659350a2dee9
-lastReviewedNote: 'Release diagnosis now distinguishes an exact promoted lineage from true main/dev drift and preserves explicit prerequisite checks after proof reuse.'
+lastReviewedCommit: 04fa6b7539156a1d3585d228b7564fc08cf7b0c2
+lastReviewedNote: 'Reviewed for Next Issue #845: no new troubleshooting rule is required after the authorized production run completed with exact cleanup and canonical evidence.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
+    "digest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "124d07d113b614a6b9d5fa9337b21a8d060cc7ef19b885193568d4b2c948e013",
+          "sha256": "497257674d84db3b2578989eba75c14bda1000c6ac4dd917af584ed5e359bbf9",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "c2bf4189d9a6dfc1e9b99698577088ec8e5bf9a06c6f97ff7a668c937c218f1e",
-    "docs/plans/i18n/route-view-coverage.json": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
+    "docs/plans/i18n/route-view-coverage.json": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-de-DE/glossary.json": "a5fd4e759af2713fbec83f2b95171c7b32206d7218da0401d28d2eecefccce3a",
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "90fa1823f8d7b1831a9f3684c81b5a79bdf42f345f15d5b4721818b7d6030999"
+  "contextDigest": "7de96c089b55070f88c14ac9f49dd424a6c24d6c6aa301aed5e6024a3f53207e"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "90fa1823f8d7b1831a9f3684c81b5a79bdf42f345f15d5b4721818b7d6030999",
-    "qualityDigest": "bd7c711569d2d4701decdc81904d3d7f03a6747b72d2a9d214baf0c6215d57a2",
+    "contextDigest": "7de96c089b55070f88c14ac9f49dd424a6c24d6c6aa301aed5e6024a3f53207e",
+    "qualityDigest": "cc71491615abac4bfd0b6c7a6aaedf073fdd9cde72556e750de55c5967753906",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
+    "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "cefd55fe40606128c9ca761d0131c59287f8c985e36a67d10c8daa512a147f77"
+  "activationDigest": "2b818fbceee75a88cc1303c63880af4ce72fdf080c3fe9b3934ad516c781566e"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "efcf05858b750fdd6343f1bcf14d08b57d238587fb63e9897b985567c84de5d0",
-    "contextDigest": "90fa1823f8d7b1831a9f3684c81b5a79bdf42f345f15d5b4721818b7d6030999"
+    "contextDigest": "7de96c089b55070f88c14ac9f49dd424a6c24d6c6aa301aed5e6024a3f53207e"
   },
   "catalog": {
     "messageCount": 3161,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "bd7c711569d2d4701decdc81904d3d7f03a6747b72d2a9d214baf0c6215d57a2"
+  "qualityDigest": "cc71491615abac4bfd0b6c7a6aaedf073fdd9cde72556e750de55c5967753906"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
+    "digest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "124d07d113b614a6b9d5fa9337b21a8d060cc7ef19b885193568d4b2c948e013",
+          "sha256": "497257674d84db3b2578989eba75c14bda1000c6ac4dd917af584ed5e359bbf9",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "c2bf4189d9a6dfc1e9b99698577088ec8e5bf9a06c6f97ff7a668c937c218f1e",
-    "docs/plans/i18n/route-view-coverage.json": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
+    "docs/plans/i18n/route-view-coverage.json": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-en-US/glossary.json": "4b8443ea3f91f15383683e9ece6221e40e24ceb75442ea830964b06c12559970",
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "de234b06f9e35409eb3d22ad3b299970684fe7ec76a8ff35d50431a30948c623"
+  "contextDigest": "d7133bbf10f40e134c19e46b82b9a64248f3c932c4c6b16c149ec2a26e526d28"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "de234b06f9e35409eb3d22ad3b299970684fe7ec76a8ff35d50431a30948c623",
-    "qualityDigest": "625e4fd12bec1b5d4856c1b0436dd5a84216d31abfe4aeb06456d45dcc019951",
+    "contextDigest": "d7133bbf10f40e134c19e46b82b9a64248f3c932c4c6b16c149ec2a26e526d28",
+    "qualityDigest": "60bcfe61cc09ff8670eabc3caa1b2971bc35e40bc7c3dd7b57dd4d14014aaed4",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
+    "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "97ee5a60d3970d64cb4b280c624886c8618c087b79066da82c807a1c50673d6b"
+  "activationDigest": "d42026e62157d6661f555269afeb08411a8461f53fa9d2c3211d537084bfc2c5"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "efcf05858b750fdd6343f1bcf14d08b57d238587fb63e9897b985567c84de5d0",
-    "contextDigest": "de234b06f9e35409eb3d22ad3b299970684fe7ec76a8ff35d50431a30948c623"
+    "contextDigest": "d7133bbf10f40e134c19e46b82b9a64248f3c932c4c6b16c149ec2a26e526d28"
   },
   "catalog": {
     "messageCount": 3161,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "625e4fd12bec1b5d4856c1b0436dd5a84216d31abfe4aeb06456d45dcc019951"
+  "qualityDigest": "60bcfe61cc09ff8670eabc3caa1b2971bc35e40bc7c3dd7b57dd4d14014aaed4"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
+    "digest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "124d07d113b614a6b9d5fa9337b21a8d060cc7ef19b885193568d4b2c948e013",
+          "sha256": "497257674d84db3b2578989eba75c14bda1000c6ac4dd917af584ed5e359bbf9",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "c2bf4189d9a6dfc1e9b99698577088ec8e5bf9a06c6f97ff7a668c937c218f1e",
-    "docs/plans/i18n/route-view-coverage.json": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
+    "docs/plans/i18n/route-view-coverage.json": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-fr-FR/glossary.json": "057cb494f02d980106469f6a16befc102d26db5ac362b9777cd5f97c7729c91b",
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "1d003a4ea9ed0f9148550b2daf459ffadc61e7387c5427c95b843c4fe1346147"
+  "contextDigest": "600484da7285fd81a83dc19cabe0179e6fa3e62580c74e064d014bd1acfa91f2"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "1d003a4ea9ed0f9148550b2daf459ffadc61e7387c5427c95b843c4fe1346147",
-    "qualityDigest": "395461f70becf073cc2152af0c87ff38c533b51be81d93faf326c2b25e881ae5",
+    "contextDigest": "600484da7285fd81a83dc19cabe0179e6fa3e62580c74e064d014bd1acfa91f2",
+    "qualityDigest": "ec579e237ccafc2a27f4dcfc7b06e1a8fdd66ab7b720ab087a95a232280b00cb",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
+    "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "b59263d826ceb9208ed8145fdaa5a278c2ab051e75e86d86eb5f360db10f37b5"
+  "activationDigest": "6f8e5d75ee81d5d03dc739954cc8562ae5fa4e8e41af18cc3a8eda8e84495c98"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "efcf05858b750fdd6343f1bcf14d08b57d238587fb63e9897b985567c84de5d0",
-    "contextDigest": "1d003a4ea9ed0f9148550b2daf459ffadc61e7387c5427c95b843c4fe1346147"
+    "contextDigest": "600484da7285fd81a83dc19cabe0179e6fa3e62580c74e064d014bd1acfa91f2"
   },
   "catalog": {
     "messageCount": 3161,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "395461f70becf073cc2152af0c87ff38c533b51be81d93faf326c2b25e881ae5"
+  "qualityDigest": "ec579e237ccafc2a27f4dcfc7b06e1a8fdd66ab7b720ab087a95a232280b00cb"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
+    "digest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "124d07d113b614a6b9d5fa9337b21a8d060cc7ef19b885193568d4b2c948e013",
+          "sha256": "497257674d84db3b2578989eba75c14bda1000c6ac4dd917af584ed5e359bbf9",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "c2bf4189d9a6dfc1e9b99698577088ec8e5bf9a06c6f97ff7a668c937c218f1e",
-    "docs/plans/i18n/route-view-coverage.json": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
+    "docs/plans/i18n/route-view-coverage.json": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-zh-CN/glossary.json": "c891add0ee4bd6d24c0213d0c839474e145d85867426df796763b8e038053d9b",
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "8056347c8a500eb13c19e6d53ffc84c8e819385b458a7b1820e35ad4f33ea8df"
+  "contextDigest": "84a3194812dfbb185e1507d9e5a49c8a49a9f917489805cd1e0045dfe25405ec"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "8056347c8a500eb13c19e6d53ffc84c8e819385b458a7b1820e35ad4f33ea8df",
-    "qualityDigest": "e1c2d0d66db37f08ed30ec69c99767031d2b8d626bf8f0d2db2fb6b8cbc73f30",
+    "contextDigest": "84a3194812dfbb185e1507d9e5a49c8a49a9f917489805cd1e0045dfe25405ec",
+    "qualityDigest": "6bddf833d41cfa3194b90f79dadbfd3f1ad051fa76c94ae5b17022fb63f3d05f",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "860cfd3791c85dfc5ae76a7de0dee9b6915e5754165ba192bcbec9dd40c820de",
+    "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "84fedf3f8b995b4bff135d85a9cc65280ff1251d9991d24b4b82818b2c6e7714"
+  "activationDigest": "62ebf548c82d79b6811a733de2dd034d7d8c230c4125e5bbf3e7ef1e0b24b0f4"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "efcf05858b750fdd6343f1bcf14d08b57d238587fb63e9897b985567c84de5d0",
-    "contextDigest": "8056347c8a500eb13c19e6d53ffc84c8e819385b458a7b1820e35ad4f33ea8df"
+    "contextDigest": "84a3194812dfbb185e1507d9e5a49c8a49a9f917489805cd1e0045dfe25405ec"
   },
   "catalog": {
     "messageCount": 3161,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "e1c2d0d66db37f08ed30ec69c99767031d2b8d626bf8f0d2db2fb6b8cbc73f30"
+  "qualityDigest": "6bddf833d41cfa3194b90f79dadbfd3f1ad051fa76c94ae5b17022fb63f3d05f"
 }

--- a/docs/plans/i18n/route-view-coverage.json
+++ b/docs/plans/i18n/route-view-coverage.json
@@ -353,7 +353,7 @@
       "executedEvidence": [
         {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "124d07d113b614a6b9d5fa9337b21a8d060cc7ef19b885193568d4b2c948e013"
+          "sha256": "497257674d84db3b2578989eba75c14bda1000c6ac4dd917af584ed5e359bbf9"
         }
       ]
     }

--- a/docs/plans/i18n/semantic-e2e-evidence.json
+++ b/docs/plans/i18n/semantic-e2e-evidence.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": "tiangong.i18n-semantic-e2e-evidence.v1",
   "status": "verified",
-  "generatedAt": "2026-08-13T16:03:03.669Z",
-  "runId": "local-e1ccecf8-011c-4dae-b4da-ff4731b2a2bf",
+  "generatedAt": "2026-08-14T03:57:26.047Z",
+  "runId": "local-348e22f4-c9f6-4876-889a-d6c46ff49560",
   "candidate": {
     "configTreeDigest": "c79878bbed6dfb7becc3cedae0fdd08e0926b674293a6f9656469ac8682cc804",
-    "observedHeadCommit": "b918c68480ac67de3ab66e332c0e5a62272963c9",
+    "observedHeadCommit": "e5991ff390c8ef3ea767fee9f4acd75b8e39e081",
     "packageManifestDigest": "2b78dea75572169f5a945913cc1d3b8b9ed3b9ecbb65c4fc0dc45b4126150437",
-    "sourceTreeDigest": "5e5430988c519280325dd6d71189e8651780c4b3eb1d78616b4a2121ddb523a9",
-    "unitTestTreeDigest": "40d09c6a1e13df8a901f7c6d5f34c2464247b49d06d5381cbfc980ac89a0bab0"
+    "sourceTreeDigest": "5e99ca4a831c91dd58d7f63f79305e14bacbb7c46f7b4c1b422d8e0d4fdc93c3",
+    "unitTestTreeDigest": "ae69a7638431b555ebc4fafbcbd0603211618484061249695009f8b6523c3592"
   },
   "target": {
     "frontend": "candidate-local",
@@ -377,7 +377,7 @@
       },
       {
         "path": "tests/unit/pages/DataProcessing/index.test.tsx",
-        "sha256": "d1930ddaf4817eb4dec31668565b1b3d52103dbeca3cb515066594807e0d0198"
+        "sha256": "d054a3c3ddc3c12f5be1c9ab19f531c6d870a429f094d898ffad035bd989fbc9"
       },
       {
         "path": "tests/unit/pages/Flowproperties/index.test.tsx",
@@ -429,7 +429,7 @@
       },
       {
         "path": "tests/unit/pages/Review/index.test.tsx",
-        "sha256": "b40f8e57d9a13c7b7754d3cc81016174a41e6445a6bab4ad3ef304b29fec66cb"
+        "sha256": "553f85cd073d0580976697488343ffe3f55dd5cd6173be3c00e1320f58166c4f"
       },
       {
         "path": "tests/unit/pages/Sources/index.test.tsx",
@@ -583,7 +583,7 @@
       },
       {
         "path": "src/pages/Review/index.tsx",
-        "sha256": "bde2c6c4f7aa2100d1dc1b7e2fbf9338c8c1754be52167636b37aa8c9182c3aa"
+        "sha256": "66014539541e015ccb4e25a042104f1b3d8215803636fb99ab6f6724437584d7"
       },
       {
         "path": "src/pages/Sources/index.tsx",

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "c6fe99aa4e212fa3a8425ae93629237a307bbd7fbfa8e9f0e2a4a45621c1e363"
+    "runResultSha256": "6ffc44acef34672128e82195d23875594eef6d88dacc2ca3d6638626202fbde0"
   },
-  "environmentManifestSha256": "8ef2de062ad20f69085cee7598f5bcf97b7379b832b14d968473f85cb67a5e15",
+  "environmentManifestSha256": "b7ed2200ac0056a4e63347f7b1c982864ba6865ed47ce7c68aaf31c70f1b0c66",
   "externalRequests": 0,
-  "generatedAt": "2026-08-14T03:08:36.440Z",
+  "generatedAt": "2026-08-14T04:12:45.305Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "63b0735ce1cab9b4368c61a90bec47f3cefc419148ccb8b6fa43683bea59950d",
-  "qualifiedCommit": "8354e00092eeb83762bccc436e2694c3cab08546",
-  "qualifiedTree": "c85f3dcbb9b0420eeb5d04a3b12feef49225e672",
+  "qualificationInputSha256": "ec69d17e9acb17a1aece22926dbe97bb4a095a1a7dee6f0ff1202123179723a1",
+  "qualifiedCommit": "bfcc81929de5f04f697d535057046265cc088cda",
+  "qualifiedTree": "8d41585522ab47949d42c11c5b8591488b95e49b",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }


### PR DESCRIPTION
## Branch Contract

- base branch: `dev`
- validated environment: exact `dev@e5991ff390c8ef3ea767fee9f4acd75b8e39e081`, the production backend through the repository-owned isolated release controller, and the credential-free closed simulator
- back-merge required after merge: No
- root workspace integration expected: No for this prerequisite PR; the later v0.0.71 promotion to `main` retains the normal workspace integration handoff

- [x] this PR targets `dev`
- [x] the work started from the exact current `dev` head, not `main`

## Linked Issue

Refs #845

## Change Facts

- refresh the tracked v0.0.71 semantic E2E evidence from an explicitly authorized authenticated production run
- regenerate the four active locales' context, quality, and activation artifacts plus their evidence descriptor
- bind the refreshed inputs to a new credential-free semantic-harness qualification receipt
- record the governed-document reviews required by Docpact; no release, authorization, cleanup, or validation contract changed

This is the reviewed evidence prerequisite that unblocks the deterministic `release:to-dev` command. It does not change the package version itself.

## Validation Facts

- `npm run e2e:env:doctor -- --format json`: passed Node/Git/Docker/image/lock/browser checks
- authorized `npm run e2e:release -- --authenticated --allow-production-data --write-verified-evidence ...`: 60 passed, 33 designed skips, all 49 semantic assertion IDs closed
- production fixture lifecycle: `created=1`, `cleaned=1`, `leaked=0`; the external recovery ledger was removed after verified cleanup
- raw controller artifact passed the canonical checker and was copied byte-for-byte into `docs/plans/i18n/semantic-e2e-evidence.json`
- `npm run i18n:locale:artifacts:idempotence`: two generations produced an identical canonical diff
- `npm run e2e:qualify`: 63 passed, 30 designed skips, 0 production writes, 0 external requests
- `npm run e2e:qualification:check`: passed
- `npm run i18n:evidence:canonical:check`: passed
- `npm run release:preflight`: passed
- Docpact enforce lint for `e5991ff3..1a2772b4`: 0 active findings, 0 uncovered paths, all 10 governed documents fresh
- managed checked-push gate: 416 suites / 5703 tests passed; 462/462 tracked source files at 100% statements, branches, functions, and lines

The runtime credential file, authentication state, screenshots, traces, video, ignored run artifacts, and recovery ledger are not included in this branch.

## Risks And Follow-Up

- the evidence is provenance-bound; any subsequent semantic input drift must fail `release:preflight` and requires the appropriate refreshed proof
- after merge, rerun the deterministic `release:to-dev -- --version 0.0.71 --issue 845` plan/apply flow from the new `dev` head
- the eventual version PR must merge before `release:promote-dev-to-main` can create the immutable promotion PR
