### PR TITLE
test: record v0.0.73 production E2E evidence

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-14"
-lastReviewedCommit: "f56913ac642a6c83f789bc6687702ad11dcbdfce"
-lastReviewedNote: 'Reviewed for Next Issue #845: refreshing provenance-bound production evidence and qualification artifacts does not change the repository routing contract.'
+lastReviewedAt: "2026-08-15"
+lastReviewedCommit: "d6b543eeb49679d1cccbb71ea69b2d2475f1bd57"
+lastReviewedNote: 'Reviewed for Next Issue #820: refreshing v0.0.73 provenance-bound production evidence and qualification artifacts does not change the repository routing contract.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,9 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: f56913ac642a6c83f789bc6687702ad11dcbdfce
-lastReviewedNote: 'Reviewed for Next Issue #845: refreshed v0.0.71 production evidence and qualification follow the existing explicit-authorization, exact-cleanup, and deterministic-release contract.'
+lastReviewedAt: 2026-08-15
+lastReviewedCommit: f99036c60dbda9a7adabc735f0037fca9d2197c6
+lastReviewedNote: 'Reviewed for Next Issue #820: refreshed v0.0.73 production evidence, qualification, and Docpact records follow the existing explicit-authorization, exact-cleanup, and deterministic-release contract.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -29,9 +29,9 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - .nvmrc
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: f56913ac642a6c83f789bc6687702ad11dcbdfce
-lastReviewedNote: 'Reviewed for Next Issue #846: the startup runtime-config switch, maintenance boundary, static fallback, and focused validation use the existing bootstrap workflow without changing local setup commands.'
+lastReviewedAt: 2026-08-15
+lastReviewedCommit: f99036c60dbda9a7adabc735f0037fca9d2197c6
+lastReviewedNote: 'Reviewed for Next Issue #820: the v0.0.73 evidence refresh, qualification, and release preflight use the existing bootstrap workflow without changing local setup commands.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -56,9 +56,9 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - .github/workflows/build.yml
   - package.json
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: 2864ff58b2778e75baee64375c906ce14c70546c
-lastReviewedNote: 'Reviewed for Next Issue #845: the refreshed v0.0.71 production proof preserves the existing evidence-binding, explicit authorization, and exact-cleanup boundaries.'
+lastReviewedAt: 2026-08-15
+lastReviewedCommit: d6b543eeb49679d1cccbb71ea69b2d2475f1bd57
+lastReviewedNote: 'Reviewed for Next Issue #820: the refreshed v0.0.73 production proof preserves the existing evidence-binding, explicit authorization, and exact-cleanup boundaries.'
 baselineObservedAt: 2026-07-18
 related:
   - ../../AGENTS.md

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -30,9 +30,9 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: f56913ac642a6c83f789bc6687702ad11dcbdfce
-lastReviewedNote: 'Reviewed for Next Issue #846: maintenance runtime, locale, component-test, and packaging changes remain covered by the existing Docpact-first managed push gate.'
+lastReviewedAt: 2026-08-15
+lastReviewedCommit: d6b543eeb49679d1cccbb71ea69b2d2475f1bd57
+lastReviewedNote: 'Reviewed for Next Issue #820: refreshed production evidence, locale artifacts, and qualification receipts remain covered by the existing Docpact-first managed push gate.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,9 +30,9 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: f56913ac642a6c83f789bc6687702ad11dcbdfce
-lastReviewedNote: 'Reviewed for Next Issue #846: the runtime-config service, maintenance UI, static fallback, locale artifacts, focused tests, lint, and production build follow the existing shared-runtime validation contract.'
+lastReviewedAt: 2026-08-15
+lastReviewedCommit: d6b543eeb49679d1cccbb71ea69b2d2475f1bd57
+lastReviewedNote: 'Reviewed for Next Issue #820: v0.0.73 semantic evidence, regenerated locale artifacts, qualification, and release preflight follow the existing validation contract.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -27,9 +27,9 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - package.json
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: f56913ac642a6c83f789bc6687702ad11dcbdfce
-lastReviewedNote: 'Reviewed for Next Issue #846: maintenance startup, fallback, environment-switch, and refresh-button coverage fit the existing focused-first strategy without changing the test-improvement plan.'
+lastReviewedAt: 2026-08-15
+lastReviewedCommit: d6b543eeb49679d1cccbb71ea69b2d2475f1bd57
+lastReviewedNote: 'Reviewed for Next Issue #820: the v0.0.73 evidence refresh preserves the existing focused-first test strategy without adding a new testing initiative.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -29,9 +29,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: f56913ac642a6c83f789bc6687702ad11dcbdfce
-lastReviewedNote: 'Reviewed for Next Issue #846: focused maintenance boundary, runtime-config, fallback, locale, lint, and build proof introduces no new exception queue.'
+lastReviewedAt: 2026-08-15
+lastReviewedCommit: d6b543eeb49679d1cccbb71ea69b2d2475f1bd57
+lastReviewedNote: 'Reviewed for Next Issue #820: 63 passing qualification tests, 30 designed skips, and production-ready locale artifacts introduce no new exception queue.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -30,9 +30,9 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: f56913ac642a6c83f789bc6687702ad11dcbdfce
-lastReviewedNote: 'Reviewed for Next Issue #846: startup maintenance, fail-open service, static fallback, refresh interaction, and environment-switch tests follow the existing component and service test patterns.'
+lastReviewedAt: 2026-08-15
+lastReviewedCommit: d6b543eeb49679d1cccbb71ea69b2d2475f1bd57
+lastReviewedNote: 'Reviewed for Next Issue #820: the v0.0.73 semantic evidence refresh follows the existing qualification and evidence-binding test patterns.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -27,9 +27,9 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: f56913ac642a6c83f789bc6687702ad11dcbdfce
-lastReviewedNote: 'Reviewed for Next Issue #846: maintenance startup, timeout, fallback, environment bypass, and refresh behavior require no troubleshooting rule beyond the existing focused-test and gate workflow.'
+lastReviewedAt: 2026-08-15
+lastReviewedCommit: d6b543eeb49679d1cccbb71ea69b2d2475f1bd57
+lastReviewedNote: 'Reviewed for Next Issue #820: evidence digest rebinding and current-candidate qualification require no troubleshooting rule beyond the existing release and gate workflow.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
+    "digest": "f0d812a92bb7c0f39948ee1301a2eb73415d8eb194763729d3819d28ff62b1d0",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "06ceb7195e2705180d87817f606e55b6eb7639888d950402a1f500dd95d1a90c",
+          "sha256": "74d17ab1b935d07e5beeeae34f07d29ecc06dd305a6bc59b06a867c5a018b481",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "c2bf4189d9a6dfc1e9b99698577088ec8e5bf9a06c6f97ff7a668c937c218f1e",
-    "docs/plans/i18n/route-view-coverage.json": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
+    "docs/plans/i18n/route-view-coverage.json": "f0d812a92bb7c0f39948ee1301a2eb73415d8eb194763729d3819d28ff62b1d0",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-de-DE/glossary.json": "a5fd4e759af2713fbec83f2b95171c7b32206d7218da0401d28d2eecefccce3a",
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "4daada40346e8620729a2cce599f159bba3af8e522a9731d3335036eb8236d0c"
+  "contextDigest": "bca39c586c3c099cd06276c0388b687605dd170e834903a04733c1f013f0a379"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4daada40346e8620729a2cce599f159bba3af8e522a9731d3335036eb8236d0c",
-    "qualityDigest": "520e3cda139e66f0f2a1cad94a156056d3ca08dc259d3d2323fd9e60a2d1dab3",
+    "contextDigest": "bca39c586c3c099cd06276c0388b687605dd170e834903a04733c1f013f0a379",
+    "qualityDigest": "7b9e723eded766e48d893848084adf66ce61ffc9abc5159eb2b91f8093c94f33",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
+    "routeViewCoverageDigest": "f0d812a92bb7c0f39948ee1301a2eb73415d8eb194763729d3819d28ff62b1d0",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "437b6bf5004df2b00831a96e2c71685845163d71bb8551c0d060a307ccaa8d50"
+  "activationDigest": "5bfbfa32a7a23005ec3dc8435f2fb654ab88f8ea31968d432f64b05d5cb8e7d0"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
-    "contextDigest": "4daada40346e8620729a2cce599f159bba3af8e522a9731d3335036eb8236d0c"
+    "contextDigest": "bca39c586c3c099cd06276c0388b687605dd170e834903a04733c1f013f0a379"
   },
   "catalog": {
     "messageCount": 3169,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "520e3cda139e66f0f2a1cad94a156056d3ca08dc259d3d2323fd9e60a2d1dab3"
+  "qualityDigest": "7b9e723eded766e48d893848084adf66ce61ffc9abc5159eb2b91f8093c94f33"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
+    "digest": "f0d812a92bb7c0f39948ee1301a2eb73415d8eb194763729d3819d28ff62b1d0",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "06ceb7195e2705180d87817f606e55b6eb7639888d950402a1f500dd95d1a90c",
+          "sha256": "74d17ab1b935d07e5beeeae34f07d29ecc06dd305a6bc59b06a867c5a018b481",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "c2bf4189d9a6dfc1e9b99698577088ec8e5bf9a06c6f97ff7a668c937c218f1e",
-    "docs/plans/i18n/route-view-coverage.json": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
+    "docs/plans/i18n/route-view-coverage.json": "f0d812a92bb7c0f39948ee1301a2eb73415d8eb194763729d3819d28ff62b1d0",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-en-US/glossary.json": "4b8443ea3f91f15383683e9ece6221e40e24ceb75442ea830964b06c12559970",
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "2794f0a4bf847deafedf8925cd2f38b2391ddfdd654a9e04f11fb9b621a274ce"
+  "contextDigest": "cbcf80392fe057d8d3fbf852f16290d4a490a0d81ba928286bcab32e54943102"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "2794f0a4bf847deafedf8925cd2f38b2391ddfdd654a9e04f11fb9b621a274ce",
-    "qualityDigest": "16c3fd6829f95407ac9a7d23d29ec3c2b87dc3779dc7e0838e147791bbda92cb",
+    "contextDigest": "cbcf80392fe057d8d3fbf852f16290d4a490a0d81ba928286bcab32e54943102",
+    "qualityDigest": "feda2c3db5dfe58a60c698822cdc8b66bab85a3c1583483621e8f808d9e14485",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
+    "routeViewCoverageDigest": "f0d812a92bb7c0f39948ee1301a2eb73415d8eb194763729d3819d28ff62b1d0",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "64c0ebb9318e00d5434afa894cc8b5df69ad7bc56f3eb768175bdcc7c11dfff2"
+  "activationDigest": "066e5bc24ee08e91b88c4e0c75c4c4c0b780303a900f810d31ccd6935b0d76a7"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
-    "contextDigest": "2794f0a4bf847deafedf8925cd2f38b2391ddfdd654a9e04f11fb9b621a274ce"
+    "contextDigest": "cbcf80392fe057d8d3fbf852f16290d4a490a0d81ba928286bcab32e54943102"
   },
   "catalog": {
     "messageCount": 3169,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "16c3fd6829f95407ac9a7d23d29ec3c2b87dc3779dc7e0838e147791bbda92cb"
+  "qualityDigest": "feda2c3db5dfe58a60c698822cdc8b66bab85a3c1583483621e8f808d9e14485"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
+    "digest": "f0d812a92bb7c0f39948ee1301a2eb73415d8eb194763729d3819d28ff62b1d0",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "06ceb7195e2705180d87817f606e55b6eb7639888d950402a1f500dd95d1a90c",
+          "sha256": "74d17ab1b935d07e5beeeae34f07d29ecc06dd305a6bc59b06a867c5a018b481",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "c2bf4189d9a6dfc1e9b99698577088ec8e5bf9a06c6f97ff7a668c937c218f1e",
-    "docs/plans/i18n/route-view-coverage.json": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
+    "docs/plans/i18n/route-view-coverage.json": "f0d812a92bb7c0f39948ee1301a2eb73415d8eb194763729d3819d28ff62b1d0",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-fr-FR/glossary.json": "057cb494f02d980106469f6a16befc102d26db5ac362b9777cd5f97c7729c91b",
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "8b67b166d405bf124c1217e44fe1ed46a6d8441c138341dc9dcf0d115424e782"
+  "contextDigest": "bebaae817319765f5b18fa082b5857e12e13de6b8e673d75c44ff189f37f3a2a"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "8b67b166d405bf124c1217e44fe1ed46a6d8441c138341dc9dcf0d115424e782",
-    "qualityDigest": "e7e35c287cf40a63d7530b1085ca2f3acf17ce3b29ceeab2ec875de8baf4318c",
+    "contextDigest": "bebaae817319765f5b18fa082b5857e12e13de6b8e673d75c44ff189f37f3a2a",
+    "qualityDigest": "e542ee14681568e0b35e641dd087fd4b8f0c0f79b15f5b003b96378bc3fab004",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
+    "routeViewCoverageDigest": "f0d812a92bb7c0f39948ee1301a2eb73415d8eb194763729d3819d28ff62b1d0",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -116,5 +116,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "8a59fa406e9ddb3228314791ada891acf6d5abbb6598b4c2e459efde584464c7"
+  "activationDigest": "ea427e2244d73ecf76cd6a96d4a478d95967adf51b11c09ab926e3bee8ae911f"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
-    "contextDigest": "8b67b166d405bf124c1217e44fe1ed46a6d8441c138341dc9dcf0d115424e782"
+    "contextDigest": "bebaae817319765f5b18fa082b5857e12e13de6b8e673d75c44ff189f37f3a2a"
   },
   "catalog": {
     "messageCount": 3169,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "e7e35c287cf40a63d7530b1085ca2f3acf17ce3b29ceeab2ec875de8baf4318c"
+  "qualityDigest": "e542ee14681568e0b35e641dd087fd4b8f0c0f79b15f5b003b96378bc3fab004"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -95,7 +95,7 @@
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
+    "digest": "f0d812a92bb7c0f39948ee1301a2eb73415d8eb194763729d3819d28ff62b1d0",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -113,7 +113,7 @@
         "requiredAssertionCount": 49,
         "executionEvidence": {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "06ceb7195e2705180d87817f606e55b6eb7639888d950402a1f500dd95d1a90c",
+          "sha256": "74d17ab1b935d07e5beeeae34f07d29ecc06dd305a6bc59b06a867c5a018b481",
           "contractDigest": "b9def444859e8fabbc7abed5c6b274e1c24896dd5de0f0ea38b28aacc0570e5e",
           "assertionCount": 49,
           "internalLocalizationAssertionCount": 42,
@@ -1114,11 +1114,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "c2bf4189d9a6dfc1e9b99698577088ec8e5bf9a06c6f97ff7a668c937c218f1e",
-    "docs/plans/i18n/route-view-coverage.json": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
+    "docs/plans/i18n/route-view-coverage.json": "f0d812a92bb7c0f39948ee1301a2eb73415d8eb194763729d3819d28ff62b1d0",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-zh-CN/glossary.json": "c891add0ee4bd6d24c0213d0c839474e145d85867426df796763b8e038053d9b",
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "fbfd89a9189535349a1e4e141cf3e36a5ae62489c7a026cf7917cc83c3ec83fa"
+  "contextDigest": "f4b514f5534ea357a37d9b1f41482f8705155a2fa24342a664b19ba9e213bf6e"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "fbfd89a9189535349a1e4e141cf3e36a5ae62489c7a026cf7917cc83c3ec83fa",
-    "qualityDigest": "9d4a347aff1759512c0f7e36be01138b9a03f78496932ae267109ce701525c3a",
+    "contextDigest": "f4b514f5534ea357a37d9b1f41482f8705155a2fa24342a664b19ba9e213bf6e",
+    "qualityDigest": "aebc2995f5548ca49cbe77404d1cf331e0f76846be23cf6d3b42bb37bf197854",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
-    "routeViewCoverageDigest": "d90277b2a9856315cefbb27a9d5bef74d15bc39f773052c12b066761f7016fdc",
+    "routeViewCoverageDigest": "f0d812a92bb7c0f39948ee1301a2eb73415d8eb194763729d3819d28ff62b1d0",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -112,5 +112,5 @@
   },
   "referenceResourceBlockers": [],
   "productionActivationBlockers": [],
-  "activationDigest": "e094707111cf1cf3c5b863502697d646e87042864398d866f10f075e53fbe645"
+  "activationDigest": "f391ceda7121297c1c4b11d19b4ebaefba5be63f70638326205ddffbf65b79fc"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
-    "contextDigest": "fbfd89a9189535349a1e4e141cf3e36a5ae62489c7a026cf7917cc83c3ec83fa"
+    "contextDigest": "f4b514f5534ea357a37d9b1f41482f8705155a2fa24342a664b19ba9e213bf6e"
   },
   "catalog": {
     "messageCount": 3169,
@@ -52,5 +52,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "9d4a347aff1759512c0f7e36be01138b9a03f78496932ae267109ce701525c3a"
+  "qualityDigest": "aebc2995f5548ca49cbe77404d1cf331e0f76846be23cf6d3b42bb37bf197854"
 }

--- a/docs/plans/i18n/route-view-coverage.json
+++ b/docs/plans/i18n/route-view-coverage.json
@@ -353,7 +353,7 @@
       "executedEvidence": [
         {
           "path": "docs/plans/i18n/semantic-e2e-evidence.json",
-          "sha256": "06ceb7195e2705180d87817f606e55b6eb7639888d950402a1f500dd95d1a90c"
+          "sha256": "74d17ab1b935d07e5beeeae34f07d29ecc06dd305a6bc59b06a867c5a018b481"
         }
       ]
     }

--- a/docs/plans/i18n/semantic-e2e-evidence.json
+++ b/docs/plans/i18n/semantic-e2e-evidence.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": "tiangong.i18n-semantic-e2e-evidence.v1",
   "status": "verified",
-  "generatedAt": "2026-08-14T11:17:52.396Z",
-  "runId": "local-451d36df-cd3e-4d10-8669-026451b45ee0",
+  "generatedAt": "2026-08-15T02:14:01.770Z",
+  "runId": "local-69152287-f7b1-41b7-9023-df263728ade0",
   "candidate": {
     "configTreeDigest": "d6ae18f74119b7b90412411bfb2f034c8c6ab9ec959d614b67b8006fed87c189",
-    "observedHeadCommit": "2864ff58b2778e75baee64375c906ce14c70546c",
+    "observedHeadCommit": "30c76a8fbb3791aad3106e75c9b6d6e758730178",
     "packageManifestDigest": "5101399bc561b0c10e04e1ab5af1ed059ad39f346d7e12c79757ebd2cca95858",
-    "sourceTreeDigest": "7703d24cd13e213addf77f5fd049c640bb8403d077582cb67accac1e8a141cfb",
-    "unitTestTreeDigest": "8810a6c9cdf79addcdabf7675f015f318317d2e04a9018d1c7a1c4b5022261a7"
+    "sourceTreeDigest": "e31480aeba670f1f6de67beaf64fdd200e9f3a4e24ee9c30af6b7187ec489d7a",
+    "unitTestTreeDigest": "44d8a2bbeb208dd18286ed02bd06353a52027ff80362449757a1eaee21f78906"
   },
   "target": {
     "frontend": "candidate-local",
@@ -425,11 +425,11 @@
       },
       {
         "path": "tests/unit/pages/Review/Components/AssignmentReview.test.tsx",
-        "sha256": "f2ebb8349076983763284b4cc467cca1a019fb37ffe455d75ca6fab9abe1ffb3"
+        "sha256": "3215d4fbef9fef285a6b471a9cb8bddc14b7c9bac0ad4a5daeddd97ae6049387"
       },
       {
         "path": "tests/unit/pages/Review/index.test.tsx",
-        "sha256": "553f85cd073d0580976697488343ffe3f55dd5cd6173be3c00e1320f58166c4f"
+        "sha256": "1377925ca44e8a8be972ac64164d2b699e9deeb0e14db2a54f7ba5b7be944494"
       },
       {
         "path": "tests/unit/pages/Sources/index.test.tsx",
@@ -583,7 +583,7 @@
       },
       {
         "path": "src/pages/Review/index.tsx",
-        "sha256": "66014539541e015ccb4e25a042104f1b3d8215803636fb99ab6f6724437584d7"
+        "sha256": "ec1bd7394f07b3c8d2c336abd27efbcb9b253d7c5ce6b8b7601c660dca75ef22"
       },
       {
         "path": "src/pages/Sources/index.tsx",

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "02de8cc080facf23d4a7066d4b44ecc83512aa910f16b67f04303b102296cdef"
+    "runResultSha256": "6d014cc6dcb862e588851f6255580c1129098020d476a4f2de7f3dbeed5f4397"
   },
-  "environmentManifestSha256": "cf5643be90445b5db08ed9565d079cadf7e8a50fbfa192e24fc7441093f9632a",
+  "environmentManifestSha256": "844dd79b77cf8aefdd4dad5ff959cf3a1aad1b662db42d5087bae9120b9e7891",
   "externalRequests": 0,
-  "generatedAt": "2026-08-14T11:36:11.215Z",
+  "generatedAt": "2026-08-15T01:26:15.366Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "93123325211692bf5c953452609a9f5d55786a11980c692420daa4029da513ab",
-  "qualifiedCommit": "ad64fd3d6752c2ab9580c629b5640f83aa080046",
-  "qualifiedTree": "b1fc70b5bc3bf994af4b280a4377e394758e7458",
+  "qualificationInputSha256": "aed7af497a25862b6f7775b9eb0052a0af6e9ce1dc70ad61fafa5d7bb676c9a1",
+  "qualifiedCommit": "0f58605e5fc7e23d709dcaf8bb152e1ddbdedb1c",
+  "qualifiedTree": "7f2d1e756e026cc687be87c760849ddf57e9da0b",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }

--- a/docs/plans/i18n/semantic-harness-qualification-receipt.json
+++ b/docs/plans/i18n/semantic-harness-qualification-receipt.json
@@ -29,15 +29,15 @@
   },
   "diagnostics": {
     "retainedOutsideGit": true,
-    "runResultSha256": "6d014cc6dcb862e588851f6255580c1129098020d476a4f2de7f3dbeed5f4397"
+    "runResultSha256": "65586851476e9a2eeb910847540aad7713f9c1d1e948c6b78007c62e44e1f591"
   },
-  "environmentManifestSha256": "844dd79b77cf8aefdd4dad5ff959cf3a1aad1b662db42d5087bae9120b9e7891",
+  "environmentManifestSha256": "29d6ede584d9626fff760752273b7762eb6fdc717598d60dc1f41ea2491f4e06",
   "externalRequests": 0,
-  "generatedAt": "2026-08-15T01:26:15.366Z",
+  "generatedAt": "2026-08-15T02:36:32.255Z",
   "productionWrites": 0,
-  "qualificationInputSha256": "aed7af497a25862b6f7775b9eb0052a0af6e9ce1dc70ad61fafa5d7bb676c9a1",
-  "qualifiedCommit": "0f58605e5fc7e23d709dcaf8bb152e1ddbdedb1c",
-  "qualifiedTree": "7f2d1e756e026cc687be87c760849ddf57e9da0b",
+  "qualificationInputSha256": "6fbf7f95b20f179f62a6d1a250ba0ddaa2acb0da0e604ea1eda53c871869ca0b",
+  "qualifiedCommit": "2506e0b8654c478c79bc2b3cd2a60b78247d4a46",
+  "qualifiedTree": "ba95114cf55998fb911ecee38a062b293305dfd9",
   "schemaVersion": "tiangong.semantic-harness-qualification.v1",
   "status": "qualified"
 }


### PR DESCRIPTION
## Summary
- Refs linancn/tiangong-lca-next#820; records current authenticated production semantic evidence for the v0.0.73 release prerequisite.
- Rebinds the evidence digest and regenerates all four locale context, quality, and activation artifacts.

## Key Decisions
- Keep production credentials and raw run diagnostics outside Git; commit only canonical digest-bound evidence and exact cleanup counts.
- Land evidence on dev before rerunning the deterministic v0.0.73 version PR.

## Validation
- Authenticated production semantic E2E: 60 passed, 33 designed skips; created=1, cleaned=1, leaked=0.
- Credential-free qualification: 63 passed, 30 designed skips.
- npm run i18n:locale:artifacts:idempotence; npm run i18n:evidence:canonical:check; npm run release:preflight.
- Managed pre-push gate: Docpact passed and 469/469 tracked source files reached 100/100/100/100 coverage.

## Risks / Rollback
- Low: tracked changes are canonical evidence, generated locale artifacts, qualification receipt, and required review metadata; rollback by reverting this PR.

## Follow-ups
- After merge, rerun release:to-dev for v0.0.73; after that Release PR merges, run release:promote-dev-to-main.

## Workspace Integration
- The eventual v0.0.73 main promotion requires the normal lca-workspace submodule integration; this prerequisite PR alone is not delivery completion.