### PR TITLE
fix: clear boot timeout for layout-free routes

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-15"
-lastReviewedCommit: "32df9d9db48bb1bf5ec577a5e9c20e84c91ad189"
+lastReviewedAt: "2026-08-17"
+lastReviewedCommit: "16d0d2954cffbb97c9595f76df064a8bd8d2b6a6"
 lastReviewedNote: 'Reviewed for Next Issue #867: browser E2E is manual PR-stage evidence and release proof covers the non-browser gate.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-17"
-lastReviewedCommit: "16d0d2954cffbb97c9595f76df064a8bd8d2b6a6"
+lastReviewedCommit: "b2eb8cbd10bdf47942650fad60efea5e8416f3a2"
 lastReviewedNote: 'Reviewed for Next Issue #867: browser E2E is manual PR-stage evidence and release proof covers the non-browser gate.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-08-15
-lastReviewedCommit: 32df9d9db48bb1bf5ec577a5e9c20e84c91ad189
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 16d0d2954cffbb97c9595f76df064a8bd8d2b6a6
 lastReviewedNote: 'Reviewed for Next Issue #867: browser E2E is manual PR-stage evidence and release proof covers the non-browser gate.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 16d0d2954cffbb97c9595f76df064a8bd8d2b6a6
+lastReviewedCommit: b2eb8cbd10bdf47942650fad60efea5e8416f3a2
 lastReviewedNote: 'Reviewed for Next Issue #867: browser E2E is manual PR-stage evidence and release proof covers the non-browser gate.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - .nvmrc
-lastReviewedAt: 2026-08-15
-lastReviewedCommit: 32df9d9db48bb1bf5ec577a5e9c20e84c91ad189
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 16d0d2954cffbb97c9595f76df064a8bd8d2b6a6
 lastReviewedNote: 'Reviewed for Next Issue #867: browser E2E is manual PR-stage evidence and release proof covers the non-browser gate.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 16d0d2954cffbb97c9595f76df064a8bd8d2b6a6
+lastReviewedCommit: b2eb8cbd10bdf47942650fad60efea5e8416f3a2
 lastReviewedNote: 'Reviewed for Next Issue #867: browser E2E is manual PR-stage evidence and release proof covers the non-browser gate.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 16d0d2954cffbb97c9595f76df064a8bd8d2b6a6
+lastReviewedCommit: b2eb8cbd10bdf47942650fad60efea5e8416f3a2
 lastReviewedNote: 'Reviewed for Next Issue #867: manual browser evidence stays outside release proof and checked-push gate budgeting.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-08-15
-lastReviewedCommit: 32df9d9db48bb1bf5ec577a5e9c20e84c91ad189
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 16d0d2954cffbb97c9595f76df064a8bd8d2b6a6
 lastReviewedNote: 'Reviewed for Next Issue #867: manual browser evidence stays outside release proof and checked-push gate budgeting.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - playwright.config.ts
   - config/docs-capture/**
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-08-15
-lastReviewedCommit: 2f4cad4b
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 16d0d2954cffbb97c9595f76df064a8bd8d2b6a6
 lastReviewedNote: 'Reviewed for Next Issue #867: frontend environment selection now separates explicit deployment inputs from the deterministic semantic-qualification profile.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 16d0d2954cffbb97c9595f76df064a8bd8d2b6a6
+lastReviewedCommit: b2eb8cbd10bdf47942650fad60efea5e8416f3a2
 lastReviewedNote: 'Reviewed for Next Issue #867: browser E2E is manual PR-stage evidence and release proof covers the non-browser gate.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-08-15
-lastReviewedCommit: 32df9d9db48bb1bf5ec577a5e9c20e84c91ad189
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 16d0d2954cffbb97c9595f76df064a8bd8d2b6a6
 lastReviewedNote: 'Reviewed for Next Issue #867: browser E2E is manual PR-stage evidence and release proof covers the non-browser gate.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 16d0d2954cffbb97c9595f76df064a8bd8d2b6a6
+lastReviewedCommit: b2eb8cbd10bdf47942650fad60efea5e8416f3a2
 lastReviewedNote: 'Reviewed for Next Issue #867: hermetic browser evidence is manual at business-PR stage and outside release proof.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - package.json
-lastReviewedAt: 2026-08-15
-lastReviewedCommit: 32df9d9db48bb1bf5ec577a5e9c20e84c91ad189
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 16d0d2954cffbb97c9595f76df064a8bd8d2b6a6
 lastReviewedNote: 'Reviewed for Next Issue #867: hermetic browser evidence is manual at business-PR stage and outside release proof.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-15
-lastReviewedCommit: 32df9d9db48bb1bf5ec577a5e9c20e84c91ad189
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 16d0d2954cffbb97c9595f76df064a8bd8d2b6a6
 lastReviewedNote: 'Reviewed for Next Issue #867: hermetic browser qualification is manual and release proof is non-browser.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 16d0d2954cffbb97c9595f76df064a8bd8d2b6a6
+lastReviewedCommit: b2eb8cbd10bdf47942650fad60efea5e8416f3a2
 lastReviewedNote: 'Reviewed for Next Issue #867: hermetic browser qualification is manual and release proof is non-browser.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -30,8 +30,8 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-15
-lastReviewedCommit: 32df9d9db48bb1bf5ec577a5e9c20e84c91ad189
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 16d0d2954cffbb97c9595f76df064a8bd8d2b6a6
 lastReviewedNote: 'Reviewed for Next Issue #867: browser qualification is manual PR-stage evidence and outside release proof.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 16d0d2954cffbb97c9595f76df064a8bd8d2b6a6
+lastReviewedCommit: b2eb8cbd10bdf47942650fad60efea5e8416f3a2
 lastReviewedNote: 'Reviewed for Next Issue #867: browser qualification is manual PR-stage evidence and outside release proof.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 16d0d2954cffbb97c9595f76df064a8bd8d2b6a6
+lastReviewedCommit: b2eb8cbd10bdf47942650fad60efea5e8416f3a2
 lastReviewedNote: 'Reviewed for Next Issue #867: manual browser failures stay on the business PR and release proof is non-browser.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -27,8 +27,8 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-15
-lastReviewedCommit: 32df9d9db48bb1bf5ec577a5e9c20e84c91ad189
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 16d0d2954cffbb97c9595f76df064a8bd8d2b6a6
 lastReviewedNote: 'Reviewed for Next Issue #867: manual browser failures stay on the business PR and release proof is non-browser.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
-    "auditedInputDigest": "e77df81f1c50318d0bcf944bc81db86f71aa5b69f0c52d60ee7d2347f1081c09"
+    "sourceManifestDigest": "6d5dc58d005907db01a2619377fa60e8fd2615f47a447c7ec75099f4f66054e0",
+    "auditedInputDigest": "8a5111d4e13ba82fd42d7b22a671386d089016a38d13eebe0dfdb5da4f8dd667"
   },
   "inventory": {
     "sourceMessageCount": 3169,
@@ -47,7 +47,7 @@
     "messageCount": 3169,
     "completeCount": 3169,
     "blockedCount": 0,
-    "dossierDigest": "39ef2f49dd825f362a325cc2bc159498a9f42ca2d574da8657084c3e48f13d8c",
+    "dossierDigest": "a98297d95363309016272807cc450d54f0881ee0bb5f633178e453bd785a8636",
     "catalogDigest": "fd1c95cd13025d8868231056bfcfdf630bb3a1de622f1c012c5e33c92ae19874",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -137,15 +137,15 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "281dc4ac4658415730c75c89181e733476cf1ac58c04bfb6fda983647cb814c7",
+      "sourceEvidenceDigest": "8020e2f93f0a102796304d40f9f6232faf7ce08ee676c4eb4955a1df1035ef68",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
           "route": "/",
           "viewState": "redirect-to-welcome",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "90475586c437a3efb6c029b3e2f711d32720892912bb502af4c10560b1e84887",
-          "focusedTestDigest": "c1b3df6b8bf133872b87def2d8ae740caa27c5ee17ac369585262e6a277946f6",
+          "sourceDigest": "fc9991da23b18042ae5be6ee756f021bbd12d48d890bcbc161d3be63f4cfc851",
+          "focusedTestDigest": "0833b19b2cc4176f72cd9e0f133e63cc99d3b747d413c5a6050d6ed71e0eca83",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "d4754f0ac91aaabda0250ca6a0977f131654b0900d1b14b36a4c840aa42f6825",
           "derivedMessageCount": 44,
@@ -170,8 +170,8 @@
           "route": "/welcome",
           "viewState": "overview",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "0e6e0e7a58888f48500cefb9b6fa69f2d3c51c4097f3aa09c2ddba4ab3568588",
-          "focusedTestDigest": "8754ce4b125cb405ae35ea8e0f309e919370c96afb29727a3cd8c6ee09f1e393",
+          "sourceDigest": "2423bd47042afbc367d1fbc9fd2b7bf6f31478d76f63b028de02e9c06e5afdd3",
+          "focusedTestDigest": "fadbe791f084b5656800f7a643c4a6814620c95177f2e321a3a2f422aff5cf80",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "811949b6e0dccca1b6aa510e63afebb8839888cf24907b1dc2bae6a1755bf3d3",
           "derivedMessageCount": 45,
@@ -196,8 +196,8 @@
           "route": "/welcome?view=carbon-footprint",
           "viewState": "carbon-footprint-guide",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "0e6e0e7a58888f48500cefb9b6fa69f2d3c51c4097f3aa09c2ddba4ab3568588",
-          "focusedTestDigest": "58a8a7f992a34c88741c511399f771c49195abc6406ed027faa25b4eaab4d2b2",
+          "sourceDigest": "2423bd47042afbc367d1fbc9fd2b7bf6f31478d76f63b028de02e9c06e5afdd3",
+          "focusedTestDigest": "44cda38b0f9719da8c039ef33084083ace644d081a4cf883b2ff16717ba5ab24",
           "plannedBrowserAssertionCount": 3,
           "plannedBrowserAssertionDigest": "7dce46b0e253c9000c52c96a89b772057bc78fbf5d13a1db1094e52d13b71be3",
           "derivedMessageCount": 77,
@@ -222,7 +222,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "52e13ba69c5fb956b444be4e1777dd96021fd18040624b6a8e743588303c4e11",
+          "sourceDigest": "1e102ad9ea57f6ab0909736dd15695f970365676db0bcdc731ab6055211a680d",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -247,7 +247,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "916ce897c1309aaf95a689671ba1b3e7e4d8fc1f89cc4a6d16b630c0e6b97405",
+          "sourceDigest": "e1cb13b93c6f16e72647e6d89e316f5f2cada0ec98cd88386d329360ca6e19fb",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -270,7 +270,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "9e45a18d4dff59e72eb9730b191c209f8e6d3a3842bdfca35c4e8efd61ce1ed7",
+          "sourceDigest": "dfad8a947d23b57b526e60f3f006beed7e7de34a79738600a610511a01ee3f7d",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -294,8 +294,8 @@
           "route": "/dashboard/national-carbon",
           "viewState": "national-carbon-dashboard",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "92fc46f60d099d7411686231d3fb438862ca6bfb4cab80f8f7b94224bfde26b5",
-          "focusedTestDigest": "b381170c5589cf81a5a2bc4c4aa8ba600d3e1cf1acbc74b80328a8ae6effe40c",
+          "sourceDigest": "08033c851aa611d365fc31d15c9b47735a0f9af619c6fe19dade997818df84f8",
+          "focusedTestDigest": "462e32043ad7a3ba37d667bf00395b2568df0383e0316a9c374c00047feb5306",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "95b95698b9168443cacad5913312e98989fb251f09feee48fbaf5f7203c57587",
           "derivedMessageCount": 264,
@@ -360,8 +360,8 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "d29434cc650be174a89168e6a9bc2ebe4028f84984716ee2959b7b4471011835",
-          "focusedTestDigest": "f049148cf7a8ed1cf0ddc19e5fda68c35fdefa4d1f8265f54a5abb6c1a892e0c",
+          "sourceDigest": "1afcca860f04443eee5ccc0d596d0e8db2ce024112845a98b570c16f68984bd0",
+          "focusedTestDigest": "d7a9730f93a394ec80488b25e370ee154fd8b79f2ff33359ab808a71b01ef207",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
           "derivedMessageCount": 6,
@@ -1035,8 +1035,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "620dd184b6808b96474612d36aadced76a377455bd152744f08bbce736069953",
-          "focusedTestDigest": "8f33451d0e730a1ba9e49f95d9249f5f085733927ffa799276b57fb7d81f72ba",
+          "sourceDigest": "8f85db12be1712d62d3452690f017484af79c2911b3f4a5f29163b6692355c9e",
+          "focusedTestDigest": "4cc0538a52de788e93da7104113af36c3e318ed70fb4a1527556cbaa4ffe6eba",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "2a2d1046587513aa11f04c815431bf35e04f2529029da0ea0bf3f5873869e892",
+      "rowEvidenceDigest": "279ce7541a88b1e2ea1baf7603f2fed594c18bc43d9ee389113809e4ad82a3af",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "781aee414f0d7de96e8bfd723f5301301376e5d39de21bbe0f9c175f0c12c34b"
+  "contextDigest": "6f23ae94007553a3cdfca9d45eca4921c253a11416a6ad7d3f93075933ec38a3"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb"
+    "sourceManifestDigest": "6d5dc58d005907db01a2619377fa60e8fd2615f47a447c7ec75099f4f66054e0"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "781aee414f0d7de96e8bfd723f5301301376e5d39de21bbe0f9c175f0c12c34b",
-    "qualityDigest": "586f29ee69934ff746333c1f23bc74320efef7fe5da8ed0118c60b04ea3bc862",
+    "contextDigest": "6f23ae94007553a3cdfca9d45eca4921c253a11416a6ad7d3f93075933ec38a3",
+    "qualityDigest": "042e75b78f83940ae4661b77ba053cf3af414d753f083092e198eb524075b5ed",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "adb6d4d6d04aff9f829f4e3c11836b0b42e10887b901823b2c23ea73774333d5"
+  "activationDigest": "b21861ba55d883591e71023bd32fb316c7409e45cc99f72e0078be8c446c46d9"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "e77df81f1c50318d0bcf944bc81db86f71aa5b69f0c52d60ee7d2347f1081c09",
+    "auditedInputDigest": "8a5111d4e13ba82fd42d7b22a671386d089016a38d13eebe0dfdb5da4f8dd667",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -13732,7 +13732,7 @@
         {
           "kind": "formatMessage",
           "path": "src/app.tsx",
-          "line": 267,
+          "line": 280,
           "column": 16,
           "symbol": "layout",
           "defaultMessage": "OpenAPI documentation",
@@ -13745,7 +13745,7 @@
           "argumentSignature": [],
           "placeholders": [],
           "locations": [
-            { "path": "src/app.tsx", "line": 267, "column": 16, "kind": "formatMessage" }
+            { "path": "src/app.tsx", "line": 280, "column": 16, "kind": "formatMessage" }
           ]
         }
       ]
@@ -25614,7 +25614,7 @@
         {
           "kind": "formatMessage",
           "path": "src/app.tsx",
-          "line": 204,
+          "line": 217,
           "column": 20,
           "symbol": "layout",
           "defaultMessage": "Data Dashboard",
@@ -25627,7 +25627,7 @@
           "argumentSignature": [],
           "placeholders": [],
           "locations": [
-            { "path": "src/app.tsx", "line": 204, "column": 20, "kind": "formatMessage" }
+            { "path": "src/app.tsx", "line": 217, "column": 20, "kind": "formatMessage" }
           ]
         }
       ]
@@ -25751,7 +25751,7 @@
         {
           "kind": "formatMessage",
           "path": "src/app.tsx",
-          "line": 220,
+          "line": 233,
           "column": 20,
           "symbol": "layout",
           "defaultMessage": "Data Processing",
@@ -25764,7 +25764,7 @@
           "argumentSignature": [],
           "placeholders": [],
           "locations": [
-            { "path": "src/app.tsx", "line": 220, "column": 20, "kind": "formatMessage" }
+            { "path": "src/app.tsx", "line": 233, "column": 20, "kind": "formatMessage" }
           ]
         }
       ]
@@ -131434,7 +131434,7 @@
         {
           "kind": "formatMessage",
           "path": "src/app.tsx",
-          "line": 147,
+          "line": 160,
           "column": 5,
           "symbol": "appTitle",
           "defaultMessage": null,

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
-    "contextDigest": "781aee414f0d7de96e8bfd723f5301301376e5d39de21bbe0f9c175f0c12c34b"
+    "sourceManifestDigest": "6d5dc58d005907db01a2619377fa60e8fd2615f47a447c7ec75099f4f66054e0",
+    "contextDigest": "6f23ae94007553a3cdfca9d45eca4921c253a11416a6ad7d3f93075933ec38a3"
   },
   "catalog": {
     "messageCount": 3169,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "5cc3daa210998768494c02a5b2c717288164e9e3dad48e6738cc0b1febf2fdf6",
-    "validationDigest": "9dfe7203f3488da19a2acf15472dfd5c0105f177ce84c3a681edeb6c13b85e61",
+    "digest": "37cd30ab0f8f267740f619c26339841ec6c66e6bc7c615b0664ede9cb52be1ed",
+    "validationDigest": "58347a8164c24b9b4053b50eb3cfe78ef47067dca0105bd5695b4078ec9401e6",
     "laneCount": 1,
     "validatedMessageCount": 3169,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "586f29ee69934ff746333c1f23bc74320efef7fe5da8ed0118c60b04ea3bc862"
+  "qualityDigest": "042e75b78f83940ae4661b77ba053cf3af414d753f083092e198eb524075b5ed"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "e77df81f1c50318d0bcf944bc81db86f71aa5b69f0c52d60ee7d2347f1081c09",
+    "auditedInputDigest": "8a5111d4e13ba82fd42d7b22a671386d089016a38d13eebe0dfdb5da4f8dd667",
     "validatedMessageCount": 3169,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1433,
     "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
     "catalogDigest": "fd1c95cd13025d8868231056bfcfdf630bb3a1de622f1c012c5e33c92ae19874",
-    "dossierDigest": "39ef2f49dd825f362a325cc2bc159498a9f42ca2d574da8657084c3e48f13d8c",
+    "dossierDigest": "a98297d95363309016272807cc450d54f0881ee0bb5f633178e453bd785a8636",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "2a2d1046587513aa11f04c815431bf35e04f2529029da0ea0bf3f5873869e892",
+    "routeEvidenceDigest": "279ce7541a88b1e2ea1baf7603f2fed594c18bc43d9ee389113809e4ad82a3af",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "720ffdb462f7c139597e6d9e9bb59f4641cd1fd1b5099b671fdef39cc900c87f",
         "highRiskMessageCount": 1433,
         "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
-        "dossierDigest": "39ef2f49dd825f362a325cc2bc159498a9f42ca2d574da8657084c3e48f13d8c",
+        "dossierDigest": "a98297d95363309016272807cc450d54f0881ee0bb5f633178e453bd785a8636",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "9dfe7203f3488da19a2acf15472dfd5c0105f177ce84c3a681edeb6c13b85e61"
+  "validationDigest": "58347a8164c24b9b4053b50eb3cfe78ef47067dca0105bd5695b4078ec9401e6"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
-    "auditedInputDigest": "e77df81f1c50318d0bcf944bc81db86f71aa5b69f0c52d60ee7d2347f1081c09"
+    "sourceManifestDigest": "6d5dc58d005907db01a2619377fa60e8fd2615f47a447c7ec75099f4f66054e0",
+    "auditedInputDigest": "8a5111d4e13ba82fd42d7b22a671386d089016a38d13eebe0dfdb5da4f8dd667"
   },
   "inventory": {
     "sourceMessageCount": 3169,
@@ -47,7 +47,7 @@
     "messageCount": 3169,
     "completeCount": 3169,
     "blockedCount": 0,
-    "dossierDigest": "e3e531d9d21e2920f8dcfc998b6e48df6135981257ea9f6d60381d052f8decb5",
+    "dossierDigest": "19d938867d8715f97c9650b2ad4bf20b0b2b6f45468152f407733f6c95421e89",
     "catalogDigest": "9fabd08ff44e959db39d1b511126d18154db14458c4811d9e40d2f0d0d57e34f",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -137,15 +137,15 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "281dc4ac4658415730c75c89181e733476cf1ac58c04bfb6fda983647cb814c7",
+      "sourceEvidenceDigest": "8020e2f93f0a102796304d40f9f6232faf7ce08ee676c4eb4955a1df1035ef68",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
           "route": "/",
           "viewState": "redirect-to-welcome",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "90475586c437a3efb6c029b3e2f711d32720892912bb502af4c10560b1e84887",
-          "focusedTestDigest": "c1b3df6b8bf133872b87def2d8ae740caa27c5ee17ac369585262e6a277946f6",
+          "sourceDigest": "fc9991da23b18042ae5be6ee756f021bbd12d48d890bcbc161d3be63f4cfc851",
+          "focusedTestDigest": "0833b19b2cc4176f72cd9e0f133e63cc99d3b747d413c5a6050d6ed71e0eca83",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "d4754f0ac91aaabda0250ca6a0977f131654b0900d1b14b36a4c840aa42f6825",
           "derivedMessageCount": 44,
@@ -170,8 +170,8 @@
           "route": "/welcome",
           "viewState": "overview",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "0e6e0e7a58888f48500cefb9b6fa69f2d3c51c4097f3aa09c2ddba4ab3568588",
-          "focusedTestDigest": "8754ce4b125cb405ae35ea8e0f309e919370c96afb29727a3cd8c6ee09f1e393",
+          "sourceDigest": "2423bd47042afbc367d1fbc9fd2b7bf6f31478d76f63b028de02e9c06e5afdd3",
+          "focusedTestDigest": "fadbe791f084b5656800f7a643c4a6814620c95177f2e321a3a2f422aff5cf80",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "811949b6e0dccca1b6aa510e63afebb8839888cf24907b1dc2bae6a1755bf3d3",
           "derivedMessageCount": 45,
@@ -196,8 +196,8 @@
           "route": "/welcome?view=carbon-footprint",
           "viewState": "carbon-footprint-guide",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "0e6e0e7a58888f48500cefb9b6fa69f2d3c51c4097f3aa09c2ddba4ab3568588",
-          "focusedTestDigest": "58a8a7f992a34c88741c511399f771c49195abc6406ed027faa25b4eaab4d2b2",
+          "sourceDigest": "2423bd47042afbc367d1fbc9fd2b7bf6f31478d76f63b028de02e9c06e5afdd3",
+          "focusedTestDigest": "44cda38b0f9719da8c039ef33084083ace644d081a4cf883b2ff16717ba5ab24",
           "plannedBrowserAssertionCount": 3,
           "plannedBrowserAssertionDigest": "7dce46b0e253c9000c52c96a89b772057bc78fbf5d13a1db1094e52d13b71be3",
           "derivedMessageCount": 77,
@@ -222,7 +222,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "52e13ba69c5fb956b444be4e1777dd96021fd18040624b6a8e743588303c4e11",
+          "sourceDigest": "1e102ad9ea57f6ab0909736dd15695f970365676db0bcdc731ab6055211a680d",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -247,7 +247,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "916ce897c1309aaf95a689671ba1b3e7e4d8fc1f89cc4a6d16b630c0e6b97405",
+          "sourceDigest": "e1cb13b93c6f16e72647e6d89e316f5f2cada0ec98cd88386d329360ca6e19fb",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -270,7 +270,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "9e45a18d4dff59e72eb9730b191c209f8e6d3a3842bdfca35c4e8efd61ce1ed7",
+          "sourceDigest": "dfad8a947d23b57b526e60f3f006beed7e7de34a79738600a610511a01ee3f7d",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -294,8 +294,8 @@
           "route": "/dashboard/national-carbon",
           "viewState": "national-carbon-dashboard",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "92fc46f60d099d7411686231d3fb438862ca6bfb4cab80f8f7b94224bfde26b5",
-          "focusedTestDigest": "b381170c5589cf81a5a2bc4c4aa8ba600d3e1cf1acbc74b80328a8ae6effe40c",
+          "sourceDigest": "08033c851aa611d365fc31d15c9b47735a0f9af619c6fe19dade997818df84f8",
+          "focusedTestDigest": "462e32043ad7a3ba37d667bf00395b2568df0383e0316a9c374c00047feb5306",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "95b95698b9168443cacad5913312e98989fb251f09feee48fbaf5f7203c57587",
           "derivedMessageCount": 264,
@@ -360,8 +360,8 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "d29434cc650be174a89168e6a9bc2ebe4028f84984716ee2959b7b4471011835",
-          "focusedTestDigest": "f049148cf7a8ed1cf0ddc19e5fda68c35fdefa4d1f8265f54a5abb6c1a892e0c",
+          "sourceDigest": "1afcca860f04443eee5ccc0d596d0e8db2ce024112845a98b570c16f68984bd0",
+          "focusedTestDigest": "d7a9730f93a394ec80488b25e370ee154fd8b79f2ff33359ab808a71b01ef207",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
           "derivedMessageCount": 6,
@@ -1035,8 +1035,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "620dd184b6808b96474612d36aadced76a377455bd152744f08bbce736069953",
-          "focusedTestDigest": "8f33451d0e730a1ba9e49f95d9249f5f085733927ffa799276b57fb7d81f72ba",
+          "sourceDigest": "8f85db12be1712d62d3452690f017484af79c2911b3f4a5f29163b6692355c9e",
+          "focusedTestDigest": "4cc0538a52de788e93da7104113af36c3e318ed70fb4a1527556cbaa4ffe6eba",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "2a2d1046587513aa11f04c815431bf35e04f2529029da0ea0bf3f5873869e892",
+      "rowEvidenceDigest": "279ce7541a88b1e2ea1baf7603f2fed594c18bc43d9ee389113809e4ad82a3af",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "b33ab8ac15e4bee3f6b264dd021dcdf59d87dbb1a9882344fe683a91ca978b9d"
+  "contextDigest": "d99cc9de0c5fcf4da2160a744c756280188d0100ca7a6e523061339c5e1eb78e"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb"
+    "sourceManifestDigest": "6d5dc58d005907db01a2619377fa60e8fd2615f47a447c7ec75099f4f66054e0"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "b33ab8ac15e4bee3f6b264dd021dcdf59d87dbb1a9882344fe683a91ca978b9d",
-    "qualityDigest": "aa36b66122d30797f018a219294633cf6f15937f83d73a10e4074bc78bfbb8e2",
+    "contextDigest": "d99cc9de0c5fcf4da2160a744c756280188d0100ca7a6e523061339c5e1eb78e",
+    "qualityDigest": "93269035fad532d8616a89ffd837c6cdef2c1bef6a7650aa383b765c43155c34",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "b755fa73c87ebda045cd831ad21db5913deb0d3d13326747f3bc0f26eea2edf9"
+  "activationDigest": "566c99f89ab2737e73a6c5baa8ec5323d1e5440ba53dc41e152915fd4c2635fe"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
-    "contextDigest": "b33ab8ac15e4bee3f6b264dd021dcdf59d87dbb1a9882344fe683a91ca978b9d"
+    "sourceManifestDigest": "6d5dc58d005907db01a2619377fa60e8fd2615f47a447c7ec75099f4f66054e0",
+    "contextDigest": "d99cc9de0c5fcf4da2160a744c756280188d0100ca7a6e523061339c5e1eb78e"
   },
   "catalog": {
     "messageCount": 3169,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "192fd2e3dceda8207d538011e6e38841458cb0baebf1095cd1e0c7ee29d98fab",
-    "validationDigest": "c86d0a65e5325e9f16ca9dacbb6ebf6fbb4373412e1e9aaa2bbf18ff9639d33b",
+    "digest": "85c82e82e0ab4af15895e3643854cc5918781b63d673888a56e2a9289553c554",
+    "validationDigest": "2fb8633e9a5a5acb0f100aa5d4c304192ba3550d01eccef25fc3a75de383d72b",
     "laneCount": 1,
     "validatedMessageCount": 3169,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "aa36b66122d30797f018a219294633cf6f15937f83d73a10e4074bc78bfbb8e2"
+  "qualityDigest": "93269035fad532d8616a89ffd837c6cdef2c1bef6a7650aa383b765c43155c34"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "e77df81f1c50318d0bcf944bc81db86f71aa5b69f0c52d60ee7d2347f1081c09",
+    "auditedInputDigest": "8a5111d4e13ba82fd42d7b22a671386d089016a38d13eebe0dfdb5da4f8dd667",
     "validatedMessageCount": 3169,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1433,
     "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
     "catalogDigest": "9fabd08ff44e959db39d1b511126d18154db14458c4811d9e40d2f0d0d57e34f",
-    "dossierDigest": "e3e531d9d21e2920f8dcfc998b6e48df6135981257ea9f6d60381d052f8decb5",
+    "dossierDigest": "19d938867d8715f97c9650b2ad4bf20b0b2b6f45468152f407733f6c95421e89",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "2a2d1046587513aa11f04c815431bf35e04f2529029da0ea0bf3f5873869e892",
+    "routeEvidenceDigest": "279ce7541a88b1e2ea1baf7603f2fed594c18bc43d9ee389113809e4ad82a3af",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "720ffdb462f7c139597e6d9e9bb59f4641cd1fd1b5099b671fdef39cc900c87f",
         "highRiskMessageCount": 1433,
         "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
-        "dossierDigest": "e3e531d9d21e2920f8dcfc998b6e48df6135981257ea9f6d60381d052f8decb5",
+        "dossierDigest": "19d938867d8715f97c9650b2ad4bf20b0b2b6f45468152f407733f6c95421e89",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "c86d0a65e5325e9f16ca9dacbb6ebf6fbb4373412e1e9aaa2bbf18ff9639d33b"
+  "validationDigest": "2fb8633e9a5a5acb0f100aa5d4c304192ba3550d01eccef25fc3a75de383d72b"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
-    "auditedInputDigest": "e77df81f1c50318d0bcf944bc81db86f71aa5b69f0c52d60ee7d2347f1081c09"
+    "sourceManifestDigest": "6d5dc58d005907db01a2619377fa60e8fd2615f47a447c7ec75099f4f66054e0",
+    "auditedInputDigest": "8a5111d4e13ba82fd42d7b22a671386d089016a38d13eebe0dfdb5da4f8dd667"
   },
   "inventory": {
     "sourceMessageCount": 3169,
@@ -47,7 +47,7 @@
     "messageCount": 3169,
     "completeCount": 3169,
     "blockedCount": 0,
-    "dossierDigest": "70530ff150f5b1e15712d798fa959b367313b39a2bcfe61f5fef3e73a5f6751f",
+    "dossierDigest": "866a158033da137263a4180b89845f45584df3292602672e7585271e200aa80b",
     "catalogDigest": "8f641cc162bdb6636b1c5e1dbcd0df3d42d30508094807a397a43a0906595856",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -137,15 +137,15 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "281dc4ac4658415730c75c89181e733476cf1ac58c04bfb6fda983647cb814c7",
+      "sourceEvidenceDigest": "8020e2f93f0a102796304d40f9f6232faf7ce08ee676c4eb4955a1df1035ef68",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
           "route": "/",
           "viewState": "redirect-to-welcome",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "90475586c437a3efb6c029b3e2f711d32720892912bb502af4c10560b1e84887",
-          "focusedTestDigest": "c1b3df6b8bf133872b87def2d8ae740caa27c5ee17ac369585262e6a277946f6",
+          "sourceDigest": "fc9991da23b18042ae5be6ee756f021bbd12d48d890bcbc161d3be63f4cfc851",
+          "focusedTestDigest": "0833b19b2cc4176f72cd9e0f133e63cc99d3b747d413c5a6050d6ed71e0eca83",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "d4754f0ac91aaabda0250ca6a0977f131654b0900d1b14b36a4c840aa42f6825",
           "derivedMessageCount": 44,
@@ -170,8 +170,8 @@
           "route": "/welcome",
           "viewState": "overview",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "0e6e0e7a58888f48500cefb9b6fa69f2d3c51c4097f3aa09c2ddba4ab3568588",
-          "focusedTestDigest": "8754ce4b125cb405ae35ea8e0f309e919370c96afb29727a3cd8c6ee09f1e393",
+          "sourceDigest": "2423bd47042afbc367d1fbc9fd2b7bf6f31478d76f63b028de02e9c06e5afdd3",
+          "focusedTestDigest": "fadbe791f084b5656800f7a643c4a6814620c95177f2e321a3a2f422aff5cf80",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "811949b6e0dccca1b6aa510e63afebb8839888cf24907b1dc2bae6a1755bf3d3",
           "derivedMessageCount": 45,
@@ -196,8 +196,8 @@
           "route": "/welcome?view=carbon-footprint",
           "viewState": "carbon-footprint-guide",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "0e6e0e7a58888f48500cefb9b6fa69f2d3c51c4097f3aa09c2ddba4ab3568588",
-          "focusedTestDigest": "58a8a7f992a34c88741c511399f771c49195abc6406ed027faa25b4eaab4d2b2",
+          "sourceDigest": "2423bd47042afbc367d1fbc9fd2b7bf6f31478d76f63b028de02e9c06e5afdd3",
+          "focusedTestDigest": "44cda38b0f9719da8c039ef33084083ace644d081a4cf883b2ff16717ba5ab24",
           "plannedBrowserAssertionCount": 3,
           "plannedBrowserAssertionDigest": "7dce46b0e253c9000c52c96a89b772057bc78fbf5d13a1db1094e52d13b71be3",
           "derivedMessageCount": 77,
@@ -222,7 +222,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "52e13ba69c5fb956b444be4e1777dd96021fd18040624b6a8e743588303c4e11",
+          "sourceDigest": "1e102ad9ea57f6ab0909736dd15695f970365676db0bcdc731ab6055211a680d",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -247,7 +247,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "916ce897c1309aaf95a689671ba1b3e7e4d8fc1f89cc4a6d16b630c0e6b97405",
+          "sourceDigest": "e1cb13b93c6f16e72647e6d89e316f5f2cada0ec98cd88386d329360ca6e19fb",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -270,7 +270,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "9e45a18d4dff59e72eb9730b191c209f8e6d3a3842bdfca35c4e8efd61ce1ed7",
+          "sourceDigest": "dfad8a947d23b57b526e60f3f006beed7e7de34a79738600a610511a01ee3f7d",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -294,8 +294,8 @@
           "route": "/dashboard/national-carbon",
           "viewState": "national-carbon-dashboard",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "92fc46f60d099d7411686231d3fb438862ca6bfb4cab80f8f7b94224bfde26b5",
-          "focusedTestDigest": "b381170c5589cf81a5a2bc4c4aa8ba600d3e1cf1acbc74b80328a8ae6effe40c",
+          "sourceDigest": "08033c851aa611d365fc31d15c9b47735a0f9af619c6fe19dade997818df84f8",
+          "focusedTestDigest": "462e32043ad7a3ba37d667bf00395b2568df0383e0316a9c374c00047feb5306",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "95b95698b9168443cacad5913312e98989fb251f09feee48fbaf5f7203c57587",
           "derivedMessageCount": 264,
@@ -360,8 +360,8 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "d29434cc650be174a89168e6a9bc2ebe4028f84984716ee2959b7b4471011835",
-          "focusedTestDigest": "f049148cf7a8ed1cf0ddc19e5fda68c35fdefa4d1f8265f54a5abb6c1a892e0c",
+          "sourceDigest": "1afcca860f04443eee5ccc0d596d0e8db2ce024112845a98b570c16f68984bd0",
+          "focusedTestDigest": "d7a9730f93a394ec80488b25e370ee154fd8b79f2ff33359ab808a71b01ef207",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
           "derivedMessageCount": 6,
@@ -1035,8 +1035,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "620dd184b6808b96474612d36aadced76a377455bd152744f08bbce736069953",
-          "focusedTestDigest": "8f33451d0e730a1ba9e49f95d9249f5f085733927ffa799276b57fb7d81f72ba",
+          "sourceDigest": "8f85db12be1712d62d3452690f017484af79c2911b3f4a5f29163b6692355c9e",
+          "focusedTestDigest": "4cc0538a52de788e93da7104113af36c3e318ed70fb4a1527556cbaa4ffe6eba",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "2a2d1046587513aa11f04c815431bf35e04f2529029da0ea0bf3f5873869e892",
+      "rowEvidenceDigest": "279ce7541a88b1e2ea1baf7603f2fed594c18bc43d9ee389113809e4ad82a3af",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "2dbbd4f4173a891146093d544a91ce190ff60b47e888bbd5eaddb428a6802aa0"
+  "contextDigest": "df168154036017c28c8870f76831068138ed3e5cce149f902cfc42fdfc616c3e"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb"
+    "sourceManifestDigest": "6d5dc58d005907db01a2619377fa60e8fd2615f47a447c7ec75099f4f66054e0"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "2dbbd4f4173a891146093d544a91ce190ff60b47e888bbd5eaddb428a6802aa0",
-    "qualityDigest": "02f38c2dfc4a667b08df0e8e9980c55b67f0bc7c0615166bf8cb2ba06dbf477e",
+    "contextDigest": "df168154036017c28c8870f76831068138ed3e5cce149f902cfc42fdfc616c3e",
+    "qualityDigest": "b14f7548c74ee6b3d94ce0ff818df5566a2d7537ed4d1f88b0cda3fba532edda",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "7dc48ff0706bf89316b4ce6d55e4d8f9d1723de29dfc9bdef250bb8d67b1e2f5"
+  "activationDigest": "0f53e5845b9ce90add6967c784226a6134f868a6435c879bc660dbf81e22213a"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
-    "contextDigest": "2dbbd4f4173a891146093d544a91ce190ff60b47e888bbd5eaddb428a6802aa0"
+    "sourceManifestDigest": "6d5dc58d005907db01a2619377fa60e8fd2615f47a447c7ec75099f4f66054e0",
+    "contextDigest": "df168154036017c28c8870f76831068138ed3e5cce149f902cfc42fdfc616c3e"
   },
   "catalog": {
     "messageCount": 3169,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "37c492b189ce5663571f73e36d0c1f2941b0181b78c936f3181e44de41d16e7d",
-    "validationDigest": "0c902617a46ff45ef4b55baef6abc805bad9125011ab2f1733dd8e5bf52e33fa",
+    "digest": "8b4f8d689299c6037271f9687560235b17f84f21698a740f33371baa02712300",
+    "validationDigest": "c6b7e93dfb479f2275aa6e9599e13ed8ba7299c5d2469df0340d6743dcf701fa",
     "laneCount": 1,
     "validatedMessageCount": 3169,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "02f38c2dfc4a667b08df0e8e9980c55b67f0bc7c0615166bf8cb2ba06dbf477e"
+  "qualityDigest": "b14f7548c74ee6b3d94ce0ff818df5566a2d7537ed4d1f88b0cda3fba532edda"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "e77df81f1c50318d0bcf944bc81db86f71aa5b69f0c52d60ee7d2347f1081c09",
+    "auditedInputDigest": "8a5111d4e13ba82fd42d7b22a671386d089016a38d13eebe0dfdb5da4f8dd667",
     "validatedMessageCount": 3169,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1433,
     "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
     "catalogDigest": "8f641cc162bdb6636b1c5e1dbcd0df3d42d30508094807a397a43a0906595856",
-    "dossierDigest": "70530ff150f5b1e15712d798fa959b367313b39a2bcfe61f5fef3e73a5f6751f",
+    "dossierDigest": "866a158033da137263a4180b89845f45584df3292602672e7585271e200aa80b",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "2a2d1046587513aa11f04c815431bf35e04f2529029da0ea0bf3f5873869e892",
+    "routeEvidenceDigest": "279ce7541a88b1e2ea1baf7603f2fed594c18bc43d9ee389113809e4ad82a3af",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "720ffdb462f7c139597e6d9e9bb59f4641cd1fd1b5099b671fdef39cc900c87f",
         "highRiskMessageCount": 1433,
         "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
-        "dossierDigest": "70530ff150f5b1e15712d798fa959b367313b39a2bcfe61f5fef3e73a5f6751f",
+        "dossierDigest": "866a158033da137263a4180b89845f45584df3292602672e7585271e200aa80b",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "0c902617a46ff45ef4b55baef6abc805bad9125011ab2f1733dd8e5bf52e33fa"
+  "validationDigest": "c6b7e93dfb479f2275aa6e9599e13ed8ba7299c5d2469df0340d6743dcf701fa"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
-    "auditedInputDigest": "e77df81f1c50318d0bcf944bc81db86f71aa5b69f0c52d60ee7d2347f1081c09"
+    "sourceManifestDigest": "6d5dc58d005907db01a2619377fa60e8fd2615f47a447c7ec75099f4f66054e0",
+    "auditedInputDigest": "8a5111d4e13ba82fd42d7b22a671386d089016a38d13eebe0dfdb5da4f8dd667"
   },
   "inventory": {
     "sourceMessageCount": 3169,
@@ -47,7 +47,7 @@
     "messageCount": 3169,
     "completeCount": 3169,
     "blockedCount": 0,
-    "dossierDigest": "e7877f526e1df8c3d7cf4abeb129a115cc41d1444e57d4861404c9f149fdec03",
+    "dossierDigest": "d05591c2c33bb355a919352d476d921d09d8340352ed6a6a0e256f4838ab916a",
     "catalogDigest": "07f4707dcc02ac32c1b76d09780d3f26503d4c4b2a1fa85331eb8beac94f2555",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -137,15 +137,15 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "281dc4ac4658415730c75c89181e733476cf1ac58c04bfb6fda983647cb814c7",
+      "sourceEvidenceDigest": "8020e2f93f0a102796304d40f9f6232faf7ce08ee676c4eb4955a1df1035ef68",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
           "route": "/",
           "viewState": "redirect-to-welcome",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "90475586c437a3efb6c029b3e2f711d32720892912bb502af4c10560b1e84887",
-          "focusedTestDigest": "c1b3df6b8bf133872b87def2d8ae740caa27c5ee17ac369585262e6a277946f6",
+          "sourceDigest": "fc9991da23b18042ae5be6ee756f021bbd12d48d890bcbc161d3be63f4cfc851",
+          "focusedTestDigest": "0833b19b2cc4176f72cd9e0f133e63cc99d3b747d413c5a6050d6ed71e0eca83",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "d4754f0ac91aaabda0250ca6a0977f131654b0900d1b14b36a4c840aa42f6825",
           "derivedMessageCount": 44,
@@ -170,8 +170,8 @@
           "route": "/welcome",
           "viewState": "overview",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "0e6e0e7a58888f48500cefb9b6fa69f2d3c51c4097f3aa09c2ddba4ab3568588",
-          "focusedTestDigest": "8754ce4b125cb405ae35ea8e0f309e919370c96afb29727a3cd8c6ee09f1e393",
+          "sourceDigest": "2423bd47042afbc367d1fbc9fd2b7bf6f31478d76f63b028de02e9c06e5afdd3",
+          "focusedTestDigest": "fadbe791f084b5656800f7a643c4a6814620c95177f2e321a3a2f422aff5cf80",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "811949b6e0dccca1b6aa510e63afebb8839888cf24907b1dc2bae6a1755bf3d3",
           "derivedMessageCount": 45,
@@ -196,8 +196,8 @@
           "route": "/welcome?view=carbon-footprint",
           "viewState": "carbon-footprint-guide",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "0e6e0e7a58888f48500cefb9b6fa69f2d3c51c4097f3aa09c2ddba4ab3568588",
-          "focusedTestDigest": "58a8a7f992a34c88741c511399f771c49195abc6406ed027faa25b4eaab4d2b2",
+          "sourceDigest": "2423bd47042afbc367d1fbc9fd2b7bf6f31478d76f63b028de02e9c06e5afdd3",
+          "focusedTestDigest": "44cda38b0f9719da8c039ef33084083ace644d081a4cf883b2ff16717ba5ab24",
           "plannedBrowserAssertionCount": 3,
           "plannedBrowserAssertionDigest": "7dce46b0e253c9000c52c96a89b772057bc78fbf5d13a1db1094e52d13b71be3",
           "derivedMessageCount": 77,
@@ -222,7 +222,7 @@
           "route": "/user/login",
           "viewState": "login-and-register",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "52e13ba69c5fb956b444be4e1777dd96021fd18040624b6a8e743588303c4e11",
+          "sourceDigest": "1e102ad9ea57f6ab0909736dd15695f970365676db0bcdc731ab6055211a680d",
           "focusedTestDigest": "607f1c1ecb646250fe3997c740e3c6e15a1babf25edf42ad16842b03e873bb32",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "5598e3ac5fb06b788671b7f7e67b5643b4f0057c5c9deef1fe99da6152ed7fc7",
@@ -247,7 +247,7 @@
           "route": "/user/login/password_forgot",
           "viewState": "password-forgot",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "916ce897c1309aaf95a689671ba1b3e7e4d8fc1f89cc4a6d16b630c0e6b97405",
+          "sourceDigest": "e1cb13b93c6f16e72647e6d89e316f5f2cada0ec98cd88386d329360ca6e19fb",
           "focusedTestDigest": "db8666e7a5327b531dda3b2b246277589e1d052b1a50297b2d85dbd4c7330e4d",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "0ed279e14ece4881b06a02af5603f00ded7d5e8b34bf6de078d7b8d46cf68f00",
@@ -270,7 +270,7 @@
           "route": "/user/login/password_reset",
           "viewState": "password-reset",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "9e45a18d4dff59e72eb9730b191c209f8e6d3a3842bdfca35c4e8efd61ce1ed7",
+          "sourceDigest": "dfad8a947d23b57b526e60f3f006beed7e7de34a79738600a610511a01ee3f7d",
           "focusedTestDigest": "b4c7930f6cea457db94afd7ab557b50e98b1420309bd38960f92d7aadc8b8af0",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "55def77fcde5265acb3f816b429fc087d63aafe080dbe461da66189fbcd75fde",
@@ -294,8 +294,8 @@
           "route": "/dashboard/national-carbon",
           "viewState": "national-carbon-dashboard",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "92fc46f60d099d7411686231d3fb438862ca6bfb4cab80f8f7b94224bfde26b5",
-          "focusedTestDigest": "b381170c5589cf81a5a2bc4c4aa8ba600d3e1cf1acbc74b80328a8ae6effe40c",
+          "sourceDigest": "08033c851aa611d365fc31d15c9b47735a0f9af619c6fe19dade997818df84f8",
+          "focusedTestDigest": "462e32043ad7a3ba37d667bf00395b2568df0383e0316a9c374c00047feb5306",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "95b95698b9168443cacad5913312e98989fb251f09feee48fbaf5f7203c57587",
           "derivedMessageCount": 264,
@@ -360,8 +360,8 @@
           "route": "*",
           "viewState": "not-found",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "d29434cc650be174a89168e6a9bc2ebe4028f84984716ee2959b7b4471011835",
-          "focusedTestDigest": "f049148cf7a8ed1cf0ddc19e5fda68c35fdefa4d1f8265f54a5abb6c1a892e0c",
+          "sourceDigest": "1afcca860f04443eee5ccc0d596d0e8db2ce024112845a98b570c16f68984bd0",
+          "focusedTestDigest": "d7a9730f93a394ec80488b25e370ee154fd8b79f2ff33359ab808a71b01ef207",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "b8ea1e9c64fab4ac0f3adc277885552796c3a6f8f15c10a81ade409284f6cb99",
           "derivedMessageCount": 6,
@@ -1035,8 +1035,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "620dd184b6808b96474612d36aadced76a377455bd152744f08bbce736069953",
-          "focusedTestDigest": "8f33451d0e730a1ba9e49f95d9249f5f085733927ffa799276b57fb7d81f72ba",
+          "sourceDigest": "8f85db12be1712d62d3452690f017484af79c2911b3f4a5f29163b6692355c9e",
+          "focusedTestDigest": "4cc0538a52de788e93da7104113af36c3e318ed70fb4a1527556cbaa4ffe6eba",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 119,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "2a2d1046587513aa11f04c815431bf35e04f2529029da0ea0bf3f5873869e892",
+      "rowEvidenceDigest": "279ce7541a88b1e2ea1baf7603f2fed594c18bc43d9ee389113809e4ad82a3af",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "d8e2e8a245d566dad4b264fce63a36f370dd7c33bffe305d13f916f36669bb36"
+  "contextDigest": "6ced4edf7f9b1204ac1995a12d72e446d0d91d9fafe9aec07b3e995057e67f48"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb"
+    "sourceManifestDigest": "6d5dc58d005907db01a2619377fa60e8fd2615f47a447c7ec75099f4f66054e0"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "d8e2e8a245d566dad4b264fce63a36f370dd7c33bffe305d13f916f36669bb36",
-    "qualityDigest": "77afe829e89fbfd2c6e40b2a9bb02bf872cf22b9bc8545f91cf547af3d2cc4bf",
+    "contextDigest": "6ced4edf7f9b1204ac1995a12d72e446d0d91d9fafe9aec07b3e995057e67f48",
+    "qualityDigest": "0635cff4b41e32f8170565e063653b5560d69f7248c085166147c43c4a45df8b",
     "correctionLedgerDigest": "0834cbfd3977baf45d0dd34cb90ee793025c3ee23b2914f034e7d56dae51bf0e",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "73e979575126a19bbb22791721e2c84217d7a244cb6ed599d68bbe0149b51e87"
+  "activationDigest": "b3ff7394ca7cee0e5e0a91e42106a69b48d29f0faa14d5ea9ff4cd1e654ca2c6"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "818e18a5079a204cffd7817eea67f4c4cc443ad21b80187aa0587108240691eb",
-    "contextDigest": "d8e2e8a245d566dad4b264fce63a36f370dd7c33bffe305d13f916f36669bb36"
+    "sourceManifestDigest": "6d5dc58d005907db01a2619377fa60e8fd2615f47a447c7ec75099f4f66054e0",
+    "contextDigest": "6ced4edf7f9b1204ac1995a12d72e446d0d91d9fafe9aec07b3e995057e67f48"
   },
   "catalog": {
     "messageCount": 3169,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "9730a770d8bb71d416d8d852304b6c6cb2fea7d583582792058dba59b0e3d2d2",
-    "validationDigest": "330c65484d296c2cabfab50200f56392c6605407d6e72a2e3226a479ed578c26",
+    "digest": "0a38e5a57048b7fabdffe730f61778abef6d25f2e14ab2fb5b4d1e879cfd8002",
+    "validationDigest": "d3df3131ed4eba5b29f26626c7822a2e6699b7923119164fe7e5f7a862acc14d",
     "laneCount": 1,
     "validatedMessageCount": 3169,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "77afe829e89fbfd2c6e40b2a9bb02bf872cf22b9bc8545f91cf547af3d2cc4bf"
+  "qualityDigest": "0635cff4b41e32f8170565e063653b5560d69f7248c085166147c43c4a45df8b"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "e77df81f1c50318d0bcf944bc81db86f71aa5b69f0c52d60ee7d2347f1081c09",
+    "auditedInputDigest": "8a5111d4e13ba82fd42d7b22a671386d089016a38d13eebe0dfdb5da4f8dd667",
     "validatedMessageCount": 3169,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1433,
     "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
     "catalogDigest": "07f4707dcc02ac32c1b76d09780d3f26503d4c4b2a1fa85331eb8beac94f2555",
-    "dossierDigest": "e7877f526e1df8c3d7cf4abeb129a115cc41d1444e57d4861404c9f149fdec03",
+    "dossierDigest": "d05591c2c33bb355a919352d476d921d09d8340352ed6a6a0e256f4838ab916a",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "2a2d1046587513aa11f04c815431bf35e04f2529029da0ea0bf3f5873869e892",
+    "routeEvidenceDigest": "279ce7541a88b1e2ea1baf7603f2fed594c18bc43d9ee389113809e4ad82a3af",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "720ffdb462f7c139597e6d9e9bb59f4641cd1fd1b5099b671fdef39cc900c87f",
         "highRiskMessageCount": 1433,
         "highRiskMessageDigest": "3e0a2033e69c686a6f32c3c1887192e3c5c168978256724bf2063930f7d20493",
-        "dossierDigest": "e7877f526e1df8c3d7cf4abeb129a115cc41d1444e57d4861404c9f149fdec03",
+        "dossierDigest": "d05591c2c33bb355a919352d476d921d09d8340352ed6a6a0e256f4838ab916a",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "330c65484d296c2cabfab50200f56392c6605407d6e72a2e3226a479ed578c26"
+  "validationDigest": "d3df3131ed4eba5b29f26626c7822a2e6699b7923119164fe7e5f7a862acc14d"
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -36,6 +36,7 @@ import type { Settings as LayoutSettings } from '@ant-design/pro-components';
 import { SettingDrawer } from '@ant-design/pro-components';
 import type { RunTimeLayoutConfig } from '@umijs/max';
 import { ConfigProvider, theme as antdTheme } from 'antd';
+import type { ReactNode } from 'react';
 import { getBrandTheme } from '../config/branding';
 import defaultSettings, { defaultAppTitle, getLocalizedAppTitle } from '../config/defaultSettings';
 import ClassificationCacheMonitor from './components/ClassificationCacheMonitor';
@@ -58,6 +59,18 @@ const systemAccessByRole = new Map<string, Auth.CurrentUser['access']>([
 export const locale = {
   getLocale: resolveBrowserRuntimeLocale,
 };
+
+/**
+ * Wraps every Umi route, including routes that opt out of ProLayout with
+ * `layout: false`, in the shared boot-success and render-failure boundary.
+ */
+export function rootContainer(container: ReactNode) {
+  return (
+    <StaticFallbackErrorBoundary>
+      <AppBootMarker>{container}</AppBootMarker>
+    </StaticFallbackErrorBoundary>
+  );
+}
 
 async function getSystemAccess(): Promise<Auth.CurrentUser['access'] | undefined> {
   try {
@@ -304,24 +317,20 @@ export const layout: RunTimeLayoutConfig = ({ initialState, setInitialState }) =
               : antdTheme.defaultAlgorithm,
           }}
         >
-          <StaticFallbackErrorBoundary>
-            <AppBootMarker>
-              {renderedChildren}
-              {isDev && !maintenanceActive && (
-                <SettingDrawer
-                  disableUrlParams
-                  enableDarkTheme
-                  settings={initialState?.settings}
-                  onSettingChange={(settings) => {
-                    setInitialState((preInitialState: any) => ({
-                      ...preInitialState,
-                      settings,
-                    }));
-                  }}
-                />
-              )}
-            </AppBootMarker>
-          </StaticFallbackErrorBoundary>
+          {renderedChildren}
+          {isDev && !maintenanceActive && (
+            <SettingDrawer
+              disableUrlParams
+              enableDarkTheme
+              settings={initialState?.settings}
+              onSettingChange={(settings) => {
+                setInitialState((preInitialState: any) => ({
+                  ...preInitialState,
+                  settings,
+                }));
+              }}
+            />
+          )}
         </ConfigProvider>
       );
     },

--- a/tests/unit/app.test.tsx
+++ b/tests/unit/app.test.tsx
@@ -50,8 +50,10 @@ jest.mock('@/components/SystemMaintenance', () => ({
 
 jest.mock('@/components/SystemMaintenance/AppBootBoundary', () => ({
   __esModule: true,
-  AppBootMarker: ({ children }: any) => children,
-  StaticFallbackErrorBoundary: ({ children }: any) => children,
+  AppBootMarker: ({ children }: any) => <div data-testid='app-boot-marker'>{children}</div>,
+  StaticFallbackErrorBoundary: ({ children }: any) => (
+    <div data-testid='static-fallback-error-boundary'>{children}</div>
+  ),
 }));
 
 jest.mock('@/components/AccessDenied', () => ({
@@ -185,6 +187,19 @@ describe('app runtime config', () => {
 
     expect(locale.getLocale()).toBe('de-DE');
     expect(mockResolveBrowserRuntimeLocale).toHaveBeenCalledTimes(1);
+  });
+
+  it('wraps every Umi route in the global boot and render-failure boundary', () => {
+    const { rootContainer } = require('@/app');
+
+    render(rootContainer(<div data-testid='root-route'>layout-free route</div>));
+
+    expect(screen.getByTestId('static-fallback-error-boundary')).toContainElement(
+      screen.getByTestId('app-boot-marker'),
+    );
+    expect(screen.getByTestId('app-boot-marker')).toContainElement(
+      screen.getByTestId('root-route'),
+    );
   });
 
   it('getInitialState returns current user and merged settings on protected routes', async () => {


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#846

## Summary
- Move the shared boot-success marker and static render-failure boundary into Umi rootContainer so every route is covered.
- Remove the duplicate ProLayout-only wrapper while preserving layout rendering behavior.
- Refresh canonical locale route-evidence artifacts derived from src/app.tsx.

## Key Decisions
- Use Umi rootContainer because routes such as /user/login opt out of ProLayout with layout: false.

## Validation
- Focused boot/runtime suites: 43 tests passed.
- Focused i18n contract suites: 30 tests passed; artifact idempotence passed.
- npm run lint and npm run build passed.
- Local production-bundle browser regression stayed on /user/login beyond 15 seconds with mounted=true and no boot watchdog.
- Managed push gate passed: 420 suites, 5745 tests, and 469 tracked source files at 100% statements/branches/functions/lines.

## Risks / Rollback
- Low: the wrapper scope changes from ProLayout children to the Umi root; rollback would restore the prior layout-only wrapper but reintroduce the login timeout.

## Follow-ups
- Promote the merged dev candidate through the normal release flow before production deployment.

## Workspace Integration
- Workspace integration remains pending until a release-semantic child main commit is available for the root pointer.