### PR TITLE
chore: prepare v0.0.78 on dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-18"
-lastReviewedCommit: "51e83e35b7dc048626c107d4f0683cce1f6f1181"
+lastReviewedCommit: "9cb49b0bd80a87fd490f81e9dac570e6d7c2930c"
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
+lastReviewedCommit: 9cb49b0bd80a87fd490f81e9dac570e6d7c2930c
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
+lastReviewedCommit: 9cb49b0bd80a87fd490f81e9dac570e6d7c2930c
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
+lastReviewedCommit: 9cb49b0bd80a87fd490f81e9dac570e6d7c2930c
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
+lastReviewedCommit: 9cb49b0bd80a87fd490f81e9dac570e6d7c2930c
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
+lastReviewedCommit: 9cb49b0bd80a87fd490f81e9dac570e6d7c2930c
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
+lastReviewedCommit: 9cb49b0bd80a87fd490f81e9dac570e6d7c2930c
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
+lastReviewedCommit: 9cb49b0bd80a87fd490f81e9dac570e6d7c2930c
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
+lastReviewedCommit: 9cb49b0bd80a87fd490f81e9dac570e6d7c2930c
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.77",
+      "version": "0.0.78",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
<!-- tiangong-next-release-automation:v2 issue=884 version=0.0.78 dev-base=9cb49b0bd80a87fd490f81e9dac570e6d7c2930c main-base=456eb5b34e9ad70273b8c5e233e8ff45500bd779 candidate=0baaa897ec594328a0dad7b8423f09f6a6da82c1 -->

## Branch Contract

- base branch: `dev`
- validated environment: exact dev Release PR non-browser gate
- back-merge required after merge: No
- root workspace integration expected: after later dev-to-main promotion

## Linked Issue

Refs #884

## Change Facts

- Prepare version `0.0.78` from exact dev base `9cb49b0bd80a87fd490f81e9dac570e6d7c2930c`.
- Keep package.json and both package-lock root version fields aligned.
- Keep release proof external to Git and bind it to the exact main/dev bases, candidate SHA/tree, version, workflow run, and artifact.
- Record Docpact review evidence only after the command proves the candidate has no other semantic change.
- Reviewed paths:
  - `.docpact/config.yaml`
  - `AGENTS.md`
  - `DEV.md`
  - `docs/agents/prepush-gate-policy.md`
  - `docs/agents/repo-validation.md`
  - `docs/agents/test_improvement_plan.md`
  - `docs/agents/test_todo_list.md`
  - `docs/agents/testing-patterns.md`
  - `docs/agents/testing-troubleshooting.md`

## Validation Facts

- Candidate: `0baaa897ec594328a0dad7b8423f09f6a6da82c1`
- Main baseline: `456eb5b34e9ad70273b8c5e233e8ff45500bd779`
- Release gate: `required_by_dev_release_candidate_gate`; static preflight: `passed`
- Docpact automatic-review status: `previously_completed`
- Docpact checked the complete main-to-candidate promotion range before the dev PR was created.
- The managed candidate push ran only structural/static checks; this PR owns one non-browser full release gate and its exact proof.
- Browser E2E is not evaluated or required by this PR. Run the manual hermetic workflow on the open business PR before release-to-dev when the change risk warrants browser evidence.

## Risks And Follow-Up

- Merge only after the exact Release Candidate release proof succeeds, then run the deterministic dev-to-main promotion command with this PR number.
