### PR TITLE
chore: prepare v0.0.75 on dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-08-15'
-lastReviewedCommit: 'c8e47ab3c22a0f5457ba9db3114272a7b0fc9152'
+lastReviewedAt: "2026-08-15"
+lastReviewedCommit: "c2d369386438a8ff88f47e637784feda2f0cf3f5"
 lastReviewedNote: 'Reviewed for Next Issue #867: validation routes now assign one aggregate proof to the exact dev Release PR and proof-only checks to immutable promotion/publication.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: c8e47ab3c22a0f5457ba9db3114272a7b0fc9152
+lastReviewedCommit: c2d369386438a8ff88f47e637784feda2f0cf3f5
 lastReviewedNote: 'Reviewed for Next Issue #867: exact dev Release PRs own aggregate acceptance and immutable main delivery reuses their external proof.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: c8e47ab3c22a0f5457ba9db3114272a7b0fc9152
+lastReviewedCommit: c2d369386438a8ff88f47e637784feda2f0cf3f5
 lastReviewedNote: 'Reviewed for Next Issue #867: the exact dev Release PR owns aggregate acceptance and later release stages verify its external proof.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: c8e47ab3c22a0f5457ba9db3114272a7b0fc9152
+lastReviewedCommit: c2d369386438a8ff88f47e637784feda2f0cf3f5
 lastReviewedNote: 'Reviewed for Next Issue #867: one exact dev Release PR owns aggregate acceptance; immutable promotion and main release reuse its external proof.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: c8e47ab3c22a0f5457ba9db3114272a7b0fc9152
+lastReviewedCommit: c2d369386438a8ff88f47e637784feda2f0cf3f5
 lastReviewedNote: 'Reviewed for Next Issue #867: exact dev Release PRs own one aggregate acceptance; promotion and main publication verify its bound proof without duplicate execution.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: c8e47ab3c22a0f5457ba9db3114272a7b0fc9152
+lastReviewedCommit: c2d369386438a8ff88f47e637784feda2f0cf3f5
 lastReviewedNote: 'Reviewed for Next Issue #867: one exact dev Release PR owns aggregate acceptance; later immutable release stages consume its proof.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: c8e47ab3c22a0f5457ba9db3114272a7b0fc9152
+lastReviewedCommit: c2d369386438a8ff88f47e637784feda2f0cf3f5
 lastReviewedNote: 'Reviewed for Next Issue #867: exact dev Release PRs own aggregate acceptance and later release stages reuse the bound external proof.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: c8e47ab3c22a0f5457ba9db3114272a7b0fc9152
+lastReviewedCommit: c2d369386438a8ff88f47e637784feda2f0cf3f5
 lastReviewedNote: 'Reviewed for Next Issue #867: aggregate qualification belongs to the exact dev Release PR and later release stages verify its proof.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: c8e47ab3c22a0f5457ba9db3114272a7b0fc9152
+lastReviewedCommit: c2d369386438a8ff88f47e637784feda2f0cf3f5
 lastReviewedNote: 'Reviewed for Next Issue #867: troubleshooting distinguishes the dev aggregate owner from proof-only promotion and publication.'
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.74",
+      "version": "0.0.75",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
<!-- tiangong-next-release-automation:v2 issue=867 version=0.0.75 dev-base=c2d369386438a8ff88f47e637784feda2f0cf3f5 main-base=23fa0b7e3df9c39a7fadaecc277500b9dd256954 candidate=a6186eb8465795da66a9bd09e69151f72eec7905 -->

## Branch Contract

- base branch: `dev`
- validated environment: exact dev Release PR aggregate gate
- back-merge required after merge: No
- root workspace integration expected: after later dev-to-main promotion

## Linked Issue

Refs #867

## Change Facts

- Prepare version `0.0.75` from exact dev base `c2d369386438a8ff88f47e637784feda2f0cf3f5`.
- Keep package.json and both package-lock root version fields aligned.
- Keep aggregate proof external to Git and bind it to the exact main/dev bases, candidate SHA/tree, version, workflow run, and artifact.
- Record Docpact review evidence only after the command proves the candidate has no other semantic change.
- Reviewed paths:
  - `.docpact/config.yaml`
  - `AGENTS.md`
  - `DEV.md`
  - `docs/agents/prepush-gate-policy.md`
  - `docs/agents/repo-validation.md`
  - `docs/agents/test_improvement_plan.md`
  - `docs/agents/test_todo_list.md`
  - `docs/agents/testing-patterns.md`
  - `docs/agents/testing-troubleshooting.md`

## Validation Facts

- Candidate: `a6186eb8465795da66a9bd09e69151f72eec7905`
- Main baseline: `23fa0b7e3df9c39a7fadaecc277500b9dd256954`
- Aggregate qualification: `required_by_dev_release_candidate_gate`; static preflight: `passed`
- Docpact automatic-review status: `completed`
- Docpact checked the complete main-to-candidate promotion range before the dev PR was created.
- The managed candidate push ran only structural/static checks; this PR owns the one full gate, semantic qualification, and public browser matrix.

## Risks And Follow-Up

- Merge only after the exact Release Candidate aggregate proof succeeds, then run the deterministic dev-to-main promotion command with this PR number.
