### PR TITLE
chore: prepare v0.0.79 on dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-18"
-lastReviewedCommit: "c1e61084060150fba9c17aee0cb3c2d1981ebcd4"
+lastReviewedCommit: "41177c7afe388aeb7b4be4e9948524616f436e96"
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 41177c7afe388aeb7b4be4e9948524616f436e96
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 41177c7afe388aeb7b4be4e9948524616f436e96
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 41177c7afe388aeb7b4be4e9948524616f436e96
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 41177c7afe388aeb7b4be4e9948524616f436e96
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 41177c7afe388aeb7b4be4e9948524616f436e96
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 41177c7afe388aeb7b4be4e9948524616f436e96
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 41177c7afe388aeb7b4be4e9948524616f436e96
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 41177c7afe388aeb7b4be4e9948524616f436e96
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.78",
+  "version": "0.0.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.78",
+      "version": "0.0.79",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.78",
+  "version": "0.0.79",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",


### PR DESCRIPTION
<!-- tiangong-next-release-automation:v2 issue=892 version=0.0.79 dev-base=41177c7afe388aeb7b4be4e9948524616f436e96 main-base=71691118f0b65a48407e83ebd5cde8b1c46db032 candidate=c5aa4ce181c276ddf873d175a93b309cb7f89e44 -->

## Branch Contract

- base branch: `dev`
- validated environment: exact dev Release PR non-browser gate
- back-merge required after merge: No
- root workspace integration expected: after later dev-to-main promotion

## Linked Issue

Refs #892

## Change Facts

- Prepare version `0.0.79` from exact dev base `41177c7afe388aeb7b4be4e9948524616f436e96`.
- Keep package.json and both package-lock root version fields aligned.
- Keep release proof external to Git and bind it to the exact main/dev bases, candidate SHA/tree, version, workflow run, and artifact.
- Record Docpact review evidence only after the command proves the candidate has no other semantic change.
- Reviewed paths:
  - `.docpact/config.yaml`
  - `AGENTS.md`
  - `DEV.md`
  - `docs/agents/prepush-gate-policy.md`
  - `docs/agents/repo-validation.md`
  - `docs/agents/test_improvement_plan.md`
  - `docs/agents/test_todo_list.md`
  - `docs/agents/testing-patterns.md`
  - `docs/agents/testing-troubleshooting.md`

## Validation Facts

- Candidate: `c5aa4ce181c276ddf873d175a93b309cb7f89e44`
- Main baseline: `71691118f0b65a48407e83ebd5cde8b1c46db032`
- Release gate: `required_by_dev_release_candidate_gate`; static preflight: `passed`
- Docpact automatic-review status: `completed`
- Docpact checked the complete main-to-candidate promotion range before the dev PR was created.
- The managed candidate push ran only structural/static checks; this PR owns one non-browser full release gate and its exact proof.
- Browser E2E is not evaluated or required by this PR. Run the manual hermetic workflow on the open business PR before release-to-dev when the change risk warrants browser evidence.

## Risks And Follow-Up

- Merge only after the exact Release Candidate release proof succeeds, then run the deterministic dev-to-main promotion command with this PR number.
