### PR TITLE
test: await remaining Data Processing async states

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-18"
-lastReviewedCommit: "61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb"
+lastReviewedCommit: "2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72"
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
+lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
+lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
+lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
+lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
+lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
+lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
+lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
+lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
-          "focusedTestDigest": "243286815301584d8147b86fe8bfc4f24813f856b81d245fdf66f7d06773840c",
+          "focusedTestDigest": "410cc0f2a8ab907cb4ce4505166f895cfc0f28b4e041461a6fd4da46c9630f89",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
+      "rowEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "128f4c15f9af3de937116d4ca15ff182018fc2f5345a19b2a121f701c16de087"
+  "contextDigest": "57b4f1ec9250d6c05e4ccd3081656478f716b6e58a81205c5c75bf64d3f7c0f4"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "128f4c15f9af3de937116d4ca15ff182018fc2f5345a19b2a121f701c16de087",
-    "qualityDigest": "9ab99366016d5bde3a0fabf995d4fe71e4d16ad047de8be1d23433da2fc0515e",
+    "contextDigest": "57b4f1ec9250d6c05e4ccd3081656478f716b6e58a81205c5c75bf64d3f7c0f4",
+    "qualityDigest": "cf01fab18a44bbe11f6121efbd852dbb123ce30d48b3f9cb9c1d484ebeef0076",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "2d935f59ffb233e27327e9c6d8b3fd212683e8b33d8d2a200d2d903c359b3a15"
+  "activationDigest": "c603d9b3be9c42619e0649846200efca8abe75fd75d0502af3783ca4e1d381ea"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
-    "contextDigest": "128f4c15f9af3de937116d4ca15ff182018fc2f5345a19b2a121f701c16de087"
+    "contextDigest": "57b4f1ec9250d6c05e4ccd3081656478f716b6e58a81205c5c75bf64d3f7c0f4"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "311e22f44256e95fd4cb805d996860ff0517d116cbd5fbdedae3ca68ebe327c7",
-    "validationDigest": "97f47fc10ac85fc00f60f6e89d6849a050d9f22d9514ccacb8aed1d804925951",
+    "digest": "3faea5655ed30e7bb287fba1c92532409c5d11122e4b8d94afd2403035ec9d5e",
+    "validationDigest": "02c25d9958352a53db1b07e924250c2ef1b84a3fa1dbd5dc42d7e126e35db41f",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "9ab99366016d5bde3a0fabf995d4fe71e4d16ad047de8be1d23433da2fc0515e"
+  "qualityDigest": "cf01fab18a44bbe11f6121efbd852dbb123ce30d48b3f9cb9c1d484ebeef0076"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "ebe1a99a1cdb1231fefa9cea59309b1e3a2d778338f2d9587dc4fd5e8a151f88",
     "dossierDigest": "5f8d57aef18349dc5f1bbbca7c5d9f9b61cdfb60a938dfb6f21dd6e281e0a6dc",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
+    "routeEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "97f47fc10ac85fc00f60f6e89d6849a050d9f22d9514ccacb8aed1d804925951"
+  "validationDigest": "02c25d9958352a53db1b07e924250c2ef1b84a3fa1dbd5dc42d7e126e35db41f"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
-          "focusedTestDigest": "243286815301584d8147b86fe8bfc4f24813f856b81d245fdf66f7d06773840c",
+          "focusedTestDigest": "410cc0f2a8ab907cb4ce4505166f895cfc0f28b4e041461a6fd4da46c9630f89",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
+      "rowEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "b7e50184640054f61d43d6fb582cf4712b4e5adb27225b981bab41c417384b93"
+  "contextDigest": "7dbd0ac795dfe31cac1c7da4614daceaa897ae5960de11aa143165bf79901e58"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "b7e50184640054f61d43d6fb582cf4712b4e5adb27225b981bab41c417384b93",
-    "qualityDigest": "8eeaf7432bff04393f50814568227f6b28332fe849c2da7877dd834fc995798e",
+    "contextDigest": "7dbd0ac795dfe31cac1c7da4614daceaa897ae5960de11aa143165bf79901e58",
+    "qualityDigest": "2d2fe484f5b4b5376a66870f4a026bd26f45266c542c294565c153c0f4a6b241",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "49b6edb34b5b48c7d034a44ec9fddcb27c2e15df3972c888489ce0fdaba31681"
+  "activationDigest": "e3569df508a483eaeee8eb91f8f5e2ef2833ec8ec7875745267e076adc992d07"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
-    "contextDigest": "b7e50184640054f61d43d6fb582cf4712b4e5adb27225b981bab41c417384b93"
+    "contextDigest": "7dbd0ac795dfe31cac1c7da4614daceaa897ae5960de11aa143165bf79901e58"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "077e078b9f15f517882c95917b7bc88d4733fc73a2ee98495527e95dab835c89",
-    "validationDigest": "ce56a7934aa9eb958da5f260c342841ffc7f0bf9b8022562bb643d0c88efd262",
+    "digest": "60e51ae8cf06d2c2ca36ba40050d2bd26bf3abb739db6c07407444d721117604",
+    "validationDigest": "7637ad5b864acdd613fa9edf4b7373b577bc2b09edf1bc5fb25980e72d845a27",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "8eeaf7432bff04393f50814568227f6b28332fe849c2da7877dd834fc995798e"
+  "qualityDigest": "2d2fe484f5b4b5376a66870f4a026bd26f45266c542c294565c153c0f4a6b241"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "c624da4a23d6cb86936aeb4b45afd52d46a8b29702e8064b2607b3ff975049d6",
     "dossierDigest": "c1be0360d1c5a69d41571104471a189c87f9179d8d5d8f67638d383212030205",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
+    "routeEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "ce56a7934aa9eb958da5f260c342841ffc7f0bf9b8022562bb643d0c88efd262"
+  "validationDigest": "7637ad5b864acdd613fa9edf4b7373b577bc2b09edf1bc5fb25980e72d845a27"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
-          "focusedTestDigest": "243286815301584d8147b86fe8bfc4f24813f856b81d245fdf66f7d06773840c",
+          "focusedTestDigest": "410cc0f2a8ab907cb4ce4505166f895cfc0f28b4e041461a6fd4da46c9630f89",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
+      "rowEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "98d8593983cc449fddd153aa7610132beac3ea2548f96d336e38c0e982b6ebda"
+  "contextDigest": "f71489b51636eebab6fb254c1d76032256e7d2f01f4cbfb0beb113bd27470dae"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "98d8593983cc449fddd153aa7610132beac3ea2548f96d336e38c0e982b6ebda",
-    "qualityDigest": "18a960d01c8ce9381d6ab384c669cb08c3fbcbfd2d550ca4449b2b78f8301592",
+    "contextDigest": "f71489b51636eebab6fb254c1d76032256e7d2f01f4cbfb0beb113bd27470dae",
+    "qualityDigest": "844b76e787f82487637172c3b603f336649b6474e91d7d41445ffdfe7317d065",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "a4998aa3deeb8c6af9ecb3939b2161e776ab9aa27f3eb0a00ccf1e0ae3e55469"
+  "activationDigest": "688435bc99178e1f206d9288b722117c6ae5f169b35d3709a492a42881c65089"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
-    "contextDigest": "98d8593983cc449fddd153aa7610132beac3ea2548f96d336e38c0e982b6ebda"
+    "contextDigest": "f71489b51636eebab6fb254c1d76032256e7d2f01f4cbfb0beb113bd27470dae"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "9a1967fdeb7bc8db740688377dab302b00367671975a2b708a2cc469ec4fbc0b",
-    "validationDigest": "02e2d064c455121e1b72bd1725ade64cec4c35a15ab7bf78ede45de89f1479c2",
+    "digest": "1491b57cca0bbcacca552f819ccd36a870288403b0bc5dc88bdd290a272a9b75",
+    "validationDigest": "c301347890bcce7c07d16d561ca429bf8da5721bde8516d081a6e026b6eceab8",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "18a960d01c8ce9381d6ab384c669cb08c3fbcbfd2d550ca4449b2b78f8301592"
+  "qualityDigest": "844b76e787f82487637172c3b603f336649b6474e91d7d41445ffdfe7317d065"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "7d583779611c1c15fbbe9d362606a7f992bd399dcb958f558b638dd85fd12156",
     "dossierDigest": "91b8413109f240e2696f872ce90410cd36bd8d31c3d4f658f420569a17607b58",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
+    "routeEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "02e2d064c455121e1b72bd1725ade64cec4c35a15ab7bf78ede45de89f1479c2"
+  "validationDigest": "c301347890bcce7c07d16d561ca429bf8da5721bde8516d081a6e026b6eceab8"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
-          "focusedTestDigest": "243286815301584d8147b86fe8bfc4f24813f856b81d245fdf66f7d06773840c",
+          "focusedTestDigest": "410cc0f2a8ab907cb4ce4505166f895cfc0f28b4e041461a6fd4da46c9630f89",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
+      "rowEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "72d264565e76ac4e121e626d047fc02616f9e22ef2373c8ca49d45d2a79528ed"
+  "contextDigest": "968886599a835ea985e2a302f5dea26ba00550fdcb9f88e825d254c85e4a8f18"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "72d264565e76ac4e121e626d047fc02616f9e22ef2373c8ca49d45d2a79528ed",
-    "qualityDigest": "4fd9107eb278b7ac903fab9cdcebff74b145127c0c16d66329499b45109b6f5c",
+    "contextDigest": "968886599a835ea985e2a302f5dea26ba00550fdcb9f88e825d254c85e4a8f18",
+    "qualityDigest": "9b762485696ff2dac37510afb5dc7a388915e6fb649f05f70908242e4e2669a6",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "0903867a9a3bd99e500688a3d3b14db07504882b37ee8e994d89bc562cb9efb0"
+  "activationDigest": "c7d5e8f5dcfa4d29bd9860e9f68d4d6bff5bca930d1e11b2149b056237c8e881"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
-    "contextDigest": "72d264565e76ac4e121e626d047fc02616f9e22ef2373c8ca49d45d2a79528ed"
+    "contextDigest": "968886599a835ea985e2a302f5dea26ba00550fdcb9f88e825d254c85e4a8f18"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "50c33db48dbd6d458c5dcc4f820fc17bdc9de84ad1873093da5a88aaebdcb420",
-    "validationDigest": "3c0984da3bc8e52bf3f3e460600901feac9ff237d5aec409a49cc8e248dd5808",
+    "digest": "de458a1626e0d5f663a848242853f4afc2746b6e17955dc7a435884791e9658c",
+    "validationDigest": "b32beb28608fcc229d6591ae3a6d7a6546b422f73e046498e3fa8da571b4c2cf",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "4fd9107eb278b7ac903fab9cdcebff74b145127c0c16d66329499b45109b6f5c"
+  "qualityDigest": "9b762485696ff2dac37510afb5dc7a388915e6fb649f05f70908242e4e2669a6"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "9a0e196cccecf0bb9f31b00c34d66eb42df680f77da9be330a12dcae6fd292ea",
     "dossierDigest": "a71ca28b3232b43894bfd6a799496c88da11fee0a2d1aa595d48c3bdb28ca187",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
+    "routeEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "3c0984da3bc8e52bf3f3e460600901feac9ff237d5aec409a49cc8e248dd5808"
+  "validationDigest": "b32beb28608fcc229d6591ae3a6d7a6546b422f73e046498e3fa8da571b4c2cf"
 }

--- a/tests/unit/pages/DataProcessing/index.test.tsx
+++ b/tests/unit/pages/DataProcessing/index.test.tsx
@@ -1387,14 +1387,15 @@ describe('DataProcessing page', () => {
     render(<DataProcessing />);
 
     expect(await screen.findByTestId('page-title')).toHaveTextContent('Data Processing');
-    expect(
-      screen.getByRole('button', { name: 'Use this check to start calculation' }),
-    ).toBeDisabled();
-    expect(await screen.findByText('blocked')).toBeInTheDocument();
+    const generationButton = await screen.findByRole(
+      'button',
+      { name: 'Use this check to start calculation' },
+      { timeout: 5000 },
+    );
+    expect(generationButton).toBeDisabled();
+    expect(await screen.findByText('blocked', undefined, { timeout: 5000 })).toBeInTheDocument();
     expect(screen.getByText('2 blockers')).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Use this check to start calculation' }),
-    ).toBeDisabled();
+    expect(generationButton).toBeDisabled();
     expect(mockCreateLciaResultBuildRequest).not.toHaveBeenCalled();
   });
 
@@ -2673,8 +2674,15 @@ describe('DataProcessing page', () => {
     expect(await screen.findByTestId('page-title')).toHaveTextContent('Data Processing');
     fireEvent.click(screen.getByTestId('tab-publication'));
 
-    await waitFor(() => expect(mockListLciaResultPublications).toHaveBeenCalledWith({ limit: 50 }));
-    const currentRow = await screen.findByTestId('data-product-publication-publication-current');
+    await waitFor(
+      () => expect(mockListLciaResultPublications).toHaveBeenCalledWith({ limit: 50 }),
+      { timeout: 5000 },
+    );
+    const currentRow = await screen.findByTestId(
+      'data-product-publication-publication-current',
+      undefined,
+      { timeout: 5000 },
+    );
     const oldRow = screen.getByTestId('data-product-publication-publication-old');
     expect(screen.getByTestId('data-product-publication-2')).toHaveTextContent(
       'Unidentified result set',


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#895

## Summary
- Await the generation action and publication rows within the bounded five-second test window exposed by the full Release Gate.

## Key Decisions
- Preserve all existing behavioral assertions; replace only premature synchronous/default-one-second queries with readiness-aware Testing Library queries.
- Regenerate deterministic locale/semantic evidence summaries because the test source participates in their digest.

## Validation
- Data Processing focused suite: 73 passed
- i18n audit and artifact idempotence passed
- Docpact lint: 0 findings
- Managed push gate: 421 suites / 5764 tests / 100% coverage; transport completed with receipt-bound push:retry

## Risks / Rollback
- Low: test-only async readiness stabilization; no production source changes.

## Follow-ups
- Merge into dev, close Issue #895, then regenerate 0.0.79 Release candidate.

## Workspace Integration
- No independent workspace pointer bump; this follows the same 0.0.79 release.