### PR TITLE
chore: prepare v0.0.74 on dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-15"
-lastReviewedCommit: "2f4cad4bcf738aae2fb965d3d7ad49fce8832513"
+lastReviewedCommit: "c8e47ab3c22a0f5457ba9db3114272a7b0fc9152"
 lastReviewedNote: 'Reviewed for Next Issue #867: deterministic qualification configuration and expanded proof inputs remain covered by the existing environment and testing routes.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: 2f4cad4bcf738aae2fb965d3d7ad49fce8832513
+lastReviewedCommit: c8e47ab3c22a0f5457ba9db3114272a7b0fc9152
 lastReviewedNote: 'Reviewed for Next Issue #867: release proof remains external and content-addressed, while closed qualification is independent of deployment configuration.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: 2f4cad4b
+lastReviewedCommit: c8e47ab3c22a0f5457ba9db3114272a7b0fc9152
 lastReviewedNote: 'Reviewed for Next Issue #867: semantic qualification uses deterministic non-production configuration and deployment env remains separately selectable.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: 2f4cad4b
+lastReviewedCommit: c8e47ab3c22a0f5457ba9db3114272a7b0fc9152
 lastReviewedNote: 'Reviewed for Next Issue #867: local pushes remain browser-free and reusable closed-simulator proof excludes deployment-only environment drift.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: 2f4cad4b
+lastReviewedCommit: c8e47ab3c22a0f5457ba9db3114272a7b0fc9152
 lastReviewedNote: 'Reviewed for Next Issue #867: closed qualification uses deterministic non-production configuration and excludes deployment-only environment drift from its reusable behavior proof.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: 2f4cad4b
+lastReviewedCommit: c8e47ab3c22a0f5457ba9db3114272a7b0fc9152
 lastReviewedNote: 'Reviewed for Next Issue #867: semantic proof now separates deterministic simulator behavior from deployment-target configuration.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: 2f4cad4b
+lastReviewedCommit: c8e47ab3c22a0f5457ba9db3114272a7b0fc9152
 lastReviewedNote: 'Reviewed for Next Issue #867: current qualification proof uses a fixed non-production backend identity and no tracked proof-maintenance queue.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: 2f4cad4b
+lastReviewedCommit: c8e47ab3c22a0f5457ba9db3114272a7b0fc9152
 lastReviewedNote: 'Reviewed for Next Issue #867: reusable qualification proof uses deterministic non-production configuration and a closed behavior-input identity.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: 2f4cad4b
+lastReviewedCommit: c8e47ab3c22a0f5457ba9db3114272a7b0fc9152
 lastReviewedNote: 'Reviewed for Next Issue #867: troubleshooting distinguishes deployment-only drift from actual qualification input changes.'
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.73",
+  "version": "0.0.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.73",
+      "version": "0.0.74",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.73",
+  "version": "0.0.74",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
<!-- tiangong-next-release-automation:v1 issue=867 version=0.0.74 base=c8e47ab3c22a0f5457ba9db3114272a7b0fc9152 candidate=73ef09a476152de3b4eb42c07db16eafb319f3c4 -->

## Branch Contract

- base branch: `dev`
- validated environment: repository-managed dev gate
- back-merge required after merge: No
- root workspace integration expected: after later dev-to-main promotion

## Linked Issue

Refs #867

## Change Facts

- Prepare version `0.0.74` from exact dev base `c8e47ab3c22a0f5457ba9db3114272a7b0fc9152`.
- Keep package.json and both package-lock root version fields aligned.
- Do not generate or commit browser proof from the version-only release command.
- Record Docpact review evidence only after the command proves the candidate has no other semantic change.
- Reviewed paths:
  - `.docpact/config.yaml`
  - `AGENTS.md`
  - `DEV.md`
  - `docs/agents/prepush-gate-policy.md`
  - `docs/agents/repo-validation.md`
  - `docs/agents/test_improvement_plan.md`
  - `docs/agents/test_todo_list.md`
  - `docs/agents/testing-patterns.md`
  - `docs/agents/testing-troubleshooting.md`

## Validation Facts

- Candidate: `73ef09a476152de3b4eb42c07db16eafb319f3c4`
- Main baseline: `23fa0b7e3df9c39a7fadaecc277500b9dd256954`
- Semantic qualification: `deferred_to_main_candidate_gate`; static preflight: `passed`
- Docpact automatic-review status: `completed`
- Docpact checked the complete main-to-candidate promotion range before the dev PR was created.
- Final push used the repository-managed dev gate; exact browser qualification is required by the later main-target PR.

## Risks And Follow-Up

- Merge this PR into dev, then run the deterministic dev-to-main promotion command with this PR number.
