### PR TITLE
chore: prepare v0.0.75 on dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-08-15'
-lastReviewedCommit: 'a29f4f3392fc22e7800b407cfe5596396d1d783b'
+lastReviewedAt: "2026-08-15"
+lastReviewedCommit: "32df9d9db48bb1bf5ec577a5e9c20e84c91ad189"
 lastReviewedNote: 'Reviewed for Next Issue #867: browser E2E is manual PR-stage evidence and release proof covers the non-browser gate.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: a29f4f3392fc22e7800b407cfe5596396d1d783b
+lastReviewedCommit: 32df9d9db48bb1bf5ec577a5e9c20e84c91ad189
 lastReviewedNote: 'Reviewed for Next Issue #867: browser E2E is manual PR-stage evidence and release proof covers the non-browser gate.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: a29f4f3392fc22e7800b407cfe5596396d1d783b
+lastReviewedCommit: 32df9d9db48bb1bf5ec577a5e9c20e84c91ad189
 lastReviewedNote: 'Reviewed for Next Issue #867: browser E2E is manual PR-stage evidence and release proof covers the non-browser gate.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: a29f4f3392fc22e7800b407cfe5596396d1d783b
+lastReviewedCommit: 32df9d9db48bb1bf5ec577a5e9c20e84c91ad189
 lastReviewedNote: 'Reviewed for Next Issue #867: manual browser evidence stays outside release proof and checked-push gate budgeting.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: a29f4f3392fc22e7800b407cfe5596396d1d783b
+lastReviewedCommit: 32df9d9db48bb1bf5ec577a5e9c20e84c91ad189
 lastReviewedNote: 'Reviewed for Next Issue #867: browser E2E is manual PR-stage evidence and release proof covers the non-browser gate.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: a29f4f3392fc22e7800b407cfe5596396d1d783b
+lastReviewedCommit: 32df9d9db48bb1bf5ec577a5e9c20e84c91ad189
 lastReviewedNote: 'Reviewed for Next Issue #867: hermetic browser evidence is manual at business-PR stage and outside release proof.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: a29f4f3392fc22e7800b407cfe5596396d1d783b
+lastReviewedCommit: 32df9d9db48bb1bf5ec577a5e9c20e84c91ad189
 lastReviewedNote: 'Reviewed for Next Issue #867: hermetic browser qualification is manual and release proof is non-browser.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: a29f4f3392fc22e7800b407cfe5596396d1d783b
+lastReviewedCommit: 32df9d9db48bb1bf5ec577a5e9c20e84c91ad189
 lastReviewedNote: 'Reviewed for Next Issue #867: browser qualification is manual PR-stage evidence and outside release proof.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-15
-lastReviewedCommit: a29f4f3392fc22e7800b407cfe5596396d1d783b
+lastReviewedCommit: 32df9d9db48bb1bf5ec577a5e9c20e84c91ad189
 lastReviewedNote: 'Reviewed for Next Issue #867: manual browser failures stay on the business PR and release proof is non-browser.'
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.74",
+      "version": "0.0.75",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
<!-- tiangong-next-release-automation:v2 issue=867 version=0.0.75 dev-base=32df9d9db48bb1bf5ec577a5e9c20e84c91ad189 main-base=23fa0b7e3df9c39a7fadaecc277500b9dd256954 candidate=45ed2c03504e4ae4d47fb277cbd0fe431506f9b7 -->

## Branch Contract

- base branch: `dev`
- validated environment: exact dev Release PR non-browser gate
- back-merge required after merge: No
- root workspace integration expected: after later dev-to-main promotion

## Linked Issue

Refs #867

## Change Facts

- Prepare version `0.0.75` from exact dev base `32df9d9db48bb1bf5ec577a5e9c20e84c91ad189`.
- Keep package.json and both package-lock root version fields aligned.
- Keep release proof external to Git and bind it to the exact main/dev bases, candidate SHA/tree, version, workflow run, and artifact.
- Record Docpact review evidence only after the command proves the candidate has no other semantic change.
- Reviewed paths:
  - `.docpact/config.yaml`
  - `AGENTS.md`
  - `DEV.md`
  - `docs/agents/prepush-gate-policy.md`
  - `docs/agents/repo-validation.md`
  - `docs/agents/test_improvement_plan.md`
  - `docs/agents/test_todo_list.md`
  - `docs/agents/testing-patterns.md`
  - `docs/agents/testing-troubleshooting.md`

## Validation Facts

- Candidate: `45ed2c03504e4ae4d47fb277cbd0fe431506f9b7`
- Main baseline: `23fa0b7e3df9c39a7fadaecc277500b9dd256954`
- Release gate: `passed` in Actions run `31888911085`; static preflight: `passed`
- Docpact automatic-review status: `completed`
- Docpact checked the complete main-to-candidate promotion range before the dev PR was created.
- The managed candidate push ran only structural/static checks; this PR completed its one non-browser full release gate and aggregated the exact external proof successfully.
- Browser E2E is not evaluated or required by this PR. Run the manual hermetic workflow on the open business PR before release-to-dev when the change risk warrants browser evidence.

## Risks And Follow-Up

- Merge only after the exact Release Candidate release proof succeeds, then run the deterministic dev-to-main promotion command with this PR number.
