### PR TITLE
fix: canonicalize closure LCIA method ids

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-14"
-lastReviewedCommit: "4c51e963368f4376303d1662750350ab6a652c11"
+lastReviewedCommit: "68dbfce92fb34cdcf3a875103eb54dac93f72c3e"
 lastReviewedNote: 'Reviewed for Next Issue #845: refreshing provenance-bound production evidence and qualification artifacts does not change the repository routing contract.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-14"
-lastReviewedCommit: "68dbfce92fb34cdcf3a875103eb54dac93f72c3e"
+lastReviewedCommit: "2be77cc77708f63b4c8671b9ff7283f6285c8784"
 lastReviewedNote: 'Reviewed for Next Issue #845: refreshing provenance-bound production evidence and qualification artifacts does not change the repository routing contract.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 4c51e963368f4376303d1662750350ab6a652c11
+lastReviewedCommit: 68dbfce92fb34cdcf3a875103eb54dac93f72c3e
 lastReviewedNote: 'Reviewed for Next Issue #845: refreshed v0.0.71 production evidence and qualification follow the existing explicit-authorization, exact-cleanup, and deterministic-release contract.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 68dbfce92fb34cdcf3a875103eb54dac93f72c3e
+lastReviewedCommit: 2be77cc77708f63b4c8671b9ff7283f6285c8784
 lastReviewedNote: 'Reviewed for Next Issue #845: refreshed v0.0.71 production evidence and qualification follow the existing explicit-authorization, exact-cleanup, and deterministic-release contract.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 68dbfce92fb34cdcf3a875103eb54dac93f72c3e
+lastReviewedCommit: 2be77cc77708f63b4c8671b9ff7283f6285c8784
 lastReviewedNote: 'Reviewed for Next Issue #846: the startup runtime-config switch, maintenance boundary, static fallback, and focused validation use the existing bootstrap workflow without changing local setup commands.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 01a3dcc00bd70ef80d0419be493c4e6f883c2f95
+lastReviewedCommit: 68dbfce92fb34cdcf3a875103eb54dac93f72c3e
 lastReviewedNote: 'Reviewed for Next Issue #846: the startup runtime-config switch, maintenance boundary, static fallback, and focused validation use the existing bootstrap workflow without changing local setup commands.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 68dbfce92fb34cdcf3a875103eb54dac93f72c3e
+lastReviewedCommit: 2be77cc77708f63b4c8671b9ff7283f6285c8784
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance runtime, locale, component-test, and packaging changes remain covered by the existing Docpact-first managed push gate.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 01a3dcc00bd70ef80d0419be493c4e6f883c2f95
+lastReviewedCommit: 68dbfce92fb34cdcf3a875103eb54dac93f72c3e
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance runtime, locale, component-test, and packaging changes remain covered by the existing Docpact-first managed push gate.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 8c735ca300f4505f436df2d1f2db4f7adc830e39
+lastReviewedCommit: 68dbfce92fb34cdcf3a875103eb54dac93f72c3e
 lastReviewedNote: 'Reviewed for Next Issue #820: Process submission now checks only the editable current record, while Review Admin owns a manual, informational joint quality diagnostic.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 01a3dcc00bd70ef80d0419be493c4e6f883c2f95
+lastReviewedCommit: 68dbfce92fb34cdcf3a875103eb54dac93f72c3e
 lastReviewedNote: 'Reviewed for Next Issue #846: the runtime-config service, maintenance UI, static fallback, locale artifacts, focused tests, lint, and production build follow the existing shared-runtime validation contract.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 68dbfce92fb34cdcf3a875103eb54dac93f72c3e
+lastReviewedCommit: 2be77cc77708f63b4c8671b9ff7283f6285c8784
 lastReviewedNote: 'Reviewed for Next Issue #846: the runtime-config service, maintenance UI, static fallback, locale artifacts, focused tests, lint, and production build follow the existing shared-runtime validation contract.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 01a3dcc00bd70ef80d0419be493c4e6f883c2f95
+lastReviewedCommit: 68dbfce92fb34cdcf3a875103eb54dac93f72c3e
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance startup, fallback, environment-switch, and refresh-button coverage fit the existing focused-first strategy without changing the test-improvement plan.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 68dbfce92fb34cdcf3a875103eb54dac93f72c3e
+lastReviewedCommit: 2be77cc77708f63b4c8671b9ff7283f6285c8784
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance startup, fallback, environment-switch, and refresh-button coverage fit the existing focused-first strategy without changing the test-improvement plan.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 68dbfce92fb34cdcf3a875103eb54dac93f72c3e
+lastReviewedCommit: 2be77cc77708f63b4c8671b9ff7283f6285c8784
 lastReviewedNote: 'Reviewed for Next Issue #846: focused maintenance boundary, runtime-config, fallback, locale, lint, and build proof introduces no new exception queue.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 01a3dcc00bd70ef80d0419be493c4e6f883c2f95
+lastReviewedCommit: 68dbfce92fb34cdcf3a875103eb54dac93f72c3e
 lastReviewedNote: 'Reviewed for Next Issue #846: focused maintenance boundary, runtime-config, fallback, locale, lint, and build proof introduces no new exception queue.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 01a3dcc00bd70ef80d0419be493c4e6f883c2f95
+lastReviewedCommit: 68dbfce92fb34cdcf3a875103eb54dac93f72c3e
 lastReviewedNote: 'Reviewed for Next Issue #846: startup maintenance, fail-open service, static fallback, refresh interaction, and environment-switch tests follow the existing component and service test patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 68dbfce92fb34cdcf3a875103eb54dac93f72c3e
+lastReviewedCommit: 2be77cc77708f63b4c8671b9ff7283f6285c8784
 lastReviewedNote: 'Reviewed for Next Issue #846: startup maintenance, fail-open service, static fallback, refresh interaction, and environment-switch tests follow the existing component and service test patterns.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 01a3dcc00bd70ef80d0419be493c4e6f883c2f95
+lastReviewedCommit: 68dbfce92fb34cdcf3a875103eb54dac93f72c3e
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance startup, timeout, fallback, environment bypass, and refresh behavior require no troubleshooting rule beyond the existing focused-test and gate workflow.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 68dbfce92fb34cdcf3a875103eb54dac93f72c3e
+lastReviewedCommit: 2be77cc77708f63b4c8671b9ff7283f6285c8784
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance startup, timeout, fallback, environment bypass, and refresh behavior require no troubleshooting rule beyond the existing focused-test and gate workflow.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "fb3b8bbbfcfd8ed87e2be2eb6926a7b48060ceed7db4841dbf5b69a99bbb8a83",
-    "auditedInputDigest": "5319c5fd34d9b2edfa6c16005a708828afb48472d13ff995672734ddb03aa3b7"
+    "sourceManifestDigest": "2cd70c01960ec4c10eb8926d24348af0ed6323026ff6aa7b5086ce65df8cd517",
+    "auditedInputDigest": "db6dbddc113c0bdef9ee215f9fdfe1810763ba176ba2e0ac983b86189ac0386f"
   },
   "inventory": {
     "sourceMessageCount": 3169,
@@ -47,7 +47,7 @@
     "messageCount": 3169,
     "completeCount": 3169,
     "blockedCount": 0,
-    "dossierDigest": "141a6ab1135341252560bbf4c87d2df423fd330ee746c9b3f9d1b5a919ae02ad",
+    "dossierDigest": "4e32eb024441da0fdea47b3f97db6945924f2ebabd9219fc0bc9a58a7f71468d",
     "catalogDigest": "a069f1d12f849e391c7c38fb44ada66b8a856cf31f92902a02cd5538a41827fa",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "3406f614df5de473d23472f1418ae4328d7e72cadfae77d0a14efec9886f07fd",
+      "sourceEvidenceDigest": "4630b63172d2d8941a43e5e5ec82b721a1fbdf63d74d847ab69e80f97f25042a",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -1042,8 +1042,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "e3d60439fa2fd590c0130267ad7f078cc512f4f929445b2c20bf6b22e7852604",
-          "focusedTestDigest": "9f8be298ef8b2f4a04f09b36a8add55f841ddecba2995657b789de448b32146f",
+          "sourceDigest": "620dd184b6808b96474612d36aadced76a377455bd152744f08bbce736069953",
+          "focusedTestDigest": "8f33451d0e730a1ba9e49f95d9249f5f085733927ffa799276b57fb7d81f72ba",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "bc7fb4c74b8cbfcc3b58c462e4320593d56bbf4256fadacbc2e2988f9c0cb361",
+      "rowEvidenceDigest": "c5d9211efd6201d53b09d372dd9c6e45d2236229100be6e68c4425d4ec2b4e18",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "a3a9bef3edb70f9f5d56e3ff5ed87a54cb94f94cbfebf137810fa267800c9071"
+  "contextDigest": "79773586c4480a43928cbf38700f322430047eb6d2738f64c6de4751d77df6b8"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "fb3b8bbbfcfd8ed87e2be2eb6926a7b48060ceed7db4841dbf5b69a99bbb8a83"
+    "sourceManifestDigest": "2cd70c01960ec4c10eb8926d24348af0ed6323026ff6aa7b5086ce65df8cd517"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "a3a9bef3edb70f9f5d56e3ff5ed87a54cb94f94cbfebf137810fa267800c9071",
-    "qualityDigest": "be2cf3132830472da39a52da7590831ca337ddb4d3ee9799f9a4be1602b878ae",
+    "contextDigest": "79773586c4480a43928cbf38700f322430047eb6d2738f64c6de4751d77df6b8",
+    "qualityDigest": "e6ebfcfdda0199b8be8055a225304a48868c0344d62b07104376617166ccb545",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "a15b3df5797dc1cb5ad6dffaf602567ee3df9df65de223de8516879199870ad1"
+  "activationDigest": "1312fb233f8183c762fe05bbeeafb555d0f4a438eef36b91abf9189f05d7b179"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "5319c5fd34d9b2edfa6c16005a708828afb48472d13ff995672734ddb03aa3b7",
+    "auditedInputDigest": "db6dbddc113c0bdef9ee215f9fdfe1810763ba176ba2e0ac983b86189ac0386f",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -57274,7 +57274,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1715,
+          "line": 1717,
           "column": 20,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Check data completeness",
@@ -57289,7 +57289,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1715,
+              "line": 1717,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -57357,7 +57357,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1732,
+          "line": 1734,
           "column": 14,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Generate result set",
@@ -57372,7 +57372,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1732,
+              "line": 1734,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -57606,7 +57606,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1445,
+          "line": 1447,
           "column": 45,
           "symbol": "previewPackageLabel",
           "defaultMessage": "Preview result set",
@@ -57615,7 +57615,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2061,
+          "line": 2063,
           "column": 14,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Preview result set",
@@ -57630,13 +57630,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1445,
+              "line": 1447,
               "column": 45,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2061,
+              "line": 2063,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -57704,7 +57704,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2345,
+          "line": 2347,
           "column": 14,
           "symbol": "renderPublication",
           "defaultMessage": "Publish result set",
@@ -57719,7 +57719,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2345,
+              "line": 2347,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -57870,7 +57870,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2411,
+          "line": 2413,
           "column": 53,
           "symbol": "unpublishPublicationLabel",
           "defaultMessage": "Unpublish publication",
@@ -57885,7 +57885,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2411,
+              "line": 2413,
               "column": 53,
               "kind": "messageHelper"
             }
@@ -61612,7 +61612,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1196,
+          "line": 1198,
           "column": 18,
           "symbol": "handleCreateBuild",
           "defaultMessage": "Run a complete data check for the current selection before generating a result set.",
@@ -61627,7 +61627,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1196,
+              "line": 1198,
               "column": 18,
               "kind": "messageHelper"
             }
@@ -61704,7 +61704,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1591,
+          "line": 1593,
           "column": 28,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Certificate",
@@ -61725,7 +61725,7 @@
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1591,
+              "line": 1593,
               "column": 28,
               "kind": "messageHelper"
             }
@@ -61802,7 +61802,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1596,
+          "line": 1598,
           "column": 28,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Scan completeness",
@@ -61823,7 +61823,7 @@
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1596,
+              "line": 1598,
               "column": 28,
               "kind": "messageHelper"
             }
@@ -62072,7 +62072,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1129,
+          "line": 1131,
           "column": 35,
           "symbol": "closureErrorMessages",
           "defaultMessage": "The current public release or snapshot is unavailable; a certificate cannot be issued.",
@@ -62087,7 +62087,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1129,
+              "line": 1131,
               "column": 35,
               "kind": "messageHelper"
             }
@@ -62155,7 +62155,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1133,
+          "line": 1135,
           "column": 41,
           "symbol": "closureErrorMessages",
           "defaultMessage": "Closure evidence integrity verification failed.",
@@ -62170,7 +62170,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1133,
+              "line": 1135,
               "column": 41,
               "kind": "messageHelper"
             }
@@ -62238,7 +62238,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1125,
+          "line": 1127,
           "column": 39,
           "symbol": "closureErrorMessages",
           "defaultMessage": "The current public release or snapshot is unavailable; a certificate cannot be issued.",
@@ -62253,7 +62253,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1125,
+              "line": 1127,
               "column": 39,
               "kind": "messageHelper"
             }
@@ -62321,7 +62321,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1105,
+          "line": 1107,
           "column": 35,
           "symbol": "closureErrorMessages",
           "defaultMessage": "The closure scan is incomplete.",
@@ -62336,7 +62336,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1105,
+              "line": 1107,
               "column": 35,
               "kind": "messageHelper"
             }
@@ -62404,7 +62404,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1097,
+          "line": 1099,
           "column": 34,
           "symbol": "closureErrorMessages",
           "defaultMessage": "The selected closure check was not found.",
@@ -62419,7 +62419,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1097,
+              "line": 1099,
               "column": 34,
               "kind": "messageHelper"
             }
@@ -62487,7 +62487,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1101,
+          "line": 1103,
           "column": 35,
           "symbol": "closureErrorMessages",
           "defaultMessage": "The closure check has not passed.",
@@ -62502,7 +62502,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1101,
+              "line": 1103,
               "column": 35,
               "kind": "messageHelper"
             }
@@ -62570,7 +62570,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1113,
+          "line": 1115,
           "column": 40,
           "symbol": "closureErrorMessages",
           "defaultMessage": "The current policy does not match this closure check.",
@@ -62585,7 +62585,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1113,
+              "line": 1115,
               "column": 40,
               "kind": "messageHelper"
             }
@@ -62653,7 +62653,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1093,
+          "line": 1095,
           "column": 33,
           "symbol": "closureErrorMessages",
           "defaultMessage": "A closure check is required.",
@@ -62668,7 +62668,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1093,
+              "line": 1095,
               "column": 33,
               "kind": "messageHelper"
             }
@@ -62736,7 +62736,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1121,
+          "line": 1123,
           "column": 32,
           "symbol": "closureErrorMessages",
           "defaultMessage": "The closure certificate was revoked.",
@@ -62751,7 +62751,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1121,
+              "line": 1123,
               "column": 32,
               "kind": "messageHelper"
             }
@@ -62819,7 +62819,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1109,
+          "line": 1111,
           "column": 39,
           "symbol": "closureErrorMessages",
           "defaultMessage": "The current selection does not match this closure check.",
@@ -62834,7 +62834,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1109,
+              "line": 1111,
               "column": 39,
               "kind": "messageHelper"
             }
@@ -62902,7 +62902,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1117,
+          "line": 1119,
           "column": 30,
           "symbol": "closureErrorMessages",
           "defaultMessage": "The closure certificate is stale.",
@@ -62917,7 +62917,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1117,
+              "line": 1119,
               "column": 30,
               "kind": "messageHelper"
             }
@@ -62985,7 +62985,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1634,
+          "line": 1636,
           "column": 31,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Error code",
@@ -63000,7 +63000,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1634,
+              "line": 1636,
               "column": 31,
               "kind": "messageHelper"
             }
@@ -63077,7 +63077,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1654,
+          "line": 1656,
           "column": 28,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Data completeness check was cancelled. Run a new check to continue.",
@@ -63098,7 +63098,7 @@
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1654,
+              "line": 1656,
               "column": 28,
               "kind": "messageHelper"
             }
@@ -63175,7 +63175,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1620,
+          "line": 1622,
           "column": 26,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Data completeness check failed to run",
@@ -63196,7 +63196,7 @@
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1620,
+              "line": 1622,
               "column": 26,
               "kind": "messageHelper"
             }
@@ -63273,7 +63273,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1627,
+          "line": 1629,
           "column": 27,
           "symbol": "renderBuildRequests",
           "defaultMessage": "The check did not complete. Retry it; if it fails again, contact an administrator with the identifiers below.",
@@ -63294,7 +63294,7 @@
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1627,
+              "line": 1629,
               "column": 27,
               "kind": "messageHelper"
             }
@@ -63371,7 +63371,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1662,
+          "line": 1664,
           "column": 28,
           "symbol": "renderBuildRequests",
           "defaultMessage": "The check is still running. Closure issues will be available after it completes.",
@@ -63392,7 +63392,7 @@
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1662,
+              "line": 1664,
               "column": 28,
               "kind": "messageHelper"
             }
@@ -63460,7 +63460,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1670,
+          "line": 1672,
           "column": 28,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Closure issues",
@@ -63475,7 +63475,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1670,
+              "line": 1672,
               "column": 28,
               "kind": "messageHelper"
             }
@@ -63552,7 +63552,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1600,
+          "line": 1602,
           "column": 45,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Issues",
@@ -63573,7 +63573,7 @@
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1600,
+              "line": 1602,
               "column": 45,
               "kind": "messageHelper"
             }
@@ -63641,7 +63641,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1674,
+          "line": 1676,
           "column": 24,
           "symbol": "renderBuildRequests",
           "defaultMessage": "No closure issues found.",
@@ -63656,7 +63656,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1674,
+              "line": 1676,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -63724,7 +63724,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1690,
+          "line": 1692,
           "column": 24,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Load more issues",
@@ -63739,7 +63739,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1690,
+              "line": 1692,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -63807,7 +63807,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1578,
+          "line": 1580,
           "column": 28,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Check data completeness before generation.",
@@ -63822,7 +63822,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1578,
+              "line": 1580,
               "column": 28,
               "kind": "messageHelper"
             }
@@ -63949,7 +63949,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1608,
+          "line": 1610,
           "column": 28,
           "symbol": "renderBuildRequests",
           "defaultMessage": "The current selection differs from this check. Run a new check before generating.",
@@ -63964,7 +63964,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1608,
+              "line": 1610,
               "column": 28,
               "kind": "messageHelper"
             }
@@ -64041,7 +64041,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1586,
+          "line": 1588,
           "column": 28,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Check status",
@@ -64062,7 +64062,7 @@
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1586,
+              "line": 1588,
               "column": 28,
               "kind": "messageHelper"
             }
@@ -64130,7 +64130,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1571,
+          "line": 1573,
           "column": 20,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Data completeness preflight",
@@ -64145,7 +64145,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1571,
+              "line": 1573,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -64222,7 +64222,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1642,
+          "line": 1644,
           "column": 31,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Worker job ID",
@@ -64243,7 +64243,7 @@
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1642,
+              "line": 1644,
               "column": 31,
               "kind": "messageHelper"
             }
@@ -64311,7 +64311,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1024,
+          "line": 1026,
           "column": 9,
           "symbol": "commandSummaryRows",
           "defaultMessage": "Generation ID",
@@ -64326,7 +64326,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1024,
+              "line": 1026,
               "column": 9,
               "kind": "messageHelper"
             }
@@ -64403,7 +64403,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1012,
+          "line": 1014,
           "column": 9,
           "symbol": "commandSummaryRows",
           "defaultMessage": "Closure check ID",
@@ -64424,7 +64424,7 @@
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1012,
+              "line": 1014,
               "column": 9,
               "kind": "messageHelper"
             }
@@ -64610,7 +64610,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1143,
+          "line": 1145,
           "column": 11,
           "symbol": "showResult",
           "defaultMessage": "Command failed",
@@ -64619,7 +64619,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1269,
+          "line": 1271,
           "column": 41,
           "symbol": "handleRecoverClosureCheck",
           "defaultMessage": "Command failed",
@@ -64634,13 +64634,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1143,
+              "line": 1145,
               "column": 11,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1269,
+              "line": 1271,
               "column": 41,
               "kind": "messageHelper"
             }
@@ -64708,7 +64708,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1050,
+          "line": 1052,
           "column": 9,
           "symbol": "commandSummaryRows",
           "defaultMessage": "Result set ID",
@@ -64723,7 +64723,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1050,
+              "line": 1052,
               "column": 9,
               "kind": "messageHelper"
             }
@@ -64909,7 +64909,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1046,
+          "line": 1048,
           "column": 9,
           "symbol": "commandSummaryRows",
           "defaultMessage": "Publication ID",
@@ -64918,7 +64918,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1058,
+          "line": 1060,
           "column": 7,
           "symbol": "commandSummaryRows",
           "defaultMessage": "Publication ID",
@@ -64933,13 +64933,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1046,
+              "line": 1048,
               "column": 9,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1058,
+              "line": 1060,
               "column": 7,
               "kind": "messageHelper"
             }
@@ -65066,7 +65066,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1053,
+          "line": 1055,
           "column": 14,
           "symbol": "commandSummaryRows",
           "defaultMessage": "Status",
@@ -65075,7 +65075,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1062,
+          "line": 1064,
           "column": 7,
           "symbol": "commandSummaryRows",
           "defaultMessage": "Status",
@@ -65084,7 +65084,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1426,
+          "line": 1428,
           "column": 20,
           "symbol": "renderBuildJobs",
           "defaultMessage": "Status",
@@ -65093,7 +65093,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2372,
+          "line": 2374,
           "column": 22,
           "symbol": "renderPublication",
           "defaultMessage": "Status",
@@ -65108,25 +65108,25 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1053,
+              "line": 1055,
               "column": 14,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1062,
+              "line": 1064,
               "column": 7,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1426,
+              "line": 1428,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2372,
+              "line": 2374,
               "column": 22,
               "kind": "messageHelper"
             }
@@ -65312,7 +65312,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1016,
+          "line": 1018,
           "column": 9,
           "symbol": "commandSummaryRows",
           "defaultMessage": "Worker job ID",
@@ -65321,7 +65321,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1028,
+          "line": 1030,
           "column": 9,
           "symbol": "commandSummaryRows",
           "defaultMessage": "Worker job ID",
@@ -65336,13 +65336,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1016,
+              "line": 1018,
               "column": 9,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1028,
+              "line": 1030,
               "column": 9,
               "kind": "messageHelper"
             }
@@ -65410,7 +65410,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 965,
+          "line": 967,
           "column": 16,
           "symbol": "coverageModeOptions",
           "defaultMessage": "Global eligible",
@@ -65425,7 +65425,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 965,
+              "line": 967,
               "column": 16,
               "kind": "messageHelper"
             }
@@ -65493,7 +65493,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 968,
+          "line": 970,
           "column": 16,
           "symbol": "coverageModeOptions",
           "defaultMessage": "Subset",
@@ -65508,7 +65508,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 968,
+              "line": 970,
               "column": 16,
               "kind": "messageHelper"
             }
@@ -65576,7 +65576,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1553,
+          "line": 1555,
           "column": 20,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Coverage mode",
@@ -65585,7 +65585,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1557,
+          "line": 1559,
           "column": 27,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Coverage mode",
@@ -65600,13 +65600,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1553,
+              "line": 1555,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1557,
+              "line": 1559,
               "column": 27,
               "kind": "messageHelper"
             }
@@ -65674,7 +65674,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1562,
+          "line": 1564,
           "column": 20,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Default impact category",
@@ -65683,7 +65683,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1566,
+          "line": 1568,
           "column": 15,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Default impact category",
@@ -65698,13 +65698,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1562,
+              "line": 1564,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1566,
+              "line": 1568,
               "column": 15,
               "kind": "messageHelper"
             }
@@ -65772,7 +65772,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1504,
+          "line": 1506,
           "column": 20,
           "symbol": "renderImpactCategorySelect",
           "defaultMessage": "Select an impact category",
@@ -65787,7 +65787,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1504,
+              "line": 1506,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -65855,7 +65855,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1538,
+          "line": 1540,
           "column": 20,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Result set name",
@@ -65864,7 +65864,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1550,
+          "line": 1552,
           "column": 32,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Result set name",
@@ -65879,13 +65879,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1538,
+              "line": 1540,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1550,
+              "line": 1552,
               "column": 32,
               "kind": "messageHelper"
             }
@@ -65953,7 +65953,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2035,
+          "line": 2037,
           "column": 19,
           "symbol": "renderPackagePreview",
           "defaultMessage": "No preview-ready result set yet. Refresh tasks or wait for the worker to complete.",
@@ -65962,7 +65962,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2291,
+          "line": 2293,
           "column": 19,
           "symbol": "renderPublication",
           "defaultMessage": "No preview-ready result set yet. Refresh tasks or wait for the worker to complete.",
@@ -65977,13 +65977,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2035,
+              "line": 2037,
               "column": 19,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2291,
+              "line": 2293,
               "column": 19,
               "kind": "messageHelper"
             }
@@ -66051,7 +66051,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1518,
+          "line": 1520,
           "column": 20,
           "symbol": "renderPackageSelect",
           "defaultMessage": "Select a preview-ready result set",
@@ -66066,7 +66066,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1518,
+              "line": 1520,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -66134,7 +66134,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2031,
+          "line": 2033,
           "column": 20,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Select result set",
@@ -66143,7 +66143,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2052,
+          "line": 2054,
           "column": 15,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Select result set",
@@ -66158,13 +66158,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2031,
+              "line": 2033,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2052,
+              "line": 2054,
               "column": 15,
               "kind": "messageHelper"
             }
@@ -66232,7 +66232,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2312,
+          "line": 2314,
           "column": 20,
           "symbol": "renderPublication",
           "defaultMessage": "Publish default impact category",
@@ -66241,7 +66241,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2328,
+          "line": 2330,
           "column": 15,
           "symbol": "renderPublication",
           "defaultMessage": "Publish default impact category",
@@ -66250,7 +66250,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2375,
+          "line": 2377,
           "column": 22,
           "symbol": "renderPublication",
           "defaultMessage": "Publish default impact category",
@@ -66265,19 +66265,19 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2312,
+              "line": 2314,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2328,
+              "line": 2330,
               "column": 15,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2375,
+              "line": 2377,
               "column": 22,
               "kind": "messageHelper"
             }
@@ -66345,7 +66345,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2287,
+          "line": 2289,
           "column": 20,
           "symbol": "renderPublication",
           "defaultMessage": "Publish result set",
@@ -66354,7 +66354,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2308,
+          "line": 2310,
           "column": 15,
           "symbol": "renderPublication",
           "defaultMessage": "Publish result set",
@@ -66369,13 +66369,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2287,
+              "line": 2289,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2308,
+              "line": 2310,
               "column": 15,
               "kind": "messageHelper"
             }
@@ -66443,7 +66443,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2335,
+          "line": 2337,
           "column": 20,
           "symbol": "renderPublication",
           "defaultMessage": "Publish reason",
@@ -66452,7 +66452,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2338,
+          "line": 2340,
           "column": 32,
           "symbol": "renderPublication",
           "defaultMessage": "Publish reason",
@@ -66467,13 +66467,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2335,
+              "line": 2337,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2338,
+              "line": 2340,
               "column": 32,
               "kind": "messageHelper"
             }
@@ -66659,7 +66659,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1434,
+          "line": 1436,
           "column": 44,
           "symbol": "renderBuildJobs",
           "defaultMessage": "Action",
@@ -66668,7 +66668,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2386,
+          "line": 2388,
           "column": 46,
           "symbol": "renderPublication",
           "defaultMessage": "Action",
@@ -66683,13 +66683,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1434,
+              "line": 1436,
               "column": 44,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2386,
+              "line": 2388,
               "column": 46,
               "kind": "messageHelper"
             }
@@ -66816,7 +66816,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1417,
+          "line": 1419,
           "column": 16,
           "symbol": "renderBuildJobs",
           "defaultMessage": "No result generation tasks",
@@ -66831,7 +66831,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1417,
+              "line": 1419,
               "column": 16,
               "kind": "messageHelper"
             }
@@ -67017,7 +67017,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1409,
+          "line": 1411,
           "column": 14,
           "symbol": "renderBuildJobs",
           "defaultMessage": "Result set generation runs asynchronously. Refresh tasks to update progress, then preview or publish the result set after completion.",
@@ -67032,7 +67032,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1409,
+              "line": 1411,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -67100,7 +67100,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1429,
+          "line": 1431,
           "column": 20,
           "symbol": "renderBuildJobs",
           "defaultMessage": "Inputs",
@@ -67109,7 +67109,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2384,
+          "line": 2386,
           "column": 22,
           "symbol": "renderPublication",
           "defaultMessage": "Inputs",
@@ -67124,13 +67124,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1429,
+              "line": 1431,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2384,
+              "line": 2386,
               "column": 22,
               "kind": "messageHelper"
             }
@@ -67198,7 +67198,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1443,
+          "line": 1445,
           "column": 19,
           "symbol": "resultSetLabel",
           "defaultMessage": "Result set generation",
@@ -67213,7 +67213,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1443,
+              "line": 1445,
               "column": 19,
               "kind": "messageHelper"
             }
@@ -67281,7 +67281,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1402,
+          "line": 1404,
           "column": 12,
           "symbol": "renderBuildJobs",
           "defaultMessage": "Refresh jobs",
@@ -67296,7 +67296,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1402,
+              "line": 1404,
               "column": 12,
               "kind": "messageHelper"
             }
@@ -67364,7 +67364,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1423,
+          "line": 1425,
           "column": 20,
           "symbol": "renderBuildJobs",
           "defaultMessage": "Result set",
@@ -67373,7 +67373,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2369,
+          "line": 2371,
           "column": 22,
           "symbol": "renderPublication",
           "defaultMessage": "Result set",
@@ -67388,13 +67388,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1423,
+              "line": 1425,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2369,
+              "line": 2371,
               "column": 22,
               "kind": "messageHelper"
             }
@@ -67462,7 +67462,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1399,
+          "line": 1401,
           "column": 14,
           "symbol": "renderBuildJobs",
           "defaultMessage": "Result generation tasks",
@@ -67477,7 +67477,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1399,
+              "line": 1401,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -67545,7 +67545,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1432,
+          "line": 1434,
           "column": 20,
           "symbol": "renderBuildJobs",
           "defaultMessage": "Updated at",
@@ -67560,7 +67560,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1432,
+              "line": 1434,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -67687,7 +67687,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1394,
+          "line": 1396,
           "column": 9,
           "symbol": "renderJobPhase",
           "defaultMessage": "Waiting for worker processing",
@@ -67702,7 +67702,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1394,
+              "line": 1396,
               "column": 9,
               "kind": "messageHelper"
             }
@@ -67770,7 +67770,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2234,
+          "line": 2236,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Manifest version",
@@ -67785,7 +67785,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2234,
+              "line": 2236,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -67853,7 +67853,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2227,
+          "line": 2229,
           "column": 20,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Artifact verification",
@@ -67868,7 +67868,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2227,
+              "line": 2229,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -67936,7 +67936,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2259,
+          "line": 2261,
           "column": 41,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Artifacts",
@@ -67951,7 +67951,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2259,
+              "line": 2261,
               "column": 41,
               "kind": "messageHelper"
             }
@@ -68019,7 +68019,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2084,
+          "line": 2086,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Coverage mode",
@@ -68034,7 +68034,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2084,
+              "line": 2086,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -68102,7 +68102,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2089,
+          "line": 2091,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Default impact category",
@@ -68117,7 +68117,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2089,
+              "line": 2091,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -68185,7 +68185,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2107,
+          "line": 2109,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Eligible inputs",
@@ -68200,7 +68200,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2107,
+              "line": 2109,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -68268,7 +68268,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2170,
+          "line": 2172,
           "column": 20,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Export Excel",
@@ -68283,7 +68283,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2170,
+              "line": 2172,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -68351,7 +68351,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1875,
+          "line": 1877,
           "column": 15,
           "symbol": "handleExportPreview",
           "defaultMessage": "Failed to export result details",
@@ -68366,7 +68366,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1875,
+              "line": 1877,
               "column": 15,
               "kind": "messageHelper"
             }
@@ -68434,7 +68434,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2112,
+          "line": 2114,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Impact category count",
@@ -68449,7 +68449,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2112,
+              "line": 2114,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -68517,7 +68517,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2102,
+          "line": 2104,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Included inputs",
@@ -68532,7 +68532,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2102,
+              "line": 2104,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -68600,7 +68600,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2097,
+          "line": 2099,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Input manifest hash",
@@ -68615,7 +68615,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2097,
+              "line": 2099,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -68683,7 +68683,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2125,
+          "line": 2127,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Input scope",
@@ -68698,7 +68698,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2125,
+              "line": 2127,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -68766,7 +68766,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2177,
+          "line": 2179,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "LCIA method",
@@ -68775,7 +68775,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2179,
+          "line": 2181,
           "column": 31,
           "symbol": "renderPackagePreview",
           "defaultMessage": "LCIA method",
@@ -68790,13 +68790,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2177,
+              "line": 2179,
               "column": 24,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2179,
+              "line": 2181,
               "column": 31,
               "kind": "messageHelper"
             }
@@ -68923,7 +68923,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1990,
+          "line": 1992,
           "column": 12,
           "symbol": "renderPreviewPager",
           "defaultMessage": "Next",
@@ -68938,7 +68938,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1990,
+              "line": 1992,
               "column": 12,
               "kind": "messageHelper"
             }
@@ -69006,7 +69006,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2071,
+          "line": 2073,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Result set ID",
@@ -69021,7 +69021,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2071,
+              "line": 2073,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -69089,7 +69089,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2076,
+          "line": 2078,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Result set version",
@@ -69104,7 +69104,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2076,
+              "line": 2078,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -69172,7 +69172,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2138,
+          "line": 2140,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Predicate version",
@@ -69187,7 +69187,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2138,
+              "line": 2140,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -69255,7 +69255,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1986,
+          "line": 1988,
           "column": 12,
           "symbol": "renderPreviewPager",
           "defaultMessage": "Previous",
@@ -69270,7 +69270,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1986,
+              "line": 1988,
               "column": 12,
               "kind": "messageHelper"
             }
@@ -69338,7 +69338,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2128,
+          "line": 2130,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Process count",
@@ -69353,7 +69353,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2128,
+              "line": 2130,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -69539,7 +69539,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1903,
+          "line": 1905,
           "column": 11,
           "symbol": "handleExportPreview",
           "defaultMessage": "Process",
@@ -69548,7 +69548,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1931,
+          "line": 1933,
           "column": 14,
           "symbol": "previewDetailColumns",
           "defaultMessage": "Process",
@@ -69563,13 +69563,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1903,
+              "line": 1905,
               "column": 11,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1931,
+              "line": 1933,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -69637,7 +69637,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1904,
+          "line": 1906,
           "column": 11,
           "symbol": "handleExportPreview",
           "defaultMessage": "Process UUID",
@@ -69652,7 +69652,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1904,
+              "line": 1906,
               "column": 11,
               "kind": "messageHelper"
             }
@@ -69720,7 +69720,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1905,
+          "line": 1907,
           "column": 11,
           "symbol": "handleExportPreview",
           "defaultMessage": "Version",
@@ -69729,7 +69729,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1945,
+          "line": 1947,
           "column": 14,
           "symbol": "previewDetailColumns",
           "defaultMessage": "Version",
@@ -69744,13 +69744,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1905,
+              "line": 1907,
               "column": 11,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1945,
+              "line": 1947,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -69818,7 +69818,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2262,
+          "line": 2264,
           "column": 21,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Query artifact",
@@ -69833,7 +69833,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2262,
+              "line": 2264,
               "column": 21,
               "kind": "messageHelper"
             }
@@ -69901,7 +69901,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2266,
+          "line": 2268,
           "column": 21,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Result artifact",
@@ -69916,7 +69916,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2266,
+              "line": 2268,
               "column": 21,
               "kind": "messageHelper"
             }
@@ -69984,7 +69984,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2154,
+          "line": 2156,
           "column": 20,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Result details",
@@ -69999,7 +69999,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2154,
+              "line": 2156,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -70067,7 +70067,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2202,
+          "line": 2204,
           "column": 21,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Calculation results are not available for this preview.",
@@ -70082,7 +70082,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2202,
+              "line": 2204,
               "column": 21,
               "kind": "messageHelper"
             }
@@ -70150,7 +70150,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2133,
+          "line": 2135,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Selection mode",
@@ -70165,7 +70165,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2133,
+              "line": 2135,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -70233,7 +70233,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2255,
+          "line": 2257,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Snapshot coverage",
@@ -70248,7 +70248,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2255,
+              "line": 2257,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -70316,7 +70316,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2245,
+          "line": 2247,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Snapshot ID",
@@ -70331,7 +70331,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2245,
+              "line": 2247,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -70399,7 +70399,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2250,
+          "line": 2252,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Snapshot matrix",
@@ -70414,7 +70414,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2250,
+              "line": 2252,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -70482,7 +70482,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1906,
+          "line": 1908,
           "column": 11,
           "symbol": "handleExportPreview",
           "defaultMessage": "State code",
@@ -70491,7 +70491,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1951,
+          "line": 1953,
           "column": 14,
           "symbol": "previewDetailColumns",
           "defaultMessage": "State code",
@@ -70506,13 +70506,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1906,
+              "line": 1908,
               "column": 11,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1951,
+              "line": 1953,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -70580,7 +70580,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2143,
+          "line": 2145,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "State codes",
@@ -70595,7 +70595,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2143,
+              "line": 2145,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -70663,7 +70663,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2080,
+          "line": 2082,
           "column": 41,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Status",
@@ -70678,7 +70678,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2080,
+              "line": 2082,
               "column": 41,
               "kind": "messageHelper"
             }
@@ -70746,7 +70746,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2241,
+          "line": 2243,
           "column": 41,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Storage",
@@ -70761,7 +70761,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2241,
+              "line": 2243,
               "column": 41,
               "kind": "messageHelper"
             }
@@ -70829,7 +70829,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2068,
+          "line": 2070,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Result set overview",
@@ -70844,7 +70844,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2068,
+              "line": 2070,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -70971,7 +70971,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1848,
+          "line": 1850,
           "column": 10,
           "symbol": "previewValueTitle",
           "defaultMessage": "Value",
@@ -70980,7 +70980,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1849,
+          "line": 1851,
           "column": 7,
           "symbol": "previewValueTitle",
           "defaultMessage": "Value",
@@ -70995,13 +70995,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1848,
+              "line": 1850,
               "column": 10,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1849,
+              "line": 1851,
               "column": 7,
               "kind": "messageHelper"
             }
@@ -71069,7 +71069,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2191,
+          "line": 2193,
           "column": 28,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Some preview data could not be loaded",
@@ -71084,7 +71084,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2191,
+              "line": 2193,
               "column": 28,
               "kind": "messageHelper"
             }
@@ -71152,7 +71152,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2438,
+          "line": 2440,
           "column": 30,
           "symbol": "renderPublication",
           "defaultMessage": "Current",
@@ -71167,7 +71167,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2438,
+              "line": 2440,
               "column": 30,
               "kind": "messageHelper"
             }
@@ -71235,7 +71235,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2363,
+          "line": 2365,
           "column": 18,
           "symbol": "renderPublication",
           "defaultMessage": "No publications yet",
@@ -71250,7 +71250,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2363,
+              "line": 2365,
               "column": 18,
               "kind": "messageHelper"
             }
@@ -71318,7 +71318,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2284,
+          "line": 2286,
           "column": 20,
           "symbol": "renderPublication",
           "defaultMessage": "Legacy LCIA publication",
@@ -71333,7 +71333,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2284,
+              "line": 2286,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -71401,7 +71401,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2381,
+          "line": 2383,
           "column": 22,
           "symbol": "renderPublication",
           "defaultMessage": "Published at",
@@ -71416,7 +71416,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2381,
+              "line": 2383,
               "column": 22,
               "kind": "messageHelper"
             }
@@ -71484,7 +71484,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2354,
+          "line": 2356,
           "column": 14,
           "symbol": "renderPublication",
           "defaultMessage": "Refresh publications",
@@ -71499,7 +71499,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2354,
+              "line": 2356,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -71567,7 +71567,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2351,
+          "line": 2353,
           "column": 16,
           "symbol": "renderPublication",
           "defaultMessage": "Publication management",
@@ -71582,7 +71582,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2351,
+              "line": 2353,
               "column": 16,
               "kind": "messageHelper"
             }
@@ -72978,7 +72978,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2490,
+          "line": 2492,
           "column": 24,
           "symbol": "DataProcessing",
           "defaultMessage": "Result Generation",
@@ -72993,7 +72993,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2490,
+              "line": 2492,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -73061,7 +73061,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2495,
+          "line": 2497,
           "column": 24,
           "symbol": "DataProcessing",
           "defaultMessage": "Result Preview",
@@ -73076,7 +73076,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2495,
+              "line": 2497,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -73144,7 +73144,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2500,
+          "line": 2502,
           "column": 24,
           "symbol": "DataProcessing",
           "defaultMessage": "Publication",
@@ -73159,7 +73159,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2500,
+              "line": 2502,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -73310,7 +73310,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2479,
+          "line": 2481,
           "column": 27,
           "symbol": "DataProcessing",
           "defaultMessage": "Data Processing",
@@ -73325,7 +73325,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2479,
+              "line": 2481,
               "column": 27,
               "kind": "messageHelper"
             }
@@ -73452,7 +73452,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2320,
+          "line": 2322,
           "column": 26,
           "symbol": "renderPublication",
           "defaultMessage": "Default impact category is required",
@@ -73467,7 +73467,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2320,
+              "line": 2322,
               "column": 26,
               "kind": "messageHelper"
             }
@@ -73535,7 +73535,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1181,
+          "line": 1183,
           "column": 18,
           "symbol": "handleCreateBuild",
           "defaultMessage": "The reviewed LCIA method catalog is unavailable.",
@@ -73544,7 +73544,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1236,
+          "line": 1238,
           "column": 20,
           "symbol": "handleRecoverClosureCheck",
           "defaultMessage": "The reviewed LCIA method catalog is unavailable.",
@@ -73559,13 +73559,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1181,
+              "line": 1183,
               "column": 18,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1236,
+              "line": 1238,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -73633,7 +73633,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2044,
+          "line": 2046,
           "column": 26,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Result set is required",
@@ -73642,7 +73642,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2300,
+          "line": 2302,
           "column": 26,
           "symbol": "renderPublication",
           "defaultMessage": "Result set is required",
@@ -73657,13 +73657,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2044,
+              "line": 2046,
               "column": 26,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2300,
+              "line": 2302,
               "column": 26,
               "kind": "messageHelper"
             }
@@ -73731,7 +73731,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 1543,
+          "line": 1545,
           "column": 26,
           "symbol": "renderBuildRequests",
           "defaultMessage": "Result set name is required",
@@ -73746,7 +73746,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 1543,
+              "line": 1545,
               "column": 26,
               "kind": "messageHelper"
             }
@@ -265496,7 +265496,7 @@
       "count": 1,
       "file": "src/pages/DataProcessing/index.tsx",
       "expression": "id",
-      "locations": ["611:45"],
+      "locations": ["613:45"],
       "category": "active-dynamic",
       "family": "dataProcessing",
       "reviewStatus": "reviewed"
@@ -265506,7 +265506,7 @@
       "count": 1,
       "file": "src/pages/DataProcessing/index.tsx",
       "expression": "messages[action].id",
-      "locations": ["996:12"],
+      "locations": ["998:12"],
       "category": "active-dynamic",
       "family": "dataProcessing",
       "reviewStatus": "reviewed"

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "fb3b8bbbfcfd8ed87e2be2eb6926a7b48060ceed7db4841dbf5b69a99bbb8a83",
-    "contextDigest": "a3a9bef3edb70f9f5d56e3ff5ed87a54cb94f94cbfebf137810fa267800c9071"
+    "sourceManifestDigest": "2cd70c01960ec4c10eb8926d24348af0ed6323026ff6aa7b5086ce65df8cd517",
+    "contextDigest": "79773586c4480a43928cbf38700f322430047eb6d2738f64c6de4751d77df6b8"
   },
   "catalog": {
     "messageCount": 3169,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "00352f08c1295c0e93054e9f70ec555df8a33a55172bc15dea9bce3032a0eb3c",
-    "validationDigest": "2fa4137659401387f8acb4a5fee08b034aaecd3b658bfebd3db642723c24e5fc",
+    "digest": "8b218c49aee6854cdbb2364fec0c2bfbc78e0a4a831d7a4602103ed39709f6b5",
+    "validationDigest": "0503b6e0719f37eff250280a27d50fdd0bf9af0a2fecec1f411935098f7365a2",
     "laneCount": 1,
     "validatedMessageCount": 3169,
     "validatedModuleCount": 32,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "be2cf3132830472da39a52da7590831ca337ddb4d3ee9799f9a4be1602b878ae"
+  "qualityDigest": "e6ebfcfdda0199b8be8055a225304a48868c0344d62b07104376617166ccb545"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "5319c5fd34d9b2edfa6c16005a708828afb48472d13ff995672734ddb03aa3b7",
+    "auditedInputDigest": "db6dbddc113c0bdef9ee215f9fdfe1810763ba176ba2e0ac983b86189ac0386f",
     "validatedMessageCount": 3169,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1433,
     "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
     "catalogDigest": "a069f1d12f849e391c7c38fb44ada66b8a856cf31f92902a02cd5538a41827fa",
-    "dossierDigest": "141a6ab1135341252560bbf4c87d2df423fd330ee746c9b3f9d1b5a919ae02ad",
+    "dossierDigest": "4e32eb024441da0fdea47b3f97db6945924f2ebabd9219fc0bc9a58a7f71468d",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "bc7fb4c74b8cbfcc3b58c462e4320593d56bbf4256fadacbc2e2988f9c0cb361",
+    "routeEvidenceDigest": "c5d9211efd6201d53b09d372dd9c6e45d2236229100be6e68c4425d4ec2b4e18",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "720ffdb462f7c139597e6d9e9bb59f4641cd1fd1b5099b671fdef39cc900c87f",
         "highRiskMessageCount": 1433,
         "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
-        "dossierDigest": "141a6ab1135341252560bbf4c87d2df423fd330ee746c9b3f9d1b5a919ae02ad",
+        "dossierDigest": "4e32eb024441da0fdea47b3f97db6945924f2ebabd9219fc0bc9a58a7f71468d",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "2fa4137659401387f8acb4a5fee08b034aaecd3b658bfebd3db642723c24e5fc"
+  "validationDigest": "0503b6e0719f37eff250280a27d50fdd0bf9af0a2fecec1f411935098f7365a2"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "fb3b8bbbfcfd8ed87e2be2eb6926a7b48060ceed7db4841dbf5b69a99bbb8a83",
-    "auditedInputDigest": "5319c5fd34d9b2edfa6c16005a708828afb48472d13ff995672734ddb03aa3b7"
+    "sourceManifestDigest": "2cd70c01960ec4c10eb8926d24348af0ed6323026ff6aa7b5086ce65df8cd517",
+    "auditedInputDigest": "db6dbddc113c0bdef9ee215f9fdfe1810763ba176ba2e0ac983b86189ac0386f"
   },
   "inventory": {
     "sourceMessageCount": 3169,
@@ -47,7 +47,7 @@
     "messageCount": 3169,
     "completeCount": 3169,
     "blockedCount": 0,
-    "dossierDigest": "b1ba494ac750e364a1b47b9296e24861d8325cf65ab5a8da82679091082afe93",
+    "dossierDigest": "f24ca4f76eb8fa6756755e438a32a3f9e7d7322499002ebe1e861efd5bc4f29e",
     "catalogDigest": "467d24cabc55fc92fcd112386a9020f4b8b55e71e970559d9c4006a8323a265e",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "3406f614df5de473d23472f1418ae4328d7e72cadfae77d0a14efec9886f07fd",
+      "sourceEvidenceDigest": "4630b63172d2d8941a43e5e5ec82b721a1fbdf63d74d847ab69e80f97f25042a",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -1042,8 +1042,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "e3d60439fa2fd590c0130267ad7f078cc512f4f929445b2c20bf6b22e7852604",
-          "focusedTestDigest": "9f8be298ef8b2f4a04f09b36a8add55f841ddecba2995657b789de448b32146f",
+          "sourceDigest": "620dd184b6808b96474612d36aadced76a377455bd152744f08bbce736069953",
+          "focusedTestDigest": "8f33451d0e730a1ba9e49f95d9249f5f085733927ffa799276b57fb7d81f72ba",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "bc7fb4c74b8cbfcc3b58c462e4320593d56bbf4256fadacbc2e2988f9c0cb361",
+      "rowEvidenceDigest": "c5d9211efd6201d53b09d372dd9c6e45d2236229100be6e68c4425d4ec2b4e18",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "38dda26777a59fe477cbb3141f3e9278b8e5fd8fff13696e235ee83abb1decbe"
+  "contextDigest": "41f4f2992b5d6ae0050857ee0ffa79ec10135f747ecd054e5a8bd81c686269cb"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "fb3b8bbbfcfd8ed87e2be2eb6926a7b48060ceed7db4841dbf5b69a99bbb8a83"
+    "sourceManifestDigest": "2cd70c01960ec4c10eb8926d24348af0ed6323026ff6aa7b5086ce65df8cd517"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "38dda26777a59fe477cbb3141f3e9278b8e5fd8fff13696e235ee83abb1decbe",
-    "qualityDigest": "3c00189f492091a7f57492680d321a22cf4910376b0224c75ecea51e0779e7d3",
+    "contextDigest": "41f4f2992b5d6ae0050857ee0ffa79ec10135f747ecd054e5a8bd81c686269cb",
+    "qualityDigest": "cae6a496f1d1b2e71b9c311fd74ba05d745b0a1d89592c4ff9bfd1c31704fd24",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "f79263bfbf7b60a6cec94d41d60a937553c62d74d3b764d87cdbb3fa57fadbcb"
+  "activationDigest": "8bbe415fc88d3f95bf8b5fbbc57fa96ce684201e0a3725f73b058295a3dea72a"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "fb3b8bbbfcfd8ed87e2be2eb6926a7b48060ceed7db4841dbf5b69a99bbb8a83",
-    "contextDigest": "38dda26777a59fe477cbb3141f3e9278b8e5fd8fff13696e235ee83abb1decbe"
+    "sourceManifestDigest": "2cd70c01960ec4c10eb8926d24348af0ed6323026ff6aa7b5086ce65df8cd517",
+    "contextDigest": "41f4f2992b5d6ae0050857ee0ffa79ec10135f747ecd054e5a8bd81c686269cb"
   },
   "catalog": {
     "messageCount": 3169,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "15e04b568edf3af75e8834ad967d86fb1c311df3c6a29c8bd6901e66c994e4a6",
-    "validationDigest": "5558be9129873ef9d70dadc43c91cbae1bdfa47696edb1aef385f69c8de2212a",
+    "digest": "cdfa2f84cc8914bc7605d390fa38711bf3d66b1dc5888f75c23f00373b6048d7",
+    "validationDigest": "286ac23e5766b528f1859b904e8c31f4325dd990f69e1e11e942bb6da9bc95c3",
     "laneCount": 1,
     "validatedMessageCount": 3169,
     "validatedModuleCount": 32,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "3c00189f492091a7f57492680d321a22cf4910376b0224c75ecea51e0779e7d3"
+  "qualityDigest": "cae6a496f1d1b2e71b9c311fd74ba05d745b0a1d89592c4ff9bfd1c31704fd24"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "5319c5fd34d9b2edfa6c16005a708828afb48472d13ff995672734ddb03aa3b7",
+    "auditedInputDigest": "db6dbddc113c0bdef9ee215f9fdfe1810763ba176ba2e0ac983b86189ac0386f",
     "validatedMessageCount": 3169,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1433,
     "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
     "catalogDigest": "467d24cabc55fc92fcd112386a9020f4b8b55e71e970559d9c4006a8323a265e",
-    "dossierDigest": "b1ba494ac750e364a1b47b9296e24861d8325cf65ab5a8da82679091082afe93",
+    "dossierDigest": "f24ca4f76eb8fa6756755e438a32a3f9e7d7322499002ebe1e861efd5bc4f29e",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "bc7fb4c74b8cbfcc3b58c462e4320593d56bbf4256fadacbc2e2988f9c0cb361",
+    "routeEvidenceDigest": "c5d9211efd6201d53b09d372dd9c6e45d2236229100be6e68c4425d4ec2b4e18",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "720ffdb462f7c139597e6d9e9bb59f4641cd1fd1b5099b671fdef39cc900c87f",
         "highRiskMessageCount": 1433,
         "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
-        "dossierDigest": "b1ba494ac750e364a1b47b9296e24861d8325cf65ab5a8da82679091082afe93",
+        "dossierDigest": "f24ca4f76eb8fa6756755e438a32a3f9e7d7322499002ebe1e861efd5bc4f29e",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "5558be9129873ef9d70dadc43c91cbae1bdfa47696edb1aef385f69c8de2212a"
+  "validationDigest": "286ac23e5766b528f1859b904e8c31f4325dd990f69e1e11e942bb6da9bc95c3"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "fb3b8bbbfcfd8ed87e2be2eb6926a7b48060ceed7db4841dbf5b69a99bbb8a83",
-    "auditedInputDigest": "5319c5fd34d9b2edfa6c16005a708828afb48472d13ff995672734ddb03aa3b7"
+    "sourceManifestDigest": "2cd70c01960ec4c10eb8926d24348af0ed6323026ff6aa7b5086ce65df8cd517",
+    "auditedInputDigest": "db6dbddc113c0bdef9ee215f9fdfe1810763ba176ba2e0ac983b86189ac0386f"
   },
   "inventory": {
     "sourceMessageCount": 3169,
@@ -47,7 +47,7 @@
     "messageCount": 3169,
     "completeCount": 3169,
     "blockedCount": 0,
-    "dossierDigest": "c3d63e7caa0a8746b0a206f8a142e4f3471bbc7a05d6109f815263808f36290c",
+    "dossierDigest": "2ddf8a29edc142ffa23add0c6f875f4094c29498cab2954cb03cd458ca949cfc",
     "catalogDigest": "1ba849eb8b7c14e431539769c1a00e471c4c12da4e821ecd42097ea07451d0b0",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "3406f614df5de473d23472f1418ae4328d7e72cadfae77d0a14efec9886f07fd",
+      "sourceEvidenceDigest": "4630b63172d2d8941a43e5e5ec82b721a1fbdf63d74d847ab69e80f97f25042a",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -1042,8 +1042,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "e3d60439fa2fd590c0130267ad7f078cc512f4f929445b2c20bf6b22e7852604",
-          "focusedTestDigest": "9f8be298ef8b2f4a04f09b36a8add55f841ddecba2995657b789de448b32146f",
+          "sourceDigest": "620dd184b6808b96474612d36aadced76a377455bd152744f08bbce736069953",
+          "focusedTestDigest": "8f33451d0e730a1ba9e49f95d9249f5f085733927ffa799276b57fb7d81f72ba",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "bc7fb4c74b8cbfcc3b58c462e4320593d56bbf4256fadacbc2e2988f9c0cb361",
+      "rowEvidenceDigest": "c5d9211efd6201d53b09d372dd9c6e45d2236229100be6e68c4425d4ec2b4e18",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "5c776467727775323164bbd900f806ada91e316ebff3b2992900fc5475034386"
+  "contextDigest": "0423d91fc2836c39d4c7c8cd60ad1675c044be67a24760a28b3d6e94cbcb285b"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "fb3b8bbbfcfd8ed87e2be2eb6926a7b48060ceed7db4841dbf5b69a99bbb8a83"
+    "sourceManifestDigest": "2cd70c01960ec4c10eb8926d24348af0ed6323026ff6aa7b5086ce65df8cd517"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "5c776467727775323164bbd900f806ada91e316ebff3b2992900fc5475034386",
-    "qualityDigest": "41d502a1f041ae77447bd7273835184caeb96413be2187c7453a27c9aa61e0e8",
+    "contextDigest": "0423d91fc2836c39d4c7c8cd60ad1675c044be67a24760a28b3d6e94cbcb285b",
+    "qualityDigest": "3451de7437b208d6ca4fc0e9910e06991520731429aaa03f187ff93885ab415a",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "137a5082ba344274caf7780d3eac821193e1354c738611023ce768b3d1cffb87"
+  "activationDigest": "74e5104c34b6f7d0bba4c4f2d6ef095428f8520f4404cc28788162574d1c8ae4"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "fb3b8bbbfcfd8ed87e2be2eb6926a7b48060ceed7db4841dbf5b69a99bbb8a83",
-    "contextDigest": "5c776467727775323164bbd900f806ada91e316ebff3b2992900fc5475034386"
+    "sourceManifestDigest": "2cd70c01960ec4c10eb8926d24348af0ed6323026ff6aa7b5086ce65df8cd517",
+    "contextDigest": "0423d91fc2836c39d4c7c8cd60ad1675c044be67a24760a28b3d6e94cbcb285b"
   },
   "catalog": {
     "messageCount": 3169,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "decedae9c3e5786bb6c2e3b32f2f145a1bd0ceed28bff437872a022a4cdbb9bc",
-    "validationDigest": "051d423cb301b89d5db383488178de2449d735860172c0262265c8367e9d7cdc",
+    "digest": "fea36cf162ff55f70e61e80d2cbbaf9f7dba8a227df5425e940c1171e57ae42d",
+    "validationDigest": "6f82f0fd5781a2cc1d92281ceb3aecb9ab79360c62f50857d4ab8a0972826a20",
     "laneCount": 1,
     "validatedMessageCount": 3169,
     "validatedModuleCount": 32,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "41d502a1f041ae77447bd7273835184caeb96413be2187c7453a27c9aa61e0e8"
+  "qualityDigest": "3451de7437b208d6ca4fc0e9910e06991520731429aaa03f187ff93885ab415a"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "5319c5fd34d9b2edfa6c16005a708828afb48472d13ff995672734ddb03aa3b7",
+    "auditedInputDigest": "db6dbddc113c0bdef9ee215f9fdfe1810763ba176ba2e0ac983b86189ac0386f",
     "validatedMessageCount": 3169,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1433,
     "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
     "catalogDigest": "1ba849eb8b7c14e431539769c1a00e471c4c12da4e821ecd42097ea07451d0b0",
-    "dossierDigest": "c3d63e7caa0a8746b0a206f8a142e4f3471bbc7a05d6109f815263808f36290c",
+    "dossierDigest": "2ddf8a29edc142ffa23add0c6f875f4094c29498cab2954cb03cd458ca949cfc",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "bc7fb4c74b8cbfcc3b58c462e4320593d56bbf4256fadacbc2e2988f9c0cb361",
+    "routeEvidenceDigest": "c5d9211efd6201d53b09d372dd9c6e45d2236229100be6e68c4425d4ec2b4e18",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "720ffdb462f7c139597e6d9e9bb59f4641cd1fd1b5099b671fdef39cc900c87f",
         "highRiskMessageCount": 1433,
         "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
-        "dossierDigest": "c3d63e7caa0a8746b0a206f8a142e4f3471bbc7a05d6109f815263808f36290c",
+        "dossierDigest": "2ddf8a29edc142ffa23add0c6f875f4094c29498cab2954cb03cd458ca949cfc",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "051d423cb301b89d5db383488178de2449d735860172c0262265c8367e9d7cdc"
+  "validationDigest": "6f82f0fd5781a2cc1d92281ceb3aecb9ab79360c62f50857d4ab8a0972826a20"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "fb3b8bbbfcfd8ed87e2be2eb6926a7b48060ceed7db4841dbf5b69a99bbb8a83",
-    "auditedInputDigest": "5319c5fd34d9b2edfa6c16005a708828afb48472d13ff995672734ddb03aa3b7"
+    "sourceManifestDigest": "2cd70c01960ec4c10eb8926d24348af0ed6323026ff6aa7b5086ce65df8cd517",
+    "auditedInputDigest": "db6dbddc113c0bdef9ee215f9fdfe1810763ba176ba2e0ac983b86189ac0386f"
   },
   "inventory": {
     "sourceMessageCount": 3169,
@@ -47,7 +47,7 @@
     "messageCount": 3169,
     "completeCount": 3169,
     "blockedCount": 0,
-    "dossierDigest": "8f83e58b0ae13bc7bf0252f22bdd71f702d35ac0d24e087d76a2772554e092bd",
+    "dossierDigest": "4e44fb369ee2e7f126057f4ef01cb930100b62720b740b14ac9c398d267db099",
     "catalogDigest": "69b254df834ac7f6856e26623aacaacf89507d7a077c22a91e410d06bcbd0e67",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "3406f614df5de473d23472f1418ae4328d7e72cadfae77d0a14efec9886f07fd",
+      "sourceEvidenceDigest": "4630b63172d2d8941a43e5e5ec82b721a1fbdf63d74d847ab69e80f97f25042a",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -1042,8 +1042,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "e3d60439fa2fd590c0130267ad7f078cc512f4f929445b2c20bf6b22e7852604",
-          "focusedTestDigest": "9f8be298ef8b2f4a04f09b36a8add55f841ddecba2995657b789de448b32146f",
+          "sourceDigest": "620dd184b6808b96474612d36aadced76a377455bd152744f08bbce736069953",
+          "focusedTestDigest": "8f33451d0e730a1ba9e49f95d9249f5f085733927ffa799276b57fb7d81f72ba",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "bc7fb4c74b8cbfcc3b58c462e4320593d56bbf4256fadacbc2e2988f9c0cb361",
+      "rowEvidenceDigest": "c5d9211efd6201d53b09d372dd9c6e45d2236229100be6e68c4425d4ec2b4e18",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "52806a3fe484904ce3ba16b9e8e02788712e919a4c1a61a0ae3f2fbaf9c58d63"
+  "contextDigest": "715f4c2826359d567bf4952c55f76cdfe0ea555988f4f342e97de978e31b21b9"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "fb3b8bbbfcfd8ed87e2be2eb6926a7b48060ceed7db4841dbf5b69a99bbb8a83"
+    "sourceManifestDigest": "2cd70c01960ec4c10eb8926d24348af0ed6323026ff6aa7b5086ce65df8cd517"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "52806a3fe484904ce3ba16b9e8e02788712e919a4c1a61a0ae3f2fbaf9c58d63",
-    "qualityDigest": "c0c90018cbd71d7ddef2be568e7a626f44e45a83989bbff762d09dc284cf5433",
+    "contextDigest": "715f4c2826359d567bf4952c55f76cdfe0ea555988f4f342e97de978e31b21b9",
+    "qualityDigest": "86d7eab0c4d3cb8c659dce6927bc4675136b4687094e856630741b50bf3fa588",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "5252539ab849e2d4659013acf1e361da4633b49a2877daa9eea05538443fb666"
+  "activationDigest": "a8f066c25bc1f6a3bab530156941e3b737395482e4df71c2f2ab44e1ad4c99de"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "fb3b8bbbfcfd8ed87e2be2eb6926a7b48060ceed7db4841dbf5b69a99bbb8a83",
-    "contextDigest": "52806a3fe484904ce3ba16b9e8e02788712e919a4c1a61a0ae3f2fbaf9c58d63"
+    "sourceManifestDigest": "2cd70c01960ec4c10eb8926d24348af0ed6323026ff6aa7b5086ce65df8cd517",
+    "contextDigest": "715f4c2826359d567bf4952c55f76cdfe0ea555988f4f342e97de978e31b21b9"
   },
   "catalog": {
     "messageCount": 3169,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "afa29ace6bbeac73525b08d7654053b8ac20ad37aba38ee87def95eddf101066",
-    "validationDigest": "7f73ca4efbcd452c67d66478362e0ad2dbd91b49adfe6a01c7e8db2d19edf8d4",
+    "digest": "37c5b8c6b3a5f7e04b615e7b09747fb914d072e77a8ebcb807189b9b71169912",
+    "validationDigest": "aaa05a2b7efa27e32ab1131f75c6d682e6a62ecf7469ce60c27dbd41862164c4",
     "laneCount": 1,
     "validatedMessageCount": 3169,
     "validatedModuleCount": 32,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "c0c90018cbd71d7ddef2be568e7a626f44e45a83989bbff762d09dc284cf5433"
+  "qualityDigest": "86d7eab0c4d3cb8c659dce6927bc4675136b4687094e856630741b50bf3fa588"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "5319c5fd34d9b2edfa6c16005a708828afb48472d13ff995672734ddb03aa3b7",
+    "auditedInputDigest": "db6dbddc113c0bdef9ee215f9fdfe1810763ba176ba2e0ac983b86189ac0386f",
     "validatedMessageCount": 3169,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1433,
     "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
     "catalogDigest": "69b254df834ac7f6856e26623aacaacf89507d7a077c22a91e410d06bcbd0e67",
-    "dossierDigest": "8f83e58b0ae13bc7bf0252f22bdd71f702d35ac0d24e087d76a2772554e092bd",
+    "dossierDigest": "4e44fb369ee2e7f126057f4ef01cb930100b62720b740b14ac9c398d267db099",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "bc7fb4c74b8cbfcc3b58c462e4320593d56bbf4256fadacbc2e2988f9c0cb361",
+    "routeEvidenceDigest": "c5d9211efd6201d53b09d372dd9c6e45d2236229100be6e68c4425d4ec2b4e18",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "720ffdb462f7c139597e6d9e9bb59f4641cd1fd1b5099b671fdef39cc900c87f",
         "highRiskMessageCount": 1433,
         "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
-        "dossierDigest": "8f83e58b0ae13bc7bf0252f22bdd71f702d35ac0d24e087d76a2772554e092bd",
+        "dossierDigest": "4e44fb369ee2e7f126057f4ef01cb930100b62720b740b14ac9c398d267db099",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "7f73ca4efbcd452c67d66478362e0ad2dbd91b49adfe6a01c7e8db2d19edf8d4"
+  "validationDigest": "aaa05a2b7efa27e32ab1131f75c6d682e6a62ecf7469ce60c27dbd41862164c4"
 }

--- a/src/pages/DataProcessing/index.tsx
+++ b/src/pages/DataProcessing/index.tsx
@@ -32,6 +32,7 @@ import {
   DEFAULT_BROWSER_APP_LOCALE,
   normalizeRuntimeLocale,
 } from '@/services/general/runtimeLocale';
+import { toCanonicalLciaMethodId } from '@/services/lciaMethods/evidence';
 import { getSystemUserRoleApi } from '@/services/roles/api';
 import { taskProgressPercent, type TaskSummaryV2 } from '@/services/taskCenter/types';
 import {
@@ -572,13 +573,14 @@ export function buildImpactCategoryOptions(
     const id = typeof file.id === 'string' ? file.id.trim() : '';
     const version = typeof file.version === 'string' ? file.version.trim() : '';
     if (!id || !/^\d{2}\.\d{2}\.\d{3}$/.test(version)) return [];
+    const methodId = toCanonicalLciaMethodId(id, version);
 
     const name = resolveLocalizedText(file.description, locale) || id;
     const unit = resolveLocalizedText(file.referenceQuantity?.['common:shortDescription'], locale);
     const suffix = [version, unit].filter(Boolean).join(' / ');
     return [
       {
-        value: id,
+        value: methodId,
         version,
         label: `${name} (${suffix})`,
       },

--- a/tests/unit/pages/DataProcessing/index.test.tsx
+++ b/tests/unit/pages/DataProcessing/index.test.tsx
@@ -469,6 +469,26 @@ describe('DataProcessing page', () => {
         label: 'String name (01.00.000 / kg eq)',
       },
     ]);
+    expect(
+      buildImpactCategoryOptions(
+        {
+          files: [
+            {
+              id: '9ec743ea-6b00-400d-a53b-61547a3fc03c',
+              version: '01.01.000',
+              description: 'Reviewed alias',
+            },
+          ],
+        },
+        'en-US',
+      ),
+    ).toEqual([
+      {
+        value: '503699e0-eca9-4089-8bf8-e0f49c93e578',
+        version: '01.01.000',
+        label: 'Reviewed alias (01.01.000)',
+      },
+    ]);
     expect(parseImpactCategoryOptionLabel('Legacy label without metadata')).toEqual({
       name: 'Legacy label without metadata',
     });
@@ -783,6 +803,48 @@ describe('DataProcessing page', () => {
     await waitFor(() =>
       expect(mockUnpublishLciaResultPublication).toHaveBeenCalledWith({
         publicationId: 'publication-1',
+      }),
+    );
+  });
+
+  it('submits the canonical LCIA method identity for a reviewed artifact alias', async () => {
+    mockLocation = { pathname: '/data-processing', search: '' };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        files: [
+          {
+            id: '9ec743ea-6b00-400d-a53b-61547a3fc03c',
+            version: '01.01.000',
+            description: 'Reviewed alias',
+          },
+        ],
+      }),
+    });
+
+    render(<DataProcessing />);
+
+    await screen.findByText('Reviewed alias (01.01.000)');
+    fireEvent.change(screen.getByLabelText('Result set name'), {
+      target: { value: 'Alias package' },
+    });
+    fireEvent.change(screen.getByLabelText('Default impact category'), {
+      target: { value: '503699e0-eca9-4089-8bf8-e0f49c93e578' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Check data completeness' }));
+
+    await waitFor(() =>
+      expect(mockCreateClosureCheck).toHaveBeenCalledWith({
+        requestedScope: {
+          coverageMode: 'global_eligible',
+          lciaMethods: [
+            {
+              id: '503699e0-eca9-4089-8bf8-e0f49c93e578',
+              version: '01.01.000',
+            },
+          ],
+        },
+        requestIdempotencyToken: expect.any(String),
       }),
     );
   });


### PR DESCRIPTION
Closes #853

## Summary
- Canonicalize reviewed LCIA method identifiers before the Data Processing page submits a data-integrity closure check.
- Preserve the displayed method labels while sending the database-approved canonical method UUID and version.

## Key Decisions
- Reuse the existing static-manifest-backed toCanonicalLciaMethodId helper; keep the database fail-closed validation unchanged.

## Validation
- Focused DataProcessing tests: 57/57 passed, including the aliased-method user flow.
- Full checked-push gate: 420/420 suites and 5732/5732 tests passed; statements, branches, functions, and lines all at 100%.
- ESLint, Prettier, TypeScript, production build, LCIA cache verification, reference-data audit, locale artifact idempotence, locale audit, and Docpact all passed.

## Risks / Rollback
- Low: this changes only submitted identifiers that have an explicit reviewed alias mapping; rollback by reverting the two branch commits.

## Workspace Integration
- After merge to dev and later promotion to child main, update the lca-workspace submodule pointer under the normal integration flow.