### PR TITLE
fix: cap annual supply volume text length

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-19"
-lastReviewedCommit: "9bae84a4cc7479ccebb42579c416287ecf5130ae"
+lastReviewedAt: "2026-08-21"
+lastReviewedCommit: "1395ddb24b9ee75a269df363eba303cea7bac513"
 lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-08-19
-lastReviewedCommit: 9bae84a4cc7479ccebb42579c416287ecf5130ae
+lastReviewedAt: 2026-08-21
+lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
 lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - .nvmrc
-lastReviewedAt: 2026-08-19
-lastReviewedCommit: 9bae84a4cc7479ccebb42579c416287ecf5130ae
+lastReviewedAt: 2026-08-21
+lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
 lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-08-19
-lastReviewedCommit: 9bae84a4cc7479ccebb42579c416287ecf5130ae
+lastReviewedAt: 2026-08-21
+lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
 lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - playwright.config.ts
   - config/docs-capture/**
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-08-19
-lastReviewedCommit: a90fc6e4878cff963bbe3cee14641c60bac80193
+lastReviewedAt: 2026-08-21
+lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
 lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/test-runner.cjs
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-08-19
-lastReviewedCommit: 9bae84a4cc7479ccebb42579c416287ecf5130ae
+lastReviewedAt: 2026-08-21
+lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
 lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
 related:
   - ../AGENTS.md

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/e2e/**
   - playwright.config.ts
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-08-19
-lastReviewedCommit: e991feacf23090647455cd28e9f7f45a01ee74a6
+lastReviewedAt: 2026-08-21
+lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
 lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -27,8 +27,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
   - package.json
-lastReviewedAt: 2026-08-19
-lastReviewedCommit: 9bae84a4cc7479ccebb42579c416287ecf5130ae
+lastReviewedAt: 2026-08-21
+lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
 lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -29,8 +29,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-19
-lastReviewedCommit: 9bae84a4cc7479ccebb42579c416287ecf5130ae
+lastReviewedAt: 2026-08-21
+lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
 lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -30,8 +30,8 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-19
-lastReviewedCommit: 9bae84a4cc7479ccebb42579c416287ecf5130ae
+lastReviewedAt: 2026-08-21
+lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
 lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -27,8 +27,8 @@ checkPaths:
   - package.json
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-19
-lastReviewedCommit: 9bae84a4cc7479ccebb42579c416287ecf5130ae
+lastReviewedAt: 2026-08-21
+lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
 lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "e847b8f65340911b91ccbfaaef5b9724451683efb9118601441b33c4cd9dc4e1",
-    "auditedInputDigest": "7fe83be2c6923ce6927e26666dcb77d160c3bd38b73fb05bfee3930813c71e3d"
+    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa",
+    "auditedInputDigest": "6eb9d4db745087fc482842636806b32f96b3d6f8e909e0406bb34a6ccddde9af"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "45ff09ce1b04e0383fade837e8d4c76a0b1f8a1366d96d13f44e139771ac6c8c",
+    "dossierDigest": "4be07faca561764260f3990821f0b910450c2a9d9e302e94d3b70c8bbfc66cad",
     "catalogDigest": "eedb0e7243bf231ee4867c31135403f77fe62cda0c4f495b4b66a0846efe2064",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "d98a1032d9e89f8ca07d320db158b6c6f066e20a47f7e89a5c9d1bceeb22cab1"
+  "contextDigest": "de97967de74affe077bd9ff4ef3ca8d83ae45184e4f91b9b85f004f0d8478381"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e847b8f65340911b91ccbfaaef5b9724451683efb9118601441b33c4cd9dc4e1"
+    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "d98a1032d9e89f8ca07d320db158b6c6f066e20a47f7e89a5c9d1bceeb22cab1",
-    "qualityDigest": "7940f87c1ae52d0d0d211e30c8f4ed1e71bbc62f014f7aadd2b92c5e8c12fb24",
+    "contextDigest": "de97967de74affe077bd9ff4ef3ca8d83ae45184e4f91b9b85f004f0d8478381",
+    "qualityDigest": "dbbca3278e76e225710d32ab4badd7e976dfb31925afc347dda3e9af39ab587d",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "73e1d1221f2a69f4cc196a80c0cc2c7d559c42a2c5a3321376cafa2aeff3562a"
+  "activationDigest": "21f575fbc2cfd21e1aa539e00d4424a4b5ed4944ff9eda906a4bf23dba1f23aa"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "7fe83be2c6923ce6927e26666dcb77d160c3bd38b73fb05bfee3930813c71e3d",
+    "auditedInputDigest": "6eb9d4db745087fc482842636806b32f96b3d6f8e909e0406bb34a6ccddde9af",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e847b8f65340911b91ccbfaaef5b9724451683efb9118601441b33c4cd9dc4e1",
-    "contextDigest": "d98a1032d9e89f8ca07d320db158b6c6f066e20a47f7e89a5c9d1bceeb22cab1"
+    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa",
+    "contextDigest": "de97967de74affe077bd9ff4ef3ca8d83ae45184e4f91b9b85f004f0d8478381"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "12aa9b493380df21ebd40108a7329fba9e1fe4604c060dfcea1d1fc411223f01",
-    "validationDigest": "2644ff8b818ac7b54240c133e0166f67f522fd278bb8ab0dbca21eef3e204152",
+    "digest": "9606a02a5219c28e307cfe4f9ad2452fe8393d0530d001211703e231c9a9a6fe",
+    "validationDigest": "242020f9a63a7ac41a0bb8da1e8837bc106b4d55435c7b01cbfc2512a72374d7",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "7940f87c1ae52d0d0d211e30c8f4ed1e71bbc62f014f7aadd2b92c5e8c12fb24"
+  "qualityDigest": "dbbca3278e76e225710d32ab4badd7e976dfb31925afc347dda3e9af39ab587d"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "7fe83be2c6923ce6927e26666dcb77d160c3bd38b73fb05bfee3930813c71e3d",
+    "auditedInputDigest": "6eb9d4db745087fc482842636806b32f96b3d6f8e909e0406bb34a6ccddde9af",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "eedb0e7243bf231ee4867c31135403f77fe62cda0c4f495b4b66a0846efe2064",
-    "dossierDigest": "45ff09ce1b04e0383fade837e8d4c76a0b1f8a1366d96d13f44e139771ac6c8c",
+    "dossierDigest": "4be07faca561764260f3990821f0b910450c2a9d9e302e94d3b70c8bbfc66cad",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "45ff09ce1b04e0383fade837e8d4c76a0b1f8a1366d96d13f44e139771ac6c8c",
+        "dossierDigest": "4be07faca561764260f3990821f0b910450c2a9d9e302e94d3b70c8bbfc66cad",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "2644ff8b818ac7b54240c133e0166f67f522fd278bb8ab0dbca21eef3e204152"
+  "validationDigest": "242020f9a63a7ac41a0bb8da1e8837bc106b4d55435c7b01cbfc2512a72374d7"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "e847b8f65340911b91ccbfaaef5b9724451683efb9118601441b33c4cd9dc4e1",
-    "auditedInputDigest": "7fe83be2c6923ce6927e26666dcb77d160c3bd38b73fb05bfee3930813c71e3d"
+    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa",
+    "auditedInputDigest": "6eb9d4db745087fc482842636806b32f96b3d6f8e909e0406bb34a6ccddde9af"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "f87d99b161cb3b308b22747bc18b5309d433052c010ba665ba3b0b20310f0dbe",
+    "dossierDigest": "7a0b44f3ed2990063cac6adc7e6b56550c606fe5d00d1ddcd221d6a89a403a93",
     "catalogDigest": "4f46de97d47c6840fc2760cf4cf6be090efb82304fb44648fa509ee6ec7d77b2",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "af97476d0c3298d9943e2f6145771078b86b9bf968e0a338c042223a45cf3ce3"
+  "contextDigest": "e25d8a49e30ba09d2e8dbe0aa2f1b759ddb2aad8f46bc10f3de39c8fa123b4ba"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e847b8f65340911b91ccbfaaef5b9724451683efb9118601441b33c4cd9dc4e1"
+    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "af97476d0c3298d9943e2f6145771078b86b9bf968e0a338c042223a45cf3ce3",
-    "qualityDigest": "8f64ce3dd951c03fb79bf425d5afe0d8100de347ee6911ae38f586cb1c9c9ccb",
+    "contextDigest": "e25d8a49e30ba09d2e8dbe0aa2f1b759ddb2aad8f46bc10f3de39c8fa123b4ba",
+    "qualityDigest": "b37f05c99b73eb00edfcbb7be66dbed52d778ca23d1041b52c0f7e5f688de92e",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "be53affbeba60bee9ce5ba37eafcd466a03bd5966f9e689b0f0c115dc49f0331"
+  "activationDigest": "080538aa085eb701ac0a4f68ab8c5ec121bb39de44f844185e6bf8dd4a6164c9"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e847b8f65340911b91ccbfaaef5b9724451683efb9118601441b33c4cd9dc4e1",
-    "contextDigest": "af97476d0c3298d9943e2f6145771078b86b9bf968e0a338c042223a45cf3ce3"
+    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa",
+    "contextDigest": "e25d8a49e30ba09d2e8dbe0aa2f1b759ddb2aad8f46bc10f3de39c8fa123b4ba"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "be7ceb958011c27acf2f618649617e267e46b755e9000f7ff5e9547249ada5d6",
-    "validationDigest": "487891471a4ac1912ea30e637f90a776aab4d90f199b0664cef006ab0e0be746",
+    "digest": "656576067f51c3e214807f40419692acb85ca864c7dc0cef291c724dc15e2e7b",
+    "validationDigest": "7f1551642c2d88b598a13a04dc12601c7e5b23dbc1a773ff1dd621e0907e85d9",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "8f64ce3dd951c03fb79bf425d5afe0d8100de347ee6911ae38f586cb1c9c9ccb"
+  "qualityDigest": "b37f05c99b73eb00edfcbb7be66dbed52d778ca23d1041b52c0f7e5f688de92e"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "7fe83be2c6923ce6927e26666dcb77d160c3bd38b73fb05bfee3930813c71e3d",
+    "auditedInputDigest": "6eb9d4db745087fc482842636806b32f96b3d6f8e909e0406bb34a6ccddde9af",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "4f46de97d47c6840fc2760cf4cf6be090efb82304fb44648fa509ee6ec7d77b2",
-    "dossierDigest": "f87d99b161cb3b308b22747bc18b5309d433052c010ba665ba3b0b20310f0dbe",
+    "dossierDigest": "7a0b44f3ed2990063cac6adc7e6b56550c606fe5d00d1ddcd221d6a89a403a93",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "f87d99b161cb3b308b22747bc18b5309d433052c010ba665ba3b0b20310f0dbe",
+        "dossierDigest": "7a0b44f3ed2990063cac6adc7e6b56550c606fe5d00d1ddcd221d6a89a403a93",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "487891471a4ac1912ea30e637f90a776aab4d90f199b0664cef006ab0e0be746"
+  "validationDigest": "7f1551642c2d88b598a13a04dc12601c7e5b23dbc1a773ff1dd621e0907e85d9"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "e847b8f65340911b91ccbfaaef5b9724451683efb9118601441b33c4cd9dc4e1",
-    "auditedInputDigest": "7fe83be2c6923ce6927e26666dcb77d160c3bd38b73fb05bfee3930813c71e3d"
+    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa",
+    "auditedInputDigest": "6eb9d4db745087fc482842636806b32f96b3d6f8e909e0406bb34a6ccddde9af"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "a7f2959e4ebcfd7f9352593da2cfe8593b1ba4a43f8fe66608abc65b824d4e2a",
+    "dossierDigest": "4059360d1b6061c6cc6a09580fd7a34d9693b3097cf69641f1dcb73ea09ce65f",
     "catalogDigest": "e613c3d8b43dba89a92524f1dbd64dd0ab664eebb919ef7608aebccb7e6fa801",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "3559b9cb5051f2976e430362fbd3cef590c329f19c7fb85b5f9981bccc573c9b"
+  "contextDigest": "6504bc10b4957877ecfc13224bad26c4fc0c295eb40056ac14e094ae36194e0c"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e847b8f65340911b91ccbfaaef5b9724451683efb9118601441b33c4cd9dc4e1"
+    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "3559b9cb5051f2976e430362fbd3cef590c329f19c7fb85b5f9981bccc573c9b",
-    "qualityDigest": "a62cd3b99d53e3dadd8e77a19d5aa4c93dd53acd5105d1a33497978407795308",
+    "contextDigest": "6504bc10b4957877ecfc13224bad26c4fc0c295eb40056ac14e094ae36194e0c",
+    "qualityDigest": "b1fc4c46d1803897fbad8d25e583890346f0b6872cec36a7f3b0e8c3b6d225ee",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "21678f8b151d561822351321c10d0ddeef550c80ca195503474f50d124123eff"
+  "activationDigest": "3a883aa7d78e42653941764a09849e5167e0df5a9fbd39f55a24fd91438b792f"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e847b8f65340911b91ccbfaaef5b9724451683efb9118601441b33c4cd9dc4e1",
-    "contextDigest": "3559b9cb5051f2976e430362fbd3cef590c329f19c7fb85b5f9981bccc573c9b"
+    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa",
+    "contextDigest": "6504bc10b4957877ecfc13224bad26c4fc0c295eb40056ac14e094ae36194e0c"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "c613857c02dedb3d488bef62c2dd30fd989f99b2479b33dc6079a369c229aa9d",
-    "validationDigest": "fb7ddbed4f519debb8cab05dbbdf679f82fe16b2f9043fde7926d9214f0b9f4c",
+    "digest": "f29b435d81a53bf5cfa9ea00cbc731c3ef2e831373cec90b88b57736180f3ea4",
+    "validationDigest": "262fad0df48e39c0dc1f4b299ca0195bdf63ef28f2304a5bfff52c0ec39681d1",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "a62cd3b99d53e3dadd8e77a19d5aa4c93dd53acd5105d1a33497978407795308"
+  "qualityDigest": "b1fc4c46d1803897fbad8d25e583890346f0b6872cec36a7f3b0e8c3b6d225ee"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "7fe83be2c6923ce6927e26666dcb77d160c3bd38b73fb05bfee3930813c71e3d",
+    "auditedInputDigest": "6eb9d4db745087fc482842636806b32f96b3d6f8e909e0406bb34a6ccddde9af",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "e613c3d8b43dba89a92524f1dbd64dd0ab664eebb919ef7608aebccb7e6fa801",
-    "dossierDigest": "a7f2959e4ebcfd7f9352593da2cfe8593b1ba4a43f8fe66608abc65b824d4e2a",
+    "dossierDigest": "4059360d1b6061c6cc6a09580fd7a34d9693b3097cf69641f1dcb73ea09ce65f",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "a7f2959e4ebcfd7f9352593da2cfe8593b1ba4a43f8fe66608abc65b824d4e2a",
+        "dossierDigest": "4059360d1b6061c6cc6a09580fd7a34d9693b3097cf69641f1dcb73ea09ce65f",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "fb7ddbed4f519debb8cab05dbbdf679f82fe16b2f9043fde7926d9214f0b9f4c"
+  "validationDigest": "262fad0df48e39c0dc1f4b299ca0195bdf63ef28f2304a5bfff52c0ec39681d1"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "e847b8f65340911b91ccbfaaef5b9724451683efb9118601441b33c4cd9dc4e1",
-    "auditedInputDigest": "7fe83be2c6923ce6927e26666dcb77d160c3bd38b73fb05bfee3930813c71e3d"
+    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa",
+    "auditedInputDigest": "6eb9d4db745087fc482842636806b32f96b3d6f8e909e0406bb34a6ccddde9af"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "1bfcfe0ae24097d60ee00e1f65ac72824de91444cd111956d70d40989837a47c",
+    "dossierDigest": "5a85279499549765f7c5b163bc628e123e05f522262e5684190297b588863018",
     "catalogDigest": "a6838914aaf7b8aa5c1c6954aeb0dff767c0618f7b980a0c2f5f28f882a2f833",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "5fe6051aa91018b7933945223f56c370b55c393d68cfdac4f6bdb04b561453d6"
+  "contextDigest": "660b805a45246059bec3420bf3e0267add43d8f9b25f3db9c0de4da89cd1fc73"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e847b8f65340911b91ccbfaaef5b9724451683efb9118601441b33c4cd9dc4e1"
+    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "5fe6051aa91018b7933945223f56c370b55c393d68cfdac4f6bdb04b561453d6",
-    "qualityDigest": "9ef095ee69f87e20a6f6ef93836e05c16aa42f80acaa5dbdb834e0c370be729b",
+    "contextDigest": "660b805a45246059bec3420bf3e0267add43d8f9b25f3db9c0de4da89cd1fc73",
+    "qualityDigest": "9baa526a5eba3f038203ee6a816e87f408cc20aa66dfbe0abbe04e970def892a",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "fabdb0718655ef83e17412e8edfd85c1776c2d091eadbf49db602a7a6194de4e"
+  "activationDigest": "1b3384872df990a1703959731a26be7b622faf83eac21114f4efeaf967d3b956"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e847b8f65340911b91ccbfaaef5b9724451683efb9118601441b33c4cd9dc4e1",
-    "contextDigest": "5fe6051aa91018b7933945223f56c370b55c393d68cfdac4f6bdb04b561453d6"
+    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa",
+    "contextDigest": "660b805a45246059bec3420bf3e0267add43d8f9b25f3db9c0de4da89cd1fc73"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "445d2ed64d6829b4da15f550e0fa841d35370809aa35b285a7ee08d692618b6e",
-    "validationDigest": "a02c8e9e0848736c92ed0ebb3a7c160cb2a3ce7d4d598f80af68ea8ba8ed0487",
+    "digest": "7aa94e71d4861c5111f3f2851e0991c3467a23c7927842ab1117a3d39a7f7d0a",
+    "validationDigest": "9f8479ee6241047d4dae7c4693ec880cb40de493ffd0c865091c200858757d93",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "9ef095ee69f87e20a6f6ef93836e05c16aa42f80acaa5dbdb834e0c370be729b"
+  "qualityDigest": "9baa526a5eba3f038203ee6a816e87f408cc20aa66dfbe0abbe04e970def892a"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "7fe83be2c6923ce6927e26666dcb77d160c3bd38b73fb05bfee3930813c71e3d",
+    "auditedInputDigest": "6eb9d4db745087fc482842636806b32f96b3d6f8e909e0406bb34a6ccddde9af",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "a6838914aaf7b8aa5c1c6954aeb0dff767c0618f7b980a0c2f5f28f882a2f833",
-    "dossierDigest": "1bfcfe0ae24097d60ee00e1f65ac72824de91444cd111956d70d40989837a47c",
+    "dossierDigest": "5a85279499549765f7c5b163bc628e123e05f522262e5684190297b588863018",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "1bfcfe0ae24097d60ee00e1f65ac72824de91444cd111956d70d40989837a47c",
+        "dossierDigest": "5a85279499549765f7c5b163bc628e123e05f522262e5684190297b588863018",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "a02c8e9e0848736c92ed0ebb3a7c160cb2a3ce7d4d598f80af68ea8ba8ed0487"
+  "validationDigest": "9f8479ee6241047d4dae7c4693ec880cb40de493ffd0c865091c200858757d93"
 }

--- a/src/services/processes/annualSupplyOrProductionVolume.ts
+++ b/src/services/processes/annualSupplyOrProductionVolume.ts
@@ -6,7 +6,9 @@ import {
 import type { ProcessExchangeData, ProcessRefUnitDisplay } from './data';
 
 export const ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX = 'reference flow';
+export const ANNUAL_SUPPLY_VOLUME_TEXT_MAX_LENGTH = 500;
 const ANNUAL_SUPPLY_VOLUME_DEFAULT_LANGS = REQUIRED_CONTENT_LANGUAGES;
+const ANNUAL_SUPPLY_VOLUME_TRUNCATION_MARKER = '...';
 
 export const ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN = /^[+-]?(\d+(\.\d*)?|\.\d+)([Ee][+-]?\d+)?\s+\S.*$/;
 export const ANNUAL_SUPPLY_VOLUME_NUMERIC_TEXT_PATTERN =
@@ -173,6 +175,26 @@ export const sanitizeAnnualSupplyVolumeNumericInput = (value: unknown) => {
   }, '');
 };
 
+const truncateAnnualSupplyVolumeText = (value: string) => {
+  if (value.length <= ANNUAL_SUPPLY_VOLUME_TEXT_MAX_LENGTH) {
+    return value;
+  }
+
+  const contentLengthLimit =
+    ANNUAL_SUPPLY_VOLUME_TEXT_MAX_LENGTH - ANNUAL_SUPPLY_VOLUME_TRUNCATION_MARKER.length;
+  let truncatedText = '';
+
+  for (const character of value) {
+    if (truncatedText.length + character.length > contentLengthLimit) {
+      break;
+    }
+
+    truncatedText += character;
+  }
+
+  return `${truncatedText}${ANNUAL_SUPPLY_VOLUME_TRUNCATION_MARKER}`;
+};
+
 export const formatAnnualSupplyVolumeText = (
   numericText: unknown,
   suffix: unknown,
@@ -186,7 +208,9 @@ export const formatAnnualSupplyVolumeText = (
 
   const normalizedSuffix = normalizeAnnualSupplyVolumeSuffix(suffix, options);
 
-  return normalizedSuffix ? `${normalizedNumericText} ${normalizedSuffix}` : normalizedNumericText;
+  return truncateAnnualSupplyVolumeText(
+    normalizedSuffix ? `${normalizedNumericText} ${normalizedSuffix}` : normalizedNumericText,
+  );
 };
 
 export const normalizeAnnualSupplyVolumeText = (

--- a/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
+++ b/tests/unit/services/processes/annualSupplyOrProductionVolume.test.ts
@@ -1,5 +1,6 @@
 import {
   ANNUAL_SUPPLY_VOLUME_DEFAULT_SUFFIX,
+  ANNUAL_SUPPLY_VOLUME_TEXT_MAX_LENGTH,
   ANNUAL_SUPPLY_VOLUME_TEXT_PATTERN,
   buildAnnualSupplyVolumeMultiLang,
   buildAnnualSupplyVolumeUnitLookupRows,
@@ -51,6 +52,55 @@ describe('annualSupplyOrProductionVolume helpers', () => {
     );
     expect(formatAnnualSupplyVolumeText('123', '', { useDefaultSuffix: false })).toBe('123');
     expect(formatAnnualSupplyVolumeText(123, 'kg/year')).toBe('');
+  });
+
+  it('keeps annual supply text at the TIDAS limit unchanged and truncates longer text', () => {
+    const suffixAtLimit = 'x'.repeat(ANNUAL_SUPPLY_VOLUME_TEXT_MAX_LENGTH - 2);
+    const textAtLimit = `1 ${suffixAtLimit}`;
+    const truncatedText = formatAnnualSupplyVolumeText('1', `${suffixAtLimit}tail`);
+
+    expect(formatAnnualSupplyVolumeText('1', suffixAtLimit)).toBe(textAtLimit);
+    expect(truncatedText).toHaveLength(ANNUAL_SUPPLY_VOLUME_TEXT_MAX_LENGTH);
+    expect(truncatedText).toBe(`${textAtLimit.slice(0, -3)}...`);
+  });
+
+  it('applies the annual supply limit independently and consistently to each language', () => {
+    const values = buildAnnualSupplyVolumeMultiLang(
+      '1',
+      (lang) => (lang === 'zh' ? '中'.repeat(600) : 'e'.repeat(600)),
+      ['en', 'zh'],
+    );
+
+    expect(values).toHaveLength(2);
+    expect(values.map((item) => item['#text'].length)).toEqual([
+      ANNUAL_SUPPLY_VOLUME_TEXT_MAX_LENGTH,
+      ANNUAL_SUPPLY_VOLUME_TEXT_MAX_LENGTH,
+    ]);
+    expect(values.every((item) => item['#text'].endsWith('...'))).toBe(true);
+  });
+
+  it('leaves a language within the limit unchanged when another language is truncated', () => {
+    expect(
+      buildAnnualSupplyVolumeMultiLang(
+        '1',
+        (lang) => (lang === 'zh' ? '短文本' : 'e'.repeat(600)),
+        ['en', 'zh'],
+      ),
+    ).toEqual([
+      {
+        '@xml:lang': 'en',
+        '#text': `${`1 ${'e'.repeat(600)}`.slice(0, 497)}...`,
+      },
+      { '@xml:lang': 'zh', '#text': '1 短文本' },
+    ]);
+  });
+
+  it('does not split a Unicode surrogate pair at the annual supply truncation boundary', () => {
+    const suffix = `${'中'.repeat(494)}😀tail`;
+    const truncatedText = formatAnnualSupplyVolumeText('1', suffix);
+
+    expect(truncatedText).toBe(`1 ${'中'.repeat(494)}...`);
+    expect(truncatedText.length).toBeLessThanOrEqual(ANNUAL_SUPPLY_VOLUME_TEXT_MAX_LENGTH);
   });
 
   it('sanitizes editable numeric input while keeping real-number partial states', () => {

--- a/tests/unit/services/processes/util.test.ts
+++ b/tests/unit/services/processes/util.test.ts
@@ -521,6 +521,55 @@ describe('Process Utility Functions', () => {
       ).toEqual([{ '@xml:lang': 'en', '#text': '100 1 kg steel' }, { '#text': '200 1 kg steel' }]);
     });
 
+    it('should cap every localized annual supply volume value while saving', () => {
+      const dataWithLongAnnualSupplyContexts = {
+        ...mockProcessData,
+        exchanges: {
+          exchange: [
+            {
+              '@dataSetInternalID': '1',
+              referenceToFlowDataSet: {
+                '@refObjectId': 'flow-id-1',
+                '@version': '01.00.000',
+                'common:shortDescription': [
+                  { '@xml:lang': 'en', '#text': 'e'.repeat(600) },
+                  { '@xml:lang': 'zh', '#text': '中'.repeat(600) },
+                ],
+              },
+              refUnitRes: {
+                refUnitName: 'kg',
+              },
+              exchangeDirection: 'Output',
+              meanAmount: '1',
+              quantitativeReference: true,
+            },
+          ],
+        },
+        modellingAndValidation: {
+          ...mockProcessData.modellingAndValidation,
+          dataSourcesTreatmentAndRepresentativeness: {
+            annualSupplyOrProductionVolume: [
+              { '@xml:lang': 'en', '#text': '100 old suffix' },
+              { '@xml:lang': 'zh', '#text': '100 旧后缀' },
+            ],
+          },
+        },
+      };
+
+      const result = genProcessJsonOrdered('test-id', dataWithLongAnnualSupplyContexts);
+      const annualSupplyValues =
+        result.processDataSet.modellingAndValidation.dataSourcesTreatmentAndRepresentativeness
+          .annualSupplyOrProductionVolume;
+
+      expect(annualSupplyValues).toHaveLength(2);
+      expect(annualSupplyValues.map((item: { '#text': string }) => item['#text'].length)).toEqual([
+        500, 500,
+      ]);
+      expect(
+        annualSupplyValues.every((item: { '#text': string }) => item['#text'].endsWith('...')),
+      ).toBe(true);
+    });
+
     it('should preserve a previously resolved annual supply volume unit suffix while saving', () => {
       const dataWithAnnualSupplyVolume = {
         ...mockProcessData,


### PR DESCRIPTION
Closes linancn/tiangong-lca-next#908

## Summary
- Apply the TIDAS 500-character limit only to annualSupplyOrProductionVolume localized #text values during process save serialization.
- Keep compliant localized values unchanged; append ... only when an individual localized value exceeds the limit.

## Key Decisions
- Use a field-specific formatter rather than changing generic multilingual assembly behavior.
- Truncate each locale independently with the same 500-character rule, so Chinese and English are treated consistently without shortening a compliant locale.
- Iterate by Unicode code point and budget for the three-character marker to avoid splitting surrogate pairs.

## Validation
- Focused Jest suites passed: 2 suites, 84 tests.
- npm run lint and npm run build passed.
- i18n audit, locale artifact idempotence, and all locale checks passed after refreshing source-derived digests.
- Docpact lint passed with zero findings.
- npm run push:checked passed the managed pre-push gate, including the full Jest coverage run and 100% coverage assertion.

## Risks / Rollback
- Low: the behavior is isolated to annualSupplyOrProductionVolume; generic multilingual helpers and other fields are unchanged.
- Rollback by reverting commit be287ca5838bac5cfce2f5f9603b9f481e7664f9.

## Workspace Integration
- After this PR merges to dev, tiangong-lca-next must follow its dev-to-main promotion path before the root workspace can bump the submodule pointer on main.