### PR TITLE
fix: allow audited system status release probe

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-14"
-lastReviewedCommit: "2be77cc77708f63b4c8671b9ff7283f6285c8784"
+lastReviewedCommit: "b1b2b6785e5153ac767b45a915f2f53dc127d6ad"
 lastReviewedNote: 'Reviewed for Next Issue #845: refreshing provenance-bound production evidence and qualification artifacts does not change the repository routing contract.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 2be77cc77708f63b4c8671b9ff7283f6285c8784
+lastReviewedCommit: b1b2b6785e5153ac767b45a915f2f53dc127d6ad
 lastReviewedNote: 'Reviewed for Next Issue #845: refreshed v0.0.71 production evidence and qualification follow the existing explicit-authorization, exact-cleanup, and deterministic-release contract.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 2be77cc77708f63b4c8671b9ff7283f6285c8784
+lastReviewedCommit: b1b2b6785e5153ac767b45a915f2f53dc127d6ad
 lastReviewedNote: 'Reviewed for Next Issue #846: the startup runtime-config switch, maintenance boundary, static fallback, and focused validation use the existing bootstrap workflow without changing local setup commands.'
 ---
 

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -57,7 +57,7 @@ checkPaths:
   - .github/workflows/build.yml
   - package.json
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 04fa6b7539156a1d3585d228b7564fc08cf7b0c2
+lastReviewedCommit: b1b2b6785e5153ac767b45a915f2f53dc127d6ad
 lastReviewedNote: 'Reviewed for Next Issue #845: the refreshed v0.0.71 production proof preserves the existing evidence-binding, explicit authorization, and exact-cleanup boundaries.'
 baselineObservedAt: 2026-07-18
 related:

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 2be77cc77708f63b4c8671b9ff7283f6285c8784
+lastReviewedCommit: b1b2b6785e5153ac767b45a915f2f53dc127d6ad
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance runtime, locale, component-test, and packaging changes remain covered by the existing Docpact-first managed push gate.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 2be77cc77708f63b4c8671b9ff7283f6285c8784
+lastReviewedCommit: b1b2b6785e5153ac767b45a915f2f53dc127d6ad
 lastReviewedNote: 'Reviewed for Next Issue #846: the runtime-config service, maintenance UI, static fallback, locale artifacts, focused tests, lint, and production build follow the existing shared-runtime validation contract.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 2be77cc77708f63b4c8671b9ff7283f6285c8784
+lastReviewedCommit: b1b2b6785e5153ac767b45a915f2f53dc127d6ad
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance startup, fallback, environment-switch, and refresh-button coverage fit the existing focused-first strategy without changing the test-improvement plan.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 2be77cc77708f63b4c8671b9ff7283f6285c8784
+lastReviewedCommit: b1b2b6785e5153ac767b45a915f2f53dc127d6ad
 lastReviewedNote: 'Reviewed for Next Issue #846: focused maintenance boundary, runtime-config, fallback, locale, lint, and build proof introduces no new exception queue.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 2be77cc77708f63b4c8671b9ff7283f6285c8784
+lastReviewedCommit: b1b2b6785e5153ac767b45a915f2f53dc127d6ad
 lastReviewedNote: 'Reviewed for Next Issue #846: startup maintenance, fail-open service, static fallback, refresh interaction, and environment-switch tests follow the existing component and service test patterns.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 2be77cc77708f63b4c8671b9ff7283f6285c8784
+lastReviewedCommit: b1b2b6785e5153ac767b45a915f2f53dc127d6ad
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance startup, timeout, fallback, environment bypass, and refresh behavior require no troubleshooting rule beyond the existing focused-test and gate workflow.'
 ---
 

--- a/tests/e2e/i18n/production-request-guard.ts
+++ b/tests/e2e/i18n/production-request-guard.ts
@@ -50,6 +50,7 @@ export const AUDITED_READ_ONLY_RPC_NAMES = [
   'qry_root_review_reference_progress_v2',
   'qry_system_find_member_candidate_by_email',
   'qry_system_get_member_list',
+  'qry_system_status',
   'qry_team_find_invitable_user_by_email',
   'qry_team_get',
   'qry_team_get_member_list',

--- a/tests/unit/e2e/productionRequestGuard.test.ts
+++ b/tests/unit/e2e/productionRequestGuard.test.ts
@@ -466,9 +466,11 @@ describe('production browser request guard', () => {
   it('pins the current app RPC surface to the reviewed exact allowlist', () => {
     const rpcNames = listTypeScriptFiles(path.join(REPOSITORY_ROOT, 'src/services')).flatMap(
       (filePath) =>
-        [...readFileSync(filePath, 'utf8').matchAll(/supabase[.]rpc[(]\s*'([^']+)'/gu)].map(
-          (match) => match[1],
-        ),
+        [
+          ...readFileSync(filePath, 'utf8').matchAll(
+            /supabase(?:[.]schema[(][^)]*[)])?[.]rpc[(]\s*'([^']+)'/gu,
+          ),
+        ].map((match) => match[1]),
     );
     expect([...new Set(rpcNames)].sort()).toEqual([...AUDITED_READ_ONLY_RPC_NAMES].sort());
   });


### PR DESCRIPTION
Closes #856

## Summary
- Allow the audited read-only qry_system_status startup probe in the production request guard so release candidate readiness can complete.
- Extend the RPC surface contract test to discover both supabase.rpc(...) and supabase.schema(...).rpc(...) calls.

## Key Decisions
- Keep the production guard fail-closed: only the exact reviewed RPC name is added; unknown and mutating RPCs remain blocked.

## Validation
- Focused production request guard suite: 128/128 passed.
- Full checked-push gate: 420 suites, 5733 tests, 100% statements/branches/functions/lines.

## Risks / Rollback
- Low-risk allowlist correction; rollback by reverting this PR.

## Workspace Integration
- Required before retrying the v0.0.72 release-to-dev qualification.