### PR TITLE
fix: normalize TIDAS scalar storage types

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -2,7 +2,7 @@ version: 1
 layout: repo
 lastReviewedAt: '2026-08-21'
 lastReviewedCommit: '9319742112a8e9dd980762789895b4f4c074e531'
-lastReviewedNote: 'Reviewed for Next Issue #910: TIDAS scalar normalization changes remain covered by the existing frontend runtime, data-boundary, and testing contracts.'
+lastReviewedNote: 'Reviewed for Next Issue #910: TIDAS scalar normalization and the resulting locale artifact digest refresh remain covered by the existing frontend runtime, data-boundary, and testing contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-21"
-lastReviewedCommit: "1395ddb24b9ee75a269df363eba303cea7bac513"
-lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
+lastReviewedAt: '2026-08-21'
+lastReviewedCommit: '9319742112a8e9dd980762789895b4f4c074e531'
+lastReviewedNote: 'Reviewed for Next Issue #910: TIDAS scalar normalization changes remain covered by the existing frontend runtime, data-boundary, and testing contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - .github/workflows/**
 lastReviewedAt: 2026-08-21
 lastReviewedCommit: 9319742112a8e9dd980762789895b4f4c074e531
-lastReviewedNote: 'Reviewed for Next Issue #910: TIDAS year and percentage scalar normalization stays in the existing frontend/service ownership boundary and does not change repo workflow or branch policy.'
+lastReviewedNote: 'Reviewed for Next Issue #910: TIDAS scalar normalization and its generated locale digest refresh stay in the existing frontend/service ownership boundary and do not change repo workflow or branch policy.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-21
-lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
-lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
+lastReviewedCommit: 9319742112a8e9dd980762789895b4f4c074e531
+lastReviewedNote: 'Reviewed for Next Issue #910: TIDAS year and percentage scalar normalization stays in the existing frontend/service ownership boundary and does not change repo workflow or branch policy.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -31,7 +31,7 @@ checkPaths:
   - .nvmrc
 lastReviewedAt: 2026-08-21
 lastReviewedCommit: 9319742112a8e9dd980762789895b4f4c074e531
-lastReviewedNote: 'Reviewed for Next Issue #910: the TIDAS scalar storage fix uses the existing focused-test, lint, build, Docpact, and managed-push loop without changing bootstrap commands.'
+lastReviewedNote: 'Reviewed for Next Issue #910: the TIDAS scalar fix and locale artifact refresh use the existing focused-test, artifact-writer, lint, build, Docpact, and managed-push loop without changing bootstrap commands.'
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .nvmrc
 lastReviewedAt: 2026-08-21
-lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
-lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
+lastReviewedCommit: 9319742112a8e9dd980762789895b4f4c074e531
+lastReviewedNote: 'Reviewed for Next Issue #910: the TIDAS scalar storage fix uses the existing focused-test, lint, build, Docpact, and managed-push loop without changing bootstrap commands.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -32,7 +32,7 @@ checkPaths:
   - .github/workflows/**
 lastReviewedAt: 2026-08-21
 lastReviewedCommit: 9319742112a8e9dd980762789895b4f4c074e531
-lastReviewedNote: 'Reviewed for Next Issue #910: focused TIDAS scalar regression tests fit the existing hook-owned full gate; no trigger or quality-bar change is required.'
+lastReviewedNote: 'Reviewed for Next Issue #910: focused TIDAS scalar regression tests and regenerated locale digests fit the existing hook-owned full gate; no trigger or quality-bar change is required.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-21
-lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
-lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
+lastReviewedCommit: 9319742112a8e9dd980762789895b4f4c074e531
+lastReviewedNote: 'Reviewed for Next Issue #910: focused TIDAS scalar regression tests fit the existing hook-owned full gate; no trigger or quality-bar change is required.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-21
-lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
-lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
+lastReviewedCommit: 9319742112a8e9dd980762789895b4f4c074e531
+lastReviewedNote: 'Reviewed for Next Issue #910: the service layer now owns explicit TIDAS year and percentage scalar normalization plus fail-closed save validation.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -52,6 +52,7 @@ This repo is a Umi-based React SPA with service-first data access, cache-backed 
 | `src/pages/*/sdkValidation.ts`, `src/pages/Utils/validation/**` | page-level SDK-code adapters plus shared localized validation messages, detail mapping, and form-support helpers |
 | `src/components/**` | shared UI and reusable flows |
 | `src/services/**` | app-side Supabase/API access, ordered-dataset shaping, typed locale normalization and runtime fallback for Node-loaded services, explicit anonymous-route policy, and service logic |
+| `src/services/general/tidasScalarStorage.ts` | canonical TIDAS year/percentage scalar normalization and the Process/Flow save-boundary issue format |
 | `src/services/dataProducts/**` | authenticated data-product commands, closure-check projections, result-package requests, and the curated `task-summary.v2` feed consumed by the global task center |
 | `src/locales/**` | UI strings; every supported locale follows one canonical message manifest, with leaf topology, key ownership, placeholders, and dynamic families kept aligned |
 | `src/global.less`, `src/style/**`, `src/manifest.json`, `src/service-worker.js`, `src/utils/appUrl.ts`, `src/utils/ruleVerification.ts`, `src/typings.d.ts` | browser shell support, global styling, and support utilities |
@@ -75,6 +76,7 @@ Rules:
 
 - route and page components orchestrate
 - service modules own app-side data access
+- Process and Flow ordered-dataset serializers normalize TIDAS year values to bounded integers and percentage values to canonical strings. Their create, update, and create-version service paths reject non-empty affected scalars that cannot be represented canonically before invoking persistence; unrelated invalid-draft behavior remains unchanged
 - the startup system-status service treats `APP_RUNTIME_CONFIG_ENABLED` as a build-time emergency bypass: loading remains enabled by default, and only an explicit case-insensitive `false` returns the normal status without starting the Supabase RPC or its timeout
 - UI copy changes must update every supported locale and the deterministic canonical-message audit; one message key owns one concept and one UI role
 - a new locale may land reviewed leaf modules before activation, but it must not gain a top-level `src/locales/<locale>.ts` entry until manifest parity and the locale-specific review gate are complete

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -32,7 +32,7 @@ checkPaths:
   - .github/workflows/**
 lastReviewedAt: 2026-08-21
 lastReviewedCommit: 9319742112a8e9dd980762789895b4f4c074e531
-lastReviewedNote: 'Reviewed for Next Issue #910: TIDAS scalar storage changes use focused normalization, serializer, and all-save-entrypoint proof without changing the repository gate.'
+lastReviewedNote: 'Reviewed for Next Issue #910: TIDAS scalar storage changes use focused normalization, serializer, all-save-entrypoint, and regenerated locale-artifact proof without changing the repository gate.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-21
-lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
-lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
+lastReviewedCommit: 9319742112a8e9dd980762789895b4f4c074e531
+lastReviewedNote: 'Reviewed for Next Issue #910: TIDAS scalar storage changes use focused normalization, serializer, and all-save-entrypoint proof without changing the repository gate.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -72,6 +72,7 @@ npm run prepush:gate
 | --- | --- | --- | --- |
 | routes, pages, app runtime, shared UI | `npm run lint`; focused `npm run test:ci -- <jest-args>`; `npm run build` | `npm run prepush:gate` | shared UX changes often affect multiple entrypoints; Process LCIA query/evidence state changes include `tests/unit/pages/Processes/Components/processLciaResultsPanel.test.tsx` |
 | services or env selection | `npm run lint`; focused `npm run test:ci -- <jest-args>`; `npm run build` | `npm run prepush:gate` | companion proof may live in another repo if schema or Edge runtime changed |
+| Process or Flow TIDAS scalar storage normalization | `npm run lint`; focused general scalar-normalizer, Process/Flow serializer, and Process/Flow API suites; `npm run build` | final `npm run prepush:gate` through `push:checked` | Assert Process years persist as integers in `1000..9999`, affected percentage values persist as TIDAS-compatible strings with at most three fractional digits, zero is retained, and create/update/create-version reject non-canonical non-empty values before persistence. |
 | TIDAS package export task identity or recovery | `npm run test:ci -- --runInBand tests/unit/services/tidasPackage/taskCenter.test.ts`; `npm run lint`; `npm run build` | final `npm run prepush:gate`; pair with Database package-cache pgTAP proof when enqueue semantics changed | Assert repeated queue responses, persisted aliases, poll completion/failure, and Worker refreshes sharing `workerJobId` or `jobId` produce one visible task; retain the earliest local presentation identity, use backend timestamps/state, and never revive an alias after canonical reconciliation. |
 | Process keyword search service or LCA picker scope | focused `tests/unit/services/processes/api.test.ts` plus the Process full-text data-workflow unit; `npm run lint`; `npm run build` | smoke against the exact non-production Database revision that exposes `search_processes`; cover public, personal, and `public_plus_owner_draft` scopes, including actor-owned state-zero rows with non-null team/review metadata | Assert explicit `query_terms`, no direct app-side ILIKE field filter, and `owner_draft_only=true` only for the personal branch of the calculation scope. Database owns latest-version, actor/state eligibility, workflow metadata, and `search_text` index semantics. |
 | LCA solve, result-query, contribution-path, or task-recovery scope contract | focused LCA API, task-center service/component, Process analysis, solve toolbar, impact compare/hotspot, and LCIA result panel suites; `npm run lint`; `npm run build` | smoke the authenticated Process analysis paths against matching non-production Edge and Database revisions | Assert every new request uses `full_library` by default or explicit `data_product`; deployment/cache labels never cross the API boundary; persisted historical task requests are normalized before recovery resubmission. |

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -23,8 +23,8 @@ checkPaths:
   - playwright.config.ts
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-21
-lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
-lastReviewedNote: 'Reviewed for Next Issue #880: persistent ResultSet continuation preserves the current repository ownership, localization, validation, and release contracts.'
+lastReviewedCommit: 9319742112a8e9dd980762789895b4f4c074e531
+lastReviewedNote: 'Reviewed for Next Issue #910: canonical TIDAS scalar shaping and its pre-persistence validation remain an app-side service responsibility.'
 ---
 
 # Supabase Environment And Database Workflow
@@ -73,6 +73,7 @@ Rules:
 - `docker/volumes/functions/**` does not transfer Edge runtime ownership to Next: it is generated only by `docker/pull-edge-functions.sh --ref <40-character-commit-sha>`, must match that exact Edge tree plus its source receipt, and must delete files absent from the source commit
 - national-carbon process-flow graph cache reads go through `src/services/nationalCarbonGraphCache/objects.ts` and its signed object bundle; the frontend no longer owns a public cache base URL override and local direct-read debugging paths should not be reintroduced without a new runtime ownership decision
 - ordered-dataset shaping in `src/services/**` stays an app-side boundary even when it mirrors backend schema names
+- canonical Process/Flow TIDAS scalar shaping also stays in that boundary: serializers convert valid year and percentage form values to their required JSON scalar types, while create/update/create-version reject affected non-empty values that cannot be represented canonically before calling dataset commands
 - TIDAS package task reconciliation in `src/services/tidasPackage/taskCenter.ts` may coalesce local aliases by backend `workerJobId` or package `jobId` and adopt backend timestamps, but `database-engine` remains authoritative for mutable-scope cache lifecycle, fresh Worker job creation, package contents, and authorization
 - persisted Calculation Bundle and release readback go through `src/services/lcaReleases/**`: private bundle reads forward the current user session, public current-release and Process projections may be anonymous, and neither path accepts a service-role credential or exposes private object locators
 - ResultSet create/list/get, closure checks, closure artifacts, result-package commands, publication reads, and the unified data-product task feed go through `src/services/dataProducts/**` and authenticated `app_data_product_commands`. Database owns ResultSet identity and ResultSet-to-closure/task joins; Next keeps `resultSetId` as URL/workbench context and derives lifecycle presentation from safe projections without adding a frontend status store. Closure requests preserve exact LCIA method `{ id, version }` identities from the reviewed static catalog, and Next consumes actor-bound curated closure, artifact-lifecycle, signed-download, and `task-summary.v2` projections rather than worker rows or private artifact locators. Signed artifact responses are navigation targets only: Next must not proxy, fetch, or buffer the artifact bytes.

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -29,7 +29,7 @@ checkPaths:
   - package.json
 lastReviewedAt: 2026-08-21
 lastReviewedCommit: 9319742112a8e9dd980762789895b4f4c074e531
-lastReviewedNote: 'Reviewed for Next Issue #910: unit-heavy scalar normalization and save-boundary coverage follows the current maintenance strategy without reopening strategy work.'
+lastReviewedNote: 'Reviewed for Next Issue #910: unit-heavy scalar normalization, save-boundary coverage, and deterministic locale-artifact refresh follow the current maintenance strategy without reopening strategy work.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -28,8 +28,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - package.json
 lastReviewedAt: 2026-08-21
-lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
-lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
+lastReviewedCommit: 9319742112a8e9dd980762789895b4f4c074e531
+lastReviewedNote: 'Reviewed for Next Issue #910: unit-heavy scalar normalization and save-boundary coverage follows the current maintenance strategy without reopening strategy work.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -30,8 +30,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-21
-lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
-lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
+lastReviewedCommit: 9319742112a8e9dd980762789895b4f4c074e531
+lastReviewedNote: 'Reviewed for Next Issue #910: focused scalar-normalizer, serializer, and save-gate coverage preserves full-closure maintenance mode and creates no queue.'
 ---
 
 # Testing Execution State
@@ -83,6 +83,7 @@ This is a checked-in reference, not a per-PR execution ledger. A delivery's post
 - checked-push eligibility now accepts the normal exact-branch `HEAD` spelling and fails every other invalid ref shape before gates; raw deletion-only pushes skip gates, so branch cleanup cannot spend the full-suite budget
 - Issue #606 plus the merged clean-runner assertions now has 87-test focused proof across the release service, Calculation Bundle panel, public release panel, Data Processing integration, Process integration, and locale inventory; the final branch-wide proof remains owned by the push hook
 - dataset SDK validation adapters, shared localized validation helpers, and validation-report navigation now ride on the maintained full-closure baseline
+- Issue #910 adds focused TIDAS scalar normalization, Process/Flow serializer, and six save-entrypoint regression coverage; it creates no open coverage queue
 - data workflow smoke fixtures now pair `fixtures/data/**` input JSON with `fixtures/result/**` expected-result Markdown; the current relationship map is in `tests/data-workflows/fixtures/result/README.md`
 - file-level coverage collection currently excludes a small set of UI orchestration wrappers from direct collection, including the canvas-heavy national carbon dashboard wallboard shell and the Review Admin quality-diagnostic report panel; the latter retains focused component proof for latest-report loading, explicit manual start, non-blocking active state, report rendering, and retryable runtime failure. If that list changes, re-check save, validation, navigation, highlighting, diagnostic-report, or visual screenshot flows before treating the baseline as settled
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -31,7 +31,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-21
 lastReviewedCommit: 9319742112a8e9dd980762789895b4f4c074e531
-lastReviewedNote: 'Reviewed for Next Issue #910: focused scalar-normalizer, serializer, and save-gate coverage preserves full-closure maintenance mode and creates no queue.'
+lastReviewedNote: 'Reviewed for Next Issue #910: focused scalar-normalizer, serializer, save-gate, and locale-contract coverage preserves full-closure maintenance mode and creates no queue.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -32,7 +32,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-21
 lastReviewedCommit: 9319742112a8e9dd980762789895b4f4c074e531
-lastReviewedNote: 'Reviewed for Next Issue #910: the new scalar helper uses direct unit proof and the service save gates use explicit side-effect assertions under the existing patterns.'
+lastReviewedNote: 'Reviewed for Next Issue #910: the scalar helper uses direct unit proof, save gates use explicit side-effect assertions, and generated locale digests use the existing idempotence contract.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -31,8 +31,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-21
-lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
-lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
+lastReviewedCommit: 9319742112a8e9dd980762789895b4f4c074e531
+lastReviewedNote: 'Reviewed for Next Issue #910: the new scalar helper uses direct unit proof and the service save gates use explicit side-effect assertions under the existing patterns.'
 ---
 
 # Testing Patterns Reference
@@ -79,6 +79,7 @@ lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI ke
 Validation-specific rule:
 
 - page-specific SDK-code adapters under `src/pages/*/sdkValidation.ts` and shared helpers under `src/pages/Utils/validation/**` should default to direct unit tests
+- ordered-dataset scalar normalizers should directly prove empty, valid, legacy string, boundary, and invalid inputs; each create/update/create-version save gate should also prove that invalid non-empty values do not reach validation or persistence
 - wrapper components that mainly coordinate drawers, forms, or modal jumps should keep behavior coverage through focused component or integration tests instead of artificial branch forcing
 
 ## Integration Pattern

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -29,7 +29,7 @@ checkPaths:
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-21
 lastReviewedCommit: 9319742112a8e9dd980762789895b4f4c074e531
-lastReviewedNote: 'Reviewed for Next Issue #910: TIDAS scalar failures are deterministic focused-test or save-boundary findings and require no new troubleshooting workflow.'
+lastReviewedNote: 'Reviewed for Next Issue #910: TIDAS scalar failures remain deterministic focused-test or save-boundary findings; locale digest drift is recovered with the existing artifact writer and contract rerun.'
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -28,8 +28,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-21
-lastReviewedCommit: 1395ddb24b9ee75a269df363eba303cea7bac513
-lastReviewedNote: 'Reviewed for Next Issue #901: the retired review-submit UI keeps immutable locale history as reserved keys, removes obsolete dynamic-callsite governance, and preserves the existing validation and release contracts.'
+lastReviewedCommit: 9319742112a8e9dd980762789895b4f4c074e531
+lastReviewedNote: 'Reviewed for Next Issue #910: TIDAS scalar failures are deterministic focused-test or save-boundary findings and require no new troubleshooting workflow.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa",
-    "auditedInputDigest": "6eb9d4db745087fc482842636806b32f96b3d6f8e909e0406bb34a6ccddde9af"
+    "sourceManifestDigest": "9a0e71346ba729ae90293c7933362b4285b38598aa456e8363a3ed02082e78b5",
+    "auditedInputDigest": "5c53affba3fa029ef9630ba390b9cd625d719fdbeddcee628c8235fbad2827af"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "4be07faca561764260f3990821f0b910450c2a9d9e302e94d3b70c8bbfc66cad",
+    "dossierDigest": "849d3af99192ed82685732c0c804499eca5704b9e28065a3ea91bdb2a9a0c9cb",
     "catalogDigest": "eedb0e7243bf231ee4867c31135403f77fe62cda0c4f495b4b66a0846efe2064",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4142,
+    "literalReferenceCount": 4143,
     "dynamicCallsiteCount": 32,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale de-DE --message <MESSAGE_ID>"
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "de97967de74affe077bd9ff4ef3ca8d83ae45184e4f91b9b85f004f0d8478381"
+  "contextDigest": "258f9bc065a4f6ce1c3c75eaa59387df5aab55bc8bbc3adfbc8db99c25c23f2a"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa"
+    "sourceManifestDigest": "9a0e71346ba729ae90293c7933362b4285b38598aa456e8363a3ed02082e78b5"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "de97967de74affe077bd9ff4ef3ca8d83ae45184e4f91b9b85f004f0d8478381",
-    "qualityDigest": "dbbca3278e76e225710d32ab4badd7e976dfb31925afc347dda3e9af39ab587d",
+    "contextDigest": "258f9bc065a4f6ce1c3c75eaa59387df5aab55bc8bbc3adfbc8db99c25c23f2a",
+    "qualityDigest": "2571136c2343a476549d85421feb75bdec52f1ae38eca06f8ca1562ea049bd85",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "21f575fbc2cfd21e1aa539e00d4424a4b5ed4944ff9eda906a4bf23dba1f23aa"
+  "activationDigest": "d252ac277b8684893f5b78a811a7197fe0fb47c2976ddee9ee70763a4eac2fee"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "6eb9d4db745087fc482842636806b32f96b3d6f8e909e0406bb34a6ccddde9af",
+    "auditedInputDigest": "5c53affba3fa029ef9630ba390b9cd625d719fdbeddcee628c8235fbad2827af",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -74,8 +74,8 @@
     "activeStaticKeyCount": 2135,
     "activeDynamicKeyCount": 306,
     "reservedKeyCount": 767,
-    "productionSourceFileCount": 440,
-    "literalReferenceCount": 4142,
+    "productionSourceFileCount": 441,
+    "literalReferenceCount": 4143,
     "dynamicCallsiteCount": 32,
     "dynamicCallsiteSummaryCount": 32,
     "registeredDynamicCallsiteCount": 32,
@@ -41351,7 +41351,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/create.tsx",
-          "line": 549,
+          "line": 556,
           "column": 31,
           "symbol": "ProcessExchangeCreate",
           "defaultMessage": "Add",
@@ -41360,7 +41360,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-          "line": 934,
+          "line": 941,
           "column": 33,
           "symbol": "ProcessExchangeEdit",
           "defaultMessage": "Add",
@@ -41384,13 +41384,13 @@
           "locations": [
             {
               "path": "src/pages/Processes/Components/Exchange/create.tsx",
-              "line": 549,
+              "line": 556,
               "column": 31,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-              "line": 934,
+              "line": 941,
               "column": 33,
               "kind": "FormattedMessage"
             },
@@ -46343,7 +46343,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/create.tsx",
-          "line": 554,
+          "line": 561,
           "column": 29,
           "symbol": "ProcessExchangeCreate",
           "defaultMessage": "Item",
@@ -46352,7 +46352,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-          "line": 939,
+          "line": 946,
           "column": 31,
           "symbol": "ProcessExchangeEdit",
           "defaultMessage": "Item",
@@ -46442,13 +46442,13 @@
             },
             {
               "path": "src/pages/Processes/Components/Exchange/create.tsx",
-              "line": 554,
+              "line": 561,
               "column": 29,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-              "line": 939,
+              "line": 946,
               "column": 31,
               "kind": "FormattedMessage"
             },
@@ -84067,7 +84067,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flows/Components/Property/create.tsx",
-          "line": 194,
+          "line": 201,
           "column": 17,
           "symbol": "PropertyCreate",
           "defaultMessage": "Data derivation type/status",
@@ -84076,7 +84076,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flows/Components/Property/edit.tsx",
-          "line": 498,
+          "line": 505,
           "column": 17,
           "symbol": "PropertyEdit",
           "defaultMessage": "Data derivation type/status",
@@ -84091,13 +84091,13 @@
           "locations": [
             {
               "path": "src/pages/Flows/Components/Property/create.tsx",
-              "line": 194,
+              "line": 201,
               "column": 17,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Flows/Components/Property/edit.tsx",
-              "line": 498,
+              "line": 505,
               "column": 17,
               "kind": "FormattedMessage"
             }
@@ -84497,7 +84497,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flows/Components/Property/create.tsx",
-          "line": 206,
+          "line": 213,
           "column": 17,
           "symbol": "PropertyCreate",
           "defaultMessage": "Comment",
@@ -84506,7 +84506,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flows/Components/Property/create.tsx",
-          "line": 215,
+          "line": 222,
           "column": 19,
           "symbol": "PropertyCreate",
           "defaultMessage": "Comment",
@@ -84515,7 +84515,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flows/Components/Property/edit.tsx",
-          "line": 510,
+          "line": 517,
           "column": 17,
           "symbol": "PropertyEdit",
           "defaultMessage": "Comment",
@@ -84524,7 +84524,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flows/Components/Property/edit.tsx",
-          "line": 520,
+          "line": 527,
           "column": 19,
           "symbol": "PropertyEdit",
           "defaultMessage": "Comment",
@@ -84539,25 +84539,25 @@
           "locations": [
             {
               "path": "src/pages/Flows/Components/Property/create.tsx",
-              "line": 206,
+              "line": 213,
               "column": 17,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Flows/Components/Property/create.tsx",
-              "line": 215,
+              "line": 222,
               "column": 19,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Flows/Components/Property/edit.tsx",
-              "line": 510,
+              "line": 517,
               "column": 17,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Flows/Components/Property/edit.tsx",
-              "line": 520,
+              "line": 527,
               "column": 19,
               "kind": "FormattedMessage"
             }
@@ -178629,7 +178629,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 472,
+          "line": 481,
           "column": 15,
           "symbol": "<module>",
           "defaultMessage": "Please input annual supply or production volume",
@@ -178644,7 +178644,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 472,
+              "line": 481,
               "column": 15,
               "kind": "schema-messageKey"
             }
@@ -178712,7 +178712,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 658,
+          "line": 667,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please input approval of overall compliance",
@@ -178727,7 +178727,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 658,
+              "line": 667,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -179074,7 +179074,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 943,
+          "line": 952,
           "column": 15,
           "symbol": "<module>",
           "defaultMessage": "Please input copyright",
@@ -179089,7 +179089,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 943,
+              "line": 952,
               "column": 15,
               "kind": "schema-messageKey"
             }
@@ -179157,7 +179157,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 394,
+          "line": 403,
           "column": 15,
           "symbol": "<module>",
           "defaultMessage": "Please input data cut-off and completeness principles",
@@ -179172,7 +179172,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 394,
+              "line": 403,
               "column": 15,
               "kind": "schema-messageKey"
             }
@@ -179240,7 +179240,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 1059,
+          "line": 1068,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please input data derivation type/status",
@@ -179255,7 +179255,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 1059,
+              "line": 1068,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -179323,7 +179323,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 986,
+          "line": 995,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please input data set internal ID",
@@ -179338,7 +179338,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 986,
+              "line": 995,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -179406,7 +179406,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 860,
+          "line": 869,
           "column": 15,
           "symbol": "<module>",
           "defaultMessage": "Please input data set version",
@@ -179421,7 +179421,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 860,
+              "line": 869,
               "column": 15,
               "kind": "schema-messageKey"
             }
@@ -179489,7 +179489,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 698,
+          "line": 707,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please input documentation compliance",
@@ -179504,7 +179504,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 698,
+              "line": 707,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -179572,7 +179572,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 1017,
+          "line": 1026,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please input exchange direction",
@@ -179587,7 +179587,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 1017,
+              "line": 1026,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -179904,7 +179904,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 755,
+          "line": 764,
           "column": 15,
           "symbol": "<module>",
           "defaultMessage": "Please input intended applications",
@@ -179919,7 +179919,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 755,
+              "line": 764,
               "column": 15,
               "kind": "schema-messageKey"
             }
@@ -179987,7 +179987,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 965,
+          "line": 974,
           "column": 15,
           "symbol": "<module>",
           "defaultMessage": "Please input license type",
@@ -180002,7 +180002,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 965,
+              "line": 974,
               "column": 15,
               "kind": "schema-messageKey"
             }
@@ -180070,7 +180070,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 222,
+          "line": 231,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please input location",
@@ -180085,7 +180085,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 222,
+              "line": 231,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -180153,7 +180153,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 1028,
+          "line": 1037,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please input mean amount",
@@ -180162,7 +180162,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 1105,
+          "line": 1114,
           "column": 15,
           "symbol": "<module>",
           "defaultMessage": "Please input mean amount",
@@ -180177,13 +180177,13 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 1028,
+              "line": 1037,
               "column": 17,
               "kind": "schema-messageKey"
             },
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 1105,
+              "line": 1114,
               "column": 15,
               "kind": "schema-messageKey"
             }
@@ -180251,7 +180251,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 556,
+          "line": 565,
           "column": 21,
           "symbol": "<module>",
           "defaultMessage": "Please input method name",
@@ -180266,7 +180266,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 556,
+              "line": 565,
               "column": 21,
               "kind": "schema-messageKey"
             }
@@ -180334,7 +180334,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 678,
+          "line": 687,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please input methodological compliance",
@@ -180349,7 +180349,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 678,
+              "line": 687,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -180500,7 +180500,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 668,
+          "line": 677,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please input nomenclature compliance",
@@ -180515,7 +180515,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 668,
+              "line": 677,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -180583,7 +180583,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 887,
+          "line": 896,
           "column": 15,
           "symbol": "<module>",
           "defaultMessage": "Please input permanent data set URI",
@@ -180598,7 +180598,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 887,
+              "line": 896,
               "column": 15,
               "kind": "schema-messageKey"
             }
@@ -180666,7 +180666,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 708,
+          "line": 717,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please input quality compliance",
@@ -180681,7 +180681,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 708,
+              "line": 717,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -180832,7 +180832,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 724,
+          "line": 733,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please input commissioner of data set",
@@ -180847,7 +180847,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 724,
+              "line": 733,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -180915,7 +180915,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 616,
+          "line": 625,
           "column": 19,
           "symbol": "<module>",
           "defaultMessage": "Please input complete review report",
@@ -180930,7 +180930,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 616,
+              "line": 625,
               "column": 19,
               "kind": "schema-messageKey"
             }
@@ -180998,7 +180998,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 641,
+          "line": 650,
           "column": 19,
           "symbol": "<module>",
           "defaultMessage": "Please input compliance system name",
@@ -181013,7 +181013,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 641,
+              "line": 650,
               "column": 19,
               "kind": "schema-messageKey"
             }
@@ -181081,7 +181081,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 792,
+          "line": 801,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please input data set format(s)",
@@ -181096,7 +181096,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 792,
+              "line": 801,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -181164,7 +181164,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 448,
+          "line": 457,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please input data source(s) used for this data set",
@@ -181179,7 +181179,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 448,
+              "line": 457,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -181247,7 +181247,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 998,
+          "line": 1007,
           "column": 19,
           "symbol": "<module>",
           "defaultMessage": "Please input flow",
@@ -181262,7 +181262,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 998,
+              "line": 1007,
               "column": 19,
               "kind": "schema-messageKey"
             }
@@ -181330,7 +181330,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 590,
+          "line": 599,
           "column": 19,
           "symbol": "<module>",
           "defaultMessage": "Please select a reviewer and institution.",
@@ -181345,7 +181345,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 590,
+              "line": 599,
               "column": 19,
               "kind": "schema-messageKey"
             }
@@ -181413,7 +181413,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 924,
+          "line": 933,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please input owner of data set",
@@ -181428,7 +181428,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 924,
+              "line": 933,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -181496,7 +181496,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 825,
+          "line": 834,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please select the person or entity entering the data.",
@@ -181511,7 +181511,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 825,
+              "line": 834,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -181745,7 +181745,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 1038,
+          "line": 1047,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please input resulting amount",
@@ -181760,7 +181760,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 1038,
+              "line": 1047,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -181828,7 +181828,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 688,
+          "line": 697,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please input review compliance",
@@ -181843,7 +181843,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 688,
+              "line": 697,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -181911,7 +181911,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 579,
+          "line": 588,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please input review details",
@@ -181926,7 +181926,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 579,
+              "line": 588,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -181994,7 +181994,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 534,
+          "line": 543,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Please input type of review",
@@ -182009,7 +182009,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 534,
+              "line": 543,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -182077,7 +182077,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 545,
+          "line": 554,
           "column": 19,
           "symbol": "<module>",
           "defaultMessage": "Please input scope name",
@@ -182092,7 +182092,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 545,
+              "line": 554,
               "column": 19,
               "kind": "schema-messageKey"
             }
@@ -182160,7 +182160,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 263,
+          "line": 272,
           "column": 15,
           "symbol": "<module>",
           "defaultMessage": "Please input technology description including background system",
@@ -182175,7 +182175,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 263,
+              "line": 272,
               "column": 15,
               "kind": "schema-messageKey"
             }
@@ -182243,7 +182243,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 781,
+          "line": 790,
           "column": 15,
           "symbol": "<module>",
           "defaultMessage": "Please enter the time stamp.",
@@ -182258,7 +182258,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 781,
+              "line": 790,
               "column": 15,
               "kind": "schema-messageKey"
             }
@@ -182409,7 +182409,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 339,
+          "line": 348,
           "column": 15,
           "symbol": "<module>",
           "defaultMessage": "Please input type of data set",
@@ -182424,7 +182424,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 339,
+              "line": 348,
               "column": 15,
               "kind": "schema-messageKey"
             }
@@ -187236,7 +187236,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/create.tsx",
-          "line": 472,
+          "line": 479,
           "column": 17,
           "symbol": "ProcessExchangeCreate",
           "defaultMessage": "Data derivation type / status",
@@ -187245,7 +187245,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-          "line": 855,
+          "line": 862,
           "column": 19,
           "symbol": "ProcessExchangeEdit",
           "defaultMessage": "Data derivation type / status",
@@ -187308,13 +187308,13 @@
             },
             {
               "path": "src/pages/Processes/Components/Exchange/create.tsx",
-              "line": 472,
+              "line": 479,
               "column": 17,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-              "line": 855,
+              "line": 862,
               "column": 19,
               "kind": "FormattedMessage"
             },
@@ -187406,7 +187406,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/create.tsx",
-          "line": 461,
+          "line": 468,
           "column": 17,
           "symbol": "ProcessExchangeCreate",
           "defaultMessage": "Data source type",
@@ -187415,7 +187415,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-          "line": 841,
+          "line": 848,
           "column": 19,
           "symbol": "ProcessExchangeEdit",
           "defaultMessage": "Data source type",
@@ -187448,13 +187448,13 @@
           "locations": [
             {
               "path": "src/pages/Processes/Components/Exchange/create.tsx",
-              "line": 461,
+              "line": 468,
               "column": 17,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-              "line": 841,
+              "line": 848,
               "column": 19,
               "kind": "FormattedMessage"
             },
@@ -187868,7 +187868,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/create.tsx",
-          "line": 602,
+          "line": 609,
           "column": 21,
           "symbol": "ProcessExchangeCreate",
           "defaultMessage": "Functional unit, Production period, or Other parameter",
@@ -187877,7 +187877,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/create.tsx",
-          "line": 610,
+          "line": 617,
           "column": 23,
           "symbol": "ProcessExchangeCreate",
           "defaultMessage": "Functional unit, Production period, or Other parameter",
@@ -187886,7 +187886,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-          "line": 1001,
+          "line": 1008,
           "column": 23,
           "symbol": "ProcessExchangeEdit",
           "defaultMessage": "Functional unit, Production period, or Other parameter",
@@ -187895,7 +187895,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-          "line": 1010,
+          "line": 1017,
           "column": 25,
           "symbol": "ProcessExchangeEdit",
           "defaultMessage": "Functional unit, Production period, or Other parameter",
@@ -187958,25 +187958,25 @@
             },
             {
               "path": "src/pages/Processes/Components/Exchange/create.tsx",
-              "line": 602,
+              "line": 609,
               "column": 21,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/Exchange/create.tsx",
-              "line": 610,
+              "line": 617,
               "column": 23,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-              "line": 1001,
+              "line": 1008,
               "column": 23,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-              "line": 1010,
+              "line": 1017,
               "column": 25,
               "kind": "FormattedMessage"
             },
@@ -188086,7 +188086,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/create.tsx",
-          "line": 564,
+          "line": 571,
           "column": 15,
           "symbol": "ProcessExchangeCreate",
           "defaultMessage": "Comment",
@@ -188095,7 +188095,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/create.tsx",
-          "line": 572,
+          "line": 579,
           "column": 17,
           "symbol": "ProcessExchangeCreate",
           "defaultMessage": "Comment",
@@ -188104,7 +188104,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-          "line": 956,
+          "line": 963,
           "column": 19,
           "symbol": "ProcessExchangeEdit",
           "defaultMessage": "Comment",
@@ -188113,7 +188113,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-          "line": 965,
+          "line": 972,
           "column": 21,
           "symbol": "ProcessExchangeEdit",
           "defaultMessage": "Comment",
@@ -188176,25 +188176,25 @@
             },
             {
               "path": "src/pages/Processes/Components/Exchange/create.tsx",
-              "line": 564,
+              "line": 571,
               "column": 15,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/Exchange/create.tsx",
-              "line": 572,
+              "line": 579,
               "column": 17,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-              "line": 956,
+              "line": 963,
               "column": 19,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-              "line": 965,
+              "line": 972,
               "column": 21,
               "kind": "FormattedMessage"
             },
@@ -188700,7 +188700,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flows/Components/Property/create.tsx",
-          "line": 225,
+          "line": 232,
           "column": 17,
           "symbol": "PropertyCreate",
           "defaultMessage": "Quantitative reference",
@@ -188709,7 +188709,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flows/Components/Property/edit.tsx",
-          "line": 530,
+          "line": 537,
           "column": 17,
           "symbol": "PropertyEdit",
           "defaultMessage": "Quantitative reference",
@@ -188745,7 +188745,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/create.tsx",
-          "line": 582,
+          "line": 589,
           "column": 17,
           "symbol": "ProcessExchangeCreate",
           "defaultMessage": "Quantitative reference",
@@ -188754,7 +188754,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-          "line": 976,
+          "line": 983,
           "column": 17,
           "symbol": "ProcessExchangeEdit",
           "defaultMessage": "Quantitative reference",
@@ -188805,13 +188805,13 @@
           "locations": [
             {
               "path": "src/pages/Flows/Components/Property/create.tsx",
-              "line": 225,
+              "line": 232,
               "column": 17,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Flows/Components/Property/edit.tsx",
-              "line": 530,
+              "line": 537,
               "column": 17,
               "kind": "FormattedMessage"
             },
@@ -188835,13 +188835,13 @@
             },
             {
               "path": "src/pages/Processes/Components/Exchange/create.tsx",
-              "line": 582,
+              "line": 589,
               "column": 17,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-              "line": 976,
+              "line": 983,
               "column": 17,
               "kind": "FormattedMessage"
             },
@@ -189076,7 +189076,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/create.tsx",
-          "line": 499,
+          "line": 506,
           "column": 21,
           "symbol": "ProcessExchangeCreate",
           "defaultMessage": "Data source(s)",
@@ -189085,7 +189085,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/create.tsx",
-          "line": 518,
+          "line": 525,
           "column": 37,
           "symbol": "ProcessExchangeCreate",
           "defaultMessage": "Data source(s)",
@@ -189094,7 +189094,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/create.tsx",
-          "line": 550,
+          "line": 557,
           "column": 29,
           "symbol": "ProcessExchangeCreate",
           "defaultMessage": "Data source(s)",
@@ -189103,7 +189103,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-          "line": 884,
+          "line": 891,
           "column": 23,
           "symbol": "ProcessExchangeEdit",
           "defaultMessage": "Data source(s)",
@@ -189112,7 +189112,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-          "line": 903,
+          "line": 910,
           "column": 39,
           "symbol": "ProcessExchangeEdit",
           "defaultMessage": "Data source(s)",
@@ -189121,7 +189121,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-          "line": 935,
+          "line": 942,
           "column": 31,
           "symbol": "ProcessExchangeEdit",
           "defaultMessage": "Data source(s)",
@@ -189163,37 +189163,37 @@
           "locations": [
             {
               "path": "src/pages/Processes/Components/Exchange/create.tsx",
-              "line": 499,
+              "line": 506,
               "column": 21,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/Exchange/create.tsx",
-              "line": 518,
+              "line": 525,
               "column": 37,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/Exchange/create.tsx",
-              "line": 550,
+              "line": 557,
               "column": 29,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-              "line": 884,
+              "line": 891,
               "column": 23,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-              "line": 903,
+              "line": 910,
               "column": 39,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-              "line": 935,
+              "line": 942,
               "column": 31,
               "kind": "FormattedMessage"
             },
@@ -189485,7 +189485,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/create.tsx",
-          "line": 590,
+          "line": 597,
           "column": 19,
           "symbol": "ProcessExchangeCreate",
           "defaultMessage": "Reference flow(s)",
@@ -189494,7 +189494,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-          "line": 986,
+          "line": 993,
           "column": 21,
           "symbol": "ProcessExchangeEdit",
           "defaultMessage": "Reference flow(s)",
@@ -189557,13 +189557,13 @@
             },
             {
               "path": "src/pages/Processes/Components/Exchange/create.tsx",
-              "line": 590,
+              "line": 597,
               "column": 19,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/Exchange/edit.tsx",
-              "line": 986,
+              "line": 993,
               "column": 21,
               "kind": "FormattedMessage"
             },
@@ -264333,7 +264333,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 228,
+          "line": 237,
           "column": 17,
           "symbol": "<module>",
           "defaultMessage": "Must not exceed 500 characters; this field may be empty.",
@@ -264354,7 +264354,7 @@
             },
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 228,
+              "line": 237,
               "column": 17,
               "kind": "schema-messageKey"
             }
@@ -265078,7 +265078,16 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 203,
+          "line": 200,
+          "column": 15,
+          "symbol": "<module>",
+          "defaultMessage": "Please enter a valid year (e.g., 2023)",
+          "defaultMessageExpression": null
+        },
+        {
+          "kind": "schema-messageKey",
+          "path": "src/pages/Processes/processes_schema.json",
+          "line": 212,
           "column": 15,
           "symbol": "<module>",
           "defaultMessage": "Please enter a valid year (e.g., 2023)",
@@ -265117,7 +265126,13 @@
             },
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 203,
+              "line": 200,
+              "column": 15,
+              "kind": "schema-messageKey"
+            },
+            {
+              "path": "src/pages/Processes/processes_schema.json",
+              "line": 212,
               "column": 15,
               "kind": "schema-messageKey"
             },
@@ -265325,7 +265340,7 @@
         {
           "kind": "schema-messageKey",
           "path": "src/pages/Processes/processes_schema.json",
-          "line": 865,
+          "line": 874,
           "column": 15,
           "symbol": "<module>",
           "defaultMessage": "Version format must be XX.XX.XXX, where X is a digit!",
@@ -265388,7 +265403,7 @@
             },
             {
               "path": "src/pages/Processes/processes_schema.json",
-              "line": 865,
+              "line": 874,
               "column": 15,
               "kind": "schema-messageKey"
             },

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa",
-    "contextDigest": "de97967de74affe077bd9ff4ef3ca8d83ae45184e4f91b9b85f004f0d8478381"
+    "sourceManifestDigest": "9a0e71346ba729ae90293c7933362b4285b38598aa456e8363a3ed02082e78b5",
+    "contextDigest": "258f9bc065a4f6ce1c3c75eaa59387df5aab55bc8bbc3adfbc8db99c25c23f2a"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "9606a02a5219c28e307cfe4f9ad2452fe8393d0530d001211703e231c9a9a6fe",
-    "validationDigest": "242020f9a63a7ac41a0bb8da1e8837bc106b4d55435c7b01cbfc2512a72374d7",
+    "digest": "03a43eae4285cfb116275e7f3cc09edf62c8cb223f9573098c4be2fe8841ed86",
+    "validationDigest": "a6fdf0a615e58c7c06370c69d6ca5efb917bf0b1d37366758e9c6779a43abbed",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "dbbca3278e76e225710d32ab4badd7e976dfb31925afc347dda3e9af39ab587d"
+  "qualityDigest": "2571136c2343a476549d85421feb75bdec52f1ae38eca06f8ca1562ea049bd85"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "6eb9d4db745087fc482842636806b32f96b3d6f8e909e0406bb34a6ccddde9af",
+    "auditedInputDigest": "5c53affba3fa029ef9630ba390b9cd625d719fdbeddcee628c8235fbad2827af",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "eedb0e7243bf231ee4867c31135403f77fe62cda0c4f495b4b66a0846efe2064",
-    "dossierDigest": "4be07faca561764260f3990821f0b910450c2a9d9e302e94d3b70c8bbfc66cad",
+    "dossierDigest": "849d3af99192ed82685732c0c804499eca5704b9e28065a3ea91bdb2a9a0c9cb",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "4be07faca561764260f3990821f0b910450c2a9d9e302e94d3b70c8bbfc66cad",
+        "dossierDigest": "849d3af99192ed82685732c0c804499eca5704b9e28065a3ea91bdb2a9a0c9cb",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "242020f9a63a7ac41a0bb8da1e8837bc106b4d55435c7b01cbfc2512a72374d7"
+  "validationDigest": "a6fdf0a615e58c7c06370c69d6ca5efb917bf0b1d37366758e9c6779a43abbed"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa",
-    "auditedInputDigest": "6eb9d4db745087fc482842636806b32f96b3d6f8e909e0406bb34a6ccddde9af"
+    "sourceManifestDigest": "9a0e71346ba729ae90293c7933362b4285b38598aa456e8363a3ed02082e78b5",
+    "auditedInputDigest": "5c53affba3fa029ef9630ba390b9cd625d719fdbeddcee628c8235fbad2827af"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "7a0b44f3ed2990063cac6adc7e6b56550c606fe5d00d1ddcd221d6a89a403a93",
+    "dossierDigest": "e056444a50f3c8e590f8526d92de54636b2090f88b7eed7688a7d5e69ec85fd6",
     "catalogDigest": "4f46de97d47c6840fc2760cf4cf6be090efb82304fb44648fa509ee6ec7d77b2",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4142,
+    "literalReferenceCount": 4143,
     "dynamicCallsiteCount": 32,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale en-US --message <MESSAGE_ID>"
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "e25d8a49e30ba09d2e8dbe0aa2f1b759ddb2aad8f46bc10f3de39c8fa123b4ba"
+  "contextDigest": "bf8c646a1438ea67afa0a2df48030997b2b06f560724d5c95d4b64d920297894"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa"
+    "sourceManifestDigest": "9a0e71346ba729ae90293c7933362b4285b38598aa456e8363a3ed02082e78b5"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "e25d8a49e30ba09d2e8dbe0aa2f1b759ddb2aad8f46bc10f3de39c8fa123b4ba",
-    "qualityDigest": "b37f05c99b73eb00edfcbb7be66dbed52d778ca23d1041b52c0f7e5f688de92e",
+    "contextDigest": "bf8c646a1438ea67afa0a2df48030997b2b06f560724d5c95d4b64d920297894",
+    "qualityDigest": "05950425c1aac05d3ca0561c09d0a49ec0588cf9e9ad4120fd5935560d466822",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "080538aa085eb701ac0a4f68ab8c5ec121bb39de44f844185e6bf8dd4a6164c9"
+  "activationDigest": "8ae89498ce914caf30113ae7719dd2d0673ecc16d288321f4fe584e90ddc3d1a"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa",
-    "contextDigest": "e25d8a49e30ba09d2e8dbe0aa2f1b759ddb2aad8f46bc10f3de39c8fa123b4ba"
+    "sourceManifestDigest": "9a0e71346ba729ae90293c7933362b4285b38598aa456e8363a3ed02082e78b5",
+    "contextDigest": "bf8c646a1438ea67afa0a2df48030997b2b06f560724d5c95d4b64d920297894"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "656576067f51c3e214807f40419692acb85ca864c7dc0cef291c724dc15e2e7b",
-    "validationDigest": "7f1551642c2d88b598a13a04dc12601c7e5b23dbc1a773ff1dd621e0907e85d9",
+    "digest": "f912f4d4f27c9cd42b95f038a715f6dd4b5917ab6ffcf11adf846ca15468da4d",
+    "validationDigest": "facf841ff86abbca005bc747244cd5b40b74c2df7921eba11f5627571d29bf23",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "b37f05c99b73eb00edfcbb7be66dbed52d778ca23d1041b52c0f7e5f688de92e"
+  "qualityDigest": "05950425c1aac05d3ca0561c09d0a49ec0588cf9e9ad4120fd5935560d466822"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "6eb9d4db745087fc482842636806b32f96b3d6f8e909e0406bb34a6ccddde9af",
+    "auditedInputDigest": "5c53affba3fa029ef9630ba390b9cd625d719fdbeddcee628c8235fbad2827af",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "4f46de97d47c6840fc2760cf4cf6be090efb82304fb44648fa509ee6ec7d77b2",
-    "dossierDigest": "7a0b44f3ed2990063cac6adc7e6b56550c606fe5d00d1ddcd221d6a89a403a93",
+    "dossierDigest": "e056444a50f3c8e590f8526d92de54636b2090f88b7eed7688a7d5e69ec85fd6",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "7a0b44f3ed2990063cac6adc7e6b56550c606fe5d00d1ddcd221d6a89a403a93",
+        "dossierDigest": "e056444a50f3c8e590f8526d92de54636b2090f88b7eed7688a7d5e69ec85fd6",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "7f1551642c2d88b598a13a04dc12601c7e5b23dbc1a773ff1dd621e0907e85d9"
+  "validationDigest": "facf841ff86abbca005bc747244cd5b40b74c2df7921eba11f5627571d29bf23"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa",
-    "auditedInputDigest": "6eb9d4db745087fc482842636806b32f96b3d6f8e909e0406bb34a6ccddde9af"
+    "sourceManifestDigest": "9a0e71346ba729ae90293c7933362b4285b38598aa456e8363a3ed02082e78b5",
+    "auditedInputDigest": "5c53affba3fa029ef9630ba390b9cd625d719fdbeddcee628c8235fbad2827af"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "4059360d1b6061c6cc6a09580fd7a34d9693b3097cf69641f1dcb73ea09ce65f",
+    "dossierDigest": "37ae668d115ff4c85abc460e38eaf7e638f9c18619780a09a8aa34d9a1e1425e",
     "catalogDigest": "e613c3d8b43dba89a92524f1dbd64dd0ab664eebb919ef7608aebccb7e6fa801",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4142,
+    "literalReferenceCount": 4143,
     "dynamicCallsiteCount": 32,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale fr-FR --message <MESSAGE_ID>"
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "6504bc10b4957877ecfc13224bad26c4fc0c295eb40056ac14e094ae36194e0c"
+  "contextDigest": "c727f732dc0a720d204410beedcd3c1513d15183d844117bf3246049336b6093"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa"
+    "sourceManifestDigest": "9a0e71346ba729ae90293c7933362b4285b38598aa456e8363a3ed02082e78b5"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "6504bc10b4957877ecfc13224bad26c4fc0c295eb40056ac14e094ae36194e0c",
-    "qualityDigest": "b1fc4c46d1803897fbad8d25e583890346f0b6872cec36a7f3b0e8c3b6d225ee",
+    "contextDigest": "c727f732dc0a720d204410beedcd3c1513d15183d844117bf3246049336b6093",
+    "qualityDigest": "e87befc1d814b8c8a72bfb5f942af8de26f87cbbe84861de972af7d7e70b5bff",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "3a883aa7d78e42653941764a09849e5167e0df5a9fbd39f55a24fd91438b792f"
+  "activationDigest": "2fff0f2574af71933bc6f8d6cbcb9b5a9fe31302f83f5eee5978eedc047b3ca0"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa",
-    "contextDigest": "6504bc10b4957877ecfc13224bad26c4fc0c295eb40056ac14e094ae36194e0c"
+    "sourceManifestDigest": "9a0e71346ba729ae90293c7933362b4285b38598aa456e8363a3ed02082e78b5",
+    "contextDigest": "c727f732dc0a720d204410beedcd3c1513d15183d844117bf3246049336b6093"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "f29b435d81a53bf5cfa9ea00cbc731c3ef2e831373cec90b88b57736180f3ea4",
-    "validationDigest": "262fad0df48e39c0dc1f4b299ca0195bdf63ef28f2304a5bfff52c0ec39681d1",
+    "digest": "ce97faebfb61953787862e6e56efd87b6e2f2de9933e2f5e02351051303d9c72",
+    "validationDigest": "a9f7e4fd73f41a8c4460aa0d26f6850e827f581722bbd2d65135abd6adba233f",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "b1fc4c46d1803897fbad8d25e583890346f0b6872cec36a7f3b0e8c3b6d225ee"
+  "qualityDigest": "e87befc1d814b8c8a72bfb5f942af8de26f87cbbe84861de972af7d7e70b5bff"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "6eb9d4db745087fc482842636806b32f96b3d6f8e909e0406bb34a6ccddde9af",
+    "auditedInputDigest": "5c53affba3fa029ef9630ba390b9cd625d719fdbeddcee628c8235fbad2827af",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "e613c3d8b43dba89a92524f1dbd64dd0ab664eebb919ef7608aebccb7e6fa801",
-    "dossierDigest": "4059360d1b6061c6cc6a09580fd7a34d9693b3097cf69641f1dcb73ea09ce65f",
+    "dossierDigest": "37ae668d115ff4c85abc460e38eaf7e638f9c18619780a09a8aa34d9a1e1425e",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "4059360d1b6061c6cc6a09580fd7a34d9693b3097cf69641f1dcb73ea09ce65f",
+        "dossierDigest": "37ae668d115ff4c85abc460e38eaf7e638f9c18619780a09a8aa34d9a1e1425e",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "262fad0df48e39c0dc1f4b299ca0195bdf63ef28f2304a5bfff52c0ec39681d1"
+  "validationDigest": "a9f7e4fd73f41a8c4460aa0d26f6850e827f581722bbd2d65135abd6adba233f"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa",
-    "auditedInputDigest": "6eb9d4db745087fc482842636806b32f96b3d6f8e909e0406bb34a6ccddde9af"
+    "sourceManifestDigest": "9a0e71346ba729ae90293c7933362b4285b38598aa456e8363a3ed02082e78b5",
+    "auditedInputDigest": "5c53affba3fa029ef9630ba390b9cd625d719fdbeddcee628c8235fbad2827af"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "5a85279499549765f7c5b163bc628e123e05f522262e5684190297b588863018",
+    "dossierDigest": "d97cfab0f6f35fb23da3d34d95a7d5141a0efa6b2508c92e807b2ef7b6d58aaf",
     "catalogDigest": "a6838914aaf7b8aa5c1c6954aeb0dff767c0618f7b980a0c2f5f28f882a2f833",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -88,7 +88,7 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4142,
+    "literalReferenceCount": 4143,
     "dynamicCallsiteCount": 32,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "npm run i18n:context:dossier -- --locale zh-CN --message <MESSAGE_ID>"
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "660b805a45246059bec3420bf3e0267add43d8f9b25f3db9c0de4da89cd1fc73"
+  "contextDigest": "35eb727481c0cab8addecccc42ce9e2b1faf32b820f6b71c13ae05e39c93f4c2"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa"
+    "sourceManifestDigest": "9a0e71346ba729ae90293c7933362b4285b38598aa456e8363a3ed02082e78b5"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "660b805a45246059bec3420bf3e0267add43d8f9b25f3db9c0de4da89cd1fc73",
-    "qualityDigest": "9baa526a5eba3f038203ee6a816e87f408cc20aa66dfbe0abbe04e970def892a",
+    "contextDigest": "35eb727481c0cab8addecccc42ce9e2b1faf32b820f6b71c13ae05e39c93f4c2",
+    "qualityDigest": "d489833bd98a702cf8f0fa318e9b860cc2202edf13d64583336daaefea13de5b",
     "correctionLedgerDigest": "b35bc2dcc3ea1f6eb3036150f15bbcec42e87614409563ffe04d3da374d36035",
     "routeViewCoverageDigest": "134baf5f810bdfb469b07e0ecf241e6500b749c2e9925004916d99bde09cef98",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "1b3384872df990a1703959731a26be7b622faf83eac21114f4efeaf967d3b956"
+  "activationDigest": "f20b13234941430eb4a3a7d812d19666184a204706d9a2cf1b11ad8794bce9fb"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "ec5c8d2ee5fc48b1ae2bf58ff4ee8fae4900023891964ee8a51cf03caae015fa",
-    "contextDigest": "660b805a45246059bec3420bf3e0267add43d8f9b25f3db9c0de4da89cd1fc73"
+    "sourceManifestDigest": "9a0e71346ba729ae90293c7933362b4285b38598aa456e8363a3ed02082e78b5",
+    "contextDigest": "35eb727481c0cab8addecccc42ce9e2b1faf32b820f6b71c13ae05e39c93f4c2"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "7aa94e71d4861c5111f3f2851e0991c3467a23c7927842ab1117a3d39a7f7d0a",
-    "validationDigest": "9f8479ee6241047d4dae7c4693ec880cb40de493ffd0c865091c200858757d93",
+    "digest": "261a4965b23d742f46ede3239ec8ca5beaf3528d0fd01e954e9d3337ba6a0551",
+    "validationDigest": "9a4d588125f681427f68657bd44a58d378007feabc1eecf8f15aabedd1cf9e38",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "9baa526a5eba3f038203ee6a816e87f408cc20aa66dfbe0abbe04e970def892a"
+  "qualityDigest": "d489833bd98a702cf8f0fa318e9b860cc2202edf13d64583336daaefea13de5b"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "6eb9d4db745087fc482842636806b32f96b3d6f8e909e0406bb34a6ccddde9af",
+    "auditedInputDigest": "5c53affba3fa029ef9630ba390b9cd625d719fdbeddcee628c8235fbad2827af",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "a6838914aaf7b8aa5c1c6954aeb0dff767c0618f7b980a0c2f5f28f882a2f833",
-    "dossierDigest": "5a85279499549765f7c5b163bc628e123e05f522262e5684190297b588863018",
+    "dossierDigest": "d97cfab0f6f35fb23da3d34d95a7d5141a0efa6b2508c92e807b2ef7b6d58aaf",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "6ce8d29cb181ca8e760b3421864daed85db54b4b8a9e57d3778e756b4ccddd04",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "5a85279499549765f7c5b163bc628e123e05f522262e5684190297b588863018",
+        "dossierDigest": "d97cfab0f6f35fb23da3d34d95a7d5141a0efa6b2508c92e807b2ef7b6d58aaf",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "9f8479ee6241047d4dae7c4693ec880cb40de493ffd0c865091c200858757d93"
+  "validationDigest": "9a4d588125f681427f68657bd44a58d378007feabc1eecf8f15aabedd1cf9e38"
 }

--- a/src/pages/Flows/Components/Property/create.tsx
+++ b/src/pages/Flows/Components/Property/create.tsx
@@ -187,7 +187,14 @@ const PropertyCreate: FC<Props> = ({ lang, onData, showRules = false }) => {
               }
               name={['relativeStandardDeviation95In']}
             >
-              <InputNumber suffix='%' min={0} max={100} style={{ width: '100%' }} />
+              <InputNumber
+                suffix='%'
+                min={0}
+                max={100}
+                precision={3}
+                stringMode
+                style={{ width: '100%' }}
+              />
             </Form.Item>
             <Form.Item
               label={

--- a/src/pages/Flows/Components/Property/edit.tsx
+++ b/src/pages/Flows/Components/Property/edit.tsx
@@ -491,7 +491,14 @@ const PropertyEdit: FC<Props> = ({
               }
               name={['relativeStandardDeviation95In']}
             >
-              <InputNumber suffix='%' min={0} max={100} style={{ width: '100%' }} />
+              <InputNumber
+                suffix='%'
+                min={0}
+                max={100}
+                precision={3}
+                stringMode
+                style={{ width: '100%' }}
+              />
             </Form.Item>
             <Form.Item
               label={

--- a/src/pages/Processes/Components/Exchange/create.tsx
+++ b/src/pages/Processes/Components/Exchange/create.tsx
@@ -452,7 +452,14 @@ const ProcessExchangeCreate: FC<Props> = ({
                 }
                 name={['allocations', 'allocation', '@allocatedFraction']}
               >
-                <InputNumber min={0} max={100} suffix='%' style={{ width: '100%' }} />
+                <InputNumber
+                  min={0}
+                  max={100}
+                  precision={3}
+                  stringMode
+                  suffix='%'
+                  style={{ width: '100%' }}
+                />
               </Form.Item>
             </Card>
             <br />

--- a/src/pages/Processes/Components/Exchange/edit.tsx
+++ b/src/pages/Processes/Components/Exchange/edit.tsx
@@ -830,7 +830,14 @@ const ProcessExchangeEdit: FC<Props> = ({
                 }
                 name={['allocations', 'allocation', '@allocatedFraction']}
               >
-                <InputNumber min={0} max={100} suffix='%' style={{ width: '100%' }} />
+                <InputNumber
+                  min={0}
+                  max={100}
+                  precision={3}
+                  stringMode
+                  suffix='%'
+                  style={{ width: '100%' }}
+                />
               </Form.Item>
             </Card>
             <br />

--- a/src/pages/Processes/Components/form.tsx
+++ b/src/pages/Processes/Components/form.tsx
@@ -1139,7 +1139,7 @@ export const ProcessForm: FC<Props> = ({
                 : []
             }
           >
-            <InputNumber style={{ width: '100%' }} />
+            <InputNumber min={1000} max={9999} precision={0} step={1} style={{ width: '100%' }} />
           </Form.Item>
           <Form.Item
             label={
@@ -1159,7 +1159,7 @@ export const ProcessForm: FC<Props> = ({
                 : []
             }
           >
-            <Input />
+            <InputNumber min={1000} max={9999} precision={0} step={1} style={{ width: '100%' }} />
           </Form.Item>
           <Divider orientationMargin='0' orientation='left' plain>
             <FormattedMessage

--- a/src/pages/Processes/processes_schema.json
+++ b/src/pages/Processes/processes_schema.json
@@ -186,20 +186,29 @@
       },
       "time": {
         "common:referenceYear": {
-          "value": "str",
+          "value": "number",
           "rules": [
             {
               "required": true,
               "messageKey": "pages.process.validator.referenceYear.required",
               "defaultMessage": "Please input reference year"
+            },
+            {
+              "type": "integer",
+              "min": 1000,
+              "max": 9999,
+              "messageKey": "validator.Year.pattern",
+              "defaultMessage": "Please enter a valid year (e.g., 2023)"
             }
           ]
         },
         "common:dataSetValidUntil": {
-          "value": "str",
+          "value": "number",
           "rules": [
             {
-              "pattern": "year",
+              "type": "integer",
+              "min": 1000,
+              "max": 9999,
               "messageKey": "validator.Year.pattern",
               "defaultMessage": "Please enter a valid year (e.g., 2023)"
             }

--- a/src/services/flows/api.ts
+++ b/src/services/flows/api.ts
@@ -28,10 +28,20 @@ import {
   normalizeLangPayloadForSave,
   type NormalizeLangPayloadForSaveOptions,
 } from '../general/api';
+import {
+  createTidasScalarValidationError,
+  validateFlowTidasScalarStorage,
+} from '../general/tidasScalarStorage';
 import { getILCDLocationByValues } from '../locations/api';
 import { getCachedLocationData } from '../locations/cache';
 import type { FlowTable } from './data';
 import { genFlowJsonOrdered, genFlowName } from './util';
+
+const getFlowTidasScalarValidationError = (payload: unknown) => {
+  const issues = validateFlowTidasScalarStorage(payload);
+  return issues.length > 0 ? createTidasScalarValidationError(issues) : undefined;
+};
+
 function normalizeLocationData(response: any): any[] {
   if (Array.isArray(response)) {
     return response;
@@ -191,6 +201,10 @@ export async function createFlows(
       options,
     );
   }
+  const scalarValidationError = getFlowTidasScalarValidationError(newData);
+  if (scalarValidationError) {
+    return attachLangNormalizationMetadata(scalarValidationError, langMetadata, options);
+  }
   const userTeamId = (await getTeamIdByUserId()) ?? '';
   const { ruleVerification: rule_verification } = await validateDatasetRuleVerification(
     'flow data set',
@@ -242,6 +256,10 @@ export async function createFlowsVersion(
       options,
     );
   }
+  const scalarValidationError = getFlowTidasScalarValidationError(newData);
+  if (scalarValidationError) {
+    return attachLangNormalizationMetadata(scalarValidationError, langMetadata, options);
+  }
   const userTeamId = (await getTeamIdByUserId()) ?? '';
   const { ruleVerification: rule_verification } = await validateDatasetRuleVerification(
     'flow data set',
@@ -292,6 +310,10 @@ export async function updateFlows(
       langMetadata,
       options,
     );
+  }
+  const scalarValidationError = getFlowTidasScalarValidationError(newData);
+  if (scalarValidationError) {
+    return attachLangNormalizationMetadata(scalarValidationError, langMetadata, options);
   }
   const userTeamId = (await getTeamIdByUserId()) ?? '';
   const { ruleVerification: rule_verification } = await validateDatasetRuleVerification(

--- a/src/services/flows/util.ts
+++ b/src/services/flows/util.ts
@@ -1,6 +1,7 @@
 import { FormFlow } from '@/services/flows/data';
 import { createFlow as createTidasFlow } from '@tiangong-lca/tidas-sdk/core';
 import type { Flow } from '@tiangong-lca/tidas-sdk/types';
+import { normalizeOptionalTidasPercentage } from '../general/tidasScalarStorage';
 import {
   classificationToJsonList,
   classificationToStringList,
@@ -48,7 +49,9 @@ export function genFlowJsonOrdered(id: string, data: any) {
       minimumValue: item?.['minimumValue'],
       maximumValue: item?.['maximumValue'],
       uncertaintyDistributionType: item?.['uncertaintyDistributionType'],
-      relativeStandardDeviation95In: item?.['relativeStandardDeviation95In'],
+      relativeStandardDeviation95In: normalizeOptionalTidasPercentage(
+        item?.['relativeStandardDeviation95In'],
+      ),
       dataDerivationTypeStatus: item?.['dataDerivationTypeStatus'],
       generalComment: getLangJson(
         item?.['common:generalComment'] ?? item?.generalComment ?? undefined,

--- a/src/services/general/tidasScalarStorage.ts
+++ b/src/services/general/tidasScalarStorage.ts
@@ -1,0 +1,160 @@
+export const TIDAS_YEAR_MIN = 1000;
+export const TIDAS_YEAR_MAX = 9999;
+
+const TIDAS_INTEGER_TEXT_PATTERN = /^\d+$/;
+const TIDAS_PERCENTAGE_TEXT_PATTERN =
+  /^[+-]?(?:\d{1,5}|\d{1,4}\.\d|\d{1,3}\.\d{2}|\d{1,2}\.\d{3})$/;
+
+export type TidasScalarStorageIssue = {
+  path: string;
+  expected: string;
+  value: unknown;
+};
+
+const isEmptyOptionalScalar = (value: unknown) =>
+  value === null || value === undefined || value === '' || value === 'undefined';
+
+const isTidasYear = (value: unknown): value is number =>
+  typeof value === 'number' &&
+  Number.isInteger(value) &&
+  value >= TIDAS_YEAR_MIN &&
+  value <= TIDAS_YEAR_MAX;
+
+const isTidasPercentage = (value: unknown): value is string =>
+  typeof value === 'string' && TIDAS_PERCENTAGE_TEXT_PATTERN.test(value);
+
+export function normalizeOptionalTidasYear(value: unknown): unknown {
+  if (isEmptyOptionalScalar(value)) {
+    return undefined;
+  }
+
+  if (isTidasYear(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalizedText = value.trim();
+    if (TIDAS_INTEGER_TEXT_PATTERN.test(normalizedText)) {
+      const normalizedValue = Number(normalizedText);
+      if (isTidasYear(normalizedValue)) {
+        return normalizedValue;
+      }
+    }
+  }
+
+  return value;
+}
+
+export function normalizeOptionalTidasPercentage(value: unknown): unknown {
+  if (isEmptyOptionalScalar(value)) {
+    return undefined;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+
+  return value;
+}
+
+const addYearIssue = (issues: TidasScalarStorageIssue[], path: string, value: unknown) => {
+  if (!isEmptyOptionalScalar(value) && !isTidasYear(value)) {
+    issues.push({
+      path,
+      expected: `an integer from ${TIDAS_YEAR_MIN} through ${TIDAS_YEAR_MAX}`,
+      value,
+    });
+  }
+};
+
+const addPercentageIssue = (issues: TidasScalarStorageIssue[], path: string, value: unknown) => {
+  if (!isEmptyOptionalScalar(value) && !isTidasPercentage(value)) {
+    issues.push({
+      path,
+      expected: 'a decimal string with at most three fractional digits',
+      value,
+    });
+  }
+};
+
+const toList = (value: unknown): any[] => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return value && typeof value === 'object' ? [value] : [];
+};
+
+export function validateProcessTidasScalarStorage(payload: any): TidasScalarStorageIssue[] {
+  const issues: TidasScalarStorageIssue[] = [];
+  const processDataSet = payload?.processDataSet;
+  const time = processDataSet?.processInformation?.time;
+
+  addYearIssue(
+    issues,
+    'processDataSet.processInformation.time.common:referenceYear',
+    time?.['common:referenceYear'],
+  );
+  addYearIssue(
+    issues,
+    'processDataSet.processInformation.time.common:dataSetValidUntil',
+    time?.['common:dataSetValidUntil'],
+  );
+
+  toList(processDataSet?.exchanges?.exchange).forEach((exchange, exchangeIndex) => {
+    addPercentageIssue(
+      issues,
+      `processDataSet.exchanges.exchange[${exchangeIndex}].relativeStandardDeviation95In`,
+      exchange?.relativeStandardDeviation95In,
+    );
+    toList(exchange?.allocations?.allocation).forEach((allocation, allocationIndex) => {
+      addPercentageIssue(
+        issues,
+        `processDataSet.exchanges.exchange[${exchangeIndex}].allocations.allocation[${allocationIndex}].@allocatedFraction`,
+        allocation?.['@allocatedFraction'],
+      );
+    });
+  });
+
+  addPercentageIssue(
+    issues,
+    'processDataSet.processInformation.mathematicalRelations.variableParameter.relativeStandardDeviation95In',
+    processDataSet?.processInformation?.mathematicalRelations?.variableParameter
+      ?.relativeStandardDeviation95In,
+  );
+
+  return issues;
+}
+
+export function validateFlowTidasScalarStorage(payload: any): TidasScalarStorageIssue[] {
+  const issues: TidasScalarStorageIssue[] = [];
+  toList(payload?.flowDataSet?.flowProperties?.flowProperty).forEach(
+    (flowProperty, flowPropertyIndex) => {
+      addPercentageIssue(
+        issues,
+        `flowDataSet.flowProperties.flowProperty[${flowPropertyIndex}].relativeStandardDeviation95In`,
+        flowProperty?.relativeStandardDeviation95In,
+      );
+    },
+  );
+  return issues;
+}
+
+export function createTidasScalarValidationError(issues: TidasScalarStorageIssue[]) {
+  return {
+    data: null,
+    error: {
+      message: 'Payload contains TIDAS scalar values that cannot be stored canonically.',
+      code: 'TIDAS_SCALAR_VALIDATION_ERROR',
+      details: JSON.stringify(issues),
+      hint: 'Correct the affected values and retry.',
+      name: 'TidasScalarValidationError',
+    },
+    status: 400,
+    statusText: 'TIDAS_SCALAR_VALIDATION_ERROR',
+    count: null,
+  };
+}

--- a/src/services/processes/api.ts
+++ b/src/services/processes/api.ts
@@ -34,6 +34,10 @@ import {
 } from '../datasetUuidMentionSearch/api';
 import { getTeamIdByUserId } from '../general/api';
 import {
+  createTidasScalarValidationError,
+  validateProcessTidasScalarStorage,
+} from '../general/tidasScalarStorage';
+import {
   classificationToString,
   genLocalizedClassification,
   getLangText,
@@ -68,6 +72,11 @@ type ProcessCommandRow = {
 
 export type UpdateProcessResult = SupabaseMutationResult<ProcessCommandRow> &
   LangNormalizationMetadata;
+
+const getProcessTidasScalarValidationError = (payload: unknown) => {
+  const issues = validateProcessTidasScalarStorage(payload);
+  return issues.length > 0 ? createTidasScalarValidationError(issues) : undefined;
+};
 
 export type LcaMyProcessOption = {
   id: string;
@@ -353,6 +362,10 @@ export async function createProcess(
       options,
     );
   }
+  const scalarValidationError = getProcessTidasScalarValidationError(newData);
+  if (scalarValidationError) {
+    return attachLangNormalizationMetadata(scalarValidationError, langMetadata, options);
+  }
   const userTeamId = (await getTeamIdByUserId()) ?? '';
   const { ruleVerification: rule_verification } = await validateDatasetRuleVerification(
     'process data set',
@@ -406,6 +419,10 @@ export async function createProcessVersion(
       options,
     );
   }
+  const scalarValidationError = getProcessTidasScalarValidationError(newData);
+  if (scalarValidationError) {
+    return attachLangNormalizationMetadata(scalarValidationError, langMetadata, options);
+  }
   const userTeamId = (await getTeamIdByUserId()) ?? '';
   const { ruleVerification: rule_verification } = await validateDatasetRuleVerification(
     'process data set',
@@ -458,6 +475,10 @@ export async function updateProcess(
       langMetadata,
       options,
     );
+  }
+  const scalarValidationError = getProcessTidasScalarValidationError(newData);
+  if (scalarValidationError) {
+    return attachLangNormalizationMetadata(scalarValidationError, langMetadata, options);
   }
   const userTeamId = (await getTeamIdByUserId()) ?? '';
   const { ruleVerification: rule_verification } = await validateDatasetRuleVerification(

--- a/src/services/processes/util.ts
+++ b/src/services/processes/util.ts
@@ -5,6 +5,10 @@ import {
   normalizeSupportedContentLanguage,
 } from '../general/contentLanguageRegistry';
 import {
+  normalizeOptionalTidasPercentage,
+  normalizeOptionalTidasYear,
+} from '../general/tidasScalarStorage';
+import {
   capitalize,
   classificationToJsonList,
   classificationToStringList,
@@ -50,19 +54,8 @@ const getExchangeLocationField = (value: unknown) => {
   return location ? { location } : {};
 };
 
-const normalizeReferenceYearValue = (value: string | number | null | undefined) => {
-  if (value === null || value === undefined || value === '' || value === 'undefined') {
-    return undefined;
-  }
-
-  const normalizedValue = Number(value);
-
-  if (Number.isNaN(normalizedValue)) {
-    return undefined;
-  }
-
-  return normalizedValue;
-};
+const normalizeAllocationPercentageValue = (value: unknown) =>
+  normalizeOptionalTidasPercentage(typeof value === 'string' ? value.replace('%', '') : value);
 
 export function genProcessJsonOrdered(id: string, data: any) {
   let quantitativeReference = {};
@@ -122,12 +115,14 @@ export function genProcessJsonOrdered(id: string, data: any) {
         allocation: {
           '@internalReferenceToCoProduct':
             item?.allocations?.allocation?.['@internalReferenceToCoProduct'],
-          '@allocatedFraction': item?.allocations?.allocation?.['@allocatedFraction']
-            ? item?.allocations?.allocation?.['@allocatedFraction']?.toString()?.replace('%', '')
-            : undefined,
+          '@allocatedFraction': normalizeAllocationPercentageValue(
+            item?.allocations?.allocation?.['@allocatedFraction'],
+          ),
         },
       },
-      relativeStandardDeviation95In: item.relativeStandardDeviation95In,
+      relativeStandardDeviation95In: normalizeOptionalTidasPercentage(
+        item.relativeStandardDeviation95In,
+      ),
       dataSourceType: item.dataSourceType,
       dataDerivationTypeStatus: item.dataDerivationTypeStatus,
       referencesToDataSource: {
@@ -216,11 +211,12 @@ export function genProcessJsonOrdered(id: string, data: any) {
         },
         quantitativeReference: { ...quantitativeReference },
         time: {
-          'common:referenceYear': normalizeReferenceYearValue(
+          'common:referenceYear': normalizeOptionalTidasYear(
             data?.processInformation?.time?.['common:referenceYear'],
           ),
-          'common:dataSetValidUntil':
-            data?.processInformation?.time?.['common:dataSetValidUntil'] ?? {},
+          'common:dataSetValidUntil': normalizeOptionalTidasYear(
+            data?.processInformation?.time?.['common:dataSetValidUntil'],
+          ),
           'common:timeRepresentativenessDescription': getLangJson(
             data?.processInformation?.time?.['common:timeRepresentativenessDescription'],
           ),
@@ -326,9 +322,10 @@ export function genProcessJsonOrdered(id: string, data: any) {
             uncertaintyDistributionType:
               data?.processInformation?.mathematicalRelations?.variableParameter
                 ?.uncertaintyDistributionType,
-            relativeStandardDeviation95In:
+            relativeStandardDeviation95In: normalizeOptionalTidasPercentage(
               data?.processInformation?.mathematicalRelations?.variableParameter
                 ?.relativeStandardDeviation95In,
+            ),
             comment: data?.processInformation?.mathematicalRelations?.variableParameter?.comment,
           },
         },
@@ -942,11 +939,12 @@ export function genProcessFromData(data: any): FormProcess {
           ),
         },
         time: {
-          'common:referenceYear': normalizeReferenceYearValue(
+          'common:referenceYear': normalizeOptionalTidasYear(
             data?.processInformation?.time?.['common:referenceYear'],
           ),
-          'common:dataSetValidUntil':
-            data?.processInformation?.time?.['common:dataSetValidUntil'] ?? {},
+          'common:dataSetValidUntil': normalizeOptionalTidasYear(
+            data?.processInformation?.time?.['common:dataSetValidUntil'],
+          ),
           'common:timeRepresentativenessDescription': getLangList(
             data?.processInformation?.time?.['common:timeRepresentativenessDescription'],
           ),

--- a/tests/unit/services/flows/api.test.ts
+++ b/tests/unit/services/flows/api.test.ts
@@ -573,6 +573,38 @@ describe('updateFlows', () => {
   });
 });
 
+const invalidFlowScalarPayload = {
+  flowDataSet: {
+    flowProperties: {
+      flowProperty: { relativeStandardDeviation95In: 12.5 },
+    },
+  },
+};
+
+describe.each([
+  ['createFlows', () => createFlows('flow-id', invalidFlowScalarPayload)],
+  [
+    'createFlowsVersion',
+    () => createFlowsVersion('flow-id', '01.00.000', invalidFlowScalarPayload),
+  ],
+  ['updateFlows', () => updateFlows('flow-id', '01.00.000', invalidFlowScalarPayload)],
+])('%s TIDAS scalar save gate', (_name, save) => {
+  it('rejects a non-canonical flow percentage before persistence', async () => {
+    const result = await save();
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        data: null,
+        status: 400,
+        statusText: 'TIDAS_SCALAR_VALIDATION_ERROR',
+        error: expect.objectContaining({ code: 'TIDAS_SCALAR_VALIDATION_ERROR' }),
+      }),
+    );
+    expect(mockInvokeDatasetCommand).not.toHaveBeenCalled();
+    expect(mockInvokeDatasetCreateVersion).not.toHaveBeenCalled();
+  });
+});
+
 describe('deleteFlows', () => {
   it('removes flow by id and version', async () => {
     const deleteResult = { data: null, error: null, count: null, status: 200, statusText: 'OK' };

--- a/tests/unit/services/flows/util.test.ts
+++ b/tests/unit/services/flows/util.test.ts
@@ -533,6 +533,21 @@ describe('Flow Utility Functions', () => {
       ).toHaveProperty('common:elementaryFlowCategorization');
     });
 
+    it('should normalize numeric relative standard deviation to a TIDAS percentage string', () => {
+      const result = genFlowJsonOrdered('test-flow-id', {
+        flowProperties: {
+          flowProperty: {
+            '@dataSetInternalID': '0',
+            relativeStandardDeviation95In: 12.5,
+          },
+        },
+      });
+
+      expect(result.flowDataSet.flowProperties.flowProperty.relativeStandardDeviation95In).toBe(
+        '12.5',
+      );
+    });
+
     it('should generate ordered JSON structure for Product flow', () => {
       const id = 'test-product-flow-id';
       const data = {

--- a/tests/unit/services/general/tidasScalarStorage.test.ts
+++ b/tests/unit/services/general/tidasScalarStorage.test.ts
@@ -1,0 +1,141 @@
+import {
+  createTidasScalarValidationError,
+  normalizeOptionalTidasPercentage,
+  normalizeOptionalTidasYear,
+  validateFlowTidasScalarStorage,
+  validateProcessTidasScalarStorage,
+} from '@/services/general/tidasScalarStorage';
+
+describe('TIDAS scalar storage normalization', () => {
+  it.each([null, undefined, '', 'undefined'])(
+    'normalizes an empty year %p to undefined',
+    (value) => {
+      expect(normalizeOptionalTidasYear(value)).toBeUndefined();
+    },
+  );
+
+  it('normalizes canonical year text while preserving invalid values for the save gate', () => {
+    expect(normalizeOptionalTidasYear(2024)).toBe(2024);
+    expect(normalizeOptionalTidasYear(' 2030 ')).toBe(2030);
+    expect(normalizeOptionalTidasYear('2030.0')).toBe('2030.0');
+    expect(normalizeOptionalTidasYear('not-a-year')).toBe('not-a-year');
+    expect(normalizeOptionalTidasYear('999')).toBe('999');
+    expect(normalizeOptionalTidasYear(2024.5)).toBe(2024.5);
+    expect(normalizeOptionalTidasYear(10_000)).toBe(10_000);
+  });
+
+  it.each([null, undefined, '', 'undefined'])(
+    'normalizes an empty percentage %p to undefined',
+    (value) => {
+      expect(normalizeOptionalTidasPercentage(value)).toBeUndefined();
+    },
+  );
+
+  it('normalizes finite percentage numbers and trims percentage text', () => {
+    expect(normalizeOptionalTidasPercentage(12.5)).toBe('12.5');
+    expect(normalizeOptionalTidasPercentage(' 12.500 ')).toBe('12.500');
+    expect(normalizeOptionalTidasPercentage(Number.POSITIVE_INFINITY)).toBe(
+      Number.POSITIVE_INFINITY,
+    );
+    const objectValue = { value: 12.5 };
+    expect(normalizeOptionalTidasPercentage(objectValue)).toBe(objectValue);
+  });
+});
+
+describe('TIDAS scalar storage validation', () => {
+  it('accepts canonical process year and percentage scalars', () => {
+    expect(
+      validateProcessTidasScalarStorage({
+        processDataSet: {
+          processInformation: {
+            time: {
+              'common:referenceYear': 2024,
+              'common:dataSetValidUntil': 2030,
+            },
+            mathematicalRelations: {
+              variableParameter: { relativeStandardDeviation95In: '1.250' },
+            },
+          },
+          exchanges: {
+            exchange: {
+              relativeStandardDeviation95In: '12.5',
+              allocations: { allocation: [{ '@allocatedFraction': '0' }] },
+            },
+          },
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it('reports every non-canonical process scalar and ignores optional empty values', () => {
+    const issues = validateProcessTidasScalarStorage({
+      processDataSet: {
+        processInformation: {
+          time: {
+            'common:referenceYear': 2024.5,
+            'common:dataSetValidUntil': '2030',
+          },
+          mathematicalRelations: {
+            variableParameter: { relativeStandardDeviation95In: null },
+          },
+        },
+        exchanges: {
+          exchange: [
+            {
+              relativeStandardDeviation95In: 12.5,
+              allocations: { allocation: { '@allocatedFraction': '12.3456' } },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(issues.map((issue) => issue.path)).toEqual([
+      'processDataSet.processInformation.time.common:referenceYear',
+      'processDataSet.processInformation.time.common:dataSetValidUntil',
+      'processDataSet.exchanges.exchange[0].relativeStandardDeviation95In',
+      'processDataSet.exchanges.exchange[0].allocations.allocation[0].@allocatedFraction',
+    ]);
+  });
+
+  it('validates singleton, array, and absent flow-property containers', () => {
+    expect(
+      validateFlowTidasScalarStorage({
+        flowDataSet: {
+          flowProperties: { flowProperty: { relativeStandardDeviation95In: '12.5' } },
+        },
+      }),
+    ).toEqual([]);
+    expect(
+      validateFlowTidasScalarStorage({
+        flowDataSet: {
+          flowProperties: {
+            flowProperty: [
+              { relativeStandardDeviation95In: '12.3456' },
+              { relativeStandardDeviation95In: {} },
+            ],
+          },
+        },
+      }).map((issue) => issue.path),
+    ).toEqual([
+      'flowDataSet.flowProperties.flowProperty[0].relativeStandardDeviation95In',
+      'flowDataSet.flowProperties.flowProperty[1].relativeStandardDeviation95In',
+    ]);
+    expect(validateFlowTidasScalarStorage({})).toEqual([]);
+  });
+
+  it('builds a structured 400 response for save-boundary failures', () => {
+    const issues = [{ path: 'path', expected: 'string', value: 12.5 }];
+    expect(createTidasScalarValidationError(issues)).toEqual(
+      expect.objectContaining({
+        data: null,
+        status: 400,
+        statusText: 'TIDAS_SCALAR_VALIDATION_ERROR',
+        error: expect.objectContaining({
+          code: 'TIDAS_SCALAR_VALIDATION_ERROR',
+          details: JSON.stringify(issues),
+        }),
+      }),
+    );
+  });
+});

--- a/tests/unit/services/processes/api.test.ts
+++ b/tests/unit/services/processes/api.test.ts
@@ -652,6 +652,39 @@ describe('updateProcess', () => {
   });
 });
 
+describe.each([
+  ['createProcess', () => processesApi.createProcess(sampleId, { raw: true })],
+  [
+    'createProcessVersion',
+    () => processesApi.createProcessVersion(sampleId, sampleVersion, { raw: true }),
+  ],
+  ['updateProcess', () => processesApi.updateProcess(sampleId, sampleVersion, { raw: true })],
+])('%s TIDAS scalar save gate', (_name, save) => {
+  it('rejects a non-canonical process year before persistence', async () => {
+    mockGenProcessJsonOrdered.mockReturnValue({
+      processDataSet: {
+        processInformation: {
+          time: { 'common:dataSetValidUntil': '2030' },
+        },
+      },
+    });
+
+    const result = await save();
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        data: null,
+        status: 400,
+        statusText: 'TIDAS_SCALAR_VALIDATION_ERROR',
+        error: expect.objectContaining({ code: 'TIDAS_SCALAR_VALIDATION_ERROR' }),
+      }),
+    );
+    expect(mockValidateDatasetRuleVerification).not.toHaveBeenCalled();
+    expect(mockInvokeDatasetCommand).not.toHaveBeenCalled();
+    expect(mockInvokeDatasetCreateVersion).not.toHaveBeenCalled();
+  });
+});
+
 describe('updateProcessApi', () => {
   it('returns a structured deprecation error', async () => {
     const payload = { json_ordered: { foo: 'bar' } };

--- a/tests/unit/services/processes/util.test.ts
+++ b/tests/unit/services/processes/util.test.ts
@@ -851,7 +851,7 @@ describe('Process Utility Functions', () => {
       expect(result.processDataSet.processInformation.time['common:referenceYear']).toBeUndefined();
     });
 
-    it('should drop invalid reference year strings instead of serializing NaN', () => {
+    it('should preserve invalid reference year strings for the save-boundary validation gate', () => {
       const dataWithInvalidReferenceYear = {
         ...mockProcessData,
         processInformation: {
@@ -865,7 +865,45 @@ describe('Process Utility Functions', () => {
 
       const result = genProcessJsonOrdered('test-id', dataWithInvalidReferenceYear);
 
-      expect(result.processDataSet.processInformation.time['common:referenceYear']).toBeUndefined();
+      expect(result.processDataSet.processInformation.time['common:referenceYear']).toBe(
+        'not-a-number',
+      );
+    });
+
+    it('should normalize process year and percentage scalars to canonical TIDAS types', () => {
+      const result = genProcessJsonOrdered('test-id', {
+        ...mockProcessData,
+        processInformation: {
+          ...mockProcessData.processInformation,
+          time: {
+            ...mockProcessData.processInformation.time,
+            'common:dataSetValidUntil': '2030',
+          },
+          mathematicalRelations: {
+            variableParameter: { relativeStandardDeviation95In: 1.25 },
+          },
+        },
+        exchanges: {
+          exchange: [
+            {
+              ...mockProcessData.exchanges.exchange[0],
+              relativeStandardDeviation95In: 12.5,
+              allocations: { allocation: { '@allocatedFraction': 0 } },
+            },
+          ],
+        },
+      });
+
+      const time = result.processDataSet.processInformation.time;
+      const exchange = result.processDataSet.exchanges.exchange[0];
+      expect(time['common:referenceYear']).toBe(2024);
+      expect(time['common:dataSetValidUntil']).toBe(2030);
+      expect(exchange.relativeStandardDeviation95In).toBe('12.5');
+      expect(exchange.allocations.allocation['@allocatedFraction']).toBe('0');
+      expect(
+        result.processDataSet.processInformation.mathematicalRelations.variableParameter
+          .relativeStandardDeviation95In,
+      ).toBe('1.25');
     });
 
     it('should not stringify missing exchange amounts to undefined', () => {


### PR DESCRIPTION
## Branch Contract

- base branch: `dev`
- validated environment: local Node 24 checkout against `origin/dev`
- back-merge required after merge: No
- root workspace integration expected: Yes, after promotion to a release-semantic commit on child `main`

- [x] this PR targets `dev`
- [x] if the work started from `main`, this PR documents why it is a hotfix or production-only exception (not applicable; branch started from `dev`)

## Linked Issue

Closes #910

## Change Facts

- Normalize Process reference year and valid-until year to TIDAS integer storage while preserving invalid non-empty input for save-boundary diagnostics.
- Normalize Flow relative standard deviation and Process percentage fields to canonical TIDAS decimal-string storage, retaining zero values.
- Add one shared scalar-storage boundary and enforce it across Process and Flow create, update, and create-version entrypoints before persistence.
- Constrain year and percentage form controls to the TIDAS-compatible ranges and precision.
- Refresh generated locale delivery digests after the controlled source inventory changed.

## Validation Facts

- `npm run test:ci -- tests/unit/services/general/tidasScalarStorage.test.ts tests/unit/services/processes/util.test.ts tests/unit/services/processes/api.test.ts tests/unit/services/flows/util.test.ts tests/unit/services/flows/api.test.ts --runInBand --testTimeout=30000` — 5 suites / 364 tests passed.
- `npm run test:ci -- tests/unit/i18n/localeDeliveryContracts.test.ts --runInBand --testTimeout=30000` — 18 tests passed.
- `npm run test:ci -- tests/unit/pages/DataProcessing/index.test.tsx --runInBand --testTimeout=30000` — 73 tests passed.
- `npm run tsc`, `npm run lint`, and `npm run build` passed locally.
- `npm run push:checked -- fork HEAD:refs/heads/codex/fix-issue-910-tidas-scalar-storage` passed the immutable Docpact gate, static-data checks, lint/type checks, 38 receipt tests, and the full 421-suite / 5,736-test coverage gate.
- Full coverage remains 100% statements, branches, functions, and lines for 469 tracked source files.

## Risks And Follow-Up

- Invalid non-empty scalar values now fail closed with HTTP 400 and `TIDAS_SCALAR_VALIDATION_ERROR`; this is intentional to prevent malformed persisted JSON.
- Rollback is the two commits in this PR; no database migration or stored-row rewrite is included.
- After merge to `dev`, normal release promotion to child `main` is required before the root workspace can integrate the submodule pointer.
