### PR TITLE
test: stabilize Data Processing preview setup

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-18"
-lastReviewedCommit: "51e83e35b7dc048626c107d4f0683cce1f6f1181"
+lastReviewedCommit: "7ab86c2d8275def668dc71c83879218a3d194ea6"
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
+lastReviewedCommit: f7c1a218ae82806a98b7db45f792394ea423c578
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
+lastReviewedCommit: f7c1a218ae82806a98b7db45f792394ea423c578
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
+lastReviewedCommit: 7ab86c2d8275def668dc71c83879218a3d194ea6
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
+lastReviewedCommit: 7ab86c2d8275def668dc71c83879218a3d194ea6
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
+lastReviewedCommit: 7ab86c2d8275def668dc71c83879218a3d194ea6
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
+lastReviewedCommit: 7ab86c2d8275def668dc71c83879218a3d194ea6
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
+lastReviewedCommit: 7ab86c2d8275def668dc71c83879218a3d194ea6
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
+lastReviewedCommit: 7ab86c2d8275def668dc71c83879218a3d194ea6
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "40501d75d8f3be85f8dba53114a319a3389594bee4526af5ce5a7fbd87b8e9db",
-          "focusedTestDigest": "29200ee29b2321916902deed958acee9c2411a4beb83522a1c7ff2530afdff92",
+          "focusedTestDigest": "3bfeb50dd515e28cba5f128301fa4ca11a0c0725f9ce2fc8aca560593e2b25d5",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "48f2dec047bbddfe126ddfc47c289408eadc01e468622c8cab92cfcf2cdafff2",
+      "rowEvidenceDigest": "f41a920621bb9da9dfaf94f0239117cfc1f439634eb83c18ca2db3e29995c614",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "c89b57739432e2dd0815cafca6ab717aa7f3327d29b85d16ccf96c786b448fe7"
+  "contextDigest": "e31dd8e0cda6a094526723ff9332b23b12208980d6a51038acc854587da7885d"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "c89b57739432e2dd0815cafca6ab717aa7f3327d29b85d16ccf96c786b448fe7",
-    "qualityDigest": "6f02d5b32d0ba922830f9bdd656664b487e196b3369e7abe4d5031cf2a75270d",
+    "contextDigest": "e31dd8e0cda6a094526723ff9332b23b12208980d6a51038acc854587da7885d",
+    "qualityDigest": "b20436b6cbc379890d8c6466acfd9067198881bc0bfe3cb3fe576ac662198c5c",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "a595722170d90790848d78a9c23faff6e9a046fa3136d76b341bb4bb0bb83f69"
+  "activationDigest": "77868a9109bb1ce2e47053583fee96143463c0819895b16c911f588a00529add"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
-    "contextDigest": "c89b57739432e2dd0815cafca6ab717aa7f3327d29b85d16ccf96c786b448fe7"
+    "contextDigest": "e31dd8e0cda6a094526723ff9332b23b12208980d6a51038acc854587da7885d"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "71582991602fda41aa31dfb98af2f120c7b1e36b233d62db871d1f1e466a3825",
-    "validationDigest": "203ce1b47f6b8a2cde9535dac74d97636a87fa27128f63ad34e2394d57634eac",
+    "digest": "78460ba01a876c3e8a1650d03afbb00cdd27831017c087395c56938bbcf6bf2c",
+    "validationDigest": "23256fe39ab2347010df30fc3250dee46970b2f1faf60f503714c185805f7d12",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "6f02d5b32d0ba922830f9bdd656664b487e196b3369e7abe4d5031cf2a75270d"
+  "qualityDigest": "b20436b6cbc379890d8c6466acfd9067198881bc0bfe3cb3fe576ac662198c5c"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "ebe1a99a1cdb1231fefa9cea59309b1e3a2d778338f2d9587dc4fd5e8a151f88",
     "dossierDigest": "2d2092a8a9953c2d6a1cd3730e285048884ba3b8c9c9f9d97ef8defa20402067",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "48f2dec047bbddfe126ddfc47c289408eadc01e468622c8cab92cfcf2cdafff2",
+    "routeEvidenceDigest": "f41a920621bb9da9dfaf94f0239117cfc1f439634eb83c18ca2db3e29995c614",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "203ce1b47f6b8a2cde9535dac74d97636a87fa27128f63ad34e2394d57634eac"
+  "validationDigest": "23256fe39ab2347010df30fc3250dee46970b2f1faf60f503714c185805f7d12"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "40501d75d8f3be85f8dba53114a319a3389594bee4526af5ce5a7fbd87b8e9db",
-          "focusedTestDigest": "29200ee29b2321916902deed958acee9c2411a4beb83522a1c7ff2530afdff92",
+          "focusedTestDigest": "3bfeb50dd515e28cba5f128301fa4ca11a0c0725f9ce2fc8aca560593e2b25d5",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "48f2dec047bbddfe126ddfc47c289408eadc01e468622c8cab92cfcf2cdafff2",
+      "rowEvidenceDigest": "f41a920621bb9da9dfaf94f0239117cfc1f439634eb83c18ca2db3e29995c614",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "9c141c9e87cb0598417927979915721f3e6834480cb1351332bd31c839f5ce1c"
+  "contextDigest": "3dd0fa6a92c924539d20f1f3df990786066e71230aee740e20b090cc32ac1e7a"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "9c141c9e87cb0598417927979915721f3e6834480cb1351332bd31c839f5ce1c",
-    "qualityDigest": "38d3ce0fbed0f6a5c4c348ee042ac98389b76f304cdc1a32af8e6c80e5e4953d",
+    "contextDigest": "3dd0fa6a92c924539d20f1f3df990786066e71230aee740e20b090cc32ac1e7a",
+    "qualityDigest": "3b26483a0208b0d9db1e9ca83569853d114e1099491325dc0eef2ca0ee2bf89c",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "b9c555c8573918cc74ba7be530a4362b20b04e6920929b55fc2957049041b769"
+  "activationDigest": "ba32ad936401210389ca8e55b79607170f14abbd0d50fc6159e95540ca432f59"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
-    "contextDigest": "9c141c9e87cb0598417927979915721f3e6834480cb1351332bd31c839f5ce1c"
+    "contextDigest": "3dd0fa6a92c924539d20f1f3df990786066e71230aee740e20b090cc32ac1e7a"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "625dd953062415d1163529ff45674f4871679b91fd9b2cb929a7c5db6c6fcd8f",
-    "validationDigest": "57e6500e5c02257b1cd188f7b41281cc40fc58e74eddc5d2f947a787b489466c",
+    "digest": "27fa16d7aa2165356c71f6954280d4bc208d157cb73c9a0115ab5b7a932d2f4d",
+    "validationDigest": "3ecc6acf0d5b3bb988e9253239e9ae5d5bf06549a4015dceacfac9105f502888",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "38d3ce0fbed0f6a5c4c348ee042ac98389b76f304cdc1a32af8e6c80e5e4953d"
+  "qualityDigest": "3b26483a0208b0d9db1e9ca83569853d114e1099491325dc0eef2ca0ee2bf89c"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "c624da4a23d6cb86936aeb4b45afd52d46a8b29702e8064b2607b3ff975049d6",
     "dossierDigest": "b37ecd1de26df45e2fbf696b10bcf996fac7684dbfcf442930879ccbf3d912aa",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "48f2dec047bbddfe126ddfc47c289408eadc01e468622c8cab92cfcf2cdafff2",
+    "routeEvidenceDigest": "f41a920621bb9da9dfaf94f0239117cfc1f439634eb83c18ca2db3e29995c614",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "57e6500e5c02257b1cd188f7b41281cc40fc58e74eddc5d2f947a787b489466c"
+  "validationDigest": "3ecc6acf0d5b3bb988e9253239e9ae5d5bf06549a4015dceacfac9105f502888"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "40501d75d8f3be85f8dba53114a319a3389594bee4526af5ce5a7fbd87b8e9db",
-          "focusedTestDigest": "29200ee29b2321916902deed958acee9c2411a4beb83522a1c7ff2530afdff92",
+          "focusedTestDigest": "3bfeb50dd515e28cba5f128301fa4ca11a0c0725f9ce2fc8aca560593e2b25d5",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "48f2dec047bbddfe126ddfc47c289408eadc01e468622c8cab92cfcf2cdafff2",
+      "rowEvidenceDigest": "f41a920621bb9da9dfaf94f0239117cfc1f439634eb83c18ca2db3e29995c614",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "1138a648b1e2a959cc8c249bb21032592397f0291b5f2008e7bb9ab43c1201a4"
+  "contextDigest": "32474da52388ed1264d4ec8761302dc4481d05ac1c1d920c12758ccec25b881d"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "1138a648b1e2a959cc8c249bb21032592397f0291b5f2008e7bb9ab43c1201a4",
-    "qualityDigest": "bf230cb07be84866c1bcbe75eb9fcfac68c5604a0fd0d70880823b7943eed531",
+    "contextDigest": "32474da52388ed1264d4ec8761302dc4481d05ac1c1d920c12758ccec25b881d",
+    "qualityDigest": "f696cc8455299b250b149b5fcca7f6002af716e3eaac677d8e0fca953657b4d4",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "de3a981c406456f2d0c6e5a47e980e2ad729eb51766c95b38741d3b2475e42ad"
+  "activationDigest": "b3d0c4b5baf69a1950bb857cc99cc989a740a94b7eb9b854b1df2a22608cec57"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
-    "contextDigest": "1138a648b1e2a959cc8c249bb21032592397f0291b5f2008e7bb9ab43c1201a4"
+    "contextDigest": "32474da52388ed1264d4ec8761302dc4481d05ac1c1d920c12758ccec25b881d"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "181357ebf8cc836d2535b484f0e691f8d3f3ae94a7775af3098d265f64bb0cd7",
-    "validationDigest": "4dbc85256ff984ae904ea51c164c6db381a62bd29865d12870ab958ebc27d947",
+    "digest": "96cd5be4975919e39ff536075e0503591a31891ac3ad3fdf1626d55a1c8de0bf",
+    "validationDigest": "993442d97467592b35885d339708b4add490b448f535b8debd2c0d212c32b822",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "bf230cb07be84866c1bcbe75eb9fcfac68c5604a0fd0d70880823b7943eed531"
+  "qualityDigest": "f696cc8455299b250b149b5fcca7f6002af716e3eaac677d8e0fca953657b4d4"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "7d583779611c1c15fbbe9d362606a7f992bd399dcb958f558b638dd85fd12156",
     "dossierDigest": "dde6832d2860d044cfef590fae4e750e8b4925cdd44abdecc897d42482cf8e43",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "48f2dec047bbddfe126ddfc47c289408eadc01e468622c8cab92cfcf2cdafff2",
+    "routeEvidenceDigest": "f41a920621bb9da9dfaf94f0239117cfc1f439634eb83c18ca2db3e29995c614",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "4dbc85256ff984ae904ea51c164c6db381a62bd29865d12870ab958ebc27d947"
+  "validationDigest": "993442d97467592b35885d339708b4add490b448f535b8debd2c0d212c32b822"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "40501d75d8f3be85f8dba53114a319a3389594bee4526af5ce5a7fbd87b8e9db",
-          "focusedTestDigest": "29200ee29b2321916902deed958acee9c2411a4beb83522a1c7ff2530afdff92",
+          "focusedTestDigest": "3bfeb50dd515e28cba5f128301fa4ca11a0c0725f9ce2fc8aca560593e2b25d5",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "48f2dec047bbddfe126ddfc47c289408eadc01e468622c8cab92cfcf2cdafff2",
+      "rowEvidenceDigest": "f41a920621bb9da9dfaf94f0239117cfc1f439634eb83c18ca2db3e29995c614",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "60b991c05cf28c7bfc837ee08fc92510a6ceab1ac38a7b08133539e06a4ec432"
+  "contextDigest": "14075c60007956ca743b24e0ac0fcba73e4d33155e7c8cfa9220a0d2b04d612e"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "60b991c05cf28c7bfc837ee08fc92510a6ceab1ac38a7b08133539e06a4ec432",
-    "qualityDigest": "a8d77d72601c7115b9f3503a259256faae4fb95b2656378a87247cfa1e3c40eb",
+    "contextDigest": "14075c60007956ca743b24e0ac0fcba73e4d33155e7c8cfa9220a0d2b04d612e",
+    "qualityDigest": "f55057d583b1981120bf39e3cbc26631bbfa76e5ce3870770b1fbce08bd27d36",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "d8c48c8b89170394ae8c813da5f096ac1dc9db473433a17bd59ddff3128249bc"
+  "activationDigest": "342651c5a23c7dbae1fe47a54f85033907b052cc8002595a5bb93fc8f0a33075"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
-    "contextDigest": "60b991c05cf28c7bfc837ee08fc92510a6ceab1ac38a7b08133539e06a4ec432"
+    "contextDigest": "14075c60007956ca743b24e0ac0fcba73e4d33155e7c8cfa9220a0d2b04d612e"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "a60b48555103d819cfc359ccaa5de2954a14d04e74a9c754893c5b99c3d7995b",
-    "validationDigest": "ebbcaa4e742405098afd320d5eb94b22041a7c65d9ea8ef82b225534b2abed27",
+    "digest": "45df6ee053dec7affa7ad89c854578c870f28ce522ef3cfad498f1673ef03673",
+    "validationDigest": "4546c69ccaddc1175550860566afed1478b49ca38719619b65e5db05c25aeddd",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "a8d77d72601c7115b9f3503a259256faae4fb95b2656378a87247cfa1e3c40eb"
+  "qualityDigest": "f55057d583b1981120bf39e3cbc26631bbfa76e5ce3870770b1fbce08bd27d36"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "9a0e196cccecf0bb9f31b00c34d66eb42df680f77da9be330a12dcae6fd292ea",
     "dossierDigest": "08f33b9b65a8eb320783cd1981e720624db21cbcc4b20d602c37dd6ee5bd228e",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "48f2dec047bbddfe126ddfc47c289408eadc01e468622c8cab92cfcf2cdafff2",
+    "routeEvidenceDigest": "f41a920621bb9da9dfaf94f0239117cfc1f439634eb83c18ca2db3e29995c614",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "ebbcaa4e742405098afd320d5eb94b22041a7c65d9ea8ef82b225534b2abed27"
+  "validationDigest": "4546c69ccaddc1175550860566afed1478b49ca38719619b65e5db05c25aeddd"
 }

--- a/tests/unit/pages/DataProcessing/index.test.tsx
+++ b/tests/unit/pages/DataProcessing/index.test.tsx
@@ -341,6 +341,7 @@ describe('DataProcessing page', () => {
       data: { items: [TEST_RESULT_SET] },
       error: null,
     });
+    mockPreviewLciaResultPackage.mockReset();
     mockPreviewLciaResultPackage.mockResolvedValue({
       data: {
         summary: {
@@ -446,6 +447,14 @@ describe('DataProcessing page', () => {
       expect(
         screen.getByRole('button', { name: 'Use this check to start calculation' }),
       ).not.toBeDisabled(),
+    );
+  }
+
+  async function waitForReadyPreviewPackage() {
+    await waitFor(() =>
+      expect(
+        screen.getByLabelText('Select result set').querySelector('option[value="package-1"]'),
+      ).not.toBeNull(),
     );
   }
 
@@ -2139,6 +2148,7 @@ describe('DataProcessing page', () => {
 
     expect(await screen.findByTestId('page-title')).toHaveTextContent('Data Processing');
     fireEvent.click(screen.getByTestId('tab-preview'));
+    await waitForReadyPreviewPackage();
     fireEvent.change(screen.getByLabelText('Select result set'), {
       target: { value: 'package-1' },
     });
@@ -2240,6 +2250,7 @@ describe('DataProcessing page', () => {
 
     expect(await screen.findByTestId('page-title')).toHaveTextContent('Data Processing');
     fireEvent.click(screen.getByTestId('tab-preview'));
+    await waitForReadyPreviewPackage();
     fireEvent.change(screen.getByLabelText('Select result set'), {
       target: { value: 'package-1' },
     });
@@ -2295,6 +2306,7 @@ describe('DataProcessing page', () => {
 
     expect(await screen.findByTestId('page-title')).toHaveTextContent('Data Processing');
     fireEvent.click(screen.getByTestId('tab-preview'));
+    await waitForReadyPreviewPackage();
     fireEvent.change(screen.getByLabelText('Select result set'), {
       target: { value: 'package-1' },
     });
@@ -2368,6 +2380,7 @@ describe('DataProcessing page', () => {
     expect(await screen.findByTestId('page-title')).toHaveTextContent('Data Processing');
     await screen.findByText('Plain impact (01.00.000)');
     fireEvent.click(screen.getByTestId('tab-preview'));
+    await waitForReadyPreviewPackage();
     fireEvent.change(screen.getByLabelText('Select result set'), {
       target: { value: 'package-1' },
     });
@@ -2452,6 +2465,7 @@ describe('DataProcessing page', () => {
     await waitFor(() => expect(mockRefreshDataProductTasks).toHaveBeenCalledTimes(2));
 
     fireEvent.click(screen.getByTestId('tab-preview'));
+    await waitForReadyPreviewPackage();
     fireEvent.change(screen.getByLabelText('Select result set'), {
       target: { value: 'package-1' },
     });


### PR DESCRIPTION
## Summary
- wait for the preview-ready package option before exercising Data Processing preview commands
- reset queued preview API responses between tests so one failure cannot cascade into later cases
- refresh deterministic i18n context/quality/activation digests and record required Docpact review evidence

## Release context
- v0.0.78 Release PR #886 exposed four deterministic Data Processing preview failures
- this change fixes the underlying async test setup without changing production behavior or the canonical `blocker` severity contract from #885
- after merge, regenerate the version-only v0.0.78 candidate from the new `dev` head

## Validation
- DataProcessing page: 73/73 tests
- i18n delivery contracts: 18/18 tests
- pre-push receipt: 38/38 tests
- full coverage: 421/421 suites, 5764/5764 tests
- coverage: 470/470 tracked source files at 100/100/100/100
- ESLint, Prettier, TypeScript, LCIA cache, reference data, i18n artifact idempotence, and Docpact: pass

Closes #884
