### PR TITLE
chore: promote v0.0.79 dev to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-18"
-lastReviewedCommit: "2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72"
+lastReviewedCommit: "b2138e512f91a0e09eba0c0470cfacfef3e519d8"
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-18"
-lastReviewedCommit: "c1e61084060150fba9c17aee0cb3c2d1981ebcd4"
+lastReviewedCommit: "61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb"
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-18"
-lastReviewedCommit: "61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb"
+lastReviewedCommit: "2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72"
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-18"
-lastReviewedCommit: "917ed4add359b2d8f0c952d365d893badaa61c4e"
+lastReviewedCommit: "c1e61084060150fba9c17aee0cb3c2d1981ebcd4"
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
+lastReviewedCommit: b2138e512f91a0e09eba0c0470cfacfef3e519d8
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 917ed4add359b2d8f0c952d365d893badaa61c4e
+lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
+lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
+lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
+lastReviewedCommit: b2138e512f91a0e09eba0c0470cfacfef3e519d8
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 917ed4add359b2d8f0c952d365d893badaa61c4e
+lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 917ed4add359b2d8f0c952d365d893badaa61c4e
+lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
+lastReviewedCommit: b2138e512f91a0e09eba0c0470cfacfef3e519d8
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
+lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 51e83e35b7dc048626c107d4f0683cce1f6f1181
+lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
+lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
+lastReviewedCommit: b2138e512f91a0e09eba0c0470cfacfef3e519d8
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 917ed4add359b2d8f0c952d365d893badaa61c4e
+lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 917ed4add359b2d8f0c952d365d893badaa61c4e
+lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
+lastReviewedCommit: b2138e512f91a0e09eba0c0470cfacfef3e519d8
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
+lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
+lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 917ed4add359b2d8f0c952d365d893badaa61c4e
+lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
+lastReviewedCommit: b2138e512f91a0e09eba0c0470cfacfef3e519d8
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,7 +30,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 917ed4add359b2d8f0c952d365d893badaa61c4e
+lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
+lastReviewedCommit: b2138e512f91a0e09eba0c0470cfacfef3e519d8
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
+lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 917ed4add359b2d8f0c952d365d893badaa61c4e
+lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
+lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: c1e61084060150fba9c17aee0cb3c2d1981ebcd4
+lastReviewedCommit: 61ac3d93b3963d3de3e355ab8b19a0fae1e1c2eb
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,7 +28,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 2e43d3dbe3290ba5ab2f4ce3f3b8639e8c7b0a72
+lastReviewedCommit: b2138e512f91a0e09eba0c0470cfacfef3e519d8
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
-    "auditedInputDigest": "3ac7a3aa040a7748977442ca12d4bbff60cbbb664a728ad17b7776a37f50a219"
+    "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
+    "auditedInputDigest": "761b2d5d8b07d623b315ac228bc6a242e39f17a9a6a462544db688db4d8fb14b"
   },
   "inventory": {
     "sourceMessageCount": 3207,
@@ -47,7 +47,7 @@
     "messageCount": 3207,
     "completeCount": 3207,
     "blockedCount": 0,
-    "dossierDigest": "2d2092a8a9953c2d6a1cd3730e285048884ba3b8c9c9f9d97ef8defa20402067",
+    "dossierDigest": "5f8d57aef18349dc5f1bbbca7c5d9f9b61cdfb60a938dfb6f21dd6e281e0a6dc",
     "catalogDigest": "ebe1a99a1cdb1231fefa9cea59309b1e3a2d778338f2d9587dc4fd5e8a151f88",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -137,7 +137,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "26e1ea958b9472090a506cec4841333e77d6c15673b1ee4fd28b6c4701da1cb3",
+      "sourceEvidenceDigest": "de9f35c8942da38b1d92f3c5436f134954e0e0e75c5cdffb2fc603481c300b77",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -1035,8 +1035,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "40501d75d8f3be85f8dba53114a319a3389594bee4526af5ce5a7fbd87b8e9db",
-          "focusedTestDigest": "d628100d6eb1cde80204db289fa0d740076f58afdbd0bda38564251ebd70f068",
+          "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
+          "focusedTestDigest": "3a0e3890139663aebcad6ebd94be52aa13fa3a524571c0f68593db6c08ee1158",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "b8af4daf42442c6f8e3ef8c0381a3ea186dd67dc706686c18a29ba60e6591df4",
+      "rowEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "82e830b1ac025099446e3cf2ae5ed382ffda4882d50fe03634fe1e2c7167638b"
+  "contextDigest": "f32a7ec6e841a0bd28b50c2d43950df7b6d415451a751cfde61dbf2781f8e6c5"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
-          "focusedTestDigest": "243286815301584d8147b86fe8bfc4f24813f856b81d245fdf66f7d06773840c",
+          "focusedTestDigest": "410cc0f2a8ab907cb4ce4505166f895cfc0f28b4e041461a6fd4da46c9630f89",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
+      "rowEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "128f4c15f9af3de937116d4ca15ff182018fc2f5345a19b2a121f701c16de087"
+  "contextDigest": "57b4f1ec9250d6c05e4ccd3081656478f716b6e58a81205c5c75bf64d3f7c0f4"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
-          "focusedTestDigest": "3a0e3890139663aebcad6ebd94be52aa13fa3a524571c0f68593db6c08ee1158",
+          "focusedTestDigest": "243286815301584d8147b86fe8bfc4f24813f856b81d245fdf66f7d06773840c",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
+      "rowEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "f32a7ec6e841a0bd28b50c2d43950df7b6d415451a751cfde61dbf2781f8e6c5"
+  "contextDigest": "128f4c15f9af3de937116d4ca15ff182018fc2f5345a19b2a121f701c16de087"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "128f4c15f9af3de937116d4ca15ff182018fc2f5345a19b2a121f701c16de087",
-    "qualityDigest": "9ab99366016d5bde3a0fabf995d4fe71e4d16ad047de8be1d23433da2fc0515e",
+    "contextDigest": "57b4f1ec9250d6c05e4ccd3081656478f716b6e58a81205c5c75bf64d3f7c0f4",
+    "qualityDigest": "cf01fab18a44bbe11f6121efbd852dbb123ce30d48b3f9cb9c1d484ebeef0076",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "2d935f59ffb233e27327e9c6d8b3fd212683e8b33d8d2a200d2d903c359b3a15"
+  "activationDigest": "c603d9b3be9c42619e0649846200efca8abe75fd75d0502af3783ca4e1d381ea"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "f32a7ec6e841a0bd28b50c2d43950df7b6d415451a751cfde61dbf2781f8e6c5",
-    "qualityDigest": "d07c8459277e4a8f02beadc8ac41d5559bd5d3179303a932808780b625c29793",
+    "contextDigest": "128f4c15f9af3de937116d4ca15ff182018fc2f5345a19b2a121f701c16de087",
+    "qualityDigest": "9ab99366016d5bde3a0fabf995d4fe71e4d16ad047de8be1d23433da2fc0515e",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "5708b690ee22164670fd42963a6c6dcb06e4a85f6e83b93a6a8b169c59d5a586"
+  "activationDigest": "2d935f59ffb233e27327e9c6d8b3fd212683e8b33d8d2a200d2d903c359b3a15"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944"
+    "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "82e830b1ac025099446e3cf2ae5ed382ffda4882d50fe03634fe1e2c7167638b",
-    "qualityDigest": "2c2c6c4103c2c787a4f4b310bcf63ff0a23a242df792a514de3bdf9fad7c2fa1",
+    "contextDigest": "f32a7ec6e841a0bd28b50c2d43950df7b6d415451a751cfde61dbf2781f8e6c5",
+    "qualityDigest": "d07c8459277e4a8f02beadc8ac41d5559bd5d3179303a932808780b625c29793",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "9ed3f565c228f6758027f32b415acbb5fda32823e351e770f529f8971d521f91"
+  "activationDigest": "5708b690ee22164670fd42963a6c6dcb06e4a85f6e83b93a6a8b169c59d5a586"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "3ac7a3aa040a7748977442ca12d4bbff60cbbb664a728ad17b7776a37f50a219",
+    "auditedInputDigest": "761b2d5d8b07d623b315ac228bc6a242e39f17a9a6a462544db688db4d8fb14b",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -57698,7 +57698,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2662,
+          "line": 2673,
           "column": 14,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Preview result set",
@@ -57719,7 +57719,7 @@
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2662,
+              "line": 2673,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -57787,7 +57787,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2946,
+          "line": 2957,
           "column": 14,
           "symbol": "renderPublication",
           "defaultMessage": "Publish result set",
@@ -57802,7 +57802,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2946,
+              "line": 2957,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -57953,7 +57953,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 3011,
+          "line": 3022,
           "column": 53,
           "symbol": "unpublishPublicationLabel",
           "defaultMessage": "Unpublish publication",
@@ -57968,7 +57968,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 3011,
+              "line": 3022,
               "column": 53,
               "kind": "messageHelper"
             }
@@ -65416,7 +65416,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2972,
+          "line": 2983,
           "column": 22,
           "symbol": "renderPublication",
           "defaultMessage": "Status",
@@ -65449,7 +65449,7 @@
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2972,
+              "line": 2983,
               "column": 22,
               "kind": "messageHelper"
             }
@@ -66276,7 +66276,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2634,
+          "line": 2645,
           "column": 19,
           "symbol": "renderPackagePreview",
           "defaultMessage": "No preview-ready result set yet. Refresh tasks or wait for the worker to complete.",
@@ -66285,7 +66285,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2891,
+          "line": 2902,
           "column": 19,
           "symbol": "renderPublication",
           "defaultMessage": "No preview-ready result set yet. Refresh tasks or wait for the worker to complete.",
@@ -66300,13 +66300,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2634,
+              "line": 2645,
               "column": 19,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2891,
+              "line": 2902,
               "column": 19,
               "kind": "messageHelper"
             }
@@ -66457,7 +66457,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2630,
+          "line": 2641,
           "column": 20,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Select result set",
@@ -66466,7 +66466,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2651,
+          "line": 2662,
           "column": 15,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Select result set",
@@ -66481,13 +66481,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2630,
+              "line": 2641,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2651,
+              "line": 2662,
               "column": 15,
               "kind": "messageHelper"
             }
@@ -66555,7 +66555,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2912,
+          "line": 2923,
           "column": 20,
           "symbol": "renderPublication",
           "defaultMessage": "Publish default impact category",
@@ -66564,7 +66564,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2928,
+          "line": 2939,
           "column": 15,
           "symbol": "renderPublication",
           "defaultMessage": "Publish default impact category",
@@ -66573,7 +66573,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2975,
+          "line": 2986,
           "column": 22,
           "symbol": "renderPublication",
           "defaultMessage": "Publish default impact category",
@@ -66588,19 +66588,19 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2912,
+              "line": 2923,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2928,
+              "line": 2939,
               "column": 15,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2975,
+              "line": 2986,
               "column": 22,
               "kind": "messageHelper"
             }
@@ -66668,7 +66668,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2887,
+          "line": 2898,
           "column": 20,
           "symbol": "renderPublication",
           "defaultMessage": "Publish result set",
@@ -66677,7 +66677,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2908,
+          "line": 2919,
           "column": 15,
           "symbol": "renderPublication",
           "defaultMessage": "Publish result set",
@@ -66692,13 +66692,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2887,
+              "line": 2898,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2908,
+              "line": 2919,
               "column": 15,
               "kind": "messageHelper"
             }
@@ -66766,7 +66766,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2935,
+          "line": 2946,
           "column": 20,
           "symbol": "renderPublication",
           "defaultMessage": "Publish reason",
@@ -66775,7 +66775,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2938,
+          "line": 2949,
           "column": 32,
           "symbol": "renderPublication",
           "defaultMessage": "Publish reason",
@@ -66790,13 +66790,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2935,
+              "line": 2946,
               "column": 20,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2938,
+              "line": 2949,
               "column": 32,
               "kind": "messageHelper"
             }
@@ -66991,7 +66991,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2986,
+          "line": 2997,
           "column": 46,
           "symbol": "renderPublication",
           "defaultMessage": "Action",
@@ -67012,7 +67012,7 @@
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2986,
+              "line": 2997,
               "column": 46,
               "kind": "messageHelper"
             }
@@ -67432,7 +67432,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2984,
+          "line": 2995,
           "column": 22,
           "symbol": "renderPublication",
           "defaultMessage": "Inputs",
@@ -67453,7 +67453,7 @@
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2984,
+              "line": 2995,
               "column": 22,
               "kind": "messageHelper"
             }
@@ -67696,7 +67696,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2969,
+          "line": 2980,
           "column": 22,
           "symbol": "renderPublication",
           "defaultMessage": "Result set",
@@ -67717,7 +67717,7 @@
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2969,
+              "line": 2980,
               "column": 22,
               "kind": "messageHelper"
             }
@@ -68093,7 +68093,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2834,
+          "line": 2845,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Manifest version",
@@ -68108,7 +68108,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2834,
+              "line": 2845,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -68176,7 +68176,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2827,
+          "line": 2838,
           "column": 20,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Artifact verification",
@@ -68191,7 +68191,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2827,
+              "line": 2838,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -68259,7 +68259,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2859,
+          "line": 2870,
           "column": 41,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Artifacts",
@@ -68274,7 +68274,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2859,
+              "line": 2870,
               "column": 41,
               "kind": "messageHelper"
             }
@@ -68342,7 +68342,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2684,
+          "line": 2695,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Coverage mode",
@@ -68357,7 +68357,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2684,
+              "line": 2695,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -68425,7 +68425,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2689,
+          "line": 2700,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Default impact category",
@@ -68440,7 +68440,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2689,
+              "line": 2700,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -68508,7 +68508,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2707,
+          "line": 2718,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Eligible inputs",
@@ -68523,7 +68523,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2707,
+              "line": 2718,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -68591,7 +68591,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2770,
+          "line": 2781,
           "column": 20,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Export Excel",
@@ -68606,7 +68606,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2770,
+              "line": 2781,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -68757,7 +68757,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2712,
+          "line": 2723,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Impact category count",
@@ -68772,7 +68772,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2712,
+              "line": 2723,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -68840,7 +68840,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2702,
+          "line": 2713,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Included inputs",
@@ -68855,7 +68855,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2702,
+              "line": 2713,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -68923,7 +68923,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2697,
+          "line": 2708,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Input manifest hash",
@@ -68938,7 +68938,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2697,
+              "line": 2708,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -69006,7 +69006,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2725,
+          "line": 2736,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Input scope",
@@ -69021,7 +69021,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2725,
+              "line": 2736,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -69089,7 +69089,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2777,
+          "line": 2788,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "LCIA method",
@@ -69098,7 +69098,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2779,
+          "line": 2790,
           "column": 31,
           "symbol": "renderPackagePreview",
           "defaultMessage": "LCIA method",
@@ -69113,13 +69113,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2777,
+              "line": 2788,
               "column": 24,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2779,
+              "line": 2790,
               "column": 31,
               "kind": "messageHelper"
             }
@@ -69246,7 +69246,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2589,
+          "line": 2600,
           "column": 12,
           "symbol": "renderPreviewPager",
           "defaultMessage": "Next",
@@ -69261,7 +69261,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2589,
+              "line": 2600,
               "column": 12,
               "kind": "messageHelper"
             }
@@ -69329,7 +69329,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2671,
+          "line": 2682,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Result set ID",
@@ -69344,7 +69344,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2671,
+              "line": 2682,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -69412,7 +69412,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2676,
+          "line": 2687,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Result set version",
@@ -69427,7 +69427,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2676,
+              "line": 2687,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -69495,7 +69495,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2738,
+          "line": 2749,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Predicate version",
@@ -69510,7 +69510,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2738,
+              "line": 2749,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -69578,7 +69578,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2585,
+          "line": 2596,
           "column": 12,
           "symbol": "renderPreviewPager",
           "defaultMessage": "Previous",
@@ -69593,7 +69593,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2585,
+              "line": 2596,
               "column": 12,
               "kind": "messageHelper"
             }
@@ -69661,7 +69661,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2728,
+          "line": 2739,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Process count",
@@ -69676,7 +69676,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2728,
+              "line": 2739,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -70052,7 +70052,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2544,
+          "line": 2555,
           "column": 14,
           "symbol": "previewDetailColumns",
           "defaultMessage": "Version",
@@ -70073,7 +70073,7 @@
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2544,
+              "line": 2555,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -70141,7 +70141,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2862,
+          "line": 2873,
           "column": 21,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Query artifact",
@@ -70156,7 +70156,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2862,
+              "line": 2873,
               "column": 21,
               "kind": "messageHelper"
             }
@@ -70224,7 +70224,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2866,
+          "line": 2877,
           "column": 21,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Result artifact",
@@ -70239,7 +70239,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2866,
+              "line": 2877,
               "column": 21,
               "kind": "messageHelper"
             }
@@ -70307,7 +70307,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2754,
+          "line": 2765,
           "column": 20,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Result details",
@@ -70322,7 +70322,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2754,
+              "line": 2765,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -70390,7 +70390,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2802,
+          "line": 2813,
           "column": 21,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Calculation results are not available for this preview.",
@@ -70405,7 +70405,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2802,
+              "line": 2813,
               "column": 21,
               "kind": "messageHelper"
             }
@@ -70473,7 +70473,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2733,
+          "line": 2744,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Selection mode",
@@ -70488,7 +70488,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2733,
+              "line": 2744,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -70556,7 +70556,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2855,
+          "line": 2866,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Snapshot coverage",
@@ -70571,7 +70571,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2855,
+              "line": 2866,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -70639,7 +70639,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2845,
+          "line": 2856,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Snapshot ID",
@@ -70654,7 +70654,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2845,
+              "line": 2856,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -70722,7 +70722,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2850,
+          "line": 2861,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Snapshot matrix",
@@ -70737,7 +70737,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2850,
+              "line": 2861,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -70814,7 +70814,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2550,
+          "line": 2561,
           "column": 14,
           "symbol": "previewDetailColumns",
           "defaultMessage": "State code",
@@ -70835,7 +70835,7 @@
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2550,
+              "line": 2561,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -70903,7 +70903,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2743,
+          "line": 2754,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "State codes",
@@ -70918,7 +70918,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2743,
+              "line": 2754,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -70986,7 +70986,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2680,
+          "line": 2691,
           "column": 41,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Status",
@@ -71001,7 +71001,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2680,
+              "line": 2691,
               "column": 41,
               "kind": "messageHelper"
             }
@@ -71069,7 +71069,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2841,
+          "line": 2852,
           "column": 41,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Storage",
@@ -71084,7 +71084,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2841,
+              "line": 2852,
               "column": 41,
               "kind": "messageHelper"
             }
@@ -71152,7 +71152,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2668,
+          "line": 2679,
           "column": 24,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Result set overview",
@@ -71167,7 +71167,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2668,
+              "line": 2679,
               "column": 24,
               "kind": "messageHelper"
             }
@@ -71392,7 +71392,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2791,
+          "line": 2802,
           "column": 28,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Some preview data could not be loaded",
@@ -71407,7 +71407,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2791,
+              "line": 2802,
               "column": 28,
               "kind": "messageHelper"
             }
@@ -71475,7 +71475,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 3038,
+          "line": 3049,
           "column": 30,
           "symbol": "renderPublication",
           "defaultMessage": "Current",
@@ -71490,7 +71490,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 3038,
+              "line": 3049,
               "column": 30,
               "kind": "messageHelper"
             }
@@ -71558,7 +71558,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2963,
+          "line": 2974,
           "column": 18,
           "symbol": "renderPublication",
           "defaultMessage": "No publications yet",
@@ -71573,7 +71573,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2963,
+              "line": 2974,
               "column": 18,
               "kind": "messageHelper"
             }
@@ -71641,7 +71641,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2884,
+          "line": 2895,
           "column": 20,
           "symbol": "renderPublication",
           "defaultMessage": "Legacy LCIA publication",
@@ -71656,7 +71656,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2884,
+              "line": 2895,
               "column": 20,
               "kind": "messageHelper"
             }
@@ -71724,7 +71724,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2981,
+          "line": 2992,
           "column": 22,
           "symbol": "renderPublication",
           "defaultMessage": "Published at",
@@ -71739,7 +71739,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2981,
+              "line": 2992,
               "column": 22,
               "kind": "messageHelper"
             }
@@ -71807,7 +71807,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2954,
+          "line": 2965,
           "column": 14,
           "symbol": "renderPublication",
           "defaultMessage": "Refresh publications",
@@ -71822,7 +71822,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2954,
+              "line": 2965,
               "column": 14,
               "kind": "messageHelper"
             }
@@ -71890,7 +71890,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2951,
+          "line": 2962,
           "column": 16,
           "symbol": "renderPublication",
           "defaultMessage": "Publication management",
@@ -71905,7 +71905,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2951,
+              "line": 2962,
               "column": 16,
               "kind": "messageHelper"
             }
@@ -75608,7 +75608,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 3093,
+          "line": 3104,
           "column": 26,
           "symbol": "DataProcessing",
           "defaultMessage": "Completeness & Calculation",
@@ -75623,7 +75623,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 3093,
+              "line": 3104,
               "column": 26,
               "kind": "messageHelper"
             }
@@ -75691,7 +75691,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 3098,
+          "line": 3109,
           "column": 26,
           "symbol": "DataProcessing",
           "defaultMessage": "Result Preview",
@@ -75706,7 +75706,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 3098,
+              "line": 3109,
               "column": 26,
               "kind": "messageHelper"
             }
@@ -75774,7 +75774,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 3103,
+          "line": 3114,
           "column": 26,
           "symbol": "DataProcessing",
           "defaultMessage": "Publication",
@@ -75789,7 +75789,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 3103,
+              "line": 3114,
               "column": 26,
               "kind": "messageHelper"
             }
@@ -75940,7 +75940,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 3079,
+          "line": 3090,
           "column": 27,
           "symbol": "DataProcessing",
           "defaultMessage": "Data Processing",
@@ -75955,7 +75955,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 3079,
+              "line": 3090,
               "column": 27,
               "kind": "messageHelper"
             }
@@ -76082,7 +76082,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2920,
+          "line": 2931,
           "column": 26,
           "symbol": "renderPublication",
           "defaultMessage": "Default impact category is required",
@@ -76097,7 +76097,7 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2920,
+              "line": 2931,
               "column": 26,
               "kind": "messageHelper"
             }
@@ -76263,7 +76263,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2643,
+          "line": 2654,
           "column": 26,
           "symbol": "renderPackagePreview",
           "defaultMessage": "Result set is required",
@@ -76272,7 +76272,7 @@
         {
           "kind": "messageHelper",
           "path": "src/pages/DataProcessing/index.tsx",
-          "line": 2900,
+          "line": 2911,
           "column": 26,
           "symbol": "renderPublication",
           "defaultMessage": "Result set is required",
@@ -76287,13 +76287,13 @@
           "locations": [
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2643,
+              "line": 2654,
               "column": 26,
               "kind": "messageHelper"
             },
             {
               "path": "src/pages/DataProcessing/index.tsx",
-              "line": 2900,
+              "line": 2911,
               "column": 26,
               "kind": "messageHelper"
             }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
-    "contextDigest": "128f4c15f9af3de937116d4ca15ff182018fc2f5345a19b2a121f701c16de087"
+    "contextDigest": "57b4f1ec9250d6c05e4ccd3081656478f716b6e58a81205c5c75bf64d3f7c0f4"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "311e22f44256e95fd4cb805d996860ff0517d116cbd5fbdedae3ca68ebe327c7",
-    "validationDigest": "97f47fc10ac85fc00f60f6e89d6849a050d9f22d9514ccacb8aed1d804925951",
+    "digest": "3faea5655ed30e7bb287fba1c92532409c5d11122e4b8d94afd2403035ec9d5e",
+    "validationDigest": "02c25d9958352a53db1b07e924250c2ef1b84a3fa1dbd5dc42d7e126e35db41f",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "9ab99366016d5bde3a0fabf995d4fe71e4d16ad047de8be1d23433da2fc0515e"
+  "qualityDigest": "cf01fab18a44bbe11f6121efbd852dbb123ce30d48b3f9cb9c1d484ebeef0076"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
-    "contextDigest": "f32a7ec6e841a0bd28b50c2d43950df7b6d415451a751cfde61dbf2781f8e6c5"
+    "contextDigest": "128f4c15f9af3de937116d4ca15ff182018fc2f5345a19b2a121f701c16de087"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "2fe50f1d3e2e5b9ba626a61ba6bc0defc2b1a7b93de695faeee383300a8b2322",
-    "validationDigest": "b60cbfba73760becf6e41fcf7266f78c1083452552128b7b38275f4a1afc85d3",
+    "digest": "311e22f44256e95fd4cb805d996860ff0517d116cbd5fbdedae3ca68ebe327c7",
+    "validationDigest": "97f47fc10ac85fc00f60f6e89d6849a050d9f22d9514ccacb8aed1d804925951",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "d07c8459277e4a8f02beadc8ac41d5559bd5d3179303a932808780b625c29793"
+  "qualityDigest": "9ab99366016d5bde3a0fabf995d4fe71e4d16ad047de8be1d23433da2fc0515e"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
-    "contextDigest": "82e830b1ac025099446e3cf2ae5ed382ffda4882d50fe03634fe1e2c7167638b"
+    "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
+    "contextDigest": "f32a7ec6e841a0bd28b50c2d43950df7b6d415451a751cfde61dbf2781f8e6c5"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "abb0331e729cd25d926e96431a20689153d5e68526058b78b768fc7f6e88cac5",
-    "validationDigest": "bfa9c458caac2ee2e4b4c813a78bedc697b3b106469405de8a6b095bba57b208",
+    "digest": "2fe50f1d3e2e5b9ba626a61ba6bc0defc2b1a7b93de695faeee383300a8b2322",
+    "validationDigest": "b60cbfba73760becf6e41fcf7266f78c1083452552128b7b38275f4a1afc85d3",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "2c2c6c4103c2c787a4f4b310bcf63ff0a23a242df792a514de3bdf9fad7c2fa1"
+  "qualityDigest": "d07c8459277e4a8f02beadc8ac41d5559bd5d3179303a932808780b625c29793"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "3ac7a3aa040a7748977442ca12d4bbff60cbbb664a728ad17b7776a37f50a219",
+    "auditedInputDigest": "761b2d5d8b07d623b315ac228bc6a242e39f17a9a6a462544db688db4d8fb14b",
     "validatedMessageCount": 3207,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1438,
     "highRiskMessageDigest": "f04d46071b685e2e8f18b83dcdc6b333345ccde36366e5c1a1b05a7b1944677f",
     "catalogDigest": "ebe1a99a1cdb1231fefa9cea59309b1e3a2d778338f2d9587dc4fd5e8a151f88",
-    "dossierDigest": "2d2092a8a9953c2d6a1cd3730e285048884ba3b8c9c9f9d97ef8defa20402067",
+    "dossierDigest": "5f8d57aef18349dc5f1bbbca7c5d9f9b61cdfb60a938dfb6f21dd6e281e0a6dc",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "b8af4daf42442c6f8e3ef8c0381a3ea186dd67dc706686c18a29ba60e6591df4",
+    "routeEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "1c44907a709976d8e99335c2656623bc9ea0d5379f10f6d81b58e724a773ab67",
         "highRiskMessageCount": 1438,
         "highRiskMessageDigest": "f04d46071b685e2e8f18b83dcdc6b333345ccde36366e5c1a1b05a7b1944677f",
-        "dossierDigest": "2d2092a8a9953c2d6a1cd3730e285048884ba3b8c9c9f9d97ef8defa20402067",
+        "dossierDigest": "5f8d57aef18349dc5f1bbbca7c5d9f9b61cdfb60a938dfb6f21dd6e281e0a6dc",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "bfa9c458caac2ee2e4b4c813a78bedc697b3b106469405de8a6b095bba57b208"
+  "validationDigest": "b60cbfba73760becf6e41fcf7266f78c1083452552128b7b38275f4a1afc85d3"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "ebe1a99a1cdb1231fefa9cea59309b1e3a2d778338f2d9587dc4fd5e8a151f88",
     "dossierDigest": "5f8d57aef18349dc5f1bbbca7c5d9f9b61cdfb60a938dfb6f21dd6e281e0a6dc",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
+    "routeEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "97f47fc10ac85fc00f60f6e89d6849a050d9f22d9514ccacb8aed1d804925951"
+  "validationDigest": "02c25d9958352a53db1b07e924250c2ef1b84a3fa1dbd5dc42d7e126e35db41f"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "ebe1a99a1cdb1231fefa9cea59309b1e3a2d778338f2d9587dc4fd5e8a151f88",
     "dossierDigest": "5f8d57aef18349dc5f1bbbca7c5d9f9b61cdfb60a938dfb6f21dd6e281e0a6dc",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
+    "routeEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "b60cbfba73760becf6e41fcf7266f78c1083452552128b7b38275f4a1afc85d3"
+  "validationDigest": "97f47fc10ac85fc00f60f6e89d6849a050d9f22d9514ccacb8aed1d804925951"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
-          "focusedTestDigest": "3a0e3890139663aebcad6ebd94be52aa13fa3a524571c0f68593db6c08ee1158",
+          "focusedTestDigest": "243286815301584d8147b86fe8bfc4f24813f856b81d245fdf66f7d06773840c",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
+      "rowEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "96e637736c14d4b87781ac5b4f2625ccc488467db6efb16b2341a425cd9492cb"
+  "contextDigest": "b7e50184640054f61d43d6fb582cf4712b4e5adb27225b981bab41c417384b93"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
-          "focusedTestDigest": "243286815301584d8147b86fe8bfc4f24813f856b81d245fdf66f7d06773840c",
+          "focusedTestDigest": "410cc0f2a8ab907cb4ce4505166f895cfc0f28b4e041461a6fd4da46c9630f89",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
+      "rowEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "b7e50184640054f61d43d6fb582cf4712b4e5adb27225b981bab41c417384b93"
+  "contextDigest": "7dbd0ac795dfe31cac1c7da4614daceaa897ae5960de11aa143165bf79901e58"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
-    "auditedInputDigest": "3ac7a3aa040a7748977442ca12d4bbff60cbbb664a728ad17b7776a37f50a219"
+    "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
+    "auditedInputDigest": "761b2d5d8b07d623b315ac228bc6a242e39f17a9a6a462544db688db4d8fb14b"
   },
   "inventory": {
     "sourceMessageCount": 3207,
@@ -47,7 +47,7 @@
     "messageCount": 3207,
     "completeCount": 3207,
     "blockedCount": 0,
-    "dossierDigest": "b37ecd1de26df45e2fbf696b10bcf996fac7684dbfcf442930879ccbf3d912aa",
+    "dossierDigest": "c1be0360d1c5a69d41571104471a189c87f9179d8d5d8f67638d383212030205",
     "catalogDigest": "c624da4a23d6cb86936aeb4b45afd52d46a8b29702e8064b2607b3ff975049d6",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -137,7 +137,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "26e1ea958b9472090a506cec4841333e77d6c15673b1ee4fd28b6c4701da1cb3",
+      "sourceEvidenceDigest": "de9f35c8942da38b1d92f3c5436f134954e0e0e75c5cdffb2fc603481c300b77",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -1035,8 +1035,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "40501d75d8f3be85f8dba53114a319a3389594bee4526af5ce5a7fbd87b8e9db",
-          "focusedTestDigest": "d628100d6eb1cde80204db289fa0d740076f58afdbd0bda38564251ebd70f068",
+          "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
+          "focusedTestDigest": "3a0e3890139663aebcad6ebd94be52aa13fa3a524571c0f68593db6c08ee1158",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "b8af4daf42442c6f8e3ef8c0381a3ea186dd67dc706686c18a29ba60e6591df4",
+      "rowEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "ffe3178ab8c88a93006ec1db5ccdbda496db60c30666c1e257f759a165ee55d9"
+  "contextDigest": "96e637736c14d4b87781ac5b4f2625ccc488467db6efb16b2341a425cd9492cb"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944"
+    "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "ffe3178ab8c88a93006ec1db5ccdbda496db60c30666c1e257f759a165ee55d9",
-    "qualityDigest": "cb1a2238d8f5a0457aed132d3858805bf455ff4244ef6a12db6e8ad96272d160",
+    "contextDigest": "96e637736c14d4b87781ac5b4f2625ccc488467db6efb16b2341a425cd9492cb",
+    "qualityDigest": "509c18b6f67552e9555136478595e8172d06d73714d925017bc1583c7dd2f5e3",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "94145bba15e68dd5b75749b4257dad49f6d6818e4d4d186c3866348bb142d1a6"
+  "activationDigest": "180098b35351a2a0125d64d9ea399393163ea6e2830d30392743786829914fdd"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "96e637736c14d4b87781ac5b4f2625ccc488467db6efb16b2341a425cd9492cb",
-    "qualityDigest": "509c18b6f67552e9555136478595e8172d06d73714d925017bc1583c7dd2f5e3",
+    "contextDigest": "b7e50184640054f61d43d6fb582cf4712b4e5adb27225b981bab41c417384b93",
+    "qualityDigest": "8eeaf7432bff04393f50814568227f6b28332fe849c2da7877dd834fc995798e",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "180098b35351a2a0125d64d9ea399393163ea6e2830d30392743786829914fdd"
+  "activationDigest": "49b6edb34b5b48c7d034a44ec9fddcb27c2e15df3972c888489ce0fdaba31681"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "b7e50184640054f61d43d6fb582cf4712b4e5adb27225b981bab41c417384b93",
-    "qualityDigest": "8eeaf7432bff04393f50814568227f6b28332fe849c2da7877dd834fc995798e",
+    "contextDigest": "7dbd0ac795dfe31cac1c7da4614daceaa897ae5960de11aa143165bf79901e58",
+    "qualityDigest": "2d2fe484f5b4b5376a66870f4a026bd26f45266c542c294565c153c0f4a6b241",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "49b6edb34b5b48c7d034a44ec9fddcb27c2e15df3972c888489ce0fdaba31681"
+  "activationDigest": "e3569df508a483eaeee8eb91f8f5e2ef2833ec8ec7875745267e076adc992d07"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
-    "contextDigest": "96e637736c14d4b87781ac5b4f2625ccc488467db6efb16b2341a425cd9492cb"
+    "contextDigest": "b7e50184640054f61d43d6fb582cf4712b4e5adb27225b981bab41c417384b93"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "bf98648096b32ec0e2f14e7edc134a23dfc3e97fd5e93a79fab0d3e07820bdc7",
-    "validationDigest": "07b4d9448d748a476fcd0598ece0c294a606271a876eab5113efd8d4e6a02063",
+    "digest": "077e078b9f15f517882c95917b7bc88d4733fc73a2ee98495527e95dab835c89",
+    "validationDigest": "ce56a7934aa9eb958da5f260c342841ffc7f0bf9b8022562bb643d0c88efd262",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "509c18b6f67552e9555136478595e8172d06d73714d925017bc1583c7dd2f5e3"
+  "qualityDigest": "8eeaf7432bff04393f50814568227f6b28332fe849c2da7877dd834fc995798e"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
-    "contextDigest": "b7e50184640054f61d43d6fb582cf4712b4e5adb27225b981bab41c417384b93"
+    "contextDigest": "7dbd0ac795dfe31cac1c7da4614daceaa897ae5960de11aa143165bf79901e58"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "077e078b9f15f517882c95917b7bc88d4733fc73a2ee98495527e95dab835c89",
-    "validationDigest": "ce56a7934aa9eb958da5f260c342841ffc7f0bf9b8022562bb643d0c88efd262",
+    "digest": "60e51ae8cf06d2c2ca36ba40050d2bd26bf3abb739db6c07407444d721117604",
+    "validationDigest": "7637ad5b864acdd613fa9edf4b7373b577bc2b09edf1bc5fb25980e72d845a27",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "8eeaf7432bff04393f50814568227f6b28332fe849c2da7877dd834fc995798e"
+  "qualityDigest": "2d2fe484f5b4b5376a66870f4a026bd26f45266c542c294565c153c0f4a6b241"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
-    "contextDigest": "ffe3178ab8c88a93006ec1db5ccdbda496db60c30666c1e257f759a165ee55d9"
+    "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
+    "contextDigest": "96e637736c14d4b87781ac5b4f2625ccc488467db6efb16b2341a425cd9492cb"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "fc3924502483ed3cad3b9a8e278b146fc56a3e3d57652112d4ffaacddcb35872",
-    "validationDigest": "d1bd6a6904e2c61bc81e37ed49f84aeb98ef2236e8bf2dbc1d05c5dd5dc38457",
+    "digest": "bf98648096b32ec0e2f14e7edc134a23dfc3e97fd5e93a79fab0d3e07820bdc7",
+    "validationDigest": "07b4d9448d748a476fcd0598ece0c294a606271a876eab5113efd8d4e6a02063",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "cb1a2238d8f5a0457aed132d3858805bf455ff4244ef6a12db6e8ad96272d160"
+  "qualityDigest": "509c18b6f67552e9555136478595e8172d06d73714d925017bc1583c7dd2f5e3"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "c624da4a23d6cb86936aeb4b45afd52d46a8b29702e8064b2607b3ff975049d6",
     "dossierDigest": "c1be0360d1c5a69d41571104471a189c87f9179d8d5d8f67638d383212030205",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
+    "routeEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "07b4d9448d748a476fcd0598ece0c294a606271a876eab5113efd8d4e6a02063"
+  "validationDigest": "ce56a7934aa9eb958da5f260c342841ffc7f0bf9b8022562bb643d0c88efd262"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "3ac7a3aa040a7748977442ca12d4bbff60cbbb664a728ad17b7776a37f50a219",
+    "auditedInputDigest": "761b2d5d8b07d623b315ac228bc6a242e39f17a9a6a462544db688db4d8fb14b",
     "validatedMessageCount": 3207,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1438,
     "highRiskMessageDigest": "f04d46071b685e2e8f18b83dcdc6b333345ccde36366e5c1a1b05a7b1944677f",
     "catalogDigest": "c624da4a23d6cb86936aeb4b45afd52d46a8b29702e8064b2607b3ff975049d6",
-    "dossierDigest": "b37ecd1de26df45e2fbf696b10bcf996fac7684dbfcf442930879ccbf3d912aa",
+    "dossierDigest": "c1be0360d1c5a69d41571104471a189c87f9179d8d5d8f67638d383212030205",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "b8af4daf42442c6f8e3ef8c0381a3ea186dd67dc706686c18a29ba60e6591df4",
+    "routeEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "1c44907a709976d8e99335c2656623bc9ea0d5379f10f6d81b58e724a773ab67",
         "highRiskMessageCount": 1438,
         "highRiskMessageDigest": "f04d46071b685e2e8f18b83dcdc6b333345ccde36366e5c1a1b05a7b1944677f",
-        "dossierDigest": "b37ecd1de26df45e2fbf696b10bcf996fac7684dbfcf442930879ccbf3d912aa",
+        "dossierDigest": "c1be0360d1c5a69d41571104471a189c87f9179d8d5d8f67638d383212030205",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "d1bd6a6904e2c61bc81e37ed49f84aeb98ef2236e8bf2dbc1d05c5dd5dc38457"
+  "validationDigest": "07b4d9448d748a476fcd0598ece0c294a606271a876eab5113efd8d4e6a02063"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "c624da4a23d6cb86936aeb4b45afd52d46a8b29702e8064b2607b3ff975049d6",
     "dossierDigest": "c1be0360d1c5a69d41571104471a189c87f9179d8d5d8f67638d383212030205",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
+    "routeEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "ce56a7934aa9eb958da5f260c342841ffc7f0bf9b8022562bb643d0c88efd262"
+  "validationDigest": "7637ad5b864acdd613fa9edf4b7373b577bc2b09edf1bc5fb25980e72d845a27"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
-          "focusedTestDigest": "243286815301584d8147b86fe8bfc4f24813f856b81d245fdf66f7d06773840c",
+          "focusedTestDigest": "410cc0f2a8ab907cb4ce4505166f895cfc0f28b4e041461a6fd4da46c9630f89",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
+      "rowEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "98d8593983cc449fddd153aa7610132beac3ea2548f96d336e38c0e982b6ebda"
+  "contextDigest": "f71489b51636eebab6fb254c1d76032256e7d2f01f4cbfb0beb113bd27470dae"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
-    "auditedInputDigest": "3ac7a3aa040a7748977442ca12d4bbff60cbbb664a728ad17b7776a37f50a219"
+    "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
+    "auditedInputDigest": "761b2d5d8b07d623b315ac228bc6a242e39f17a9a6a462544db688db4d8fb14b"
   },
   "inventory": {
     "sourceMessageCount": 3207,
@@ -47,7 +47,7 @@
     "messageCount": 3207,
     "completeCount": 3207,
     "blockedCount": 0,
-    "dossierDigest": "dde6832d2860d044cfef590fae4e750e8b4925cdd44abdecc897d42482cf8e43",
+    "dossierDigest": "91b8413109f240e2696f872ce90410cd36bd8d31c3d4f658f420569a17607b58",
     "catalogDigest": "7d583779611c1c15fbbe9d362606a7f992bd399dcb958f558b638dd85fd12156",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -137,7 +137,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "26e1ea958b9472090a506cec4841333e77d6c15673b1ee4fd28b6c4701da1cb3",
+      "sourceEvidenceDigest": "de9f35c8942da38b1d92f3c5436f134954e0e0e75c5cdffb2fc603481c300b77",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -1035,8 +1035,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "40501d75d8f3be85f8dba53114a319a3389594bee4526af5ce5a7fbd87b8e9db",
-          "focusedTestDigest": "d628100d6eb1cde80204db289fa0d740076f58afdbd0bda38564251ebd70f068",
+          "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
+          "focusedTestDigest": "3a0e3890139663aebcad6ebd94be52aa13fa3a524571c0f68593db6c08ee1158",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "b8af4daf42442c6f8e3ef8c0381a3ea186dd67dc706686c18a29ba60e6591df4",
+      "rowEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "652d65e19ff09a2e854d014e665a8f95697ef25b4259b70485788e06283a2919"
+  "contextDigest": "bacec26ecf599b000d5f5887bc6bd352d6417fe5479cdcbad58ba7bd18096e9e"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
-          "focusedTestDigest": "3a0e3890139663aebcad6ebd94be52aa13fa3a524571c0f68593db6c08ee1158",
+          "focusedTestDigest": "243286815301584d8147b86fe8bfc4f24813f856b81d245fdf66f7d06773840c",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
+      "rowEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "bacec26ecf599b000d5f5887bc6bd352d6417fe5479cdcbad58ba7bd18096e9e"
+  "contextDigest": "98d8593983cc449fddd153aa7610132beac3ea2548f96d336e38c0e982b6ebda"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944"
+    "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "652d65e19ff09a2e854d014e665a8f95697ef25b4259b70485788e06283a2919",
-    "qualityDigest": "62eb7a59d1e0e190cf47b880ecbde6ab44aa850b1b048f97b9814553ddcdbde5",
+    "contextDigest": "bacec26ecf599b000d5f5887bc6bd352d6417fe5479cdcbad58ba7bd18096e9e",
+    "qualityDigest": "2bc0a22ae1e7e9a4035042eddffa50bd10572751d0ede8917813c9d29071cf0b",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "d37db654026abf6978c3cc51ee90f66846b95a84cfbedd0dd63711022a64f1a2"
+  "activationDigest": "6a9b24d98b4637e058c939591457cde2f8123a0cdabbff79e8c8aa8c06657470"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "98d8593983cc449fddd153aa7610132beac3ea2548f96d336e38c0e982b6ebda",
-    "qualityDigest": "18a960d01c8ce9381d6ab384c669cb08c3fbcbfd2d550ca4449b2b78f8301592",
+    "contextDigest": "f71489b51636eebab6fb254c1d76032256e7d2f01f4cbfb0beb113bd27470dae",
+    "qualityDigest": "844b76e787f82487637172c3b603f336649b6474e91d7d41445ffdfe7317d065",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "a4998aa3deeb8c6af9ecb3939b2161e776ab9aa27f3eb0a00ccf1e0ae3e55469"
+  "activationDigest": "688435bc99178e1f206d9288b722117c6ae5f169b35d3709a492a42881c65089"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "bacec26ecf599b000d5f5887bc6bd352d6417fe5479cdcbad58ba7bd18096e9e",
-    "qualityDigest": "2bc0a22ae1e7e9a4035042eddffa50bd10572751d0ede8917813c9d29071cf0b",
+    "contextDigest": "98d8593983cc449fddd153aa7610132beac3ea2548f96d336e38c0e982b6ebda",
+    "qualityDigest": "18a960d01c8ce9381d6ab384c669cb08c3fbcbfd2d550ca4449b2b78f8301592",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "6a9b24d98b4637e058c939591457cde2f8123a0cdabbff79e8c8aa8c06657470"
+  "activationDigest": "a4998aa3deeb8c6af9ecb3939b2161e776ab9aa27f3eb0a00ccf1e0ae3e55469"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
-    "contextDigest": "98d8593983cc449fddd153aa7610132beac3ea2548f96d336e38c0e982b6ebda"
+    "contextDigest": "f71489b51636eebab6fb254c1d76032256e7d2f01f4cbfb0beb113bd27470dae"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "9a1967fdeb7bc8db740688377dab302b00367671975a2b708a2cc469ec4fbc0b",
-    "validationDigest": "02e2d064c455121e1b72bd1725ade64cec4c35a15ab7bf78ede45de89f1479c2",
+    "digest": "1491b57cca0bbcacca552f819ccd36a870288403b0bc5dc88bdd290a272a9b75",
+    "validationDigest": "c301347890bcce7c07d16d561ca429bf8da5721bde8516d081a6e026b6eceab8",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "18a960d01c8ce9381d6ab384c669cb08c3fbcbfd2d550ca4449b2b78f8301592"
+  "qualityDigest": "844b76e787f82487637172c3b603f336649b6474e91d7d41445ffdfe7317d065"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
-    "contextDigest": "bacec26ecf599b000d5f5887bc6bd352d6417fe5479cdcbad58ba7bd18096e9e"
+    "contextDigest": "98d8593983cc449fddd153aa7610132beac3ea2548f96d336e38c0e982b6ebda"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "e41f4f0fc5b11e84e4345eea53fc6e5663f0e6b9a86daf8a56ebd3cf95fe7e26",
-    "validationDigest": "0f6a3c52513a432c63dcfc6c4f096d8750ee231c20271b4980737e405643d258",
+    "digest": "9a1967fdeb7bc8db740688377dab302b00367671975a2b708a2cc469ec4fbc0b",
+    "validationDigest": "02e2d064c455121e1b72bd1725ade64cec4c35a15ab7bf78ede45de89f1479c2",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "2bc0a22ae1e7e9a4035042eddffa50bd10572751d0ede8917813c9d29071cf0b"
+  "qualityDigest": "18a960d01c8ce9381d6ab384c669cb08c3fbcbfd2d550ca4449b2b78f8301592"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
-    "contextDigest": "652d65e19ff09a2e854d014e665a8f95697ef25b4259b70485788e06283a2919"
+    "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
+    "contextDigest": "bacec26ecf599b000d5f5887bc6bd352d6417fe5479cdcbad58ba7bd18096e9e"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "ff8291e79860e84b17298c4a0519454e4f7f34b4c06567504e48dc56d82dc80a",
-    "validationDigest": "8f8fbde6cd752c7bef7fe1937a11932c57281c48a74905580664f4da3b490112",
+    "digest": "e41f4f0fc5b11e84e4345eea53fc6e5663f0e6b9a86daf8a56ebd3cf95fe7e26",
+    "validationDigest": "0f6a3c52513a432c63dcfc6c4f096d8750ee231c20271b4980737e405643d258",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "62eb7a59d1e0e190cf47b880ecbde6ab44aa850b1b048f97b9814553ddcdbde5"
+  "qualityDigest": "2bc0a22ae1e7e9a4035042eddffa50bd10572751d0ede8917813c9d29071cf0b"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "7d583779611c1c15fbbe9d362606a7f992bd399dcb958f558b638dd85fd12156",
     "dossierDigest": "91b8413109f240e2696f872ce90410cd36bd8d31c3d4f658f420569a17607b58",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
+    "routeEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "02e2d064c455121e1b72bd1725ade64cec4c35a15ab7bf78ede45de89f1479c2"
+  "validationDigest": "c301347890bcce7c07d16d561ca429bf8da5721bde8516d081a6e026b6eceab8"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "7d583779611c1c15fbbe9d362606a7f992bd399dcb958f558b638dd85fd12156",
     "dossierDigest": "91b8413109f240e2696f872ce90410cd36bd8d31c3d4f658f420569a17607b58",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
+    "routeEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "0f6a3c52513a432c63dcfc6c4f096d8750ee231c20271b4980737e405643d258"
+  "validationDigest": "02e2d064c455121e1b72bd1725ade64cec4c35a15ab7bf78ede45de89f1479c2"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "3ac7a3aa040a7748977442ca12d4bbff60cbbb664a728ad17b7776a37f50a219",
+    "auditedInputDigest": "761b2d5d8b07d623b315ac228bc6a242e39f17a9a6a462544db688db4d8fb14b",
     "validatedMessageCount": 3207,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1438,
     "highRiskMessageDigest": "f04d46071b685e2e8f18b83dcdc6b333345ccde36366e5c1a1b05a7b1944677f",
     "catalogDigest": "7d583779611c1c15fbbe9d362606a7f992bd399dcb958f558b638dd85fd12156",
-    "dossierDigest": "dde6832d2860d044cfef590fae4e750e8b4925cdd44abdecc897d42482cf8e43",
+    "dossierDigest": "91b8413109f240e2696f872ce90410cd36bd8d31c3d4f658f420569a17607b58",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "b8af4daf42442c6f8e3ef8c0381a3ea186dd67dc706686c18a29ba60e6591df4",
+    "routeEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "1c44907a709976d8e99335c2656623bc9ea0d5379f10f6d81b58e724a773ab67",
         "highRiskMessageCount": 1438,
         "highRiskMessageDigest": "f04d46071b685e2e8f18b83dcdc6b333345ccde36366e5c1a1b05a7b1944677f",
-        "dossierDigest": "dde6832d2860d044cfef590fae4e750e8b4925cdd44abdecc897d42482cf8e43",
+        "dossierDigest": "91b8413109f240e2696f872ce90410cd36bd8d31c3d4f658f420569a17607b58",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "8f8fbde6cd752c7bef7fe1937a11932c57281c48a74905580664f4da3b490112"
+  "validationDigest": "0f6a3c52513a432c63dcfc6c4f096d8750ee231c20271b4980737e405643d258"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
-          "focusedTestDigest": "3a0e3890139663aebcad6ebd94be52aa13fa3a524571c0f68593db6c08ee1158",
+          "focusedTestDigest": "243286815301584d8147b86fe8bfc4f24813f856b81d245fdf66f7d06773840c",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
+      "rowEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "3a47df742c7bae1b2d1ec13e7ac2d8be9e0c1d615b7311a2f27d4106a73769ec"
+  "contextDigest": "72d264565e76ac4e121e626d047fc02616f9e22ef2373c8ca49d45d2a79528ed"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -1036,7 +1036,7 @@
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
           "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
-          "focusedTestDigest": "243286815301584d8147b86fe8bfc4f24813f856b81d245fdf66f7d06773840c",
+          "focusedTestDigest": "410cc0f2a8ab907cb4ce4505166f895cfc0f28b4e041461a6fd4da46c9630f89",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
+      "rowEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "72d264565e76ac4e121e626d047fc02616f9e22ef2373c8ca49d45d2a79528ed"
+  "contextDigest": "968886599a835ea985e2a302f5dea26ba00550fdcb9f88e825d254c85e4a8f18"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
-    "auditedInputDigest": "3ac7a3aa040a7748977442ca12d4bbff60cbbb664a728ad17b7776a37f50a219"
+    "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
+    "auditedInputDigest": "761b2d5d8b07d623b315ac228bc6a242e39f17a9a6a462544db688db4d8fb14b"
   },
   "inventory": {
     "sourceMessageCount": 3207,
@@ -47,7 +47,7 @@
     "messageCount": 3207,
     "completeCount": 3207,
     "blockedCount": 0,
-    "dossierDigest": "08f33b9b65a8eb320783cd1981e720624db21cbcc4b20d602c37dd6ee5bd228e",
+    "dossierDigest": "a71ca28b3232b43894bfd6a799496c88da11fee0a2d1aa595d48c3bdb28ca187",
     "catalogDigest": "9a0e196cccecf0bb9f31b00c34d66eb42df680f77da9be330a12dcae6fd292ea",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -137,7 +137,7 @@
         "focusedVariantCount": 7
       },
       "sourceFileCount": 35,
-      "sourceEvidenceDigest": "26e1ea958b9472090a506cec4841333e77d6c15673b1ee4fd28b6c4701da1cb3",
+      "sourceEvidenceDigest": "de9f35c8942da38b1d92f3c5436f134954e0e0e75c5cdffb2fc603481c300b77",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -1035,8 +1035,8 @@
           "route": "/data-processing",
           "viewState": "build-preview-publication-tabs",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "40501d75d8f3be85f8dba53114a319a3389594bee4526af5ce5a7fbd87b8e9db",
-          "focusedTestDigest": "d628100d6eb1cde80204db289fa0d740076f58afdbd0bda38564251ebd70f068",
+          "sourceDigest": "bf4c9528156d37aeaa92f722cbf2fe28866feb7fecaa03d3b6c4f22c916af0db",
+          "focusedTestDigest": "3a0e3890139663aebcad6ebd94be52aa13fa3a524571c0f68593db6c08ee1158",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "bab91c736a148188c3778bd30db083f6ac1af6408c3505f399dfdebf9d510ccc",
           "derivedMessageCount": 137,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "b8af4daf42442c6f8e3ef8c0381a3ea186dd67dc706686c18a29ba60e6591df4",
+      "rowEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "e71204e21fb213db8d76bea2f681559c26d06f90b8c6a6d8e1cf96f1abc516dc"
+  "contextDigest": "3a47df742c7bae1b2d1ec13e7ac2d8be9e0c1d615b7311a2f27d4106a73769ec"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "72d264565e76ac4e121e626d047fc02616f9e22ef2373c8ca49d45d2a79528ed",
-    "qualityDigest": "4fd9107eb278b7ac903fab9cdcebff74b145127c0c16d66329499b45109b6f5c",
+    "contextDigest": "968886599a835ea985e2a302f5dea26ba00550fdcb9f88e825d254c85e4a8f18",
+    "qualityDigest": "9b762485696ff2dac37510afb5dc7a388915e6fb649f05f70908242e4e2669a6",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "0903867a9a3bd99e500688a3d3b14db07504882b37ee8e994d89bc562cb9efb0"
+  "activationDigest": "c7d5e8f5dcfa4d29bd9860e9f68d4d6bff5bca930d1e11b2149b056237c8e881"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "3a47df742c7bae1b2d1ec13e7ac2d8be9e0c1d615b7311a2f27d4106a73769ec",
-    "qualityDigest": "0d0498dad3e7f2f74c6df62118f54b8d6bb5a4356c46f8d3fdfc93db2a81e3b1",
+    "contextDigest": "72d264565e76ac4e121e626d047fc02616f9e22ef2373c8ca49d45d2a79528ed",
+    "qualityDigest": "4fd9107eb278b7ac903fab9cdcebff74b145127c0c16d66329499b45109b6f5c",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "43473c3ac3bf925a897c86e4d8c4afe50fa270e2af32d1c60dcc31d8cb124be9"
+  "activationDigest": "0903867a9a3bd99e500688a3d3b14db07504882b37ee8e994d89bc562cb9efb0"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944"
+    "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "e71204e21fb213db8d76bea2f681559c26d06f90b8c6a6d8e1cf96f1abc516dc",
-    "qualityDigest": "651285dde4997bc617abe6a6152f78d5f82c02494e8f9494c5a0ad26beef0e01",
+    "contextDigest": "3a47df742c7bae1b2d1ec13e7ac2d8be9e0c1d615b7311a2f27d4106a73769ec",
+    "qualityDigest": "0d0498dad3e7f2f74c6df62118f54b8d6bb5a4356c46f8d3fdfc93db2a81e3b1",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "a8924c676c5ea817890b62ce258b5c0fbb8d3060300c450fb8cae78392f89472"
+  "activationDigest": "43473c3ac3bf925a897c86e4d8c4afe50fa270e2af32d1c60dcc31d8cb124be9"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
-    "contextDigest": "72d264565e76ac4e121e626d047fc02616f9e22ef2373c8ca49d45d2a79528ed"
+    "contextDigest": "968886599a835ea985e2a302f5dea26ba00550fdcb9f88e825d254c85e4a8f18"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "50c33db48dbd6d458c5dcc4f820fc17bdc9de84ad1873093da5a88aaebdcb420",
-    "validationDigest": "3c0984da3bc8e52bf3f3e460600901feac9ff237d5aec409a49cc8e248dd5808",
+    "digest": "de458a1626e0d5f663a848242853f4afc2746b6e17955dc7a435884791e9658c",
+    "validationDigest": "b32beb28608fcc229d6591ae3a6d7a6546b422f73e046498e3fa8da571b4c2cf",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "4fd9107eb278b7ac903fab9cdcebff74b145127c0c16d66329499b45109b6f5c"
+  "qualityDigest": "9b762485696ff2dac37510afb5dc7a388915e6fb649f05f70908242e4e2669a6"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6f99b86e4f3c6a81321fa9cd7595d30226bdcb64c584e775b7731a4feca72944",
-    "contextDigest": "e71204e21fb213db8d76bea2f681559c26d06f90b8c6a6d8e1cf96f1abc516dc"
+    "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
+    "contextDigest": "3a47df742c7bae1b2d1ec13e7ac2d8be9e0c1d615b7311a2f27d4106a73769ec"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "bbcb2c6a395d26ad10446a1252e3c6c065fac2905c457a467452436878b6ba5f",
-    "validationDigest": "b4f6f469718b6c2de4c3c0541595ab926e8686b6e8ebd745135408f03e82e106",
+    "digest": "5c11cde70d7025e4bc1160b2f8cb23a7d164ccd71387ffc5bc7d795a30ac52ee",
+    "validationDigest": "b33a19ac868cf9da2ed7c91642677b71d8978a1aae958d2ec860553f0ef690a1",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "651285dde4997bc617abe6a6152f78d5f82c02494e8f9494c5a0ad26beef0e01"
+  "qualityDigest": "0d0498dad3e7f2f74c6df62118f54b8d6bb5a4356c46f8d3fdfc93db2a81e3b1"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "f6b990a9683775af6c73c71e88da23709aae1d17b1e4886f9e75bae46cb6c754",
-    "contextDigest": "3a47df742c7bae1b2d1ec13e7ac2d8be9e0c1d615b7311a2f27d4106a73769ec"
+    "contextDigest": "72d264565e76ac4e121e626d047fc02616f9e22ef2373c8ca49d45d2a79528ed"
   },
   "catalog": {
     "messageCount": 3207,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "5c11cde70d7025e4bc1160b2f8cb23a7d164ccd71387ffc5bc7d795a30ac52ee",
-    "validationDigest": "b33a19ac868cf9da2ed7c91642677b71d8978a1aae958d2ec860553f0ef690a1",
+    "digest": "50c33db48dbd6d458c5dcc4f820fc17bdc9de84ad1873093da5a88aaebdcb420",
+    "validationDigest": "3c0984da3bc8e52bf3f3e460600901feac9ff237d5aec409a49cc8e248dd5808",
     "laneCount": 1,
     "validatedMessageCount": 3207,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "0d0498dad3e7f2f74c6df62118f54b8d6bb5a4356c46f8d3fdfc93db2a81e3b1"
+  "qualityDigest": "4fd9107eb278b7ac903fab9cdcebff74b145127c0c16d66329499b45109b6f5c"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "9a0e196cccecf0bb9f31b00c34d66eb42df680f77da9be330a12dcae6fd292ea",
     "dossierDigest": "a71ca28b3232b43894bfd6a799496c88da11fee0a2d1aa595d48c3bdb28ca187",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
+    "routeEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "3c0984da3bc8e52bf3f3e460600901feac9ff237d5aec409a49cc8e248dd5808"
+  "validationDigest": "b32beb28608fcc229d6591ae3a6d7a6546b422f73e046498e3fa8da571b4c2cf"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "9a0e196cccecf0bb9f31b00c34d66eb42df680f77da9be330a12dcae6fd292ea",
     "dossierDigest": "a71ca28b3232b43894bfd6a799496c88da11fee0a2d1aa595d48c3bdb28ca187",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
+    "routeEvidenceDigest": "ba0b828d078cfada8616877bce8a408c51f226f1517536c34ea70edb0b5e27c3",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "b33a19ac868cf9da2ed7c91642677b71d8978a1aae958d2ec860553f0ef690a1"
+  "validationDigest": "3c0984da3bc8e52bf3f3e460600901feac9ff237d5aec409a49cc8e248dd5808"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "3ac7a3aa040a7748977442ca12d4bbff60cbbb664a728ad17b7776a37f50a219",
+    "auditedInputDigest": "761b2d5d8b07d623b315ac228bc6a242e39f17a9a6a462544db688db4d8fb14b",
     "validatedMessageCount": 3207,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1438,
     "highRiskMessageDigest": "f04d46071b685e2e8f18b83dcdc6b333345ccde36366e5c1a1b05a7b1944677f",
     "catalogDigest": "9a0e196cccecf0bb9f31b00c34d66eb42df680f77da9be330a12dcae6fd292ea",
-    "dossierDigest": "08f33b9b65a8eb320783cd1981e720624db21cbcc4b20d602c37dd6ee5bd228e",
+    "dossierDigest": "a71ca28b3232b43894bfd6a799496c88da11fee0a2d1aa595d48c3bdb28ca187",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "b8af4daf42442c6f8e3ef8c0381a3ea186dd67dc706686c18a29ba60e6591df4",
+    "routeEvidenceDigest": "4d1d596a4d508c5acb993becf4b86be60fa2da28d46e910a9609baa87098d365",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "1c44907a709976d8e99335c2656623bc9ea0d5379f10f6d81b58e724a773ab67",
         "highRiskMessageCount": 1438,
         "highRiskMessageDigest": "f04d46071b685e2e8f18b83dcdc6b333345ccde36366e5c1a1b05a7b1944677f",
-        "dossierDigest": "08f33b9b65a8eb320783cd1981e720624db21cbcc4b20d602c37dd6ee5bd228e",
+        "dossierDigest": "a71ca28b3232b43894bfd6a799496c88da11fee0a2d1aa595d48c3bdb28ca187",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "b4f6f469718b6c2de4c3c0541595ab926e8686b6e8ebd745135408f03e82e106"
+  "validationDigest": "b33a19ac868cf9da2ed7c91642677b71d8978a1aae958d2ec860553f0ef690a1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.78",
+  "version": "0.0.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiangong-lca-next",
-      "version": "0.0.78",
+      "version": "0.0.79",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.78",
+  "version": "0.0.79",
   "private": true,
   "description": "An out-of-box LCA Data solution",
   "homepage": "./",

--- a/src/pages/DataProcessing/index.tsx
+++ b/src/pages/DataProcessing/index.tsx
@@ -2537,7 +2537,18 @@ const DataProcessing = () => {
         if (!processId || !processVersion) {
           return processName;
         }
-        return <a href={processDetailHref(processId, processVersion)}>{processName}</a>;
+        const href = processDetailHref(processId, processVersion);
+        return (
+          <a
+            href={href}
+            onClick={(event) => {
+              event.preventDefault();
+              history.push(href);
+            }}
+          >
+            {processName}
+          </a>
+        );
       },
     },
     {

--- a/tests/unit/pages/DataProcessing/index.test.tsx
+++ b/tests/unit/pages/DataProcessing/index.test.tsx
@@ -171,6 +171,7 @@ let mockLocale: string | undefined = 'en-US';
 let mockLocation = { pathname: '/data-processing', search: '' };
 let mockInjectResultSet = true;
 const mockHistoryReplace = jest.fn();
+const mockHistoryPush = jest.fn();
 
 function mockWithTestResultSet(search: string): string {
   if (!mockInjectResultSet) return search;
@@ -256,7 +257,10 @@ const expectedReviewedLciaMethods = [
 jest.mock('@umijs/max', () => ({
   __esModule: true,
   FormattedMessage: ({ defaultMessage, id }: any) => defaultMessage ?? id,
-  history: { replace: (...args: any[]) => Reflect.apply(mockHistoryReplace, undefined, args) },
+  history: {
+    push: (...args: any[]) => Reflect.apply(mockHistoryPush, undefined, args),
+    replace: (...args: any[]) => Reflect.apply(mockHistoryReplace, undefined, args),
+  },
   useIntl: () => ({
     formatMessage: mockFormatMessage,
     locale: mockLocale,
@@ -1996,6 +2000,10 @@ describe('DataProcessing page', () => {
     const processLink = screen.getByRole('link', { name: 'Portland cement production' });
     expect(processLink).toHaveAttribute(
       'href',
+      '/mydata/processes?id=process-a&version=01.00.000&mode=view',
+    );
+    fireEvent.click(processLink);
+    expect(mockHistoryPush).toHaveBeenCalledWith(
       '/mydata/processes?id=process-a&version=01.00.000&mode=view',
     );
     expect(screen.getByText('Electricity, medium voltage')).toBeInTheDocument();

--- a/tests/unit/pages/DataProcessing/index.test.tsx
+++ b/tests/unit/pages/DataProcessing/index.test.tsx
@@ -1387,14 +1387,15 @@ describe('DataProcessing page', () => {
     render(<DataProcessing />);
 
     expect(await screen.findByTestId('page-title')).toHaveTextContent('Data Processing');
-    expect(
-      screen.getByRole('button', { name: 'Use this check to start calculation' }),
-    ).toBeDisabled();
-    expect(await screen.findByText('blocked')).toBeInTheDocument();
+    const generationButton = await screen.findByRole(
+      'button',
+      { name: 'Use this check to start calculation' },
+      { timeout: 5000 },
+    );
+    expect(generationButton).toBeDisabled();
+    expect(await screen.findByText('blocked', undefined, { timeout: 5000 })).toBeInTheDocument();
     expect(screen.getByText('2 blockers')).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Use this check to start calculation' }),
-    ).toBeDisabled();
+    expect(generationButton).toBeDisabled();
     expect(mockCreateLciaResultBuildRequest).not.toHaveBeenCalled();
   });
 
@@ -2673,8 +2674,15 @@ describe('DataProcessing page', () => {
     expect(await screen.findByTestId('page-title')).toHaveTextContent('Data Processing');
     fireEvent.click(screen.getByTestId('tab-publication'));
 
-    await waitFor(() => expect(mockListLciaResultPublications).toHaveBeenCalledWith({ limit: 50 }));
-    const currentRow = await screen.findByTestId('data-product-publication-publication-current');
+    await waitFor(
+      () => expect(mockListLciaResultPublications).toHaveBeenCalledWith({ limit: 50 }),
+      { timeout: 5000 },
+    );
+    const currentRow = await screen.findByTestId(
+      'data-product-publication-publication-current',
+      undefined,
+      { timeout: 5000 },
+    );
     const oldRow = screen.getByTestId('data-product-publication-publication-old');
     expect(screen.getByTestId('data-product-publication-2')).toHaveTextContent(
       'Unidentified result set',

--- a/tests/unit/pages/DataProcessing/index.test.tsx
+++ b/tests/unit/pages/DataProcessing/index.test.tsx
@@ -1506,7 +1506,16 @@ describe('DataProcessing page', () => {
 
   it('shows an empty closure-issue state without blocking task history rendering', async () => {
     render(<DataProcessing />);
-    expect(await screen.findByText('No closure issues found.')).toBeInTheDocument();
+    await waitFor(
+      () =>
+        expect(mockListClosureCheckIssues).toHaveBeenCalledWith('closure-valid', {
+          limit: 50,
+        }),
+      { timeout: 5000 },
+    );
+    expect(
+      await screen.findByText('No closure issues found.', undefined, { timeout: 5000 }),
+    ).toBeInTheDocument();
     expect(screen.getByTestId('data-product-job-worker-job-1')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Promotion Contract

- base branch: `main`
- source identity: exact dev commit `e991feacf23090647455cd28e9f7f45a01ee74a6` from Release PR #899
- back-merge required after merge: No; this is the normal dev-to-main path
- root workspace integration expected: Yes, after promotion

## Linked Issue

Closes #892

## Promotion Facts

- Promote version `0.0.79` from immutable dev candidate `e991feacf23090647455cd28e9f7f45a01ee74a6`.
- Main baseline bound by the dev Release PR proof: `71691118f0b65a48407e83ebd5cde8b1c46db032`.

## Validation Facts

- The promotion branch points exactly at the merged dev candidate.
- The managed promotion push ran only structural/static checks.
- The main PR check verifies the exact dev Release PR proof and tree identity; it does not rerun the full gate or browser E2E.

## Integration And Follow-Up

- After merge, the canonical main release workflow verifies the same proof before tag/publication without repeating candidate acceptance.
