### PR TITLE
fix: decode canonical Closure blocker severity

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-18"
-lastReviewedCommit: "099718185617d240e4e1849837b0b446f3a4e5c7"
+lastReviewedCommit: "51e83e35b7dc048626c107d4f0683cce1f6f1181"
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 099718185617d240e4e1849837b0b446f3a4e5c7
+lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 099718185617d240e4e1849837b0b446f3a4e5c7
+lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 099718185617d240e4e1849837b0b446f3a4e5c7
+lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - playwright.config.ts
   - config/docs-capture/**
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-08-17
-lastReviewedCommit: a3e698836494da8ddc6f4263cf77425ea683348f
+lastReviewedAt: 2026-08-18
+lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 099718185617d240e4e1849837b0b446f3a4e5c7
+lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - ../AGENTS.md

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/e2e/**
   - playwright.config.ts
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-08-17
-lastReviewedCommit: d338df0622f177805905da29f65862175c7adb5f
+lastReviewedAt: 2026-08-18
+lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 099718185617d240e4e1849837b0b446f3a4e5c7
+lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 099718185617d240e4e1849837b0b446f3a4e5c7
+lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 099718185617d240e4e1849837b0b446f3a4e5c7
+lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 099718185617d240e4e1849837b0b446f3a4e5c7
+lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "50f1e034ec619d7afd2e14591e035fa2e99081aefb557d251c5b6ac42eb0e177",
-    "auditedInputDigest": "599fda1a714cefeb582493881f995ce37be3e2787488e5c1d93b740fd95990ca"
+    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
+    "auditedInputDigest": "3ac7a3aa040a7748977442ca12d4bbff60cbbb664a728ad17b7776a37f50a219"
   },
   "inventory": {
     "sourceMessageCount": 3207,
@@ -47,7 +47,7 @@
     "messageCount": 3207,
     "completeCount": 3207,
     "blockedCount": 0,
-    "dossierDigest": "92ec7b3f91d5377510197a616ded3f9d31fc8f6592e966e120513c06d2e40abd",
+    "dossierDigest": "2d2092a8a9953c2d6a1cd3730e285048884ba3b8c9c9f9d97ef8defa20402067",
     "catalogDigest": "ebe1a99a1cdb1231fefa9cea59309b1e3a2d778338f2d9587dc4fd5e8a151f88",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "40501d75d8f3be85f8dba53114a319a3389594bee4526af5ce5a7fbd87b8e9db",
-          "focusedTestDigest": "344c1701cd9df82000f6ae3dce9478c882650c4de1d452c8456531de87b32148",
+          "focusedTestDigest": "29200ee29b2321916902deed958acee9c2411a4beb83522a1c7ff2530afdff92",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "0f0f573f13c33592e0167581beaf12e5f7dbf4b7790573be3cca02ed7c89aa91",
+      "rowEvidenceDigest": "48f2dec047bbddfe126ddfc47c289408eadc01e468622c8cab92cfcf2cdafff2",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "124513943c6680bfc3073c5498fd20dd41c5bd45d1c723e7644431a7c3848c1e"
+  "contextDigest": "c89b57739432e2dd0815cafca6ab717aa7f3327d29b85d16ccf96c786b448fe7"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "50f1e034ec619d7afd2e14591e035fa2e99081aefb557d251c5b6ac42eb0e177"
+    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "124513943c6680bfc3073c5498fd20dd41c5bd45d1c723e7644431a7c3848c1e",
-    "qualityDigest": "f130f7e34b720b8b06ac8d7f0cbb159d3e62ecf34e74987ab8ab3a9dd592385b",
+    "contextDigest": "c89b57739432e2dd0815cafca6ab717aa7f3327d29b85d16ccf96c786b448fe7",
+    "qualityDigest": "6f02d5b32d0ba922830f9bdd656664b487e196b3369e7abe4d5031cf2a75270d",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "b44d8aa7809ae4ab8346bf9c6f2122709c3666376398e04cbfb9c73fb3244ec3"
+  "activationDigest": "a595722170d90790848d78a9c23faff6e9a046fa3136d76b341bb4bb0bb83f69"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "599fda1a714cefeb582493881f995ce37be3e2787488e5c1d93b740fd95990ca",
+    "auditedInputDigest": "3ac7a3aa040a7748977442ca12d4bbff60cbbb664a728ad17b7776a37f50a219",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "50f1e034ec619d7afd2e14591e035fa2e99081aefb557d251c5b6ac42eb0e177",
-    "contextDigest": "124513943c6680bfc3073c5498fd20dd41c5bd45d1c723e7644431a7c3848c1e"
+    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
+    "contextDigest": "c89b57739432e2dd0815cafca6ab717aa7f3327d29b85d16ccf96c786b448fe7"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "ffa395c73d3d31c5af1a1e152ada5e3420e77256e62e6d8070a7f53002392f6a",
-    "validationDigest": "d3eda3c25cf8783460fa7dd291b528675478f32d1b9ce786cfef02964af6ede2",
+    "digest": "71582991602fda41aa31dfb98af2f120c7b1e36b233d62db871d1f1e466a3825",
+    "validationDigest": "203ce1b47f6b8a2cde9535dac74d97636a87fa27128f63ad34e2394d57634eac",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "f130f7e34b720b8b06ac8d7f0cbb159d3e62ecf34e74987ab8ab3a9dd592385b"
+  "qualityDigest": "6f02d5b32d0ba922830f9bdd656664b487e196b3369e7abe4d5031cf2a75270d"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "599fda1a714cefeb582493881f995ce37be3e2787488e5c1d93b740fd95990ca",
+    "auditedInputDigest": "3ac7a3aa040a7748977442ca12d4bbff60cbbb664a728ad17b7776a37f50a219",
     "validatedMessageCount": 3207,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1438,
     "highRiskMessageDigest": "f04d46071b685e2e8f18b83dcdc6b333345ccde36366e5c1a1b05a7b1944677f",
     "catalogDigest": "ebe1a99a1cdb1231fefa9cea59309b1e3a2d778338f2d9587dc4fd5e8a151f88",
-    "dossierDigest": "92ec7b3f91d5377510197a616ded3f9d31fc8f6592e966e120513c06d2e40abd",
+    "dossierDigest": "2d2092a8a9953c2d6a1cd3730e285048884ba3b8c9c9f9d97ef8defa20402067",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "0f0f573f13c33592e0167581beaf12e5f7dbf4b7790573be3cca02ed7c89aa91",
+    "routeEvidenceDigest": "48f2dec047bbddfe126ddfc47c289408eadc01e468622c8cab92cfcf2cdafff2",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "1c44907a709976d8e99335c2656623bc9ea0d5379f10f6d81b58e724a773ab67",
         "highRiskMessageCount": 1438,
         "highRiskMessageDigest": "f04d46071b685e2e8f18b83dcdc6b333345ccde36366e5c1a1b05a7b1944677f",
-        "dossierDigest": "92ec7b3f91d5377510197a616ded3f9d31fc8f6592e966e120513c06d2e40abd",
+        "dossierDigest": "2d2092a8a9953c2d6a1cd3730e285048884ba3b8c9c9f9d97ef8defa20402067",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "d3eda3c25cf8783460fa7dd291b528675478f32d1b9ce786cfef02964af6ede2"
+  "validationDigest": "203ce1b47f6b8a2cde9535dac74d97636a87fa27128f63ad34e2394d57634eac"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "50f1e034ec619d7afd2e14591e035fa2e99081aefb557d251c5b6ac42eb0e177",
-    "auditedInputDigest": "599fda1a714cefeb582493881f995ce37be3e2787488e5c1d93b740fd95990ca"
+    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
+    "auditedInputDigest": "3ac7a3aa040a7748977442ca12d4bbff60cbbb664a728ad17b7776a37f50a219"
   },
   "inventory": {
     "sourceMessageCount": 3207,
@@ -47,7 +47,7 @@
     "messageCount": 3207,
     "completeCount": 3207,
     "blockedCount": 0,
-    "dossierDigest": "dd328660aa44bedf551a75bce59abb2e8663e8390546045309ab8d556aad00d4",
+    "dossierDigest": "b37ecd1de26df45e2fbf696b10bcf996fac7684dbfcf442930879ccbf3d912aa",
     "catalogDigest": "c624da4a23d6cb86936aeb4b45afd52d46a8b29702e8064b2607b3ff975049d6",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "40501d75d8f3be85f8dba53114a319a3389594bee4526af5ce5a7fbd87b8e9db",
-          "focusedTestDigest": "344c1701cd9df82000f6ae3dce9478c882650c4de1d452c8456531de87b32148",
+          "focusedTestDigest": "29200ee29b2321916902deed958acee9c2411a4beb83522a1c7ff2530afdff92",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "0f0f573f13c33592e0167581beaf12e5f7dbf4b7790573be3cca02ed7c89aa91",
+      "rowEvidenceDigest": "48f2dec047bbddfe126ddfc47c289408eadc01e468622c8cab92cfcf2cdafff2",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "bb0d149052570fbb2b749ca02464c2b562d166277dbfc195e940912d96c6a659"
+  "contextDigest": "9c141c9e87cb0598417927979915721f3e6834480cb1351332bd31c839f5ce1c"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "50f1e034ec619d7afd2e14591e035fa2e99081aefb557d251c5b6ac42eb0e177"
+    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "bb0d149052570fbb2b749ca02464c2b562d166277dbfc195e940912d96c6a659",
-    "qualityDigest": "1433839bcaa683f95a14adc720acff14d639de35b84e94d2bda4ee8ff86b908e",
+    "contextDigest": "9c141c9e87cb0598417927979915721f3e6834480cb1351332bd31c839f5ce1c",
+    "qualityDigest": "38d3ce0fbed0f6a5c4c348ee042ac98389b76f304cdc1a32af8e6c80e5e4953d",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "1fa56f82eda419a6e69eff9d6e9a3e640769a7825a9c774b54353150a93eb913"
+  "activationDigest": "b9c555c8573918cc74ba7be530a4362b20b04e6920929b55fc2957049041b769"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "50f1e034ec619d7afd2e14591e035fa2e99081aefb557d251c5b6ac42eb0e177",
-    "contextDigest": "bb0d149052570fbb2b749ca02464c2b562d166277dbfc195e940912d96c6a659"
+    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
+    "contextDigest": "9c141c9e87cb0598417927979915721f3e6834480cb1351332bd31c839f5ce1c"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "8640dce22ee878e1a2c39b38d95a1edf1e259b224818641e41f1559af7029705",
-    "validationDigest": "87e7f1243c62a1ec3f0fa08ffc5a5bae0a21253108fe79eeb6e7f7261dd50a35",
+    "digest": "625dd953062415d1163529ff45674f4871679b91fd9b2cb929a7c5db6c6fcd8f",
+    "validationDigest": "57e6500e5c02257b1cd188f7b41281cc40fc58e74eddc5d2f947a787b489466c",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "1433839bcaa683f95a14adc720acff14d639de35b84e94d2bda4ee8ff86b908e"
+  "qualityDigest": "38d3ce0fbed0f6a5c4c348ee042ac98389b76f304cdc1a32af8e6c80e5e4953d"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "599fda1a714cefeb582493881f995ce37be3e2787488e5c1d93b740fd95990ca",
+    "auditedInputDigest": "3ac7a3aa040a7748977442ca12d4bbff60cbbb664a728ad17b7776a37f50a219",
     "validatedMessageCount": 3207,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1438,
     "highRiskMessageDigest": "f04d46071b685e2e8f18b83dcdc6b333345ccde36366e5c1a1b05a7b1944677f",
     "catalogDigest": "c624da4a23d6cb86936aeb4b45afd52d46a8b29702e8064b2607b3ff975049d6",
-    "dossierDigest": "dd328660aa44bedf551a75bce59abb2e8663e8390546045309ab8d556aad00d4",
+    "dossierDigest": "b37ecd1de26df45e2fbf696b10bcf996fac7684dbfcf442930879ccbf3d912aa",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "0f0f573f13c33592e0167581beaf12e5f7dbf4b7790573be3cca02ed7c89aa91",
+    "routeEvidenceDigest": "48f2dec047bbddfe126ddfc47c289408eadc01e468622c8cab92cfcf2cdafff2",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "1c44907a709976d8e99335c2656623bc9ea0d5379f10f6d81b58e724a773ab67",
         "highRiskMessageCount": 1438,
         "highRiskMessageDigest": "f04d46071b685e2e8f18b83dcdc6b333345ccde36366e5c1a1b05a7b1944677f",
-        "dossierDigest": "dd328660aa44bedf551a75bce59abb2e8663e8390546045309ab8d556aad00d4",
+        "dossierDigest": "b37ecd1de26df45e2fbf696b10bcf996fac7684dbfcf442930879ccbf3d912aa",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "87e7f1243c62a1ec3f0fa08ffc5a5bae0a21253108fe79eeb6e7f7261dd50a35"
+  "validationDigest": "57e6500e5c02257b1cd188f7b41281cc40fc58e74eddc5d2f947a787b489466c"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "50f1e034ec619d7afd2e14591e035fa2e99081aefb557d251c5b6ac42eb0e177",
-    "auditedInputDigest": "599fda1a714cefeb582493881f995ce37be3e2787488e5c1d93b740fd95990ca"
+    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
+    "auditedInputDigest": "3ac7a3aa040a7748977442ca12d4bbff60cbbb664a728ad17b7776a37f50a219"
   },
   "inventory": {
     "sourceMessageCount": 3207,
@@ -47,7 +47,7 @@
     "messageCount": 3207,
     "completeCount": 3207,
     "blockedCount": 0,
-    "dossierDigest": "c9a62bffe0703703e68e27501363261e8ac3d56ea2d1003a72291cea77048a0f",
+    "dossierDigest": "dde6832d2860d044cfef590fae4e750e8b4925cdd44abdecc897d42482cf8e43",
     "catalogDigest": "7d583779611c1c15fbbe9d362606a7f992bd399dcb958f558b638dd85fd12156",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "40501d75d8f3be85f8dba53114a319a3389594bee4526af5ce5a7fbd87b8e9db",
-          "focusedTestDigest": "344c1701cd9df82000f6ae3dce9478c882650c4de1d452c8456531de87b32148",
+          "focusedTestDigest": "29200ee29b2321916902deed958acee9c2411a4beb83522a1c7ff2530afdff92",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "0f0f573f13c33592e0167581beaf12e5f7dbf4b7790573be3cca02ed7c89aa91",
+      "rowEvidenceDigest": "48f2dec047bbddfe126ddfc47c289408eadc01e468622c8cab92cfcf2cdafff2",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "847a6e0d1c4631f8dc7ef53288f552a2b18bcbbc9fd5b6779cc237f81628d160"
+  "contextDigest": "1138a648b1e2a959cc8c249bb21032592397f0291b5f2008e7bb9ab43c1201a4"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "50f1e034ec619d7afd2e14591e035fa2e99081aefb557d251c5b6ac42eb0e177"
+    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "847a6e0d1c4631f8dc7ef53288f552a2b18bcbbc9fd5b6779cc237f81628d160",
-    "qualityDigest": "fdbea9107c6fcd15899fb5d5ce5c182a5f20568d7dbbafc4e9fd5cd69cb3dbca",
+    "contextDigest": "1138a648b1e2a959cc8c249bb21032592397f0291b5f2008e7bb9ab43c1201a4",
+    "qualityDigest": "bf230cb07be84866c1bcbe75eb9fcfac68c5604a0fd0d70880823b7943eed531",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "91783150b9f115c280b54a333ec844ea14b0de3ab9e22ecf5cc80f80e5dc971c"
+  "activationDigest": "de3a981c406456f2d0c6e5a47e980e2ad729eb51766c95b38741d3b2475e42ad"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "50f1e034ec619d7afd2e14591e035fa2e99081aefb557d251c5b6ac42eb0e177",
-    "contextDigest": "847a6e0d1c4631f8dc7ef53288f552a2b18bcbbc9fd5b6779cc237f81628d160"
+    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
+    "contextDigest": "1138a648b1e2a959cc8c249bb21032592397f0291b5f2008e7bb9ab43c1201a4"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "f93952f904bfe4fedff5da94131919387d7a632ed2f67e89ea28065c23efd472",
-    "validationDigest": "cf983a0c96ea3a8074efac518a8512bf5ffba70d466c330fd5c39b3e7e1180b7",
+    "digest": "181357ebf8cc836d2535b484f0e691f8d3f3ae94a7775af3098d265f64bb0cd7",
+    "validationDigest": "4dbc85256ff984ae904ea51c164c6db381a62bd29865d12870ab958ebc27d947",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "fdbea9107c6fcd15899fb5d5ce5c182a5f20568d7dbbafc4e9fd5cd69cb3dbca"
+  "qualityDigest": "bf230cb07be84866c1bcbe75eb9fcfac68c5604a0fd0d70880823b7943eed531"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "599fda1a714cefeb582493881f995ce37be3e2787488e5c1d93b740fd95990ca",
+    "auditedInputDigest": "3ac7a3aa040a7748977442ca12d4bbff60cbbb664a728ad17b7776a37f50a219",
     "validatedMessageCount": 3207,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1438,
     "highRiskMessageDigest": "f04d46071b685e2e8f18b83dcdc6b333345ccde36366e5c1a1b05a7b1944677f",
     "catalogDigest": "7d583779611c1c15fbbe9d362606a7f992bd399dcb958f558b638dd85fd12156",
-    "dossierDigest": "c9a62bffe0703703e68e27501363261e8ac3d56ea2d1003a72291cea77048a0f",
+    "dossierDigest": "dde6832d2860d044cfef590fae4e750e8b4925cdd44abdecc897d42482cf8e43",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "0f0f573f13c33592e0167581beaf12e5f7dbf4b7790573be3cca02ed7c89aa91",
+    "routeEvidenceDigest": "48f2dec047bbddfe126ddfc47c289408eadc01e468622c8cab92cfcf2cdafff2",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "1c44907a709976d8e99335c2656623bc9ea0d5379f10f6d81b58e724a773ab67",
         "highRiskMessageCount": 1438,
         "highRiskMessageDigest": "f04d46071b685e2e8f18b83dcdc6b333345ccde36366e5c1a1b05a7b1944677f",
-        "dossierDigest": "c9a62bffe0703703e68e27501363261e8ac3d56ea2d1003a72291cea77048a0f",
+        "dossierDigest": "dde6832d2860d044cfef590fae4e750e8b4925cdd44abdecc897d42482cf8e43",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "cf983a0c96ea3a8074efac518a8512bf5ffba70d466c330fd5c39b3e7e1180b7"
+  "validationDigest": "4dbc85256ff984ae904ea51c164c6db381a62bd29865d12870ab958ebc27d947"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "50f1e034ec619d7afd2e14591e035fa2e99081aefb557d251c5b6ac42eb0e177",
-    "auditedInputDigest": "599fda1a714cefeb582493881f995ce37be3e2787488e5c1d93b740fd95990ca"
+    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
+    "auditedInputDigest": "3ac7a3aa040a7748977442ca12d4bbff60cbbb664a728ad17b7776a37f50a219"
   },
   "inventory": {
     "sourceMessageCount": 3207,
@@ -47,7 +47,7 @@
     "messageCount": 3207,
     "completeCount": 3207,
     "blockedCount": 0,
-    "dossierDigest": "75e0764d1366a2a857fe0a2f104a9fbdd4529a3b09ee91100fbba719f61983d0",
+    "dossierDigest": "08f33b9b65a8eb320783cd1981e720624db21cbcc4b20d602c37dd6ee5bd228e",
     "catalogDigest": "9a0e196cccecf0bb9f31b00c34d66eb42df680f77da9be330a12dcae6fd292ea",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "40501d75d8f3be85f8dba53114a319a3389594bee4526af5ce5a7fbd87b8e9db",
-          "focusedTestDigest": "344c1701cd9df82000f6ae3dce9478c882650c4de1d452c8456531de87b32148",
+          "focusedTestDigest": "29200ee29b2321916902deed958acee9c2411a4beb83522a1c7ff2530afdff92",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "0f0f573f13c33592e0167581beaf12e5f7dbf4b7790573be3cca02ed7c89aa91",
+      "rowEvidenceDigest": "48f2dec047bbddfe126ddfc47c289408eadc01e468622c8cab92cfcf2cdafff2",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "f1a3909973f3449566804f5462ec6b912a0026d9d375f4f93cb2feef08067b86"
+  "contextDigest": "60b991c05cf28c7bfc837ee08fc92510a6ceab1ac38a7b08133539e06a4ec432"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "50f1e034ec619d7afd2e14591e035fa2e99081aefb557d251c5b6ac42eb0e177"
+    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "f1a3909973f3449566804f5462ec6b912a0026d9d375f4f93cb2feef08067b86",
-    "qualityDigest": "908d25ac2c831bf833fb976dc1ece50b651309b55f4dfde37ed88b9d5b2cde33",
+    "contextDigest": "60b991c05cf28c7bfc837ee08fc92510a6ceab1ac38a7b08133539e06a4ec432",
+    "qualityDigest": "a8d77d72601c7115b9f3503a259256faae4fb95b2656378a87247cfa1e3c40eb",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "f1146853d7496df9e451066b4cb190441b089322ac8df1afb9f1ed755dc3c8c6"
+  "activationDigest": "d8c48c8b89170394ae8c813da5f096ac1dc9db473433a17bd59ddff3128249bc"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "50f1e034ec619d7afd2e14591e035fa2e99081aefb557d251c5b6ac42eb0e177",
-    "contextDigest": "f1a3909973f3449566804f5462ec6b912a0026d9d375f4f93cb2feef08067b86"
+    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
+    "contextDigest": "60b991c05cf28c7bfc837ee08fc92510a6ceab1ac38a7b08133539e06a4ec432"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "1dd094f2e0f27449544522ac8b40b4853a3a022fb67e9be5be6b4c1a354b662b",
-    "validationDigest": "b8b3f8e67fc0d750ef183c9af5a766e420a9bc02520ec21e748597547301ca48",
+    "digest": "a60b48555103d819cfc359ccaa5de2954a14d04e74a9c754893c5b99c3d7995b",
+    "validationDigest": "ebbcaa4e742405098afd320d5eb94b22041a7c65d9ea8ef82b225534b2abed27",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "908d25ac2c831bf833fb976dc1ece50b651309b55f4dfde37ed88b9d5b2cde33"
+  "qualityDigest": "a8d77d72601c7115b9f3503a259256faae4fb95b2656378a87247cfa1e3c40eb"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "599fda1a714cefeb582493881f995ce37be3e2787488e5c1d93b740fd95990ca",
+    "auditedInputDigest": "3ac7a3aa040a7748977442ca12d4bbff60cbbb664a728ad17b7776a37f50a219",
     "validatedMessageCount": 3207,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1438,
     "highRiskMessageDigest": "f04d46071b685e2e8f18b83dcdc6b333345ccde36366e5c1a1b05a7b1944677f",
     "catalogDigest": "9a0e196cccecf0bb9f31b00c34d66eb42df680f77da9be330a12dcae6fd292ea",
-    "dossierDigest": "75e0764d1366a2a857fe0a2f104a9fbdd4529a3b09ee91100fbba719f61983d0",
+    "dossierDigest": "08f33b9b65a8eb320783cd1981e720624db21cbcc4b20d602c37dd6ee5bd228e",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "0f0f573f13c33592e0167581beaf12e5f7dbf4b7790573be3cca02ed7c89aa91",
+    "routeEvidenceDigest": "48f2dec047bbddfe126ddfc47c289408eadc01e468622c8cab92cfcf2cdafff2",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "1c44907a709976d8e99335c2656623bc9ea0d5379f10f6d81b58e724a773ab67",
         "highRiskMessageCount": 1438,
         "highRiskMessageDigest": "f04d46071b685e2e8f18b83dcdc6b333345ccde36366e5c1a1b05a7b1944677f",
-        "dossierDigest": "75e0764d1366a2a857fe0a2f104a9fbdd4529a3b09ee91100fbba719f61983d0",
+        "dossierDigest": "08f33b9b65a8eb320783cd1981e720624db21cbcc4b20d602c37dd6ee5bd228e",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "b8b3f8e67fc0d750ef183c9af5a766e420a9bc02520ec21e748597547301ca48"
+  "validationDigest": "ebbcaa4e742405098afd320d5eb94b22041a7c65d9ea8ef82b225534b2abed27"
 }

--- a/src/services/dataProducts/closure.ts
+++ b/src/services/dataProducts/closure.ts
@@ -117,7 +117,7 @@ export type ClosureCheckRequestV1 = {
 /** A curated issue row; never a raw worker log, stack trace, or closure artifact. */
 export type ClosureCheckIssueV1 = {
   issueId: string;
-  severity: 'blocking' | 'warning' | 'info';
+  severity: 'blocker' | 'warning' | 'info';
   blocking: boolean;
   code: string;
   title: string;
@@ -422,7 +422,7 @@ export function decodeClosureCheckIssue(value: unknown): ClosureCheckIssueV1 | n
   const affectedRootCount = numberValue(value.affectedRootCount);
   if (
     !isNonEmptyString(issueId) ||
-    !['blocking', 'warning', 'info'].includes(String(severity)) ||
+    !['blocker', 'warning', 'info'].includes(String(severity)) ||
     typeof value.blocking !== 'boolean' ||
     !isNonEmptyString(code) ||
     !isNonEmptyString(title) ||

--- a/tests/unit/pages/DataProcessing/index.test.tsx
+++ b/tests/unit/pages/DataProcessing/index.test.tsx
@@ -1432,7 +1432,7 @@ describe('DataProcessing page', () => {
           issues: [
             {
               issueId: 'issue-1',
-              severity: 'blocking',
+              severity: 'blocker',
               blocking: true,
               code: 'missing_provider',
               title: 'Missing provider',
@@ -1453,7 +1453,7 @@ describe('DataProcessing page', () => {
           issues: [
             {
               issueId: 'issue-1',
-              severity: 'blocking',
+              severity: 'blocker',
               blocking: true,
               code: 'missing_provider',
               title: 'Missing provider',

--- a/tests/unit/services/dataProducts/taskCenter.test.ts
+++ b/tests/unit/services/dataProducts/taskCenter.test.ts
@@ -287,10 +287,11 @@ describe('Data Product TaskSummaryV2 safe projection', () => {
         schemaVersion: 'lcia.scope-closure-issues-page.v1',
         closureCheckId: 'closure-1',
         totalCount: 1,
+        nextCursor: null,
         issues: [
           {
             issueId: 'issue-1',
-            severity: 'blocking',
+            severity: 'blocker',
             blocking: true,
             code: 'missing_reference',
             title: 'missing_reference',
@@ -316,7 +317,7 @@ describe('Data Product TaskSummaryV2 safe projection', () => {
     });
     expect(result.data?.issues[0]).toEqual({
       issueId: 'issue-1',
-      severity: 'blocking',
+      severity: 'blocker',
       blocking: true,
       code: 'missing_reference',
       title: 'missing_reference',
@@ -325,6 +326,7 @@ describe('Data Product TaskSummaryV2 safe projection', () => {
     });
     expect(result.data?.issues[0]).not.toHaveProperty('affectedProcess');
     expect(result.data?.totalCount).toBe(1);
+    expect(result.data).not.toHaveProperty('nextCursor');
   });
 
   it('whitelists only the safe short-lived report descriptor fields', async () => {
@@ -759,7 +761,7 @@ describe('Data Product TaskSummaryV2 safe projection', () => {
   it('validates closure issues, pages, and report descriptors field by field', () => {
     const issueBase = {
       issueId: 'issue-1',
-      severity: 'blocking',
+      severity: 'blocker',
       blocking: true,
       code: 'missing_ref',
       title: 'Missing reference',
@@ -769,6 +771,7 @@ describe('Data Product TaskSummaryV2 safe projection', () => {
     expect(decodeClosureCheckIssue(null)).toBeNull();
     for (const patch of [
       { issueId: '' },
+      { severity: 'blocking' },
       { severity: 'invalid' },
       { blocking: 'yes' },
       { code: '' },


### PR DESCRIPTION
Closes #884

## Summary
- Render valid production Closure issue pages instead of reporting Invalid closure command response.

## Key Decisions
- Align Next with the canonical Database and Worker severity value blocker; do not accept the erroneous blocking alias or relax the strict decoder.
- Treat nextCursor null as a valid terminal issue page while continuing to omit it from the decoded safe projection.

## Validation
- Focused Closure service and Data Processing suites: 88 tests passed.
- closure.ts focused coverage: 100% statements, branches, functions, and lines.
- ESLint, Prettier, TypeScript, production build, i18n audit/artifact idempotence, and Docpact passed.
- Full repository proof on exact clean commit 6123da95: receipt 38/38; coverage 421 suites / 5764 tests; 470/470 source files at 100/100/100/100. One earlier native Jest SIGSEGV and one isolated receipt-fixture transient were diagnosed and recovered with the repository playbook before the final passing evidence.

## Risks / Rollback
- Low: changes one frontend enum literal and matching fixtures; unsupported values still fail closed.

## Follow-ups
- After merge, publish the normal Next patch release and update the workspace pointer. The underlying snapshot_dataset_not_allowed data blockers are separate.

## Workspace Integration
- Requires normal dev-to-main release promotion and a later root workspace pointer update.