### PR TITLE
chore: prepare v0.0.72

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-14"
-lastReviewedCommit: "ead5823accc3b4fbecbea4110b723160633d5965"
+lastReviewedCommit: "bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3"
 lastReviewedNote: 'Reviewed for Next Issue #845: refreshing provenance-bound production evidence and qualification artifacts does not change the repository routing contract.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-14"
-lastReviewedCommit: "bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3"
+lastReviewedCommit: "2864ff58b2778e75baee64375c906ce14c70546c"
 lastReviewedNote: 'Reviewed for Next Issue #845: refreshing provenance-bound production evidence and qualification artifacts does not change the repository routing contract.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3
+lastReviewedCommit: 2864ff58b2778e75baee64375c906ce14c70546c
 lastReviewedNote: 'Reviewed for Next Issue #845: refreshed v0.0.71 production evidence and qualification follow the existing explicit-authorization, exact-cleanup, and deterministic-release contract.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: ead5823accc3b4fbecbea4110b723160633d5965
+lastReviewedCommit: bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3
 lastReviewedNote: 'Reviewed for Next Issue #845: refreshed v0.0.71 production evidence and qualification follow the existing explicit-authorization, exact-cleanup, and deterministic-release contract.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3
+lastReviewedCommit: 2864ff58b2778e75baee64375c906ce14c70546c
 lastReviewedNote: 'Reviewed for Next Issue #846: the startup runtime-config switch, maintenance boundary, static fallback, and focused validation use the existing bootstrap workflow without changing local setup commands.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: ead5823accc3b4fbecbea4110b723160633d5965
+lastReviewedCommit: bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3
 lastReviewedNote: 'Reviewed for Next Issue #846: the startup runtime-config switch, maintenance boundary, static fallback, and focused validation use the existing bootstrap workflow without changing local setup commands.'
 ---
 

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -57,7 +57,7 @@ checkPaths:
   - .github/workflows/build.yml
   - package.json
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: b1b2b6785e5153ac767b45a915f2f53dc127d6ad
+lastReviewedCommit: 2864ff58b2778e75baee64375c906ce14c70546c
 lastReviewedNote: 'Reviewed for Next Issue #845: the refreshed v0.0.71 production proof preserves the existing evidence-binding, explicit authorization, and exact-cleanup boundaries.'
 baselineObservedAt: 2026-07-18
 related:

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: ead5823accc3b4fbecbea4110b723160633d5965
+lastReviewedCommit: bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance runtime, locale, component-test, and packaging changes remain covered by the existing Docpact-first managed push gate.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3
+lastReviewedCommit: 2864ff58b2778e75baee64375c906ce14c70546c
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance runtime, locale, component-test, and packaging changes remain covered by the existing Docpact-first managed push gate.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3
+lastReviewedCommit: 2864ff58b2778e75baee64375c906ce14c70546c
 lastReviewedNote: 'Reviewed for Next Issue #846: the runtime-config service, maintenance UI, static fallback, locale artifacts, focused tests, lint, and production build follow the existing shared-runtime validation contract.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: ead5823accc3b4fbecbea4110b723160633d5965
+lastReviewedCommit: bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3
 lastReviewedNote: 'Reviewed for Next Issue #846: the runtime-config service, maintenance UI, static fallback, locale artifacts, focused tests, lint, and production build follow the existing shared-runtime validation contract.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: ead5823accc3b4fbecbea4110b723160633d5965
+lastReviewedCommit: bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance startup, fallback, environment-switch, and refresh-button coverage fit the existing focused-first strategy without changing the test-improvement plan.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3
+lastReviewedCommit: 2864ff58b2778e75baee64375c906ce14c70546c
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance startup, fallback, environment-switch, and refresh-button coverage fit the existing focused-first strategy without changing the test-improvement plan.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: ead5823accc3b4fbecbea4110b723160633d5965
+lastReviewedCommit: bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3
 lastReviewedNote: 'Reviewed for Next Issue #846: focused maintenance boundary, runtime-config, fallback, locale, lint, and build proof introduces no new exception queue.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3
+lastReviewedCommit: 2864ff58b2778e75baee64375c906ce14c70546c
 lastReviewedNote: 'Reviewed for Next Issue #846: focused maintenance boundary, runtime-config, fallback, locale, lint, and build proof introduces no new exception queue.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3
+lastReviewedCommit: 2864ff58b2778e75baee64375c906ce14c70546c
 lastReviewedNote: 'Reviewed for Next Issue #846: startup maintenance, fail-open service, static fallback, refresh interaction, and environment-switch tests follow the existing component and service test patterns.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: ead5823accc3b4fbecbea4110b723160633d5965
+lastReviewedCommit: bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3
 lastReviewedNote: 'Reviewed for Next Issue #846: startup maintenance, fail-open service, static fallback, refresh interaction, and environment-switch tests follow the existing component and service test patterns.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3
+lastReviewedCommit: 2864ff58b2778e75baee64375c906ce14c70546c
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance startup, timeout, fallback, environment bypass, and refresh behavior require no troubleshooting rule beyond the existing focused-test and gate workflow.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: ead5823accc3b4fbecbea4110b723160633d5965
+lastReviewedCommit: bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3
 lastReviewedNote: 'Reviewed for Next Issue #846: maintenance startup, timeout, fallback, environment bypass, and refresh behavior require no troubleshooting rule beyond the existing focused-test and gate workflow.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
+    "digest": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "497257674d84db3b2578989eba75c14bda1000c6ac4dd917af584ed5e359bbf9",
+          "sha256": "06ceb7195e2705180d87817f606e55b6eb7639888d950402a1f500dd95d1a90c",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "c2bf4189d9a6dfc1e9b99698577088ec8e5bf9a06c6f97ff7a668c937c218f1e",
-    "docs/plans/i18n/route-view-coverage.json": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
+    "docs/plans/i18n/route-view-coverage.json": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-de-DE/glossary.json": "a5fd4e759af2713fbec83f2b95171c7b32206d7218da0401d28d2eecefccce3a",
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "7bd60b20abaece0c7d5678a9fa90f0c4c7dd536a246755ad4acbf4e71cffdfb2"
+  "contextDigest": "8a4e3947debb6be017bbbbf9faaca4306a69635d6429619625cf62e42ab88772"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "7bd60b20abaece0c7d5678a9fa90f0c4c7dd536a246755ad4acbf4e71cffdfb2",
-    "qualityDigest": "7708f21c4e7982708ede709b2647b1f654997d9c0191716215d51ceb6eafadea",
+    "contextDigest": "8a4e3947debb6be017bbbbf9faaca4306a69635d6429619625cf62e42ab88772",
+    "qualityDigest": "a22fe6ef65f462c86315e35e2d0443c4c73d5d81f806a7b9d2cc1f751a501758",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
+    "routeViewCoverageDigest": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "4ab3d24095b5d60c869fd331fe50fece0177851222f42f1f664b4027ecedede7"
+  "activationDigest": "21f20c709a1fae57973cc7542e3ff80bd39e9aed23707d4011d0e98738134fb1"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "0b2304ee30d8e632363e3e5e231be49bdc5bab2ca8eecb458e9b2c189b5f6bb1",
-    "contextDigest": "7bd60b20abaece0c7d5678a9fa90f0c4c7dd536a246755ad4acbf4e71cffdfb2"
+    "contextDigest": "8a4e3947debb6be017bbbbf9faaca4306a69635d6429619625cf62e42ab88772"
   },
   "catalog": {
     "messageCount": 3169,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "7708f21c4e7982708ede709b2647b1f654997d9c0191716215d51ceb6eafadea"
+  "qualityDigest": "a22fe6ef65f462c86315e35e2d0443c4c73d5d81f806a7b9d2cc1f751a501758"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
+    "digest": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "497257674d84db3b2578989eba75c14bda1000c6ac4dd917af584ed5e359bbf9",
+          "sha256": "06ceb7195e2705180d87817f606e55b6eb7639888d950402a1f500dd95d1a90c",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "c2bf4189d9a6dfc1e9b99698577088ec8e5bf9a06c6f97ff7a668c937c218f1e",
-    "docs/plans/i18n/route-view-coverage.json": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
+    "docs/plans/i18n/route-view-coverage.json": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-en-US/glossary.json": "4b8443ea3f91f15383683e9ece6221e40e24ceb75442ea830964b06c12559970",
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "0812de89ff3f3658f4d4848edd1765e42d072263766d0119a2019be2a365f4f3"
+  "contextDigest": "de9bb0673d5c0e12baa6846f8054aef9e0267b243dbf7548e1d3c78c10491899"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "0812de89ff3f3658f4d4848edd1765e42d072263766d0119a2019be2a365f4f3",
-    "qualityDigest": "b3508c45287f11e856388e0411d92d90dd863716bbb19c6c4a6395ed1887d80d",
+    "contextDigest": "de9bb0673d5c0e12baa6846f8054aef9e0267b243dbf7548e1d3c78c10491899",
+    "qualityDigest": "51aaddb974f1ac5b836caa2dcaebc36050f69831098630fbeebbba0573454909",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
+    "routeViewCoverageDigest": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "095b0b167aa3c48209e0095bea9a42b9774fad2fa25d1b13159e0470c8d97559"
+  "activationDigest": "39269a48779a29f8e9c83a1c9e3fc9a2f8aceaf130f454c607bef3a15c0e71cd"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "0b2304ee30d8e632363e3e5e231be49bdc5bab2ca8eecb458e9b2c189b5f6bb1",
-    "contextDigest": "0812de89ff3f3658f4d4848edd1765e42d072263766d0119a2019be2a365f4f3"
+    "contextDigest": "de9bb0673d5c0e12baa6846f8054aef9e0267b243dbf7548e1d3c78c10491899"
   },
   "catalog": {
     "messageCount": 3169,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "b3508c45287f11e856388e0411d92d90dd863716bbb19c6c4a6395ed1887d80d"
+  "qualityDigest": "51aaddb974f1ac5b836caa2dcaebc36050f69831098630fbeebbba0573454909"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
+    "digest": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "497257674d84db3b2578989eba75c14bda1000c6ac4dd917af584ed5e359bbf9",
+          "sha256": "06ceb7195e2705180d87817f606e55b6eb7639888d950402a1f500dd95d1a90c",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "c2bf4189d9a6dfc1e9b99698577088ec8e5bf9a06c6f97ff7a668c937c218f1e",
-    "docs/plans/i18n/route-view-coverage.json": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
+    "docs/plans/i18n/route-view-coverage.json": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-fr-FR/glossary.json": "057cb494f02d980106469f6a16befc102d26db5ac362b9777cd5f97c7729c91b",
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "dd7211a7a1bcc850e49179ff694e8930c64561f27e708948adf0c2bbb2b7b6a8"
+  "contextDigest": "14717116cadd936f3e7859d54ab64c5aa948ceeaa93b59cadf5c569acff433fe"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "dd7211a7a1bcc850e49179ff694e8930c64561f27e708948adf0c2bbb2b7b6a8",
-    "qualityDigest": "6c57761c4936bf43e1d04a40ab912d60716ae3155d9d108cfb649a194009696c",
+    "contextDigest": "14717116cadd936f3e7859d54ab64c5aa948ceeaa93b59cadf5c569acff433fe",
+    "qualityDigest": "fc45eb7e819968bf50c476f04de907ed6c1c763267acf0983c3d8f89ebbc6c2d",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
+    "routeViewCoverageDigest": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "7b49efef164a6bb2590d764f43a3a3eaf2dcc14e2363d9c3b3a3bcddda8a4f54"
+  "activationDigest": "6ac9520404f8ac69c8a6fb376ade290353dc08ef6406099c50f85a4c0ed3e52f"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "0b2304ee30d8e632363e3e5e231be49bdc5bab2ca8eecb458e9b2c189b5f6bb1",
-    "contextDigest": "dd7211a7a1bcc850e49179ff694e8930c64561f27e708948adf0c2bbb2b7b6a8"
+    "contextDigest": "14717116cadd936f3e7859d54ab64c5aa948ceeaa93b59cadf5c569acff433fe"
   },
   "catalog": {
     "messageCount": 3169,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "6c57761c4936bf43e1d04a40ab912d60716ae3155d9d108cfb649a194009696c"
+  "qualityDigest": "fc45eb7e819968bf50c476f04de907ed6c1c763267acf0983c3d8f89ebbc6c2d"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
+    "digest": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "497257674d84db3b2578989eba75c14bda1000c6ac4dd917af584ed5e359bbf9",
+          "sha256": "06ceb7195e2705180d87817f606e55b6eb7639888d950402a1f500dd95d1a90c",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "c2bf4189d9a6dfc1e9b99698577088ec8e5bf9a06c6f97ff7a668c937c218f1e",
-    "docs/plans/i18n/route-view-coverage.json": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
+    "docs/plans/i18n/route-view-coverage.json": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-zh-CN/glossary.json": "c891add0ee4bd6d24c0213d0c839474e145d85867426df796763b8e038053d9b",
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "1e6b7ae4f5612bd3492733b8b2d200d9cf2dcec1288410572cac31f4137821b5"
+  "contextDigest": "7949a83da3716561e35f44bb0fcd27711a3e014c414bf499da43302e62c669fe"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "1e6b7ae4f5612bd3492733b8b2d200d9cf2dcec1288410572cac31f4137821b5",
-    "qualityDigest": "fa5c980141bd5fed7ad7b60a6b9732be9ad4d35c5a8813c832b0453ab0f6d163",
+    "contextDigest": "7949a83da3716561e35f44bb0fcd27711a3e014c414bf499da43302e62c669fe",
+    "qualityDigest": "01b13db7a35bd2eb422219c30f0d43fb1d9b656ab0a5c551dd9278b0908faaf5",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "36300dac06812701ed56868f4d28ca545124aaa8dae117ce6f24b5ba8afb3003",
+    "routeViewCoverageDigest": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "bd6aac78b9514bc3d1e8a6617eb34b073cef0cb093c1bdfe191bf716c01d484d"
+  "activationDigest": "31ef7f03e48d76fd2de5c753c7d9756b0d705405be1ac90f5b1d91b110c3bfe8"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "0b2304ee30d8e632363e3e5e231be49bdc5bab2ca8eecb458e9b2c189b5f6bb1",
-    "contextDigest": "1e6b7ae4f5612bd3492733b8b2d200d9cf2dcec1288410572cac31f4137821b5"
+    "contextDigest": "7949a83da3716561e35f44bb0fcd27711a3e014c414bf499da43302e62c669fe"
   },
   "catalog": {
     "messageCount": 3169,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "fa5c980141bd5fed7ad7b60a6b9732be9ad4d35c5a8813c832b0453ab0f6d163"
+  "qualityDigest": "01b13db7a35bd2eb422219c30f0d43fb1d9b656ab0a5c551dd9278b0908faaf5"
 }

--- a/docs/plans/i18n/route-view-coverage.json
+++ b/docs/plans/i18n/route-view-coverage.json
@@ -353,7 +353,7 @@
       "executedEvidence": [
         {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "497257674d84db3b2578989eba75c14bda1000c6ac4dd917af584ed5e359bbf9"
+          "sha256": "06ceb7195e2705180d87817f606e55b6eb7639888d950402a1f500dd95d1a90c"
         }
       ]
     }

--- a/docs/plans/i18n/semantic-e2e-digest-compatibility.json
+++ b/docs/plans/i18n/semantic-e2e-digest-compatibility.json
@@ -1,48 +1,5 @@
 {
   "schemaVersion": "tiangong.i18n-semantic-e2e-digest-compatibility.v1",
-  "entries": [
-    {
-      "path": "tests/e2e/i18n/production-request-guard.ts",
-      "evidenceObservedHeadCommit": "e5991ff390c8ef3ea767fee9f4acd75b8e39e081",
-      "evidenceSha256": "705432cfe2e6cb39a1f97913ab9f4fb53d516835b4a551d02cc8f29ef41565a4",
-      "compatibleSha256": "26317756b4235350a3ed60b38a76007ddf7e45a44b72814c393efe7108e8a0f2",
-      "scope": "reviewed-read-only-request-guard-expansion",
-      "ownerIssue": "#858",
-      "reviewedAt": "2026-08-14",
-      "sunset": "next-verified-evidence-for-compatible-sha",
-      "proofCommands": [
-        "npm run i18n:evidence:canonical:check",
-        "npm run test:ci -- tests/unit/e2e/productionRequestGuard.test.ts --runInBand --no-coverage"
-      ]
-    },
-    {
-      "path": "tests/unit/e2e/productionRequestGuard.test.ts",
-      "evidenceObservedHeadCommit": "e5991ff390c8ef3ea767fee9f4acd75b8e39e081",
-      "evidenceSha256": "4286f37e6b8132aa49ad4afecd16490e9d55427ba7d3167603a58fbf5e2a7b5a",
-      "compatibleSha256": "036b074b88f3e7274b07977f6beccf50d957596a73876e3837289f17c045444f",
-      "scope": "reviewed-read-only-request-guard-expansion",
-      "ownerIssue": "#858",
-      "reviewedAt": "2026-08-14",
-      "sunset": "next-verified-evidence-for-compatible-sha",
-      "proofCommands": [
-        "npm run i18n:evidence:canonical:check",
-        "npm run test:ci -- tests/unit/e2e/productionRequestGuard.test.ts --runInBand --no-coverage"
-      ]
-    },
-    {
-      "path": "tests/unit/i18n/localeDeliveryContracts.test.ts",
-      "evidenceObservedHeadCommit": "e5991ff390c8ef3ea767fee9f4acd75b8e39e081",
-      "evidenceSha256": "7bbc1317683c8a2418134a59c0de7735973fe74b42ecf76a0ea6b0a79c0b180e",
-      "compatibleSha256": "17f651fd688d46dd6c012e6c1fcdc0eb0fbc16fed8949f44f037d8f1efadece1",
-      "scope": "non-browser-semantic-release-harness-only",
-      "ownerIssue": "#858",
-      "reviewedAt": "2026-08-14",
-      "sunset": "next-verified-evidence-for-compatible-sha",
-      "proofCommands": [
-        "npm run i18n:evidence:canonical:check",
-        "npm run i18n:locale:artifacts:idempotence"
-      ]
-    }
-  ],
+  "entries": [],
   "releaseCandidateWaivers": []
 }

--- a/docs/plans/i18n/semantic-e2e-evidence.json
+++ b/docs/plans/i18n/semantic-e2e-evidence.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": "tiangong.i18n-semantic-e2e-evidence.v1",
   "status": "verified",
-  "generatedAt": "2026-08-14T03:57:26.047Z",
-  "runId": "local-348e22f4-c9f6-4876-889a-d6c46ff49560",
+  "generatedAt": "2026-08-14T11:17:52.396Z",
+  "runId": "local-451d36df-cd3e-4d10-8669-026451b45ee0",
   "candidate": {
-    "configTreeDigest": "c79878bbed6dfb7becc3cedae0fdd08e0926b674293a6f9656469ac8682cc804",
-    "observedHeadCommit": "e5991ff390c8ef3ea767fee9f4acd75b8e39e081",
-    "packageManifestDigest": "2b78dea75572169f5a945913cc1d3b8b9ed3b9ecbb65c4fc0dc45b4126150437",
-    "sourceTreeDigest": "5e99ca4a831c91dd58d7f63f79305e14bacbb7c46f7b4c1b422d8e0d4fdc93c3",
-    "unitTestTreeDigest": "ae69a7638431b555ebc4fafbcbd0603211618484061249695009f8b6523c3592"
+    "configTreeDigest": "d6ae18f74119b7b90412411bfb2f034c8c6ab9ec959d614b67b8006fed87c189",
+    "observedHeadCommit": "2864ff58b2778e75baee64375c906ce14c70546c",
+    "packageManifestDigest": "5101399bc561b0c10e04e1ab5af1ed059ad39f346d7e12c79757ebd2cca95858",
+    "sourceTreeDigest": "7703d24cd13e213addf77f5fd049c640bb8403d077582cb67accac1e8a141cfb",
+    "unitTestTreeDigest": "8810a6c9cdf79addcdabf7675f015f318317d2e04a9018d1c7a1c4b5022261a7"
   },
   "target": {
     "frontend": "candidate-local",
@@ -34,7 +34,7 @@
   "digests": {
     "packageLock": {
       "path": "package-lock.json",
-      "sha256": "9fd2ed1e848cbdbc78d612167f5672ab034a3b5445d5e9a391d113a1fe1f6d69"
+      "sha256": "90f3ead68eaf5860e326a8160c467db06e134ab35eb9814ae67e054879e677b7"
     },
     "runtimeAssets": [
       {
@@ -237,7 +237,7 @@
       },
       {
         "path": "tests/e2e/i18n/production-request-guard.ts",
-        "sha256": "705432cfe2e6cb39a1f97913ab9f4fb53d516835b4a551d02cc8f29ef41565a4"
+        "sha256": "26317756b4235350a3ed60b38a76007ddf7e45a44b72814c393efe7108e8a0f2"
       },
       {
         "path": "tests/e2e/i18n/qualification-reporter.ts",
@@ -293,7 +293,7 @@
       },
       {
         "path": "tests/unit/app.test.tsx",
-        "sha256": "f06a7a68b95c89f6082e45ea57e24f45a5f133879351749b5cbad3b5b3cdadc9"
+        "sha256": "2382de84191678f71e01340a7023191b4779a50d6afe99d5394c2d215a130fb1"
       },
       {
         "path": "tests/unit/components/AccessDenied.test.tsx",
@@ -349,7 +349,7 @@
       },
       {
         "path": "tests/unit/e2e/productionRequestGuard.test.ts",
-        "sha256": "4286f37e6b8132aa49ad4afecd16490e9d55427ba7d3167603a58fbf5e2a7b5a"
+        "sha256": "036b074b88f3e7274b07977f6beccf50d957596a73876e3837289f17c045444f"
       },
       {
         "path": "tests/unit/e2e/referenceRefreshContract.test.ts",
@@ -357,7 +357,7 @@
       },
       {
         "path": "tests/unit/i18n/localeDeliveryContracts.test.ts",
-        "sha256": "7bbc1317683c8a2418134a59c0de7735973fe74b42ecf76a0ea6b0a79c0b180e"
+        "sha256": "17f651fd688d46dd6c012e6c1fcdc0eb0fbc16fed8949f44f037d8f1efadece1"
       },
       {
         "path": "tests/unit/i18n/packageLockRuntimeFingerprint.test.js",
@@ -377,7 +377,7 @@
       },
       {
         "path": "tests/unit/pages/DataProcessing/index.test.tsx",
-        "sha256": "d054a3c3ddc3c12f5be1c9ab19f531c6d870a429f094d898ffad035bd989fbc9"
+        "sha256": "c6df6664fcb609fbd54b225543a8831994ec9ad079975e28d732c99066c1d004"
       },
       {
         "path": "tests/unit/pages/Flowproperties/index.test.tsx",
@@ -469,7 +469,7 @@
       },
       {
         "path": "tests/unit/services/general/publicRoutePolicy.test.ts",
-        "sha256": "27196590823ba86e70f8c74115b726680f37cfe3916f54db231e829a08de7595"
+        "sha256": "e64f1071d54c3669ae16931f1cafac95f9395ba2e2c93015b4b1be13ca68e4b6"
       },
       {
         "path": "tests/unit/services/general/routeViewStateRegistry.test.ts",
@@ -477,7 +477,7 @@
       },
       {
         "path": "tests/unit/wrappers/AuthGuard.test.tsx",
-        "sha256": "2dfded1227b15be060de9d75d1fdde01667f049a39e16889ad15c3f333ad12a6"
+        "sha256": "4a9b3d2ec6df03ee8e54658637d04080e636b2d25e7c5ec198799da503675a8c"
       },
       {
         "path": "tests/unit/wrappers/LoginFlowGuard.test.tsx",
@@ -499,7 +499,7 @@
       },
       {
         "path": "src/app.tsx",
-        "sha256": "3664a1c3256a78cc488cceabf9d577617daed2fad7a789f1f01a2fe484717994"
+        "sha256": "a33f6d65e41e53fc451d0bea994cc5a52bcaf03deebfb8de63c788ede6dfec1c"
       },
       {
         "path": "src/components/AccessDenied/index.tsx",
@@ -543,7 +543,7 @@
       },
       {
         "path": "src/pages/DataProcessing/index.tsx",
-        "sha256": "940f8843458a176296cfb41b824204bedd203b45981657b409dc1d38734d50da"
+        "sha256": "82cc9efa10be3831085a3d185f2bd25a6a79adbdce7186e2781d0c1b18a3fc46"
       },
       {
         "path": "src/pages/Flowproperties/index.tsx",
@@ -643,7 +643,7 @@
       },
       {
         "path": "src/wrappers/AuthGuard.tsx",
-        "sha256": "07b1736f8f5bd09b67b387cfeaacbc13293bdfb0e35648510d800229d3f89364"
+        "sha256": "0a3a4fb13c52d9415c4d9be393938619eb431b88eaa6e79bfabf1ccfd1af823b"
       },
       {
         "path": "src/wrappers/LoginFlowGuard.tsx",

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "4f3a24dcadf79f6b8f3fc0c539c4584052fc3b76fa10fab2163769c0ba869fdc"
+    "runResultSha256": "02de8cc080facf23d4a7066d4b44ecc83512aa910f16b67f04303b102296cdef"
   },
-  "environmentManifestSha256": "24b9985f1823747fbe219b873814603c5ad0fdcb50aa82bdad95a71f1812a524",
+  "environmentManifestSha256": "cf5643be90445b5db08ed9565d079cadf7e8a50fbfa192e24fc7441093f9632a",
   "externalRequests": 0,
-  "generatedAt": "2026-08-14T10:51:17.544Z",
+  "generatedAt": "2026-08-14T11:36:11.215Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "1a19caeeb2a6f9d5658ef083ecc2cf6bfbc584f37e6f10e8bcfcbea2bdb83c62",
-  "qualifiedCommit": "bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3",
-  "qualifiedTree": "8bd7d3907ea48903e4a33a227a291e146df9a520",
+  "qualificationInputSha256": "93123325211692bf5c953452609a9f5d55786a11980c692420daa4029da513ab",
+  "qualifiedCommit": "ad64fd3d6752c2ab9580c629b5640f83aa080046",
+  "qualifiedTree": "b1fc70b5bc3bf994af4b280a4377e394758e7458",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "6ffc44acef34672128e82195d23875594eef6d88dacc2ca3d6638626202fbde0"
+    "runResultSha256": "4f3a24dcadf79f6b8f3fc0c539c4584052fc3b76fa10fab2163769c0ba869fdc"
   },
-  "environmentManifestSha256": "b7ed2200ac0056a4e63347f7b1c982864ba6865ed47ce7c68aaf31c70f1b0c66",
+  "environmentManifestSha256": "24b9985f1823747fbe219b873814603c5ad0fdcb50aa82bdad95a71f1812a524",
   "externalRequests": 0,
-  "generatedAt": "2026-08-14T04:12:45.305Z",
+  "generatedAt": "2026-08-14T10:51:17.544Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "ec69d17e9acb17a1aece22926dbe97bb4a095a1a7dee6f0ff1202123179723a1",
-  "qualifiedCommit": "bfcc81929de5f04f697d535057046265cc088cda",
-  "qualifiedTree": "8d41585522ab47949d42c11c5b8591488b95e49b",
+  "qualificationInputSha256": "1a19caeeb2a6f9d5658ef083ecc2cf6bfbc584f37e6f10e8bcfcbea2bdb83c62",
+  "qualifiedCommit": "bdb122563a6ae4fd4bfe4bb3c6aa1302246119a3",
+  "qualifiedTree": "8bd7d3907ea48903e4a33a227a291e146df9a520",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.71",
+      "version": "0.0.72",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#853

## Summary
- Prepare the deterministic v0.0.72 package and lockfile version metadata from the latest dev merge.
- Record exact authenticated candidate-local/production-backend semantic evidence and regenerate all four locale delivery summaries.

## Key Decisions
- Bind verified evidence to clean candidate 2864ff58 and retain the resulting qualification receipt on the same release branch.
- Sunset the three Issue #858 digest-compatibility records because the fresh verified evidence now directly covers their compatible hashes.

## Validation
- Authenticated release E2E: 60 passed, 33 designed skips, 49/49 stable assertion IDs across Chromium/Firefox/WebKit and zh-CN/en-US/de-DE/fr-FR; production Process created=1, cleaned=1, leaked=0.
- Credential-free qualification: 63 passed, 30 designed skips across all 93 discovered cases.
- release:preflight passed for qualification, all four production locale gates, and five reference resources.
- Managed pre-push gate: 420/420 suites and 5,738/5,738 tests passed; 469/469 tracked source files reached 100% statements/branches/functions/lines.

## Risks / Rollback
- Low release-metadata risk. Evidence is digest-bound to the exact candidate; rollback is to revert this PR before promotion. The authorized production fixture was exactly cleaned with zero leaks.

## Follow-ups
- After this PR merges to dev, create a separate immutable dev-to-main promotion PR and stop for maintainer merge.

## Workspace Integration
- After the main promotion merges, update the lca-workspace tiangong-lca-next submodule pointer under the root integration policy.