### PR TITLE
test: stabilize closure empty-state wait

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-18"
-lastReviewedCommit: "c1e61084060150fba9c17aee0cb3c2d1981ebcd4"
+lastReviewedCommit: "61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb"
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
-          "focusedTestDigest": "3a0e3890139663aebcad6ebd94be52aa13fa3a524571c0f68593db6c08ee1158",
+          "focusedTestDigest": "243286815301584d8147b86fe8bfc4f24813f856b81d245fdf66f7d06773840c",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
+      "rowEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "f32a7ec6e841a0bd28b50c2d43950df7b6d415451a751cfde61dbf2781f8e6c5"
+  "contextDigest": "128f4c15f9af3de937116d4ca15ff182018fc2f5345a19b2a121f701c16de087"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "f32a7ec6e841a0bd28b50c2d43950df7b6d415451a751cfde61dbf2781f8e6c5",
-    "qualityDigest": "d07c8459277e4a8f02beadc8ac41d5559bd5d3179303a932808780b625c29793",
+    "contextDigest": "128f4c15f9af3de937116d4ca15ff182018fc2f5345a19b2a121f701c16de087",
+    "qualityDigest": "9ab99366016d5bde3a0fabf995d4fe71e4d16ad047de8be1d23433da2fc0515e",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "5708b690ee22164670fd42963a6c6dcb06e4a85f6e83b93a6a8b169c59d5a586"
+  "activationDigest": "2d935f59ffb233e27327e9c6d8b3fd212683e8b33d8d2a200d2d903c359b3a15"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
-    "contextDigest": "f32a7ec6e841a0bd28b50c2d43950df7b6d415451a751cfde61dbf2781f8e6c5"
+    "contextDigest": "128f4c15f9af3de937116d4ca15ff182018fc2f5345a19b2a121f701c16de087"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "2fe50f1d3e2e5b9ba626a61ba6bc0defc2b1a7b93de695faeee383300a8b2322",
-    "validationDigest": "b60cbfba73760becf6e41fcf7266f78c1083452552128b7b38275f4a1afc85d3",
+    "digest": "311e22f44256e95fd4cb805d996860ff0517d116cbd5fbdedae3ca68ebe327c7",
+    "validationDigest": "97f47fc10ac85fc00f60f6e89d6849a050d9f22d9514ccacb8aed1d804925951",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "d07c8459277e4a8f02beadc8ac41d5559bd5d3179303a932808780b625c29793"
+  "qualityDigest": "9ab99366016d5bde3a0fabf995d4fe71e4d16ad047de8be1d23433da2fc0515e"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "ebe1a99a1cdb1231fefa9cea59309b1e3a2d778338f2d9587dc4fd5e8a151f88",
     "dossierDigest": "5f8d57aef18349dc5f1bbbca7c5d9f9b61cdfb60a938dfb6f21dd6e281e0a6dc",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
+    "routeEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "b60cbfba73760becf6e41fcf7266f78c1083452552128b7b38275f4a1afc85d3"
+  "validationDigest": "97f47fc10ac85fc00f60f6e89d6849a050d9f22d9514ccacb8aed1d804925951"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
-          "focusedTestDigest": "3a0e3890139663aebcad6ebd94be52aa13fa3a524571c0f68593db6c08ee1158",
+          "focusedTestDigest": "243286815301584d8147b86fe8bfc4f24813f856b81d245fdf66f7d06773840c",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
+      "rowEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "96e637736c14d4b87781ac5b4f2625ccc488467db6efb16b2341a425cd9492cb"
+  "contextDigest": "b7e50184640054f61d43d6fb582cf4712b4e5adb27225b981bab41c417384b93"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "96e637736c14d4b87781ac5b4f2625ccc488467db6efb16b2341a425cd9492cb",
-    "qualityDigest": "509c18b6f67552e9555136478595e8172d06d73714d925017bc1583c7dd2f5e3",
+    "contextDigest": "b7e50184640054f61d43d6fb582cf4712b4e5adb27225b981bab41c417384b93",
+    "qualityDigest": "8eeaf7432bff04393f50814568227f6b28332fe849c2da7877dd834fc995798e",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "180098b35351a2a0125d64d9ea399393163ea6e2830d30392743786829914fdd"
+  "activationDigest": "49b6edb34b5b48c7d034a44ec9fddcb27c2e15df3972c888489ce0fdaba31681"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
-    "contextDigest": "96e637736c14d4b87781ac5b4f2625ccc488467db6efb16b2341a425cd9492cb"
+    "contextDigest": "b7e50184640054f61d43d6fb582cf4712b4e5adb27225b981bab41c417384b93"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "bf98648096b32ec0e2f14e7edc134a23dfc3e97fd5e93a79fab0d3e07820bdc7",
-    "validationDigest": "07b4d9448d748a476fcd0598ece0c294a606271a876eab5113efd8d4e6a02063",
+    "digest": "077e078b9f15f517882c95917b7bc88d4733fc73a2ee98495527e95dab835c89",
+    "validationDigest": "ce56a7934aa9eb958da5f260c342841ffc7f0bf9b8022562bb643d0c88efd262",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "509c18b6f67552e9555136478595e8172d06d73714d925017bc1583c7dd2f5e3"
+  "qualityDigest": "8eeaf7432bff04393f50814568227f6b28332fe849c2da7877dd834fc995798e"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "c624da4a23d6cb86936aeb4b45afd52d46a8b29702e8064b2607b3ff975049d6",
     "dossierDigest": "c1be0360d1c5a69d41571104471a189c87f9179d8d5d8f67638d383212030205",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
+    "routeEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "07b4d9448d748a476fcd0598ece0c294a606271a876eab5113efd8d4e6a02063"
+  "validationDigest": "ce56a7934aa9eb958da5f260c342841ffc7f0bf9b8022562bb643d0c88efd262"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
-          "focusedTestDigest": "3a0e3890139663aebcad6ebd94be52aa13fa3a524571c0f68593db6c08ee1158",
+          "focusedTestDigest": "243286815301584d8147b86fe8bfc4f24813f856b81d245fdf66f7d06773840c",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
+      "rowEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "bacec26ecf599b000d5f5887bc6bd352d6417fe5479cdcbad58ba7bd18096e9e"
+  "contextDigest": "98d8593983cc449fddd153aa7610132beac3ea2548f96d336e38c0e982b6ebda"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "bacec26ecf599b000d5f5887bc6bd352d6417fe5479cdcbad58ba7bd18096e9e",
-    "qualityDigest": "2bc0a22ae1e7e9a4035042eddffa50bd10572751d0ede8917813c9d29071cf0b",
+    "contextDigest": "98d8593983cc449fddd153aa7610132beac3ea2548f96d336e38c0e982b6ebda",
+    "qualityDigest": "18a960d01c8ce9381d6ab384c669cb08c3fbcbfd2d550ca4449b2b78f8301592",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "6a9b24d98b4637e058c939591457cde2f8123a0cdabbff79e8c8aa8c06657470"
+  "activationDigest": "a4998aa3deeb8c6af9ecb3939b2161e776ab9aa27f3eb0a00ccf1e0ae3e55469"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
-    "contextDigest": "bacec26ecf599b000d5f5887bc6bd352d6417fe5479cdcbad58ba7bd18096e9e"
+    "contextDigest": "98d8593983cc449fddd153aa7610132beac3ea2548f96d336e38c0e982b6ebda"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "e41f4f0fc5b11e84e4345eea53fc6e5663f0e6b9a86daf8a56ebd3cf95fe7e26",
-    "validationDigest": "0f6a3c52513a432c63dcfc6c4f096d8750ee231c20271b4980737e405643d258",
+    "digest": "9a1967fdeb7bc8db740688377dab302b00367671975a2b708a2cc469ec4fbc0b",
+    "validationDigest": "02e2d064c455121e1b72bd1725ade64cec4c35a15ab7bf78ede45de89f1479c2",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "2bc0a22ae1e7e9a4035042eddffa50bd10572751d0ede8917813c9d29071cf0b"
+  "qualityDigest": "18a960d01c8ce9381d6ab384c669cb08c3fbcbfd2d550ca4449b2b78f8301592"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "7d583779611c1c15fbbe9d362606a7f992bd399dcb958f558b638dd85fd12156",
     "dossierDigest": "91b8413109f240e2696f872ce90410cd36bd8d31c3d4f658f420569a17607b58",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
+    "routeEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "0f6a3c52513a432c63dcfc6c4f096d8750ee231c20271b4980737e405643d258"
+  "validationDigest": "02e2d064c455121e1b72bd1725ade64cec4c35a15ab7bf78ede45de89f1479c2"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
-          "focusedTestDigest": "3a0e3890139663aebcad6ebd94be52aa13fa3a524571c0f68593db6c08ee1158",
+          "focusedTestDigest": "243286815301584d8147b86fe8bfc4f24813f856b81d245fdf66f7d06773840c",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
+      "rowEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "3a47df742c7bae1b2d1ec13e7ac2d8be9e0c1d615b7311a2f27d4106a73769ec"
+  "contextDigest": "72d264565e76ac4e121e626d047fc02616f9e22ef2373c8ca49d45d2a79528ed"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "3a47df742c7bae1b2d1ec13e7ac2d8be9e0c1d615b7311a2f27d4106a73769ec",
-    "qualityDigest": "0d0498dad3e7f2f74c6df62118f54b8d6bb5a4356c46f8d3fdfc93db2a81e3b1",
+    "contextDigest": "72d264565e76ac4e121e626d047fc02616f9e22ef2373c8ca49d45d2a79528ed",
+    "qualityDigest": "4fd9107eb278b7ac903fab9cdcebff74b145127c0c16d66329499b45109b6f5c",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "43473c3ac3bf925a897c86e4d8c4afe50fa270e2af32d1c60dcc31d8cb124be9"
+  "activationDigest": "0903867a9a3bd99e500688a3d3b14db07504882b37ee8e994d89bc562cb9efb0"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
-    "contextDigest": "3a47df742c7bae1b2d1ec13e7ac2d8be9e0c1d615b7311a2f27d4106a73769ec"
+    "contextDigest": "72d264565e76ac4e121e626d047fc02616f9e22ef2373c8ca49d45d2a79528ed"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "5c11cde70d7025e4bc1160b2f8cb23a7d164ccd71387ffc5bc7d795a30ac52ee",
-    "validationDigest": "b33a19ac868cf9da2ed7c91642677b71d8978a1aae958d2ec860553f0ef690a1",
+    "digest": "50c33db48dbd6d458c5dcc4f820fc17bdc9de84ad1873093da5a88aaebdcb420",
+    "validationDigest": "3c0984da3bc8e52bf3f3e460600901feac9ff237d5aec409a49cc8e248dd5808",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "0d0498dad3e7f2f74c6df62118f54b8d6bb5a4356c46f8d3fdfc93db2a81e3b1"
+  "qualityDigest": "4fd9107eb278b7ac903fab9cdcebff74b145127c0c16d66329499b45109b6f5c"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "9a0e196cccecf0bb9f31b00c34d66eb42df680f77da9be330a12dcae6fd292ea",
     "dossierDigest": "a71ca28b3232b43894bfd6a799496c88da11fee0a2d1aa595d48c3bdb28ca187",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
+    "routeEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "b33a19ac868cf9da2ed7c91642677b71d8978a1aae958d2ec860553f0ef690a1"
+  "validationDigest": "3c0984da3bc8e52bf3f3e460600901feac9ff237d5aec409a49cc8e248dd5808"
 }

--- a/tests/unit/pages/DataProcessing/index.test.tsx
+++ b/tests/unit/pages/DataProcessing/index.test.tsx
@@ -1506,7 +1506,16 @@ describe('DataProcessing page', () => {
 
   it('shows an empty closure-issue state without blocking task history rendering', async () => {
     render(<DataProcessing />);
-    expect(await screen.findByText('No closure issues found.')).toBeInTheDocument();
+    await waitFor(
+      () =>
+        expect(mockListClosureCheckIssues).toHaveBeenCalledWith('closure-valid', {
+          limit: 50,
+        }),
+      { timeout: 5000 },
+    );
+    expect(
+      await screen.findByText('No closure issues found.', undefined, { timeout: 5000 }),
+    ).toBeInTheDocument();
     expect(screen.getByTestId('data-product-job-worker-job-1')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#895

## Summary
- Wait for the exact closure-issue request and give the asynchronous empty-state render a bounded five-second assertion window under full coverage.

## Key Decisions
- Keep the original empty-state and task-history behavior assertions; add no retry, fixed sleep, or runtime change.
- Regenerate the locale/semantic evidence summaries because the test file participates in their deterministic input digest.

## Validation
- npm run test:ci -- tests/unit/pages/DataProcessing/index.test.tsx --runInBand (73 passed)
- npm run i18n:audit
- npm run i18n:locale:artifacts:idempotence
- Docpact worktree lint (0 findings)
- npm run push:checked -- fork fix/issue-895 (421 suites / 5764 tests / 100% coverage; transport completed with receipt-bound npm run push:retry)

## Risks / Rollback
- Low: test-only timing stabilization; production source is unchanged.

## Follow-ups
- Merge this PR into dev, then regenerate the 0.0.79 Release candidate for Issue #892.

## Workspace Integration
- No independent workspace pointer bump; this commit will travel with the same 0.0.79 release.