### PR TITLE
style: move review quality diagnostic into themed modal

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-14"
-lastReviewedCommit: "2864ff58b2778e75baee64375c906ce14c70546c"
+lastReviewedCommit: "f56913ac642a6c83f789bc6687702ad11dcbdfce"
 lastReviewedNote: 'Reviewed for Next Issue #845: refreshing provenance-bound production evidence and qualification artifacts does not change the repository routing contract.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-14"
-lastReviewedCommit: "ead5823accc3b4fbecbea4110b723160633d5965"
+lastReviewedCommit: "3784deb29e1da1a2e15833214315a455c7cb2369"
 lastReviewedNote: 'Reviewed for Next Issue #845: refreshing provenance-bound production evidence and qualification artifacts does not change the repository routing contract.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 2864ff58b2778e75baee64375c906ce14c70546c
+lastReviewedCommit: f56913ac642a6c83f789bc6687702ad11dcbdfce
 lastReviewedNote: 'Reviewed for Next Issue #845: refreshed v0.0.71 production evidence and qualification follow the existing explicit-authorization, exact-cleanup, and deterministic-release contract.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: ead5823accc3b4fbecbea4110b723160633d5965
+lastReviewedCommit: 3784deb29e1da1a2e15833214315a455c7cb2369
 lastReviewedNote: 'Reviewed for Next Issue #845: refreshed v0.0.71 production evidence and qualification follow the existing explicit-authorization, exact-cleanup, and deterministic-release contract.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 2864ff58b2778e75baee64375c906ce14c70546c
+lastReviewedCommit: f56913ac642a6c83f789bc6687702ad11dcbdfce
 lastReviewedNote: 'Reviewed for Next Issue #846: the startup runtime-config switch, maintenance boundary, static fallback, and focused validation use the existing bootstrap workflow without changing local setup commands.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: ead5823accc3b4fbecbea4110b723160633d5965
+lastReviewedCommit: e2aedd54b92140edc67dbafc1ca8e14805d86085
 lastReviewedNote: 'Reviewed for Next Issue #846: the startup runtime-config switch, maintenance boundary, static fallback, and focused validation use the existing bootstrap workflow without changing local setup commands.'
 ---
 

--- a/docs/agents/data_audit_instruction.md
+++ b/docs/agents/data_audit_instruction.md
@@ -18,8 +18,8 @@ checkPaths:
   - docs/agents/data_audit_instruction.md
   - src/pages/Review/**
   - src/pages/ManageSystem/**
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: 6ca549026b03097cfd9e9fdf81d0cee7469337e0
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: 3784deb29e1da1a2e15833214315a455c7cb2369
 lastReviewedNote: 'Reviewed for Next Issue #820: submission admission is separated from the Review Admin informational quality diagnostic without changing review-state transitions.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: ead5823accc3b4fbecbea4110b723160633d5965
+lastReviewedCommit: 3784deb29e1da1a2e15833214315a455c7cb2369
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance runtime, locale, component-test, and packaging changes remain covered by the existing Docpact-first managed push gate.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 2864ff58b2778e75baee64375c906ce14c70546c
+lastReviewedCommit: f56913ac642a6c83f789bc6687702ad11dcbdfce
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance runtime, locale, component-test, and packaging changes remain covered by the existing Docpact-first managed push gate.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 313c80a7081a68464221a669b2cd630464d08b0c
+lastReviewedCommit: 3784deb29e1da1a2e15833214315a455c7cb2369
 lastReviewedNote: 'Reviewed for Next Issue #820: Process submission now checks only the editable current record, while Review Admin owns a manual, informational joint quality diagnostic.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 2864ff58b2778e75baee64375c906ce14c70546c
+lastReviewedCommit: f56913ac642a6c83f789bc6687702ad11dcbdfce
 lastReviewedNote: 'Reviewed for Next Issue #846: the runtime-config service, maintenance UI, static fallback, locale artifacts, focused tests, lint, and production build follow the existing shared-runtime validation contract.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: ead5823accc3b4fbecbea4110b723160633d5965
+lastReviewedCommit: 3784deb29e1da1a2e15833214315a455c7cb2369
 lastReviewedNote: 'Reviewed for Next Issue #846: the runtime-config service, maintenance UI, static fallback, locale artifacts, focused tests, lint, and production build follow the existing shared-runtime validation contract.'
 related:
   - ../AGENTS.md

--- a/docs/agents/team_management.md
+++ b/docs/agents/team_management.md
@@ -19,8 +19,8 @@ checkPaths:
   - src/pages/Teams/**
   - src/pages/Review/**
   - src/pages/ManageSystem/**
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: 6ca549026b03097cfd9e9fdf81d0cee7469337e0
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: 3784deb29e1da1a2e15833214315a455c7cb2369
 lastReviewedNote: 'Reviewed for Next Issue #820: the manual quality diagnostic belongs only to Review Admin and grants no workflow authority to team roles or Review Members.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: ead5823accc3b4fbecbea4110b723160633d5965
+lastReviewedCommit: 3784deb29e1da1a2e15833214315a455c7cb2369
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance startup, fallback, environment-switch, and refresh-button coverage fit the existing focused-first strategy without changing the test-improvement plan.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 2864ff58b2778e75baee64375c906ce14c70546c
+lastReviewedCommit: f56913ac642a6c83f789bc6687702ad11dcbdfce
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance startup, fallback, environment-switch, and refresh-button coverage fit the existing focused-first strategy without changing the test-improvement plan.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: ead5823accc3b4fbecbea4110b723160633d5965
+lastReviewedCommit: 3784deb29e1da1a2e15833214315a455c7cb2369
 lastReviewedNote: 'Reviewed for Next Issue #846: focused maintenance boundary, runtime-config, fallback, locale, lint, and build proof introduces no new exception queue.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 2864ff58b2778e75baee64375c906ce14c70546c
+lastReviewedCommit: f56913ac642a6c83f789bc6687702ad11dcbdfce
 lastReviewedNote: 'Reviewed for Next Issue #846: focused maintenance boundary, runtime-config, fallback, locale, lint, and build proof introduces no new exception queue.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: ead5823accc3b4fbecbea4110b723160633d5965
+lastReviewedCommit: 3784deb29e1da1a2e15833214315a455c7cb2369
 lastReviewedNote: 'Reviewed for Next Issue #846: startup maintenance, fail-open service, static fallback, refresh interaction, and environment-switch tests follow the existing component and service test patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 2864ff58b2778e75baee64375c906ce14c70546c
+lastReviewedCommit: f56913ac642a6c83f789bc6687702ad11dcbdfce
 lastReviewedNote: 'Reviewed for Next Issue #846: startup maintenance, fail-open service, static fallback, refresh interaction, and environment-switch tests follow the existing component and service test patterns.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 2864ff58b2778e75baee64375c906ce14c70546c
+lastReviewedCommit: f56913ac642a6c83f789bc6687702ad11dcbdfce
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance startup, timeout, fallback, environment bypass, and refresh behavior require no troubleshooting rule beyond the existing focused-test and gate workflow.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: ead5823accc3b4fbecbea4110b723160633d5965
+lastReviewedCommit: 3784deb29e1da1a2e15833214315a455c7cb2369
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance startup, timeout, fallback, environment bypass, and refresh behavior require no troubleshooting rule beyond the existing focused-test and gate workflow.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "0b2304ee30d8e632363e3e5e231be49bdc5bab2ca8eecb458e9b2c189b5f6bb1",
-    "auditedInputDigest": "a3f28c7ecc55713f38a02b0d2c87d826d7acedb64e600c628e2d5723c918cb06"
+    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
+    "auditedInputDigest": "e77df81f1c50318d0bcf944bc81db86f71aa5b69f0c52d60ee7d2347f1081c09"
   },
   "inventory": {
     "sourceMessageCount": 3169,
@@ -47,8 +47,8 @@
     "messageCount": 3169,
     "completeCount": 3169,
     "blockedCount": 0,
-    "dossierDigest": "5550437ecf823b9ae72d9fbdbcde01c203afc5cc9b0550ceab7c090b291a83c7",
-    "catalogDigest": "a069f1d12f849e391c7c38fb44ada66b8a856cf31f92902a02cd5538a41827fa",
+    "dossierDigest": "39ef2f49dd825f362a325cc2bc159498a9f42ca2d574da8657084c3e48f13d8c",
+    "catalogDigest": "fd1c95cd13025d8868231056bfcfdf630bb3a1de622f1c012c5e33c92ae19874",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
     "roleCounts": {
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4165,
+    "literalReferenceCount": 4166,
     "dynamicCallsiteCount": 35,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale de-DE --message <MESSAGE_ID>"
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "4630b63172d2d8941a43e5e5ec82b721a1fbdf63d74d847ab69e80f97f25042a",
+      "sourceEvidenceDigest": "281dc4ac4658415730c75c89181e733476cf1ac58c04bfb6fda983647cb814c7",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -502,8 +502,8 @@
           "route": "/review",
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "c83add5c6565f7b1ce08296dbf734f84f06a1dd7feb45161b797d88979b62e8e",
-          "focusedTestDigest": "532ae6ebc5fe409c9b976ee0dedaf3d83ede0f406c63159c1ef267c800610f00",
+          "sourceDigest": "b3c3efd697284811e4e5e7dd6322c41315725d38afe8857851757feb45608f68",
+          "focusedTestDigest": "e83ab4bf9f28cb84f21b01da50f2f42ac585485f0bc1ab46905c2a41dd681cde",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "63115bb60cd34c1e5602f2cb4e6669fee1581f79588bc2116b44c581d9375b49",
+      "rowEvidenceDigest": "d6dbbc5cfde0f3a2856b0d7e2b7fce79cc7e524cf8c6f60f657bcbfaa34a6d8f",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "7bd60b20abaece0c7d5678a9fa90f0c4c7dd536a246755ad4acbf4e71cffdfb2"
+  "contextDigest": "21d87c6ee4a9d200466dbefa11d22335184d1d36c28f71edb96b069abe31e7fe"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -503,7 +503,7 @@
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "b3c3efd697284811e4e5e7dd6322c41315725d38afe8857851757feb45608f68",
-          "focusedTestDigest": "e83ab4bf9f28cb84f21b01da50f2f42ac585485f0bc1ab46905c2a41dd681cde",
+          "focusedTestDigest": "3b4acaa3b212d6787bba4a1cbbd639e734320626e98d17cbe27f031bf16676a6",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "d6dbbc5cfde0f3a2856b0d7e2b7fce79cc7e524cf8c6f60f657bcbfaa34a6d8f",
+      "rowEvidenceDigest": "b9be0c6b0415d774ad4cd5fabadc4215261b4e116ced14a869dca1e82583cf8a",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "21d87c6ee4a9d200466dbefa11d22335184d1d36c28f71edb96b069abe31e7fe"
+  "contextDigest": "54561f648057368fd3470cbe05f251d90e0851b1c723eb428d1c7c4315770e76"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0b2304ee30d8e632363e3e5e231be49bdc5bab2ca8eecb458e9b2c189b5f6bb1"
+    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "7bd60b20abaece0c7d5678a9fa90f0c4c7dd536a246755ad4acbf4e71cffdfb2",
-    "qualityDigest": "7708f21c4e7982708ede709b2647b1f654997d9c0191716215d51ceb6eafadea",
+    "contextDigest": "21d87c6ee4a9d200466dbefa11d22335184d1d36c28f71edb96b069abe31e7fe",
+    "qualityDigest": "7b024b81b4def3ca97ed2642653575ca2af61e1b248887214657fa5ab3f45aa3",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "4ab3d24095b5d60c869fd331fe50fece0177851222f42f1f664b4027ecedede7"
+  "activationDigest": "7ebec021658121c2d33ee58a6b6d1532c4094a68f49e80abaad43575fad8f8a2"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "21d87c6ee4a9d200466dbefa11d22335184d1d36c28f71edb96b069abe31e7fe",
-    "qualityDigest": "7b024b81b4def3ca97ed2642653575ca2af61e1b248887214657fa5ab3f45aa3",
+    "contextDigest": "54561f648057368fd3470cbe05f251d90e0851b1c723eb428d1c7c4315770e76",
+    "qualityDigest": "41b63e4b814f0f216a6b16b03be4229d8bedc5f6f25353d50cb2e978767eec0e",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "7ebec021658121c2d33ee58a6b6d1532c4094a68f49e80abaad43575fad8f8a2"
+  "activationDigest": "1db8dc06b969a7cb20def5284230eb5068c03ce695b982e92262c867446a8ee3"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "a3f28c7ecc55713f38a02b0d2c87d826d7acedb64e600c628e2d5723c918cb06",
+    "auditedInputDigest": "e77df81f1c50318d0bcf944bc81db86f71aa5b69f0c52d60ee7d2347f1081c09",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -75,7 +75,7 @@
     "activeDynamicKeyCount": 355,
     "reservedKeyCount": 660,
     "productionSourceFileCount": 441,
-    "literalReferenceCount": 4165,
+    "literalReferenceCount": 4166,
     "dynamicCallsiteCount": 35,
     "dynamicCallsiteSummaryCount": 35,
     "registeredDynamicCallsiteCount": 35,
@@ -27009,7 +27009,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 340,
+          "line": 356,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -27941,7 +27941,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 360,
+          "line": 376,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -28010,7 +28010,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 348,
+          "line": 364,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -28079,7 +28079,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 344,
+          "line": 360,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -28384,7 +28384,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 356,
+          "line": 372,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -28453,7 +28453,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 352,
+          "line": 368,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -28605,7 +28605,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 336,
+          "line": 352,
           "column": 14,
           "symbol": "targetTableOptionCandidates",
           "defaultMessage": null,
@@ -29146,7 +29146,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1188,
+          "line": 1222,
           "column": 17,
           "symbol": "AssignmentReview",
           "defaultMessage": "Review Management",
@@ -29170,7 +29170,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1188,
+              "line": 1222,
               "column": 17,
               "kind": "FormattedMessage"
             },
@@ -207459,7 +207459,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 634,
+          "line": 650,
           "column": 14,
           "symbol": "AssignmentReview",
           "defaultMessage": "Actions",
@@ -207468,7 +207468,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 755,
+          "line": 771,
           "column": 14,
           "symbol": "AssignmentReview",
           "defaultMessage": "Actions",
@@ -207477,7 +207477,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 805,
+          "line": 821,
           "column": 18,
           "symbol": "AssignmentReview",
           "defaultMessage": "Actions",
@@ -207486,7 +207486,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 874,
+          "line": 890,
           "column": 18,
           "symbol": "AssignmentReview",
           "defaultMessage": "Actions",
@@ -207495,7 +207495,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 965,
+          "line": 981,
           "column": 18,
           "symbol": "AssignmentReview",
           "defaultMessage": "Actions",
@@ -207519,31 +207519,31 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 634,
+              "line": 650,
               "column": 14,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 755,
+              "line": 771,
               "column": 14,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 805,
+              "line": 821,
               "column": 18,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 874,
+              "line": 890,
               "column": 18,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 965,
+              "line": 981,
               "column": 18,
               "kind": "FormattedMessage"
             },
@@ -209050,7 +209050,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 367,
+          "line": 383,
           "column": 14,
           "symbol": "targetTableOptions",
           "defaultMessage": "All data types",
@@ -209065,7 +209065,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 367,
+              "line": 383,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -209133,7 +209133,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1138,
+          "line": 1171,
           "column": 29,
           "symbol": "filterControls",
           "defaultMessage": "Data type",
@@ -209148,7 +209148,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1138,
+              "line": 1171,
               "column": 29,
               "kind": "formatMessage"
             }
@@ -209216,7 +209216,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 309,
+          "line": 325,
           "column": 14,
           "symbol": "displayModeOptions",
           "defaultMessage": "All reviews",
@@ -209231,7 +209231,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 309,
+              "line": 325,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -209299,7 +209299,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1127,
+          "line": 1160,
           "column": 29,
           "symbol": "filterControls",
           "defaultMessage": "Display mode",
@@ -209314,7 +209314,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1127,
+              "line": 1160,
               "column": 29,
               "kind": "formatMessage"
             }
@@ -209382,7 +209382,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 316,
+          "line": 332,
           "column": 14,
           "symbol": "displayModeOptions",
           "defaultMessage": "Process and model reviews",
@@ -209397,7 +209397,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 316,
+              "line": 332,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -209465,7 +209465,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 323,
+          "line": 339,
           "column": 14,
           "symbol": "displayModeOptions",
           "defaultMessage": "Other reviews",
@@ -209480,7 +209480,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 323,
+              "line": 339,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -212922,7 +212922,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 624,
+          "line": 640,
           "column": 9,
           "symbol": "subColumns",
           "defaultMessage": "Review Progress",
@@ -212931,7 +212931,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 789,
+          "line": 805,
           "column": 13,
           "symbol": "AssignmentReview",
           "defaultMessage": "Review Progress",
@@ -212946,13 +212946,13 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 624,
+              "line": 640,
               "column": 9,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 789,
+              "line": 805,
               "column": 13,
               "kind": "FormattedMessage"
             }
@@ -214348,7 +214348,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 474,
+          "line": 525,
           "column": 26,
           "symbol": "ReviewQualityDiagnostic",
           "defaultMessage": "No quality diagnostic has been run yet.",
@@ -214363,7 +214363,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 474,
+              "line": 525,
               "column": 26,
               "kind": "formatMessage"
             }
@@ -214431,7 +214431,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 311,
+          "line": 347,
           "column": 16,
           "symbol": "sectionItems",
           "defaultMessage": "{count} findings",
@@ -214446,7 +214446,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 311,
+              "line": 347,
               "column": 16,
               "kind": "formatMessage"
             }
@@ -214514,7 +214514,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 340,
+          "line": 379,
           "column": 39,
           "symbol": "sectionItems",
           "defaultMessage": "Finding details",
@@ -214529,7 +214529,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 340,
+              "line": 379,
               "column": 39,
               "kind": "formatMessage"
             }
@@ -214597,7 +214597,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 148,
+          "line": 154,
           "column": 14,
           "symbol": "formatDiagnosticFindingLevel",
           "defaultMessage": "Error",
@@ -214612,7 +214612,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 148,
+              "line": 154,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -214680,7 +214680,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 138,
+          "line": 144,
           "column": 14,
           "symbol": "formatDiagnosticFindingLevel",
           "defaultMessage": "Info",
@@ -214695,7 +214695,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 138,
+              "line": 144,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -214763,7 +214763,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 143,
+          "line": 149,
           "column": 14,
           "symbol": "formatDiagnosticFindingLevel",
           "defaultMessage": "Warning",
@@ -214778,7 +214778,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 143,
+              "line": 149,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -214846,7 +214846,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 402,
+          "line": 477,
           "column": 14,
           "symbol": "ReviewQualityDiagnostic",
           "defaultMessage": "Informational only",
@@ -214861,7 +214861,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 402,
+              "line": 477,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -214929,7 +214929,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 466,
+          "line": 517,
           "column": 14,
           "symbol": "ReviewQualityDiagnostic",
           "defaultMessage": "Loading the latest report…",
@@ -214944,7 +214944,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 466,
+              "line": 517,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -215012,7 +215012,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 367,
+          "line": 406,
           "column": 16,
           "symbol": "sectionItems",
           "defaultMessage": "No findings in this section.",
@@ -215027,7 +215027,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 367,
+              "line": 406,
               "column": 16,
               "kind": "formatMessage"
             }
@@ -215095,8 +215095,8 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 445,
-          "column": 20,
+          "line": 495,
+          "column": 17,
           "symbol": "ReviewQualityDiagnostic",
           "defaultMessage": "This manual report checks the joint pending-review matrix. Its findings and failures never disable assignment, approval, or rejection.",
           "defaultMessageExpression": null
@@ -215110,8 +215110,8 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 445,
-              "column": 20,
+              "line": 495,
+              "column": 17,
               "kind": "formatMessage"
             }
           ]
@@ -215178,7 +215178,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 69,
+          "line": 75,
           "column": 14,
           "symbol": "formatDiagnosticOutcome",
           "defaultMessage": "Clear",
@@ -215193,7 +215193,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 69,
+              "line": 75,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -215261,7 +215261,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 74,
+          "line": 80,
           "column": 14,
           "symbol": "formatDiagnosticOutcome",
           "defaultMessage": "Findings detected",
@@ -215276,7 +215276,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 74,
+              "line": 80,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -215344,7 +215344,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 79,
+          "line": 85,
           "column": 14,
           "symbol": "formatDiagnosticOutcome",
           "defaultMessage": "Not evaluable",
@@ -215359,7 +215359,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 79,
+              "line": 85,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -215427,7 +215427,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 416,
+          "line": 434,
           "column": 14,
           "symbol": "ReviewQualityDiagnostic",
           "defaultMessage": "Refresh report",
@@ -215442,7 +215442,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 416,
+              "line": 434,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -215510,7 +215510,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 456,
+          "line": 507,
           "column": 22,
           "symbol": "ReviewQualityDiagnostic",
           "defaultMessage": "Quality diagnostic request failed",
@@ -215525,7 +215525,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 456,
+              "line": 507,
               "column": 22,
               "kind": "formatMessage"
             }
@@ -215593,7 +215593,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 429,
+          "line": 447,
           "column": 17,
           "symbol": "ReviewQualityDiagnostic",
           "defaultMessage": "Run again",
@@ -215608,7 +215608,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 429,
+              "line": 447,
               "column": 17,
               "kind": "formatMessage"
             }
@@ -215675,8 +215675,17 @@
       "references": [
         {
           "kind": "formatMessage",
+          "path": "src/pages/Review/Components/AssignmentReview.tsx",
+          "line": 1140,
+          "column": 42,
+          "symbol": "qualityDiagnosticLabel",
+          "defaultMessage": "Run quality diagnostic",
+          "defaultMessageExpression": null
+        },
+        {
+          "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 433,
+          "line": 451,
           "column": 17,
           "symbol": "ReviewQualityDiagnostic",
           "defaultMessage": "Run quality diagnostic",
@@ -215690,8 +215699,14 @@
           "placeholders": [],
           "locations": [
             {
+              "path": "src/pages/Review/Components/AssignmentReview.tsx",
+              "line": 1140,
+              "column": 42,
+              "kind": "formatMessage"
+            },
+            {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 433,
+              "line": 451,
               "column": 17,
               "kind": "formatMessage"
             }
@@ -215711,7 +215726,7 @@
       },
       "translations": {
         "en-US": {
-          "value": "The diagnostic is running in the background. Review actions remain available.",
+          "value": "The diagnostic is checking the joint pending-review matrix in the background for information only; review actions remain available.",
           "argumentSignature": [],
           "placeholders": [],
           "source": {
@@ -215722,7 +215737,7 @@
           }
         },
         "zh-CN": {
-          "value": "诊断正在后台运行，审核操作仍然可用。",
+          "value": "诊断正在后台检查待审核数据联合矩阵，仅供参考，不影响审核操作。",
           "argumentSignature": [],
           "placeholders": [],
           "source": {
@@ -215733,7 +215748,7 @@
           }
         },
         "de-DE": {
-          "value": "Die Diagnose läuft im Hintergrund. Prüfaktionen bleiben verfügbar.",
+          "value": "Die Diagnose prüft die gemeinsame Matrix ausstehender Prüfungen im Hintergrund nur zur Information; Prüfaktionen bleiben verfügbar.",
           "argumentSignature": [],
           "placeholders": [],
           "source": {
@@ -215744,7 +215759,7 @@
           }
         },
         "fr-FR": {
-          "value": "Le diagnostic s’exécute en arrière-plan. Les actions de revue restent disponibles.",
+          "value": "Le diagnostic vérifie en arrière-plan la matrice conjointe des révisions en attente, à titre informatif uniquement ; les actions de revue restent disponibles.",
           "argumentSignature": [],
           "placeholders": [],
           "source": {
@@ -215759,23 +215774,23 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 516,
-          "column": 26,
+          "line": 490,
+          "column": 17,
           "symbol": "ReviewQualityDiagnostic",
-          "defaultMessage": "The diagnostic is running in the background. Review actions remain available.",
+          "defaultMessage": "The diagnostic is checking the joint pending-review matrix in the background for information only; review actions remain available.",
           "defaultMessageExpression": null
         }
       ],
       "defaultMessages": [
         {
-          "value": "The diagnostic is running in the background. Review actions remain available.",
+          "value": "The diagnostic is checking the joint pending-review matrix in the background for information only; review actions remain available.",
           "argumentSignature": [],
           "placeholders": [],
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 516,
-              "column": 26,
+              "line": 490,
+              "column": 17,
               "kind": "formatMessage"
             }
           ]
@@ -215842,7 +215857,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 504,
+          "line": 569,
           "column": 26,
           "symbol": "ReviewQualityDiagnostic",
           "defaultMessage": "The diagnostic did not produce a report.",
@@ -215857,7 +215872,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 504,
+              "line": 569,
               "column": 26,
               "kind": "formatMessage"
             }
@@ -215925,7 +215940,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 566,
+          "line": 619,
           "column": 24,
           "symbol": "ReviewQualityDiagnostic",
           "defaultMessage": "Dataset scope",
@@ -215940,7 +215955,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 566,
+              "line": 619,
               "column": 24,
               "kind": "formatMessage"
             }
@@ -216008,7 +216023,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 541,
+          "line": 594,
           "column": 28,
           "symbol": "ReviewQualityDiagnostic",
           "defaultMessage": "Datasets checked",
@@ -216023,7 +216038,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 541,
+              "line": 594,
               "column": 28,
               "kind": "formatMessage"
             }
@@ -216091,7 +216106,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 555,
+          "line": 608,
           "column": 28,
           "symbol": "ReviewQualityDiagnostic",
           "defaultMessage": "Findings",
@@ -216106,7 +216121,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 555,
+              "line": 608,
               "column": 28,
               "kind": "formatMessage"
             }
@@ -216174,7 +216189,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 580,
+          "line": 633,
           "column": 24,
           "symbol": "ReviewQualityDiagnostic",
           "defaultMessage": "Process sample",
@@ -216189,7 +216204,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 580,
+              "line": 633,
               "column": 24,
               "kind": "formatMessage"
             }
@@ -216257,7 +216272,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 548,
+          "line": 601,
           "column": 28,
           "symbol": "ReviewQualityDiagnostic",
           "defaultMessage": "Pending Processes",
@@ -216272,7 +216287,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 548,
+              "line": 601,
               "column": 28,
               "kind": "formatMessage"
             }
@@ -216340,7 +216355,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 534,
+          "line": 587,
           "column": 28,
           "symbol": "ReviewQualityDiagnostic",
           "defaultMessage": "Reviews checked",
@@ -216355,7 +216370,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 534,
+              "line": 587,
               "column": 28,
               "kind": "formatMessage"
             }
@@ -216423,7 +216438,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 594,
+          "line": 647,
           "column": 30,
           "symbol": "ReviewQualityDiagnostic",
           "defaultMessage": "Additional Processes are included in the run.",
@@ -216438,7 +216453,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 594,
+              "line": 647,
               "column": 30,
               "kind": "formatMessage"
             }
@@ -216506,7 +216521,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 92,
+          "line": 98,
           "column": 14,
           "symbol": "formatDiagnosticSection",
           "defaultMessage": "Data completeness",
@@ -216521,7 +216536,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 92,
+              "line": 98,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -216589,7 +216604,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 97,
+          "line": 103,
           "column": 14,
           "symbol": "formatDiagnosticSection",
           "defaultMessage": "Numerical stability",
@@ -216604,7 +216619,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 97,
+              "line": 103,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -216672,7 +216687,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 110,
+          "line": 116,
           "column": 14,
           "symbol": "formatDiagnosticSectionStatus",
           "defaultMessage": "Clear",
@@ -216687,7 +216702,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 110,
+              "line": 116,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -216755,7 +216770,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 115,
+          "line": 121,
           "column": 14,
           "symbol": "formatDiagnosticSectionStatus",
           "defaultMessage": "Findings detected",
@@ -216770,7 +216785,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 115,
+              "line": 121,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -216838,7 +216853,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 125,
+          "line": 131,
           "column": 14,
           "symbol": "formatDiagnosticSectionStatus",
           "defaultMessage": "Not applicable",
@@ -216853,7 +216868,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 125,
+              "line": 131,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -216921,7 +216936,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 120,
+          "line": 126,
           "column": 14,
           "symbol": "formatDiagnosticSectionStatus",
           "defaultMessage": "Not evaluable",
@@ -216936,7 +216951,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 120,
+              "line": 126,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -217004,7 +217019,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 59,
+          "line": 65,
           "column": 14,
           "symbol": "formatDiagnosticStatus",
           "defaultMessage": "Cancelled",
@@ -217019,7 +217034,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 59,
+              "line": 65,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -217087,7 +217102,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 49,
+          "line": 55,
           "column": 14,
           "symbol": "formatDiagnosticStatus",
           "defaultMessage": "Completed",
@@ -217102,7 +217117,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 49,
+              "line": 55,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -217170,7 +217185,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 54,
+          "line": 60,
           "column": 14,
           "symbol": "formatDiagnosticStatus",
           "defaultMessage": "Failed",
@@ -217185,7 +217200,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 54,
+              "line": 60,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -217253,7 +217268,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 29,
+          "line": 35,
           "column": 14,
           "symbol": "formatDiagnosticStatus",
           "defaultMessage": "Queued",
@@ -217268,7 +217283,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 29,
+              "line": 35,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -217336,7 +217351,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 34,
+          "line": 40,
           "column": 14,
           "symbol": "formatDiagnosticStatus",
           "defaultMessage": "Running",
@@ -217351,7 +217366,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 34,
+              "line": 40,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -217419,7 +217434,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 44,
+          "line": 50,
           "column": 14,
           "symbol": "formatDiagnosticStatus",
           "defaultMessage": "Stale",
@@ -217434,7 +217449,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 44,
+              "line": 50,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -217502,7 +217517,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 39,
+          "line": 45,
           "column": 14,
           "symbol": "formatDiagnosticStatus",
           "defaultMessage": "Waiting",
@@ -217517,7 +217532,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 39,
+              "line": 45,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -217585,7 +217600,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 396,
+          "line": 471,
           "column": 14,
           "symbol": "ReviewQualityDiagnostic",
           "defaultMessage": "Pending-review quality diagnostic",
@@ -217600,7 +217615,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 396,
+              "line": 471,
               "column": 14,
               "kind": "formatMessage"
             }
@@ -217668,7 +217683,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-          "line": 489,
+          "line": 554,
           "column": 20,
           "symbol": "ReviewQualityDiagnostic",
           "defaultMessage": "Updated {time}",
@@ -217683,7 +217698,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/ReviewQualityDiagnostic.tsx",
-              "line": 489,
+              "line": 554,
               "column": 20,
               "kind": "formatMessage"
             }
@@ -217810,7 +217825,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 591,
+          "line": 607,
           "column": 23,
           "symbol": "status",
           "defaultMessage": "Approved",
@@ -217825,7 +217840,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 591,
+              "line": 607,
               "column": 23,
               "kind": "formatMessage"
             }
@@ -217893,7 +217908,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 607,
+          "line": 623,
           "column": 27,
           "symbol": "status",
           "defaultMessage": "In review",
@@ -217908,7 +217923,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 607,
+              "line": 623,
               "column": 27,
               "kind": "formatMessage"
             }
@@ -217976,7 +217991,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 599,
+          "line": 615,
           "column": 25,
           "symbol": "status",
           "defaultMessage": "Rejected",
@@ -217991,7 +218006,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 599,
+              "line": 615,
               "column": 25,
               "kind": "formatMessage"
             }
@@ -218059,7 +218074,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 614,
+          "line": 630,
           "column": 27,
           "symbol": "status",
           "defaultMessage": "Unassigned",
@@ -218074,7 +218089,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 614,
+              "line": 630,
               "column": 27,
               "kind": "formatMessage"
             }
@@ -218142,7 +218157,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 573,
+          "line": 589,
           "column": 14,
           "symbol": "subColumns",
           "defaultMessage": "Data type",
@@ -218157,7 +218172,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 573,
+              "line": 589,
               "column": 14,
               "kind": "FormattedMessage"
             }
@@ -218225,7 +218240,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 578,
+          "line": 594,
           "column": 14,
           "symbol": "subColumns",
           "defaultMessage": "Data version",
@@ -218240,7 +218255,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 578,
+              "line": 594,
               "column": 14,
               "kind": "FormattedMessage"
             }
@@ -218557,7 +218572,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1156,
+          "line": 1189,
           "column": 21,
           "symbol": "AssignmentReview",
           "defaultMessage": "Failed to load referenced reviews. Reselect the root review to retry.",
@@ -218572,7 +218587,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1156,
+              "line": 1189,
               "column": 21,
               "kind": "FormattedMessage"
             }
@@ -218711,7 +218726,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1235,
+          "line": 1269,
           "column": 15,
           "symbol": "AssignmentReview",
           "defaultMessage": "Selected {rootCount} root reviews and {referenceCount} reference reviews",
@@ -218729,7 +218744,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1235,
+              "line": 1269,
               "column": 15,
               "kind": "FormattedMessage"
             }
@@ -219574,7 +219589,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 744,
+          "line": 760,
           "column": 9,
           "symbol": "columns",
           "defaultMessage": "Submitted at",
@@ -219589,7 +219604,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 744,
+              "line": 760,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -219657,7 +219672,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 561,
+          "line": 577,
           "column": 9,
           "symbol": "subColumns",
           "defaultMessage": "Data name",
@@ -219666,7 +219681,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 708,
+          "line": 724,
           "column": 9,
           "symbol": "columns",
           "defaultMessage": "Data name",
@@ -219681,13 +219696,13 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 561,
+              "line": 577,
               "column": 9,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 708,
+              "line": 724,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -219755,7 +219770,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 780,
+          "line": 796,
           "column": 13,
           "symbol": "AssignmentReview",
           "defaultMessage": "Deadline",
@@ -219764,7 +219779,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 866,
+          "line": 882,
           "column": 13,
           "symbol": "AssignmentReview",
           "defaultMessage": "Deadline",
@@ -219773,7 +219788,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 957,
+          "line": 973,
           "column": 13,
           "symbol": "AssignmentReview",
           "defaultMessage": "Deadline",
@@ -219788,19 +219803,19 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 780,
+              "line": 796,
               "column": 13,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 866,
+              "line": 882,
               "column": 13,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 957,
+              "line": 973,
               "column": 13,
               "kind": "FormattedMessage"
             }
@@ -220045,7 +220060,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 728,
+          "line": 744,
           "column": 9,
           "symbol": "columns",
           "defaultMessage": "User Name",
@@ -220060,7 +220075,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 728,
+              "line": 744,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -220318,7 +220333,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 583,
+          "line": 599,
           "column": 14,
           "symbol": "subColumns",
           "defaultMessage": "Status",
@@ -220339,7 +220354,7 @@
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 583,
+              "line": 599,
               "column": 14,
               "kind": "FormattedMessage"
             }
@@ -220883,7 +220898,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1011,
+          "line": 1027,
           "column": 16,
           "symbol": "getSubTitle",
           "defaultMessage": "Assigned Task",
@@ -220892,7 +220907,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/index.tsx",
-          "line": 83,
+          "line": 85,
           "column": 18,
           "symbol": "tabs",
           "defaultMessage": null,
@@ -220907,7 +220922,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1011,
+              "line": 1027,
               "column": 16,
               "kind": "FormattedMessage"
             }
@@ -220984,7 +220999,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/index.tsx",
-          "line": 105,
+          "line": 108,
           "column": 18,
           "symbol": "tabs",
           "defaultMessage": null,
@@ -221067,7 +221082,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1015,
+          "line": 1031,
           "column": 16,
           "symbol": "getSubTitle",
           "defaultMessage": "Pending Review",
@@ -221076,7 +221091,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/index.tsx",
-          "line": 123,
+          "line": 126,
           "column": 18,
           "symbol": "tabs",
           "defaultMessage": null,
@@ -221091,7 +221106,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1015,
+              "line": 1031,
               "column": 16,
               "kind": "FormattedMessage"
             }
@@ -221159,7 +221174,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1017,
+          "line": 1033,
           "column": 16,
           "symbol": "getSubTitle",
           "defaultMessage": "Rejected",
@@ -221168,7 +221183,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/index.tsx",
-          "line": 130,
+          "line": 133,
           "column": 18,
           "symbol": "tabs",
           "defaultMessage": null,
@@ -221183,7 +221198,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1017,
+              "line": 1033,
               "column": 16,
               "kind": "FormattedMessage"
             }
@@ -221251,7 +221266,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1020,
+          "line": 1036,
           "column": 11,
           "symbol": "getSubTitle",
           "defaultMessage": "Rejected Task",
@@ -221260,7 +221275,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/index.tsx",
-          "line": 94,
+          "line": 97,
           "column": 18,
           "symbol": "tabs",
           "defaultMessage": null,
@@ -221275,7 +221290,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1020,
+              "line": 1036,
               "column": 11,
               "kind": "FormattedMessage"
             }
@@ -221343,7 +221358,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1013,
+          "line": 1029,
           "column": 16,
           "symbol": "getSubTitle",
           "defaultMessage": "Reviewed",
@@ -221352,7 +221367,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/index.tsx",
-          "line": 112,
+          "line": 115,
           "column": 18,
           "symbol": "tabs",
           "defaultMessage": null,
@@ -221367,7 +221382,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1013,
+              "line": 1029,
               "column": 16,
               "kind": "FormattedMessage"
             }
@@ -221435,7 +221450,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1008,
+          "line": 1024,
           "column": 11,
           "symbol": "getSubTitle",
           "defaultMessage": "Unassigned Task",
@@ -221444,7 +221459,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/index.tsx",
-          "line": 72,
+          "line": 73,
           "column": 18,
           "symbol": "tabs",
           "defaultMessage": null,
@@ -221459,7 +221474,7 @@
           "locations": [
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 1008,
+              "line": 1024,
               "column": 11,
               "kind": "FormattedMessage"
             }
@@ -221723,7 +221738,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/index.tsx",
-          "line": 151,
+          "line": 154,
           "column": 27,
           "symbol": "Review",
           "defaultMessage": null,
@@ -223225,7 +223240,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 1069,
+          "line": 1085,
           "column": 30,
           "symbol": "AssignmentReview",
           "defaultMessage": null,
@@ -224476,7 +224491,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 160,
+          "line": 176,
           "column": 5,
           "symbol": "defaultTableAlertOptionRender",
           "defaultMessage": "Clear selection",
@@ -224587,7 +224602,7 @@
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 160,
+              "line": 176,
               "column": 5,
               "kind": "FormattedMessage"
             },
@@ -235276,7 +235291,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Review/Components/AssignmentReview.tsx",
-          "line": 701,
+          "line": 717,
           "column": 14,
           "symbol": "columns",
           "defaultMessage": "Index",
@@ -235501,7 +235516,7 @@
             },
             {
               "path": "src/pages/Review/Components/AssignmentReview.tsx",
-              "line": 701,
+              "line": 717,
               "column": 14,
               "kind": "FormattedMessage"
             },

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,12 +3,12 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0b2304ee30d8e632363e3e5e231be49bdc5bab2ca8eecb458e9b2c189b5f6bb1",
-    "contextDigest": "7bd60b20abaece0c7d5678a9fa90f0c4c7dd536a246755ad4acbf4e71cffdfb2"
+    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
+    "contextDigest": "21d87c6ee4a9d200466dbefa11d22335184d1d36c28f71edb96b069abe31e7fe"
   },
   "catalog": {
     "messageCount": 3169,
-    "catalogDigest": "a069f1d12f849e391c7c38fb44ada66b8a856cf31f92902a02cd5538a41827fa",
+    "catalogDigest": "fd1c95cd13025d8868231056bfcfdf630bb3a1de622f1c012c5e33c92ae19874",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "04168351057a073663df5a7e4c0f7f5c7a841484e3d6d827cd2d4e2b0194b6dc",
-    "validationDigest": "1797a7123a7c19987d202ab9cdffebfd8e8113b90cb773f2906f72e013b77b4f",
+    "digest": "a4b1692c2eedd6b2b2018bdb26d99e4a5464c31e3e4a89ef811fc8491ad23493",
+    "validationDigest": "84b8135ac4a9cc5e7d10b033276bfc82837b2ea4fe36204972cdbc3727137967",
     "laneCount": 1,
     "validatedMessageCount": 3169,
     "validatedModuleCount": 32,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "7708f21c4e7982708ede709b2647b1f654997d9c0191716215d51ceb6eafadea"
+  "qualityDigest": "7b024b81b4def3ca97ed2642653575ca2af61e1b248887214657fa5ab3f45aa3"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
-    "contextDigest": "21d87c6ee4a9d200466dbefa11d22335184d1d36c28f71edb96b069abe31e7fe"
+    "contextDigest": "54561f648057368fd3470cbe05f251d90e0851b1c723eb428d1c7c4315770e76"
   },
   "catalog": {
     "messageCount": 3169,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "a4b1692c2eedd6b2b2018bdb26d99e4a5464c31e3e4a89ef811fc8491ad23493",
-    "validationDigest": "84b8135ac4a9cc5e7d10b033276bfc82837b2ea4fe36204972cdbc3727137967",
+    "digest": "6272b57173f1306cf5ae912245193adb019ed9e22c89bae835d46f33e18f4b24",
+    "validationDigest": "fc9d4cb0aff44a282a886a87c02f1b0889dd5c7a9553e719707d1b15157fa503",
     "laneCount": 1,
     "validatedMessageCount": 3169,
     "validatedModuleCount": 32,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "7b024b81b4def3ca97ed2642653575ca2af61e1b248887214657fa5ab3f45aa3"
+  "qualityDigest": "41b63e4b814f0f216a6b16b03be4229d8bedc5f6f25353d50cb2e978767eec0e"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "a3f28c7ecc55713f38a02b0d2c87d826d7acedb64e600c628e2d5723c918cb06",
+    "auditedInputDigest": "e77df81f1c50318d0bcf944bc81db86f71aa5b69f0c52d60ee7d2347f1081c09",
     "validatedMessageCount": 3169,
     "validatedModules": [
       "$entry",
@@ -41,10 +41,10 @@
     ],
     "highRiskMessageCount": 1433,
     "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
-    "catalogDigest": "a069f1d12f849e391c7c38fb44ada66b8a856cf31f92902a02cd5538a41827fa",
-    "dossierDigest": "5550437ecf823b9ae72d9fbdbcde01c203afc5cc9b0550ceab7c090b291a83c7",
+    "catalogDigest": "fd1c95cd13025d8868231056bfcfdf630bb3a1de622f1c012c5e33c92ae19874",
+    "dossierDigest": "39ef2f49dd825f362a325cc2bc159498a9f42ca2d574da8657084c3e48f13d8c",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "63115bb60cd34c1e5602f2cb4e6669fee1581f79588bc2116b44c581d9375b49",
+    "routeEvidenceDigest": "d6dbbc5cfde0f3a2856b0d7e2b7fce79cc7e524cf8c6f60f657bcbfaa34a6d8f",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "720ffdb462f7c139597e6d9e9bb59f4641cd1fd1b5099b671fdef39cc900c87f",
         "highRiskMessageCount": 1433,
         "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
-        "dossierDigest": "5550437ecf823b9ae72d9fbdbcde01c203afc5cc9b0550ceab7c090b291a83c7",
+        "dossierDigest": "39ef2f49dd825f362a325cc2bc159498a9f42ca2d574da8657084c3e48f13d8c",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "1797a7123a7c19987d202ab9cdffebfd8e8113b90cb773f2906f72e013b77b4f"
+  "validationDigest": "84b8135ac4a9cc5e7d10b033276bfc82837b2ea4fe36204972cdbc3727137967"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "fd1c95cd13025d8868231056bfcfdf630bb3a1de622f1c012c5e33c92ae19874",
     "dossierDigest": "39ef2f49dd825f362a325cc2bc159498a9f42ca2d574da8657084c3e48f13d8c",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "d6dbbc5cfde0f3a2856b0d7e2b7fce79cc7e524cf8c6f60f657bcbfaa34a6d8f",
+    "routeEvidenceDigest": "b9be0c6b0415d774ad4cd5fabadc4215261b4e116ced14a869dca1e82583cf8a",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "84b8135ac4a9cc5e7d10b033276bfc82837b2ea4fe36204972cdbc3727137967"
+  "validationDigest": "fc9d4cb0aff44a282a886a87c02f1b0889dd5c7a9553e719707d1b15157fa503"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -503,7 +503,7 @@
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "b3c3efd697284811e4e5e7dd6322c41315725d38afe8857851757feb45608f68",
-          "focusedTestDigest": "e83ab4bf9f28cb84f21b01da50f2f42ac585485f0bc1ab46905c2a41dd681cde",
+          "focusedTestDigest": "3b4acaa3b212d6787bba4a1cbbd639e734320626e98d17cbe27f031bf16676a6",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "d6dbbc5cfde0f3a2856b0d7e2b7fce79cc7e524cf8c6f60f657bcbfaa34a6d8f",
+      "rowEvidenceDigest": "b9be0c6b0415d774ad4cd5fabadc4215261b4e116ced14a869dca1e82583cf8a",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "618ca288c0d4d8639731838e8cd2968f055a6b7ecb84134a57038f9a1b8a501d"
+  "contextDigest": "f16c8d7de0b08071f6d14ddba4f38d64e0741652746e4465b7ca7842734165ad"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "0b2304ee30d8e632363e3e5e231be49bdc5bab2ca8eecb458e9b2c189b5f6bb1",
-    "auditedInputDigest": "a3f28c7ecc55713f38a02b0d2c87d826d7acedb64e600c628e2d5723c918cb06"
+    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
+    "auditedInputDigest": "e77df81f1c50318d0bcf944bc81db86f71aa5b69f0c52d60ee7d2347f1081c09"
   },
   "inventory": {
     "sourceMessageCount": 3169,
@@ -47,8 +47,8 @@
     "messageCount": 3169,
     "completeCount": 3169,
     "blockedCount": 0,
-    "dossierDigest": "c81633a407d0a7d0f7c67c5a514eced89f4357d2fc0d081b397ad382509f1b14",
-    "catalogDigest": "467d24cabc55fc92fcd112386a9020f4b8b55e71e970559d9c4006a8323a265e",
+    "dossierDigest": "e3e531d9d21e2920f8dcfc998b6e48df6135981257ea9f6d60381d052f8decb5",
+    "catalogDigest": "9fabd08ff44e959db39d1b511126d18154db14458c4811d9e40d2f0d0d57e34f",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
     "roleCounts": {
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4165,
+    "literalReferenceCount": 4166,
     "dynamicCallsiteCount": 35,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale en-US --message <MESSAGE_ID>"
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "4630b63172d2d8941a43e5e5ec82b721a1fbdf63d74d847ab69e80f97f25042a",
+      "sourceEvidenceDigest": "281dc4ac4658415730c75c89181e733476cf1ac58c04bfb6fda983647cb814c7",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -502,8 +502,8 @@
           "route": "/review",
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "c83add5c6565f7b1ce08296dbf734f84f06a1dd7feb45161b797d88979b62e8e",
-          "focusedTestDigest": "532ae6ebc5fe409c9b976ee0dedaf3d83ede0f406c63159c1ef267c800610f00",
+          "sourceDigest": "b3c3efd697284811e4e5e7dd6322c41315725d38afe8857851757feb45608f68",
+          "focusedTestDigest": "e83ab4bf9f28cb84f21b01da50f2f42ac585485f0bc1ab46905c2a41dd681cde",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "63115bb60cd34c1e5602f2cb4e6669fee1581f79588bc2116b44c581d9375b49",
+      "rowEvidenceDigest": "d6dbbc5cfde0f3a2856b0d7e2b7fce79cc7e524cf8c6f60f657bcbfaa34a6d8f",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "0812de89ff3f3658f4d4848edd1765e42d072263766d0119a2019be2a365f4f3"
+  "contextDigest": "618ca288c0d4d8639731838e8cd2968f055a6b7ecb84134a57038f9a1b8a501d"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "618ca288c0d4d8639731838e8cd2968f055a6b7ecb84134a57038f9a1b8a501d",
-    "qualityDigest": "cfc81fc1c25b241aca02724b58d9e5c3685967225820ccbc73d72505fe85d481",
+    "contextDigest": "f16c8d7de0b08071f6d14ddba4f38d64e0741652746e4465b7ca7842734165ad",
+    "qualityDigest": "d9ee024dc5f9b15282078cb248a0c257c6a155bf50df3e46b195421baadf0377",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "c7b3db3fe21be2163329dac812dff86ea5f0a55f4413dd41df719d700d8c144a"
+  "activationDigest": "b91226a7c0d9c7b9c6b2f8e1b0ae0d6781dd339e4f89746d4e7838ece25c1b52"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0b2304ee30d8e632363e3e5e231be49bdc5bab2ca8eecb458e9b2c189b5f6bb1"
+    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "0812de89ff3f3658f4d4848edd1765e42d072263766d0119a2019be2a365f4f3",
-    "qualityDigest": "b3508c45287f11e856388e0411d92d90dd863716bbb19c6c4a6395ed1887d80d",
+    "contextDigest": "618ca288c0d4d8639731838e8cd2968f055a6b7ecb84134a57038f9a1b8a501d",
+    "qualityDigest": "cfc81fc1c25b241aca02724b58d9e5c3685967225820ccbc73d72505fe85d481",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "095b0b167aa3c48209e0095bea9a42b9774fad2fa25d1b13159e0470c8d97559"
+  "activationDigest": "c7b3db3fe21be2163329dac812dff86ea5f0a55f4413dd41df719d700d8c144a"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,12 +3,12 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0b2304ee30d8e632363e3e5e231be49bdc5bab2ca8eecb458e9b2c189b5f6bb1",
-    "contextDigest": "0812de89ff3f3658f4d4848edd1765e42d072263766d0119a2019be2a365f4f3"
+    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
+    "contextDigest": "618ca288c0d4d8639731838e8cd2968f055a6b7ecb84134a57038f9a1b8a501d"
   },
   "catalog": {
     "messageCount": 3169,
-    "catalogDigest": "467d24cabc55fc92fcd112386a9020f4b8b55e71e970559d9c4006a8323a265e",
+    "catalogDigest": "9fabd08ff44e959db39d1b511126d18154db14458c4811d9e40d2f0d0d57e34f",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "1d1265417e979e5f5f1609652d0f2cfe6907d87e8253f5a3c3b89dc4a3224b34",
-    "validationDigest": "130337bbf27b5e88fcaae66f0809135427444a614e3f06543240122457f5cef9",
+    "digest": "2ecdf607cf17da61f41da1414a94f03bc66aa8d7db71a8cc92652306f0f27e48",
+    "validationDigest": "2f03a854b3d9be66dfb4654b312fed2cfaee8aef578e45a0c0f20dc7cdf76831",
     "laneCount": 1,
     "validatedMessageCount": 3169,
     "validatedModuleCount": 32,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "b3508c45287f11e856388e0411d92d90dd863716bbb19c6c4a6395ed1887d80d"
+  "qualityDigest": "cfc81fc1c25b241aca02724b58d9e5c3685967225820ccbc73d72505fe85d481"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
-    "contextDigest": "618ca288c0d4d8639731838e8cd2968f055a6b7ecb84134a57038f9a1b8a501d"
+    "contextDigest": "f16c8d7de0b08071f6d14ddba4f38d64e0741652746e4465b7ca7842734165ad"
   },
   "catalog": {
     "messageCount": 3169,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "2ecdf607cf17da61f41da1414a94f03bc66aa8d7db71a8cc92652306f0f27e48",
-    "validationDigest": "2f03a854b3d9be66dfb4654b312fed2cfaee8aef578e45a0c0f20dc7cdf76831",
+    "digest": "3860913e6104f04a6f3884d8602a3a88f786e6e77b5dcd4660447f2cd2d4990d",
+    "validationDigest": "1c59c51f9c26015d988266e451e5e2db0579ec3cdb25772bbc48c3a84f84760d",
     "laneCount": 1,
     "validatedMessageCount": 3169,
     "validatedModuleCount": 32,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "cfc81fc1c25b241aca02724b58d9e5c3685967225820ccbc73d72505fe85d481"
+  "qualityDigest": "d9ee024dc5f9b15282078cb248a0c257c6a155bf50df3e46b195421baadf0377"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "9fabd08ff44e959db39d1b511126d18154db14458c4811d9e40d2f0d0d57e34f",
     "dossierDigest": "e3e531d9d21e2920f8dcfc998b6e48df6135981257ea9f6d60381d052f8decb5",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "d6dbbc5cfde0f3a2856b0d7e2b7fce79cc7e524cf8c6f60f657bcbfaa34a6d8f",
+    "routeEvidenceDigest": "b9be0c6b0415d774ad4cd5fabadc4215261b4e116ced14a869dca1e82583cf8a",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "2f03a854b3d9be66dfb4654b312fed2cfaee8aef578e45a0c0f20dc7cdf76831"
+  "validationDigest": "1c59c51f9c26015d988266e451e5e2db0579ec3cdb25772bbc48c3a84f84760d"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "a3f28c7ecc55713f38a02b0d2c87d826d7acedb64e600c628e2d5723c918cb06",
+    "auditedInputDigest": "e77df81f1c50318d0bcf944bc81db86f71aa5b69f0c52d60ee7d2347f1081c09",
     "validatedMessageCount": 3169,
     "validatedModules": [
       "$entry",
@@ -41,10 +41,10 @@
     ],
     "highRiskMessageCount": 1433,
     "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
-    "catalogDigest": "467d24cabc55fc92fcd112386a9020f4b8b55e71e970559d9c4006a8323a265e",
-    "dossierDigest": "c81633a407d0a7d0f7c67c5a514eced89f4357d2fc0d081b397ad382509f1b14",
+    "catalogDigest": "9fabd08ff44e959db39d1b511126d18154db14458c4811d9e40d2f0d0d57e34f",
+    "dossierDigest": "e3e531d9d21e2920f8dcfc998b6e48df6135981257ea9f6d60381d052f8decb5",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "63115bb60cd34c1e5602f2cb4e6669fee1581f79588bc2116b44c581d9375b49",
+    "routeEvidenceDigest": "d6dbbc5cfde0f3a2856b0d7e2b7fce79cc7e524cf8c6f60f657bcbfaa34a6d8f",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "720ffdb462f7c139597e6d9e9bb59f4641cd1fd1b5099b671fdef39cc900c87f",
         "highRiskMessageCount": 1433,
         "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
-        "dossierDigest": "c81633a407d0a7d0f7c67c5a514eced89f4357d2fc0d081b397ad382509f1b14",
+        "dossierDigest": "e3e531d9d21e2920f8dcfc998b6e48df6135981257ea9f6d60381d052f8decb5",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "130337bbf27b5e88fcaae66f0809135427444a614e3f06543240122457f5cef9"
+  "validationDigest": "2f03a854b3d9be66dfb4654b312fed2cfaee8aef578e45a0c0f20dc7cdf76831"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "0b2304ee30d8e632363e3e5e231be49bdc5bab2ca8eecb458e9b2c189b5f6bb1",
-    "auditedInputDigest": "a3f28c7ecc55713f38a02b0d2c87d826d7acedb64e600c628e2d5723c918cb06"
+    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
+    "auditedInputDigest": "e77df81f1c50318d0bcf944bc81db86f71aa5b69f0c52d60ee7d2347f1081c09"
   },
   "inventory": {
     "sourceMessageCount": 3169,
@@ -47,8 +47,8 @@
     "messageCount": 3169,
     "completeCount": 3169,
     "blockedCount": 0,
-    "dossierDigest": "757dcdb4ce03e57778f4cb2b8685b5b963f6e31ab4da52f35d12627deb01b35d",
-    "catalogDigest": "1ba849eb8b7c14e431539769c1a00e471c4c12da4e821ecd42097ea07451d0b0",
+    "dossierDigest": "70530ff150f5b1e15712d798fa959b367313b39a2bcfe61f5fef3e73a5f6751f",
+    "catalogDigest": "8f641cc162bdb6636b1c5e1dbcd0df3d42d30508094807a397a43a0906595856",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
     "roleCounts": {
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4165,
+    "literalReferenceCount": 4166,
     "dynamicCallsiteCount": 35,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale fr-FR --message <MESSAGE_ID>"
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "4630b63172d2d8941a43e5e5ec82b721a1fbdf63d74d847ab69e80f97f25042a",
+      "sourceEvidenceDigest": "281dc4ac4658415730c75c89181e733476cf1ac58c04bfb6fda983647cb814c7",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -502,8 +502,8 @@
           "route": "/review",
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "c83add5c6565f7b1ce08296dbf734f84f06a1dd7feb45161b797d88979b62e8e",
-          "focusedTestDigest": "532ae6ebc5fe409c9b976ee0dedaf3d83ede0f406c63159c1ef267c800610f00",
+          "sourceDigest": "b3c3efd697284811e4e5e7dd6322c41315725d38afe8857851757feb45608f68",
+          "focusedTestDigest": "e83ab4bf9f28cb84f21b01da50f2f42ac585485f0bc1ab46905c2a41dd681cde",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "63115bb60cd34c1e5602f2cb4e6669fee1581f79588bc2116b44c581d9375b49",
+      "rowEvidenceDigest": "d6dbbc5cfde0f3a2856b0d7e2b7fce79cc7e524cf8c6f60f657bcbfaa34a6d8f",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "dd7211a7a1bcc850e49179ff694e8930c64561f27e708948adf0c2bbb2b7b6a8"
+  "contextDigest": "73159a91127be89458f7668f7e56d41ffda21eca8b8b6bf7996907144e89843d"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -503,7 +503,7 @@
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "b3c3efd697284811e4e5e7dd6322c41315725d38afe8857851757feb45608f68",
-          "focusedTestDigest": "e83ab4bf9f28cb84f21b01da50f2f42ac585485f0bc1ab46905c2a41dd681cde",
+          "focusedTestDigest": "3b4acaa3b212d6787bba4a1cbbd639e734320626e98d17cbe27f031bf16676a6",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "d6dbbc5cfde0f3a2856b0d7e2b7fce79cc7e524cf8c6f60f657bcbfaa34a6d8f",
+      "rowEvidenceDigest": "b9be0c6b0415d774ad4cd5fabadc4215261b4e116ced14a869dca1e82583cf8a",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "73159a91127be89458f7668f7e56d41ffda21eca8b8b6bf7996907144e89843d"
+  "contextDigest": "d47b1a453f0d868aff44803393bc95dbf2d3b4cf66b169a999278c72f2155488"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "73159a91127be89458f7668f7e56d41ffda21eca8b8b6bf7996907144e89843d",
-    "qualityDigest": "6c6157f597453a6d3219f48e2de7d84a0ae0fbbbe2515d46e68c91705079735f",
+    "contextDigest": "d47b1a453f0d868aff44803393bc95dbf2d3b4cf66b169a999278c72f2155488",
+    "qualityDigest": "b9af8782bcb8b7d5137e6603f4cd1b8933d413bcded06d2b9eeda62b023f8fda",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "f851930785d1f19fcd70de18a3eb9a8d3328763d8f80b6ec4f3ab50a32713855"
+  "activationDigest": "ec507186e2f4fbf0b7697f8f20fbfbdf0f455dc4313a0c8f4de567c5a8b9c026"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0b2304ee30d8e632363e3e5e231be49bdc5bab2ca8eecb458e9b2c189b5f6bb1"
+    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "dd7211a7a1bcc850e49179ff694e8930c64561f27e708948adf0c2bbb2b7b6a8",
-    "qualityDigest": "6c57761c4936bf43e1d04a40ab912d60716ae3155d9d108cfb649a194009696c",
+    "contextDigest": "73159a91127be89458f7668f7e56d41ffda21eca8b8b6bf7996907144e89843d",
+    "qualityDigest": "6c6157f597453a6d3219f48e2de7d84a0ae0fbbbe2515d46e68c91705079735f",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "7b49efef164a6bb2590d764f43a3a3eaf2dcc14e2363d9c3b3a3bcddda8a4f54"
+  "activationDigest": "f851930785d1f19fcd70de18a3eb9a8d3328763d8f80b6ec4f3ab50a32713855"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,12 +3,12 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0b2304ee30d8e632363e3e5e231be49bdc5bab2ca8eecb458e9b2c189b5f6bb1",
-    "contextDigest": "dd7211a7a1bcc850e49179ff694e8930c64561f27e708948adf0c2bbb2b7b6a8"
+    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
+    "contextDigest": "73159a91127be89458f7668f7e56d41ffda21eca8b8b6bf7996907144e89843d"
   },
   "catalog": {
     "messageCount": 3169,
-    "catalogDigest": "1ba849eb8b7c14e431539769c1a00e471c4c12da4e821ecd42097ea07451d0b0",
+    "catalogDigest": "8f641cc162bdb6636b1c5e1dbcd0df3d42d30508094807a397a43a0906595856",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "1d723028d2c72ecb94925872a52f7253932c851268379f0d4543429e0105991f",
-    "validationDigest": "69b0696f2ffb64aaf3f767f2dca79e337eecfcc9a27e75bcf1fc97b3d52c255b",
+    "digest": "6f3fe852767a2f34f84246ad2264f2037b4f49ace846cb8de086ae869d1ef484",
+    "validationDigest": "c43a0081ac73278d7cd7f21506eccf1ba5ae15131bf32e7024220f68cb8016ba",
     "laneCount": 1,
     "validatedMessageCount": 3169,
     "validatedModuleCount": 32,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "6c57761c4936bf43e1d04a40ab912d60716ae3155d9d108cfb649a194009696c"
+  "qualityDigest": "6c6157f597453a6d3219f48e2de7d84a0ae0fbbbe2515d46e68c91705079735f"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
-    "contextDigest": "73159a91127be89458f7668f7e56d41ffda21eca8b8b6bf7996907144e89843d"
+    "contextDigest": "d47b1a453f0d868aff44803393bc95dbf2d3b4cf66b169a999278c72f2155488"
   },
   "catalog": {
     "messageCount": 3169,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "6f3fe852767a2f34f84246ad2264f2037b4f49ace846cb8de086ae869d1ef484",
-    "validationDigest": "c43a0081ac73278d7cd7f21506eccf1ba5ae15131bf32e7024220f68cb8016ba",
+    "digest": "c1a5616298758fb17b56bbfe79c848a6ee70c02e70eff63475da23ebe4f676b1",
+    "validationDigest": "029bc926c7909179831d0fbf1e4ebac905d1b762326729526333f48afeee6b72",
     "laneCount": 1,
     "validatedMessageCount": 3169,
     "validatedModuleCount": 32,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "6c6157f597453a6d3219f48e2de7d84a0ae0fbbbe2515d46e68c91705079735f"
+  "qualityDigest": "b9af8782bcb8b7d5137e6603f4cd1b8933d413bcded06d2b9eeda62b023f8fda"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "8f641cc162bdb6636b1c5e1dbcd0df3d42d30508094807a397a43a0906595856",
     "dossierDigest": "70530ff150f5b1e15712d798fa959b367313b39a2bcfe61f5fef3e73a5f6751f",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "d6dbbc5cfde0f3a2856b0d7e2b7fce79cc7e524cf8c6f60f657bcbfaa34a6d8f",
+    "routeEvidenceDigest": "b9be0c6b0415d774ad4cd5fabadc4215261b4e116ced14a869dca1e82583cf8a",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "c43a0081ac73278d7cd7f21506eccf1ba5ae15131bf32e7024220f68cb8016ba"
+  "validationDigest": "029bc926c7909179831d0fbf1e4ebac905d1b762326729526333f48afeee6b72"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "a3f28c7ecc55713f38a02b0d2c87d826d7acedb64e600c628e2d5723c918cb06",
+    "auditedInputDigest": "e77df81f1c50318d0bcf944bc81db86f71aa5b69f0c52d60ee7d2347f1081c09",
     "validatedMessageCount": 3169,
     "validatedModules": [
       "$entry",
@@ -41,10 +41,10 @@
     ],
     "highRiskMessageCount": 1433,
     "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
-    "catalogDigest": "1ba849eb8b7c14e431539769c1a00e471c4c12da4e821ecd42097ea07451d0b0",
-    "dossierDigest": "757dcdb4ce03e57778f4cb2b8685b5b963f6e31ab4da52f35d12627deb01b35d",
+    "catalogDigest": "8f641cc162bdb6636b1c5e1dbcd0df3d42d30508094807a397a43a0906595856",
+    "dossierDigest": "70530ff150f5b1e15712d798fa959b367313b39a2bcfe61f5fef3e73a5f6751f",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "63115bb60cd34c1e5602f2cb4e6669fee1581f79588bc2116b44c581d9375b49",
+    "routeEvidenceDigest": "d6dbbc5cfde0f3a2856b0d7e2b7fce79cc7e524cf8c6f60f657bcbfaa34a6d8f",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "720ffdb462f7c139597e6d9e9bb59f4641cd1fd1b5099b671fdef39cc900c87f",
         "highRiskMessageCount": 1433,
         "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
-        "dossierDigest": "757dcdb4ce03e57778f4cb2b8685b5b963f6e31ab4da52f35d12627deb01b35d",
+        "dossierDigest": "70530ff150f5b1e15712d798fa959b367313b39a2bcfe61f5fef3e73a5f6751f",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "69b0696f2ffb64aaf3f767f2dca79e337eecfcc9a27e75bcf1fc97b3d52c255b"
+  "validationDigest": "c43a0081ac73278d7cd7f21506eccf1ba5ae15131bf32e7024220f68cb8016ba"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -503,7 +503,7 @@
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "b3c3efd697284811e4e5e7dd6322c41315725d38afe8857851757feb45608f68",
-          "focusedTestDigest": "e83ab4bf9f28cb84f21b01da50f2f42ac585485f0bc1ab46905c2a41dd681cde",
+          "focusedTestDigest": "3b4acaa3b212d6787bba4a1cbbd639e734320626e98d17cbe27f031bf16676a6",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "d6dbbc5cfde0f3a2856b0d7e2b7fce79cc7e524cf8c6f60f657bcbfaa34a6d8f",
+      "rowEvidenceDigest": "b9be0c6b0415d774ad4cd5fabadc4215261b4e116ced14a869dca1e82583cf8a",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "9e30a8d2f294a59b219c264854fd5bf9e34fdcfb0a6b45a450b67356083ca0f8"
+  "contextDigest": "c78ab2972594a50925e2ea89cd278938946ba398944ce6c4a79803b104fa36b4"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "0b2304ee30d8e632363e3e5e231be49bdc5bab2ca8eecb458e9b2c189b5f6bb1",
-    "auditedInputDigest": "a3f28c7ecc55713f38a02b0d2c87d826d7acedb64e600c628e2d5723c918cb06"
+    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
+    "auditedInputDigest": "e77df81f1c50318d0bcf944bc81db86f71aa5b69f0c52d60ee7d2347f1081c09"
   },
   "inventory": {
     "sourceMessageCount": 3169,
@@ -47,8 +47,8 @@
     "messageCount": 3169,
     "completeCount": 3169,
     "blockedCount": 0,
-    "dossierDigest": "4b40c8e881a7828930da89fe84bb90bff00956950eb0b84933245fa4893e862b",
-    "catalogDigest": "69b254df834ac7f6856e26623aacaacf89507d7a077c22a91e410d06bcbd0e67",
+    "dossierDigest": "e7877f526e1df8c3d7cf4abeb129a115cc41d1444e57d4861404c9f149fdec03",
+    "catalogDigest": "07f4707dcc02ac32c1b76d09780d3f26503d4c4b2a1fa85331eb8beac94f2555",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
     "roleCounts": {
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4165,
+    "literalReferenceCount": 4166,
     "dynamicCallsiteCount": 35,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale zh-CN --message <MESSAGE_ID>"
@@ -144,7 +144,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "4630b63172d2d8941a43e5e5ec82b721a1fbdf63d74d847ab69e80f97f25042a",
+      "sourceEvidenceDigest": "281dc4ac4658415730c75c89181e733476cf1ac58c04bfb6fda983647cb814c7",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -502,8 +502,8 @@
           "route": "/review",
           "viewState": "review-workbench",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "c83add5c6565f7b1ce08296dbf734f84f06a1dd7feb45161b797d88979b62e8e",
-          "focusedTestDigest": "532ae6ebc5fe409c9b976ee0dedaf3d83ede0f406c63159c1ef267c800610f00",
+          "sourceDigest": "b3c3efd697284811e4e5e7dd6322c41315725d38afe8857851757feb45608f68",
+          "focusedTestDigest": "e83ab4bf9f28cb84f21b01da50f2f42ac585485f0bc1ab46905c2a41dd681cde",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5a8c72f83ffaf3ff28bf1ba10eb392dc9595f22dc25398575a67c71a636d6af4",
           "derivedMessageCount": 10,
@@ -1096,7 +1096,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "63115bb60cd34c1e5602f2cb4e6669fee1581f79588bc2116b44c581d9375b49",
+      "rowEvidenceDigest": "d6dbbc5cfde0f3a2856b0d7e2b7fce79cc7e524cf8c6f60f657bcbfaa34a6d8f",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1120,5 +1120,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "1e6b7ae4f5612bd3492733b8b2d200d9cf2dcec1288410572cac31f4137821b5"
+  "contextDigest": "9e30a8d2f294a59b219c264854fd5bf9e34fdcfb0a6b45a450b67356083ca0f8"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0b2304ee30d8e632363e3e5e231be49bdc5bab2ca8eecb458e9b2c189b5f6bb1"
+    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "1e6b7ae4f5612bd3492733b8b2d200d9cf2dcec1288410572cac31f4137821b5",
-    "qualityDigest": "fa5c980141bd5fed7ad7b60a6b9732be9ad4d35c5a8813c832b0453ab0f6d163",
+    "contextDigest": "9e30a8d2f294a59b219c264854fd5bf9e34fdcfb0a6b45a450b67356083ca0f8",
+    "qualityDigest": "b84e1c522d20cd2cdc18f5028dcd0c0305832d37c654e05fb3b6f3ada706a228",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "bd6aac78b9514bc3d1e8a6617eb34b073cef0cb093c1bdfe191bf716c01d484d"
+  "activationDigest": "98b6c607a38c3de7cbb3e3a27d7b6a51fbaa293e7d93d23dfd5da2ee6095dc21"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "9e30a8d2f294a59b219c264854fd5bf9e34fdcfb0a6b45a450b67356083ca0f8",
-    "qualityDigest": "b84e1c522d20cd2cdc18f5028dcd0c0305832d37c654e05fb3b6f3ada706a228",
+    "contextDigest": "c78ab2972594a50925e2ea89cd278938946ba398944ce6c4a79803b104fa36b4",
+    "qualityDigest": "5c7bfd76272121dc89c96e570c2c4bc08cc18e736f242f3133ebec2ab9d6f299",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "98b6c607a38c3de7cbb3e3a27d7b6a51fbaa293e7d93d23dfd5da2ee6095dc21"
+  "activationDigest": "b1467f3f6bc7022319c66f3a34a0cca1cfb7015c33b34ab1e4330a9e090f3ce6"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,12 +3,12 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0b2304ee30d8e632363e3e5e231be49bdc5bab2ca8eecb458e9b2c189b5f6bb1",
-    "contextDigest": "1e6b7ae4f5612bd3492733b8b2d200d9cf2dcec1288410572cac31f4137821b5"
+    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
+    "contextDigest": "9e30a8d2f294a59b219c264854fd5bf9e34fdcfb0a6b45a450b67356083ca0f8"
   },
   "catalog": {
     "messageCount": 3169,
-    "catalogDigest": "69b254df834ac7f6856e26623aacaacf89507d7a077c22a91e410d06bcbd0e67",
+    "catalogDigest": "07f4707dcc02ac32c1b76d09780d3f26503d4c4b2a1fa85331eb8beac94f2555",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "2b82fee6fe0fe6a93e0498da2b683785ecd675245f88b2ade8896cd2a49cfcbb",
-    "validationDigest": "0e4b2833d769dface938dd178fe3570d8d503010494b7e644fae6048073d892d",
+    "digest": "541796276277197077879ba10fdfae2a3e4241683ebd6d00113134356c78f120",
+    "validationDigest": "844cdaa56460aaf427f51797adae6111fc11b497e6280f6ed631d2822aae697e",
     "laneCount": 1,
     "validatedMessageCount": 3169,
     "validatedModuleCount": 32,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "fa5c980141bd5fed7ad7b60a6b9732be9ad4d35c5a8813c832b0453ab0f6d163"
+  "qualityDigest": "b84e1c522d20cd2cdc18f5028dcd0c0305832d37c654e05fb3b6f3ada706a228"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
-    "contextDigest": "9e30a8d2f294a59b219c264854fd5bf9e34fdcfb0a6b45a450b67356083ca0f8"
+    "contextDigest": "c78ab2972594a50925e2ea89cd278938946ba398944ce6c4a79803b104fa36b4"
   },
   "catalog": {
     "messageCount": 3169,
@@ -41,8 +41,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "541796276277197077879ba10fdfae2a3e4241683ebd6d00113134356c78f120",
-    "validationDigest": "844cdaa56460aaf427f51797adae6111fc11b497e6280f6ed631d2822aae697e",
+    "digest": "23c45f5efdfec56a403523f3d98c91cf68787e094b3ee1dc80256330b36e3edd",
+    "validationDigest": "1088f1af7ffe42c8a78facf869b16a8adff80df87a8082d4a5cfd2f43c62148e",
     "laneCount": 1,
     "validatedMessageCount": 3169,
     "validatedModuleCount": 32,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "b84e1c522d20cd2cdc18f5028dcd0c0305832d37c654e05fb3b6f3ada706a228"
+  "qualityDigest": "5c7bfd76272121dc89c96e570c2c4bc08cc18e736f242f3133ebec2ab9d6f299"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "a3f28c7ecc55713f38a02b0d2c87d826d7acedb64e600c628e2d5723c918cb06",
+    "auditedInputDigest": "e77df81f1c50318d0bcf944bc81db86f71aa5b69f0c52d60ee7d2347f1081c09",
     "validatedMessageCount": 3169,
     "validatedModules": [
       "$entry",
@@ -41,10 +41,10 @@
     ],
     "highRiskMessageCount": 1433,
     "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
-    "catalogDigest": "69b254df834ac7f6856e26623aacaacf89507d7a077c22a91e410d06bcbd0e67",
-    "dossierDigest": "4b40c8e881a7828930da89fe84bb90bff00956950eb0b84933245fa4893e862b",
+    "catalogDigest": "07f4707dcc02ac32c1b76d09780d3f26503d4c4b2a1fa85331eb8beac94f2555",
+    "dossierDigest": "e7877f526e1df8c3d7cf4abeb129a115cc41d1444e57d4861404c9f149fdec03",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "63115bb60cd34c1e5602f2cb4e6669fee1581f79588bc2116b44c581d9375b49",
+    "routeEvidenceDigest": "d6dbbc5cfde0f3a2856b0d7e2b7fce79cc7e524cf8c6f60f657bcbfaa34a6d8f",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "720ffdb462f7c139597e6d9e9bb59f4641cd1fd1b5099b671fdef39cc900c87f",
         "highRiskMessageCount": 1433,
         "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
-        "dossierDigest": "4b40c8e881a7828930da89fe84bb90bff00956950eb0b84933245fa4893e862b",
+        "dossierDigest": "e7877f526e1df8c3d7cf4abeb129a115cc41d1444e57d4861404c9f149fdec03",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "0e4b2833d769dface938dd178fe3570d8d503010494b7e644fae6048073d892d"
+  "validationDigest": "844cdaa56460aaf427f51797adae6111fc11b497e6280f6ed631d2822aae697e"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "07f4707dcc02ac32c1b76d09780d3f26503d4c4b2a1fa85331eb8beac94f2555",
     "dossierDigest": "e7877f526e1df8c3d7cf4abeb129a115cc41d1444e57d4861404c9f149fdec03",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "d6dbbc5cfde0f3a2856b0d7e2b7fce79cc7e524cf8c6f60f657bcbfaa34a6d8f",
+    "routeEvidenceDigest": "b9be0c6b0415d774ad4cd5fabadc4215261b4e116ced14a869dca1e82583cf8a",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "844cdaa56460aaf427f51797adae6111fc11b497e6280f6ed631d2822aae697e"
+  "validationDigest": "1088f1af7ffe42c8a78facf869b16a8adff80df87a8082d4a5cfd2f43c62148e"
 }

--- a/src/locales/de-DE/pages_review.ts
+++ b/src/locales/de-DE/pages_review.ts
@@ -19,7 +19,7 @@ export default {
   'pages.review.qualityDiagnostic.empty': 'Es wurde noch keine Qualitätsdiagnose ausgeführt.',
   'pages.review.qualityDiagnostic.updatedAt': 'Aktualisiert um {time}',
   'pages.review.qualityDiagnostic.runtimeFailed': 'Die Diagnose hat keinen Bericht erstellt.',
-  'pages.review.qualityDiagnostic.running': 'Die Diagnose läuft im Hintergrund. Prüfaktionen bleiben verfügbar.',
+  'pages.review.qualityDiagnostic.running': 'Die Diagnose prüft die gemeinsame Matrix ausstehender Prüfungen im Hintergrund nur zur Information; Prüfaktionen bleiben verfügbar.',
   'pages.review.qualityDiagnostic.scope.reviews': 'Geprüfte Prüfungen',
   'pages.review.qualityDiagnostic.scope.datasets': 'Geprüfte Datensätze',
   'pages.review.qualityDiagnostic.scope.processes': 'Ausstehende Prozesse',

--- a/src/locales/en-US/pages_review.ts
+++ b/src/locales/en-US/pages_review.ts
@@ -19,7 +19,7 @@ export default {
   'pages.review.qualityDiagnostic.empty': 'No quality diagnostic has been run yet.',
   'pages.review.qualityDiagnostic.updatedAt': 'Updated {time}',
   'pages.review.qualityDiagnostic.runtimeFailed': 'The diagnostic did not produce a report.',
-  'pages.review.qualityDiagnostic.running': 'The diagnostic is running in the background. Review actions remain available.',
+  'pages.review.qualityDiagnostic.running': 'The diagnostic is checking the joint pending-review matrix in the background for information only; review actions remain available.',
   'pages.review.qualityDiagnostic.scope.reviews': 'Reviews checked',
   'pages.review.qualityDiagnostic.scope.datasets': 'Datasets checked',
   'pages.review.qualityDiagnostic.scope.processes': 'Pending Processes',

--- a/src/locales/fr-FR/pages_review.ts
+++ b/src/locales/fr-FR/pages_review.ts
@@ -19,7 +19,7 @@ export default {
   'pages.review.qualityDiagnostic.empty': 'Aucun diagnostic qualité n’a encore été exécuté.',
   'pages.review.qualityDiagnostic.updatedAt': 'Mis à jour à {time}',
   'pages.review.qualityDiagnostic.runtimeFailed': 'Le diagnostic n’a produit aucun rapport.',
-  'pages.review.qualityDiagnostic.running': 'Le diagnostic s’exécute en arrière-plan. Les actions de revue restent disponibles.',
+  'pages.review.qualityDiagnostic.running': 'Le diagnostic vérifie en arrière-plan la matrice conjointe des révisions en attente, à titre informatif uniquement ; les actions de revue restent disponibles.',
   'pages.review.qualityDiagnostic.scope.reviews': 'Revues vérifiées',
   'pages.review.qualityDiagnostic.scope.datasets': 'Jeux de données vérifiés',
   'pages.review.qualityDiagnostic.scope.processes': 'Processus en attente',

--- a/src/locales/zh-CN/pages_review.ts
+++ b/src/locales/zh-CN/pages_review.ts
@@ -20,7 +20,7 @@ export default {
   'pages.review.qualityDiagnostic.empty': '尚未运行质量诊断。',
   'pages.review.qualityDiagnostic.updatedAt': '更新于 {time}',
   'pages.review.qualityDiagnostic.runtimeFailed': '本次诊断未生成报告。',
-  'pages.review.qualityDiagnostic.running': '诊断正在后台运行，审核操作仍然可用。',
+  'pages.review.qualityDiagnostic.running': '诊断正在后台检查待审核数据联合矩阵，仅供参考，不影响审核操作。',
   'pages.review.qualityDiagnostic.scope.reviews': '审核项数量',
   'pages.review.qualityDiagnostic.scope.datasets': '数据集数量',
   'pages.review.qualityDiagnostic.scope.processes': '待审核过程',

--- a/src/pages/Review/Components/AssignmentReview.tsx
+++ b/src/pages/Review/Components/AssignmentReview.tsx
@@ -21,9 +21,23 @@ import {
 } from '@/services/reviews/api';
 import { ReviewsTable } from '@/services/reviews/data';
 import { isCurrentAssignedReviewerCommentState } from '@/services/reviews/util';
+import { ExperimentOutlined } from '@ant-design/icons';
 import { ProColumns, ProTable } from '@ant-design/pro-components';
 import { FormattedMessage, useIntl } from '@umijs/max';
-import { Card, Col, Input, Row, Select, Space, Spin, Table, Tag, theme, Tooltip } from 'antd';
+import {
+  Button,
+  Card,
+  Col,
+  Input,
+  Row,
+  Select,
+  Space,
+  Spin,
+  Table,
+  Tag,
+  theme,
+  Tooltip,
+} from 'antd';
 import { SearchProps } from 'antd/es/input/Search';
 import { SortOrder } from 'antd/es/table/interface';
 import { useEffect, useRef, useState } from 'react';
@@ -72,6 +86,7 @@ type AssignmentReviewProps = {
   actionRef: any;
   actionFrom?: 'reviewMember';
   hideReviewButton?: boolean;
+  onOpenQualityDiagnostic?: () => void;
 };
 
 export const isReferenceMatchingReviewTab = (
@@ -140,6 +155,7 @@ const AssignmentReview = ({
   actionRef,
   actionFrom,
   hideReviewButton = false,
+  onOpenQualityDiagnostic,
 }: AssignmentReviewProps) => {
   // const intl = useIntl();
   const { locale } = useIntl();
@@ -1121,6 +1137,23 @@ const AssignmentReview = ({
           },
         }}
         toolBarRender={() => {
+          const qualityDiagnosticLabel = intl.formatMessage({
+            id: 'pages.review.qualityDiagnostic.run',
+            defaultMessage: 'Run quality diagnostic',
+          });
+          const qualityDiagnosticAction =
+            userData?.role === 'review-admin' &&
+            tableType !== 'admin-rejected' &&
+            onOpenQualityDiagnostic ? (
+              <Tooltip key='review-quality-diagnostic' title={qualityDiagnosticLabel}>
+                <Button
+                  type='text'
+                  aria-label={qualityDiagnosticLabel}
+                  icon={<ExperimentOutlined />}
+                  onClick={onOpenQualityDiagnostic}
+                />
+              </Tooltip>
+            ) : null;
           const filterControls = (
             <Space key='review-list-filters' wrap>
               <Select<ReviewDisplayMode>
@@ -1177,9 +1210,10 @@ const AssignmentReview = ({
                   onFinished={reloadAfterChildAction}
                 />
               </Space>,
+              qualityDiagnosticAction,
             ];
           }
-          return [filterControls];
+          return [filterControls, qualityDiagnosticAction];
         }}
         headerTitle={
           <>

--- a/src/pages/Review/Components/ReviewQualityDiagnostic.tsx
+++ b/src/pages/Review/Components/ReviewQualityDiagnostic.tsx
@@ -6,9 +6,15 @@ import {
   type ReviewQualityDiagnosticSection,
   type ReviewQualityDiagnosticStatus,
 } from '@/services/reviews/api';
-import { ExperimentOutlined, InfoCircleOutlined, ReloadOutlined } from '@ant-design/icons';
+import {
+  CheckOutlined,
+  CopyOutlined,
+  ExperimentOutlined,
+  InfoCircleOutlined,
+  ReloadOutlined,
+} from '@ant-design/icons';
 import { useIntl } from '@umijs/max';
-import { Alert, Button, Card, Collapse, Empty, List, Space, Tag, Typography, theme } from 'antd';
+import { Alert, Button, Collapse, Empty, List, Modal, Space, Tag, Typography, theme } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 const { Paragraph, Text } = Typography;
@@ -187,7 +193,7 @@ const findingColor = (level: ReviewQualityDiagnosticFinding['level']) => {
     case 'warning':
       return 'orange';
     default:
-      return 'blue';
+      return undefined;
   }
 };
 
@@ -236,7 +242,12 @@ const Metric = ({ label, value }: { label: React.ReactNode; value?: number }) =>
   );
 };
 
-const ReviewQualityDiagnostic = () => {
+type ReviewQualityDiagnosticProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+const ReviewQualityDiagnostic = ({ open, onClose }: ReviewQualityDiagnosticProps) => {
   const intl = useIntl();
   const { token } = theme.useToken();
   const [diagnostic, setDiagnostic] = useState<ReviewQualityDiagnosticRun>();
@@ -296,6 +307,31 @@ const ReviewQualityDiagnostic = () => {
     typeof report?.summary?.findingCount === 'number'
       ? report.summary.findingCount
       : report?.findings?.length;
+  const primaryTagStyle = useMemo(
+    () => ({
+      color: token.colorPrimaryText,
+      background: token.colorPrimaryBg,
+      borderColor: token.colorPrimaryBorder,
+    }),
+    [token.colorPrimaryBg, token.colorPrimaryBorder, token.colorPrimaryText],
+  );
+  const informationalTagStyle = useMemo(
+    () => ({
+      color: token.colorPrimaryText,
+      background: 'transparent',
+      border: 'none',
+      paddingInline: 0,
+    }),
+    [token.colorPrimaryText],
+  );
+  const activeStatusTagStyle = useMemo(
+    () => ({
+      color: token.colorPrimaryText,
+      background: 'transparent',
+      borderColor: token.colorPrimaryBorder,
+    }),
+    [token.colorPrimaryBorder, token.colorPrimaryText],
+  );
 
   const sectionItems = useMemo(
     () =>
@@ -329,7 +365,10 @@ const ReviewQualityDiagnostic = () => {
                   <List.Item key={`${finding.code}-${index}`}>
                     <Space direction='vertical' size={4} style={{ width: '100%' }}>
                       <Space wrap>
-                        <Tag color={findingColor(finding.level)}>
+                        <Tag
+                          color={findingColor(finding.level)}
+                          style={finding.level === 'info' ? primaryTagStyle : undefined}
+                        >
                           {formatDiagnosticFindingLevel(intl, finding.level)}
                         </Tag>
                         <Text code>{finding.code}</Text>
@@ -371,7 +410,7 @@ const ReviewQualityDiagnostic = () => {
             </Text>
           ),
       })),
-    [intl, report?.sections, token],
+    [intl, primaryTagStyle, report?.sections, token],
   );
 
   const statusLabel = diagnostic ? formatDiagnosticStatus(intl, diagnostic.status) : null;
@@ -381,32 +420,11 @@ const ReviewQualityDiagnostic = () => {
   const isActive = isDiagnosticActive(diagnostic?.status);
 
   return (
-    <Card
+    <Modal
       data-testid='review-quality-diagnostic'
-      size='small'
-      style={{
-        marginBottom: 16,
-        borderInlineStart: `3px solid ${token.colorInfo}`,
-        boxShadow: token.boxShadowTertiary,
-      }}
-      title={
-        <Space wrap>
-          <ExperimentOutlined />
-          <span>
-            {intl.formatMessage({
-              id: 'pages.review.qualityDiagnostic.title',
-              defaultMessage: 'Pending-review quality diagnostic',
-            })}
-          </span>
-          <Tag icon={<InfoCircleOutlined />} color='blue'>
-            {intl.formatMessage({
-              id: 'pages.review.qualityDiagnostic.informationalOnly',
-              defaultMessage: 'Informational only',
-            })}
-          </Tag>
-        </Space>
-      }
-      extra={
+      open={open}
+      onCancel={onClose}
+      footer={
         <Space wrap>
           <Button
             icon={<ReloadOutlined />}
@@ -437,17 +455,50 @@ const ReviewQualityDiagnostic = () => {
           </Button>
         </Space>
       }
+      width={960}
+      centered
+      styles={{
+        body: {
+          maxHeight: 'calc(100vh - 180px)',
+          overflowY: 'auto',
+          paddingTop: token.paddingXS,
+        },
+      }}
+      title={
+        <Space wrap>
+          <ExperimentOutlined style={{ color: token.colorPrimary }} />
+          <span>
+            {intl.formatMessage({
+              id: 'pages.review.qualityDiagnostic.title',
+              defaultMessage: 'Pending-review quality diagnostic',
+            })}
+          </span>
+          <Tag icon={<InfoCircleOutlined />} style={informationalTagStyle}>
+            {intl.formatMessage({
+              id: 'pages.review.qualityDiagnostic.informationalOnly',
+              defaultMessage: 'Informational only',
+            })}
+          </Tag>
+        </Space>
+      }
     >
       <Space direction='vertical' size='middle' style={{ width: '100%' }} aria-live='polite'>
-        <Alert
-          showIcon
-          type='info'
-          message={intl.formatMessage({
-            id: 'pages.review.qualityDiagnostic.nonBlockingNotice',
-            defaultMessage:
-              'This manual report checks the joint pending-review matrix. Its findings and failures never disable assignment, approval, or rejection.',
-          })}
-        />
+        <Space size='small' align='start'>
+          <InfoCircleOutlined style={{ color: token.colorTextTertiary, marginTop: 3 }} />
+          <Text type='secondary'>
+            {isActive
+              ? intl.formatMessage({
+                  id: 'pages.review.qualityDiagnostic.running',
+                  defaultMessage:
+                    'The diagnostic is checking the joint pending-review matrix in the background for information only; review actions remain available.',
+                })
+              : intl.formatMessage({
+                  id: 'pages.review.qualityDiagnostic.nonBlockingNotice',
+                  defaultMessage:
+                    'This manual report checks the joint pending-review matrix. Its findings and failures never disable assignment, approval, or rejection.',
+                })}
+          </Text>
+        </Space>
 
         {requestError && (
           <Alert
@@ -479,9 +530,23 @@ const ReviewQualityDiagnostic = () => {
         ) : (
           <>
             <Space wrap>
-              <Tag color={statusColor(diagnostic.status)}>{statusLabel}</Tag>
+              <Tag
+                color={isActive ? undefined : statusColor(diagnostic.status)}
+                style={isActive ? activeStatusTagStyle : undefined}
+              >
+                {statusLabel}
+              </Tag>
               {outcomeLabel && <Tag color={outcomeColor(outcome)}>{outcomeLabel}</Tag>}
-              <Text type='secondary' copyable={{ text: diagnostic.runId }}>
+              <Text
+                type='secondary'
+                copyable={{
+                  text: diagnostic.runId,
+                  icon: [
+                    <CopyOutlined key='copy' style={{ color: token.colorPrimary }} />,
+                    <CheckOutlined key='copied' style={{ color: token.colorSuccess }} />,
+                  ],
+                }}
+              >
                 {diagnostic.runId}
               </Text>
               {lastUpdatedAt && (
@@ -506,18 +571,6 @@ const ReviewQualityDiagnostic = () => {
                   defaultMessage: 'The diagnostic did not produce a report.',
                 })}
                 description={diagnostic.error?.message ?? diagnostic.error?.code}
-              />
-            )}
-
-            {isActive && (
-              <Alert
-                showIcon
-                type='info'
-                message={intl.formatMessage({
-                  id: 'pages.review.qualityDiagnostic.running',
-                  defaultMessage:
-                    'The diagnostic is running in the background. Review actions remain available.',
-                })}
               />
             )}
 
@@ -608,7 +661,7 @@ const ReviewQualityDiagnostic = () => {
           </>
         )}
       </Space>
-    </Card>
+    </Modal>
   );
 };
 

--- a/src/pages/Review/index.tsx
+++ b/src/pages/Review/index.tsx
@@ -12,6 +12,7 @@ const Review = () => {
   const [activeTabKey, setActiveTabKey] = useState('');
   const [loading, setLoading] = useState(false);
   const [authResolved, setAuthResolved] = useState(false);
+  const [qualityDiagnosticOpen, setQualityDiagnosticOpen] = useState(false);
   const [userData, setUserData] = useState<{ user_id: string; role: string } | null>(null);
   const actionRef = useRef<any>();
   const unassignedTableRef = useRef<any>();
@@ -75,6 +76,7 @@ const Review = () => {
               actionRef={unassignedTableRef}
               tableType='unassigned'
               userData={userData}
+              onOpenQualityDiagnostic={() => setQualityDiagnosticOpen(true)}
             />
           ),
         },
@@ -86,6 +88,7 @@ const Review = () => {
               actionRef={assignedTableRef}
               tableType='assigned'
               userData={userData}
+              onOpenQualityDiagnostic={() => setQualityDiagnosticOpen(true)}
             />
           ),
         },
@@ -154,7 +157,12 @@ const Review = () => {
           <AccessDenied />
         ) : (
           <>
-            {isReviewAdmin && <ReviewQualityDiagnostic />}
+            {isReviewAdmin && (
+              <ReviewQualityDiagnostic
+                open={qualityDiagnosticOpen}
+                onClose={() => setQualityDiagnosticOpen(false)}
+              />
+            )}
             <Tabs activeKey={activeTabKey} onChange={onTabChange} tabPosition='left' items={tabs} />
           </>
         )}

--- a/tests/integration/reviews/ReviewWorkflow.integration.test.tsx
+++ b/tests/integration/reviews/ReviewWorkflow.integration.test.tsx
@@ -95,6 +95,7 @@ jest.mock('@ant-design/icons', () => ({
   CloseOutlined: () => <span data-testid='icon-close' />,
   CrownOutlined: () => <span data-testid='icon-crown' />,
   DeleteOutlined: () => <span data-testid='icon-delete' />,
+  ExperimentOutlined: () => <span data-testid='icon-experiment' />,
   PlusOutlined: () => <span data-testid='icon-plus' />,
   UserOutlined: () => <span data-testid='icon-user' />,
 }));

--- a/tests/unit/pages/Review/Components/AssignmentReview.test.tsx
+++ b/tests/unit/pages/Review/Components/AssignmentReview.test.tsx
@@ -143,8 +143,9 @@ jest.mock('antd', () => {
   const React = require('react');
 
   const Card = ({ children }: any) => <section>{children}</section>;
-  const Button = ({ children, onClick }: any) => (
-    <button type='button' onClick={onClick}>
+  const Button = ({ children, icon, onClick, 'aria-label': ariaLabel }: any) => (
+    <button type='button' aria-label={ariaLabel} onClick={onClick}>
+      {icon}
       {children}
     </button>
   );
@@ -685,6 +686,38 @@ describe('AssignmentReview', () => {
     expect(dataTypeSelect).toHaveValue('all');
     expect(screen.queryByRole('option', { name: 'menu.processes' })).not.toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'menu.mydata.sources' })).toBeInTheDocument();
+  });
+
+  it('opens the Review Admin quality diagnostic from the list toolbar', async () => {
+    const onOpenQualityDiagnostic = jest.fn();
+    render(
+      <AssignmentReview
+        userData={{ user_id: 'admin-1', role: 'review-admin' }}
+        tableType='unassigned'
+        actionRef={{ current: { reload: jest.fn() } }}
+        onOpenQualityDiagnostic={onOpenQualityDiagnostic}
+      />,
+    );
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Run quality diagnostic' }));
+
+    expect(onOpenQualityDiagnostic).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the quality diagnostic action from the rejected admin list', async () => {
+    render(
+      <AssignmentReview
+        userData={{ user_id: 'admin-1', role: 'review-admin' }}
+        tableType='admin-rejected'
+        actionRef={{ current: { reload: jest.fn() } }}
+        onOpenQualityDiagnostic={jest.fn()}
+      />,
+    );
+
+    await screen.findByTestId('protable');
+    expect(
+      screen.queryByRole('button', { name: 'Run quality diagnostic' }),
+    ).not.toBeInTheDocument();
   });
 
   it('selects a flat reference row directly without loading a child table', async () => {

--- a/tests/unit/pages/Review/Components/ReviewQualityDiagnostic.test.tsx
+++ b/tests/unit/pages/Review/Components/ReviewQualityDiagnostic.test.tsx
@@ -92,7 +92,7 @@ describe('ReviewQualityDiagnostic', () => {
       statusText: 'OK',
     });
 
-    render(<ReviewQualityDiagnostic />);
+    render(<ReviewQualityDiagnostic open onClose={jest.fn()} />);
 
     expect(await screen.findByText('Pending-review quality diagnostic')).toBeInTheDocument();
     await waitFor(() =>
@@ -134,7 +134,7 @@ describe('ReviewQualityDiagnostic', () => {
         statusText: 'Accepted',
       });
 
-    const { unmount } = render(<ReviewQualityDiagnostic />);
+    const { unmount } = render(<ReviewQualityDiagnostic open onClose={jest.fn()} />);
 
     expect(await screen.findByText('No quality diagnostic has been run yet.')).toBeInTheDocument();
     expect(mockRequestReviewQualityDiagnosticApi).toHaveBeenCalledTimes(1);
@@ -176,7 +176,7 @@ describe('ReviewQualityDiagnostic', () => {
         statusText: 'Service Unavailable',
       });
 
-    render(<ReviewQualityDiagnostic />);
+    render(<ReviewQualityDiagnostic open onClose={jest.fn()} />);
 
     expect(await screen.findByText('No quality diagnostic has been run yet.')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /Refresh report/i }));
@@ -202,7 +202,7 @@ describe('ReviewQualityDiagnostic', () => {
       statusText: 'OK',
     });
 
-    render(<ReviewQualityDiagnostic />);
+    render(<ReviewQualityDiagnostic open onClose={jest.fn()} />);
 
     expect(await screen.findByText('The diagnostic did not produce a report.')).toBeInTheDocument();
     expect(screen.getByText('Worker unavailable')).toBeInTheDocument();

--- a/tests/unit/pages/Review/index.test.tsx
+++ b/tests/unit/pages/Review/index.test.tsx
@@ -17,7 +17,7 @@ jest.mock('@/services/roles/api', () => ({
 
 jest.mock('@/pages/Review/Components/AssignmentReview', () => ({
   __esModule: true,
-  default: ({ actionRef, tableType, userData }: any) => {
+  default: ({ actionRef, tableType, userData, onOpenQualityDiagnostic }: any) => {
     const reload = assignmentReloads[tableType] ?? jest.fn();
     assignmentReloads[tableType] = reload;
     if (actionRef) {
@@ -26,6 +26,11 @@ jest.mock('@/pages/Review/Components/AssignmentReview', () => ({
     return (
       <div data-testid={`assignment-${tableType}`}>
         {`${tableType}:${userData?.role ?? 'none'}`}
+        {onOpenQualityDiagnostic && (
+          <button type='button' onClick={onOpenQualityDiagnostic}>
+            open-quality-diagnostic
+          </button>
+        )}
       </div>
     );
   },
@@ -38,7 +43,16 @@ jest.mock('@/pages/Review/Components/ReviewMember', () => ({
 
 jest.mock('@/pages/Review/Components/ReviewQualityDiagnostic', () => ({
   __esModule: true,
-  default: () => <div data-testid='review-quality-diagnostic'>quality diagnostic</div>,
+  default: ({ open, onClose }: any) => (
+    <div data-testid='review-quality-diagnostic' data-open={String(open)}>
+      quality diagnostic
+      {open && (
+        <button type='button' onClick={onClose}>
+          close-quality-diagnostic
+        </button>
+      )}
+    </div>
+  ),
 }));
 
 jest.mock('@ant-design/pro-components', () => ({
@@ -101,6 +115,11 @@ describe('Review page', () => {
       'unassigned:review-admin',
     );
     expect(screen.getByTestId('review-quality-diagnostic')).toBeInTheDocument();
+    expect(screen.getByTestId('review-quality-diagnostic')).toHaveAttribute('data-open', 'false');
+    fireEvent.click(screen.getByRole('button', { name: 'open-quality-diagnostic' }));
+    expect(screen.getByTestId('review-quality-diagnostic')).toHaveAttribute('data-open', 'true');
+    fireEvent.click(screen.getByRole('button', { name: 'close-quality-diagnostic' }));
+    expect(screen.getByTestId('review-quality-diagnostic')).toHaveAttribute('data-open', 'false');
     expect(screen.getByRole('button', { name: 'pages.review.tabs.assigned' })).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'pages.review.tabs.rejectedTask' }),

--- a/tests/unit/pages/Review/index.test.tsx
+++ b/tests/unit/pages/Review/index.test.tsx
@@ -131,6 +131,9 @@ describe('Review page', () => {
     await waitFor(() => {
       expect(screen.getByTestId('assignment-assigned')).toHaveTextContent('assigned:review-admin');
     });
+    fireEvent.click(screen.getByRole('button', { name: 'open-quality-diagnostic' }));
+    expect(screen.getByTestId('review-quality-diagnostic')).toHaveAttribute('data-open', 'true');
+    fireEvent.click(screen.getByRole('button', { name: 'close-quality-diagnostic' }));
 
     fireEvent.click(screen.getByRole('button', { name: 'pages.review.tabs.rejectedTask' }));
 


### PR DESCRIPTION
Closes #820

## Summary
- Move the Review Admin quality diagnostic from the persistent page card into a modal opened from the list toolbar.
- Use Ant Design theme tokens and lightweight status/help presentation, including the requested theme-colored icons and bottom-right actions.
- Show the diagnostic trigger only on unassigned and assigned admin lists; keep it hidden for rejected tasks and Review Members.

## Key Decisions
- Preserve the existing report read, manual start, refresh, retry, polling, and authorization behavior; only change presentation and entry placement.
- Keep the diagnostic component mounted while the modal is closed so background behavior remains unchanged.

## Validation
- Repository checked-push gate passed against dev commit bdb12256: Docpact, LCIA cache, reference data, ESLint, Prettier, TypeScript, and full coverage.
- 420 test suites and 5,740 tests passed; 469/469 tracked source files reached 100/100/100/100 coverage.
- Four locale artifacts are canonical and activation checks pass for zh-CN, en-US, de-DE, and fr-FR.

## Risks / Rollback
- Low UI-only risk; no service/API/backend implementation changed. Rollback by reverting this PR.

## Follow-ups
- After merge and release promotion, complete workspace integration tracking in lca-workspace#576.

## Workspace Integration
- Workspace submodule pointer update remains pending until this change is eligible on the child repository main branch.