### PR TITLE
fix: propagate edit mode to dataset forms

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-24"
-lastReviewedCommit: "4679f0ff6a34b41a5980376f9a883ddb4629728c"
+lastReviewedCommit: "97bdd539964fb800e52d0ae0625e9783f7337b7a"
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 / Ant Design 6 dependency, runtime, fixture, semantic-browser, and generated locale paths remain covered by the existing routing and testing contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
+lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
 lastReviewedNote: 'Reviewed for Next Issue #924: the exact React 19 / Ant Design 6 runtime, App feedback boundary, semantic UI slots, and regenerated locale evidence stay within existing repository ownership and branch policy.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/build.yml
   - .nvmrc
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
+lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
 lastReviewedNote: 'Reviewed for Next Issue #924: the React 19 / Ant Design 6 migration, semantic browser proof, and no-argument E2E resume parser fix use the existing install, Docpact, build, gate, and managed-push workflow.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -43,7 +43,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
+lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 / Ant Design 6 focused and browser evidence remains additive to the existing hook-owned full gate; no trigger or quality-bar change is required.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
+lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
 lastReviewedNote: 'Reviewed for Next Issue #924: the UI runtime now uses one React 19 / Ant Design 6 / ProComponents 3 generation with Umi-global App, theme, and non-component feedback registration.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -44,7 +44,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
+lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
 lastReviewedNote: 'Reviewed for Next Issue #924: Pro Components proof now closes 121 runtime instances and exercises responsive option strips, nested selectors, forms, layouts, and overlays.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -44,7 +44,7 @@ checkPaths:
   - pnpm-workspace.yaml
   - Dockerfile.app
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
+lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 / Ant Design 6 fixture migration, handle-free browser shims, and focused semantic proof extend the maintained validation model without reopening broader strategy work.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -41,7 +41,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
+lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
 lastReviewedNote: 'Reviewed for Next Issue #924: native Ant Design 6 App, Form.List, fixture, dependency, and semantic-browser proof preserve full-closure maintenance mode and create no compatibility queue.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
+lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
 lastReviewedNote: 'Reviewed for Next Issue #924: every shipped Pro Components JSX instance now maps to one explicit surface family with live static or browser evidence.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -40,7 +40,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
+lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 timing, App.useApp fixtures, Image/Drawer semantic API drift, MessageChannel handles, and locale artifact refresh now have explicit recovery guidance.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
-    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
+    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "bf04176d9c21a494c6f4805816fa676c9cba42fa88f7fd1216c898688e916f05",
+    "dossierDigest": "fa534f58078993dded15f645ede6935779ca8c2980e0072c41fec073ea8bc701",
     "catalogDigest": "09e1a503bd8add3c0b25f62a2ba1553d8fdeb75a027816ff98c304a9b2c7ad5e",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "c2c4f78cc1f9f9fab15f4560421ee316d6fab8969cb867982f474421bdc8174e"
+  "contextDigest": "f399e8844f0bee8d721b8e180b7bbb3727203780c8c7a95fd44d3e1a5940088e"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "c2c4f78cc1f9f9fab15f4560421ee316d6fab8969cb867982f474421bdc8174e",
-    "qualityDigest": "4e2e6929e7ac33ee44ef19ec4cac5cfb3b21ca5e27a58b03edc5efe66eed0f7b",
+    "contextDigest": "f399e8844f0bee8d721b8e180b7bbb3727203780c8c7a95fd44d3e1a5940088e",
+    "qualityDigest": "76d624c43ebde4162b7a42cd17436786394d0e1d011f99e21a1aa85746e41ba0",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "1d6fe925f15b36937aba6fe250e7f11405056b24f74b17e287e031d01f642d35"
+  "activationDigest": "1d742777a3ad4f3e703015fbe4e968b87db72f89b818d080982c8af437b7ee14"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048",
+    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
-    "contextDigest": "c2c4f78cc1f9f9fab15f4560421ee316d6fab8969cb867982f474421bdc8174e"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
+    "contextDigest": "f399e8844f0bee8d721b8e180b7bbb3727203780c8c7a95fd44d3e1a5940088e"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "8ea7a866f5373343855d2ac79faefd06808d7d8eec6d04cd66bb0669437bf6c9",
-    "validationDigest": "fe0921fcb4e7ade39c46babe60fdb3dd7327b165d54d9ddf04acf82eb96b6ffa",
+    "digest": "1be40ea60131588e261101dee1141ece2d9473631c640d0e020d0868020cc4c5",
+    "validationDigest": "0aaffaa949544c784c426410ffe5bf9b6bc3e98db60490f2328a01bf277e1182",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "4e2e6929e7ac33ee44ef19ec4cac5cfb3b21ca5e27a58b03edc5efe66eed0f7b"
+  "qualityDigest": "76d624c43ebde4162b7a42cd17436786394d0e1d011f99e21a1aa85746e41ba0"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048",
+    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "09e1a503bd8add3c0b25f62a2ba1553d8fdeb75a027816ff98c304a9b2c7ad5e",
-    "dossierDigest": "bf04176d9c21a494c6f4805816fa676c9cba42fa88f7fd1216c898688e916f05",
+    "dossierDigest": "fa534f58078993dded15f645ede6935779ca8c2980e0072c41fec073ea8bc701",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "bf04176d9c21a494c6f4805816fa676c9cba42fa88f7fd1216c898688e916f05",
+        "dossierDigest": "fa534f58078993dded15f645ede6935779ca8c2980e0072c41fec073ea8bc701",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "fe0921fcb4e7ade39c46babe60fdb3dd7327b165d54d9ddf04acf82eb96b6ffa"
+  "validationDigest": "0aaffaa949544c784c426410ffe5bf9b6bc3e98db60490f2328a01bf277e1182"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
-    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
+    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "35c48fae856f3352c7cedc0be6591ae71d4ae59bea6b42ad470d26dcdfc1355a",
+    "dossierDigest": "89bef4912e5f812171e55e4cbbc135e8e367bbad58cbe049edf6168fe26cc0ca",
     "catalogDigest": "93741a89fe46709918133c289bd4567e9261befb763495e91d6f667bb3595c83",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "4a1d1587226135ddc0e2b0033a3cefb3d19359ad5be07b9dda83b829159c5988"
+  "contextDigest": "df684ce6d280670ee1ebeb7af69b5e328a76f773a1f813842b04c5f21c2c679e"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4a1d1587226135ddc0e2b0033a3cefb3d19359ad5be07b9dda83b829159c5988",
-    "qualityDigest": "2cce778a94912ae0988c3907864d4f60f2c9feed31554ef4e68e8b4c48c7bcd5",
+    "contextDigest": "df684ce6d280670ee1ebeb7af69b5e328a76f773a1f813842b04c5f21c2c679e",
+    "qualityDigest": "e75b67af19fa4369aa58df071b9cacfabfb45d0daab25a79763cdc688e53bdc9",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "bb261fc1df53c04859c84e6a719258492f946c477bc4aa48a2a5e839ecfc7d43"
+  "activationDigest": "2a2c5a49b9cc10c5a0760817c30179077dedd48b4274a7445ae869c96e3b5b1f"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
-    "contextDigest": "4a1d1587226135ddc0e2b0033a3cefb3d19359ad5be07b9dda83b829159c5988"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
+    "contextDigest": "df684ce6d280670ee1ebeb7af69b5e328a76f773a1f813842b04c5f21c2c679e"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "7f4c12d31464c02717fad6b8c9e83f33170d4156a316c8aecd980fdbb6e28649",
-    "validationDigest": "b69d4e05e8ad01baecc0c05e487694c3a0120796b5dcb66817b3e116ee549a60",
+    "digest": "765d556e5ac3d248d7919f294764c99760800d41120ffee2bfad0a6a1ce0936d",
+    "validationDigest": "8ddde266f2ccb852022fc03e68ea8f7a1747d71c2b7b46922d9f9815c5899963",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "2cce778a94912ae0988c3907864d4f60f2c9feed31554ef4e68e8b4c48c7bcd5"
+  "qualityDigest": "e75b67af19fa4369aa58df071b9cacfabfb45d0daab25a79763cdc688e53bdc9"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048",
+    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "93741a89fe46709918133c289bd4567e9261befb763495e91d6f667bb3595c83",
-    "dossierDigest": "35c48fae856f3352c7cedc0be6591ae71d4ae59bea6b42ad470d26dcdfc1355a",
+    "dossierDigest": "89bef4912e5f812171e55e4cbbc135e8e367bbad58cbe049edf6168fe26cc0ca",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "35c48fae856f3352c7cedc0be6591ae71d4ae59bea6b42ad470d26dcdfc1355a",
+        "dossierDigest": "89bef4912e5f812171e55e4cbbc135e8e367bbad58cbe049edf6168fe26cc0ca",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "b69d4e05e8ad01baecc0c05e487694c3a0120796b5dcb66817b3e116ee549a60"
+  "validationDigest": "8ddde266f2ccb852022fc03e68ea8f7a1747d71c2b7b46922d9f9815c5899963"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
-    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
+    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "14e636b03791f59dc4aa9306f792e83939fb8631a03a904d453d3b9af1a9baa6",
+    "dossierDigest": "3a42aab00878ab536c7bf36c5b6e002c04ca95c98979c8cbdefe0457a82f5526",
     "catalogDigest": "24238218499ffff02768ab879d2c55877b656be79221b03b56b8d951d0f0068b",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "3ebc21810992cf565de4f920646be28a0fbc67cda9996f93dbfc55d44b810651"
+  "contextDigest": "8fd7559f292494a345765a3158204163ff97635ae5a796e961f01a12e604589e"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "3ebc21810992cf565de4f920646be28a0fbc67cda9996f93dbfc55d44b810651",
-    "qualityDigest": "999c6f191afc4ee0421b3706f52f7706fbb94e4a91241d9ecfa74396654f1cd6",
+    "contextDigest": "8fd7559f292494a345765a3158204163ff97635ae5a796e961f01a12e604589e",
+    "qualityDigest": "458ad10f6f3e1807d19101d3d8a0a6cb7aafa550dbe41cb9daf8d311fe451c79",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "e1ccbc815b688359b056553d8b238ce30539112e40b6eb18296f51ddffe445a1"
+  "activationDigest": "55afaa3f63df3d754b6473012bb39beba04f7f59e1d1c4d94cbe9498f49f6ae2"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
-    "contextDigest": "3ebc21810992cf565de4f920646be28a0fbc67cda9996f93dbfc55d44b810651"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
+    "contextDigest": "8fd7559f292494a345765a3158204163ff97635ae5a796e961f01a12e604589e"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "967b196ffbcf799fbd4aaa2f7fb57ede8b876a4ed91d9de514dd889acc4b2fa8",
-    "validationDigest": "921df1314634444420fd3bd769f98ae6055dcccfabd75e3b011a8105800b84b7",
+    "digest": "8dc723588f88a58a0897163574902cef0c17661cb8c9b493aaaced5cd72da45d",
+    "validationDigest": "95be742c64f8f9f0a135612bbcc27291a521bd3c1dfbcfca6b72f831775f520e",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "999c6f191afc4ee0421b3706f52f7706fbb94e4a91241d9ecfa74396654f1cd6"
+  "qualityDigest": "458ad10f6f3e1807d19101d3d8a0a6cb7aafa550dbe41cb9daf8d311fe451c79"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048",
+    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "24238218499ffff02768ab879d2c55877b656be79221b03b56b8d951d0f0068b",
-    "dossierDigest": "14e636b03791f59dc4aa9306f792e83939fb8631a03a904d453d3b9af1a9baa6",
+    "dossierDigest": "3a42aab00878ab536c7bf36c5b6e002c04ca95c98979c8cbdefe0457a82f5526",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "14e636b03791f59dc4aa9306f792e83939fb8631a03a904d453d3b9af1a9baa6",
+        "dossierDigest": "3a42aab00878ab536c7bf36c5b6e002c04ca95c98979c8cbdefe0457a82f5526",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "921df1314634444420fd3bd769f98ae6055dcccfabd75e3b011a8105800b84b7"
+  "validationDigest": "95be742c64f8f9f0a135612bbcc27291a521bd3c1dfbcfca6b72f831775f520e"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
-    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
+    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "f13b23880c443c15fac8e49abb6c9b1acb3580f5774e29c33264de92d52a6d9e",
+    "dossierDigest": "7a45e6ac1777353ccfc0ac886f659b00424365489a67ff41e1fe545122bea688",
     "catalogDigest": "a7934690a8abe6e2d5866a0542d6a0df3a9219136af620e7324431f1caf87cff",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "05f47b76918b5642761d51a591866e3a706c21f28e0c5dc5241a0316fb053053"
+  "contextDigest": "b875dd5e612f7800b1936a45978d0176cb8a4feb1ce030a4211c84dfeb9f9e1b"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "05f47b76918b5642761d51a591866e3a706c21f28e0c5dc5241a0316fb053053",
-    "qualityDigest": "9abf1ebd7a09ca9559ea3875520b0afba4975750e82b46d6d855ca86556d556f",
+    "contextDigest": "b875dd5e612f7800b1936a45978d0176cb8a4feb1ce030a4211c84dfeb9f9e1b",
+    "qualityDigest": "3fa390ff9c10ea649e33d6fa07ec8cd6f1227ce6660ee726533a0c7785df0624",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "07cf92451e944d4733ec55b06eb24069873d4073e256da042c0fc96136b69238"
+  "activationDigest": "f9c88f7d498412f7a1e1dafa1a915f4e5af5cda4e984ad31e03ff866c7e686ff"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
-    "contextDigest": "05f47b76918b5642761d51a591866e3a706c21f28e0c5dc5241a0316fb053053"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
+    "contextDigest": "b875dd5e612f7800b1936a45978d0176cb8a4feb1ce030a4211c84dfeb9f9e1b"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "bfc93617da9c196c43c39652f1d2526c0cf72cf6c6d3a231e7e19131f6b77a1a",
-    "validationDigest": "8421ca9d1c3cf87ef75a6cc951ef3bbb8e3ec9868108b3c7e90315156f1a02c7",
+    "digest": "bbe1b3bf0e50ce367203c8bb6bbf25d2bf530c3147e4e20b624da1b8bb7eed3f",
+    "validationDigest": "3fb3ef57b23a2b2d5c4137f2781e759ceae737804d4131bb7ab7ae3b3e146bd8",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "9abf1ebd7a09ca9559ea3875520b0afba4975750e82b46d6d855ca86556d556f"
+  "qualityDigest": "3fa390ff9c10ea649e33d6fa07ec8cd6f1227ce6660ee726533a0c7785df0624"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048",
+    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "a7934690a8abe6e2d5866a0542d6a0df3a9219136af620e7324431f1caf87cff",
-    "dossierDigest": "f13b23880c443c15fac8e49abb6c9b1acb3580f5774e29c33264de92d52a6d9e",
+    "dossierDigest": "7a45e6ac1777353ccfc0ac886f659b00424365489a67ff41e1fe545122bea688",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "f13b23880c443c15fac8e49abb6c9b1acb3580f5774e29c33264de92d52a6d9e",
+        "dossierDigest": "7a45e6ac1777353ccfc0ac886f659b00424365489a67ff41e1fe545122bea688",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "8421ca9d1c3cf87ef75a6cc951ef3bbb8e3ec9868108b3c7e90315156f1a02c7"
+  "validationDigest": "3fb3ef57b23a2b2d5c4137f2781e759ceae737804d4131bb7ab7ae3b3e146bd8"
 }

--- a/src/pages/Contacts/Components/edit.tsx
+++ b/src/pages/Contacts/Components/edit.tsx
@@ -808,6 +808,7 @@ const ContactEdit: FC<Props> = ({
               }}
             >
               <ContactForm
+                formType='edit'
                 lang={lang}
                 activeTabKey={activeTabKey}
                 formRef={formRefEdit}

--- a/src/pages/Flowproperties/Components/edit.tsx
+++ b/src/pages/Flowproperties/Components/edit.tsx
@@ -636,6 +636,7 @@ const FlowpropertiesEdit: FC<Props> = ({
               }}
             >
               <FlowpropertyForm
+                formType='edit'
                 lang={lang}
                 activeTabKey={activeTabKey}
                 drawerVisible={drawerVisible}

--- a/src/pages/Flows/Components/edit.tsx
+++ b/src/pages/Flows/Components/edit.tsx
@@ -742,6 +742,7 @@ const FlowsEdit: FC<Props> = ({
               }}
             >
               <FlowForm
+                formType='edit'
                 lang={lang}
                 activeTabKey={activeTabKey}
                 drawerVisible={drawerVisible}

--- a/src/pages/Processes/Components/edit.tsx
+++ b/src/pages/Processes/Components/edit.tsx
@@ -1292,6 +1292,7 @@ const ProcessEdit: FC<Props> = ({
               }}
             >
               <ProcessForm
+                formType='edit'
                 lang={lang}
                 activeTabKey={activeTabKey}
                 actionFrom={actionFrom}

--- a/src/pages/Sources/Components/edit.tsx
+++ b/src/pages/Sources/Components/edit.tsx
@@ -663,6 +663,7 @@ const SourceEdit: FC<Props> = ({
               }}
             >
               <SourceForm
+                formType='edit'
                 lang={lang}
                 activeTabKey={activeTabKey}
                 formRef={formRefEdit}

--- a/src/pages/Unitgroups/Components/edit.tsx
+++ b/src/pages/Unitgroups/Components/edit.tsx
@@ -686,6 +686,7 @@ const UnitGroupEdit: FC<Props> = ({
               }}
             >
               <UnitGroupForm
+                formType='edit'
                 lang={lang}
                 activeTabKey={activeTabKey}
                 formRef={formRefEdit}

--- a/tests/unit/pages/Contacts/ContactEdit.test.tsx
+++ b/tests/unit/pages/Contacts/ContactEdit.test.tsx
@@ -591,6 +591,7 @@ describe('ContactEdit component', () => {
     await waitFor(() =>
       expect(mockGetContactDetail).toHaveBeenCalledWith('contact-123', '01.00.000'),
     );
+    expect(latestContactFormProps.formType).toBe('edit');
 
     const shortNameInput = within(drawer).getByDisplayValue('Original contact');
     await user.clear(shortNameInput);

--- a/tests/unit/pages/Flowproperties/edit.test.tsx
+++ b/tests/unit/pages/Flowproperties/edit.test.tsx
@@ -436,6 +436,7 @@ describe('FlowpropertiesEdit', () => {
     await userEvent.click(screen.getByRole('button', { name: /edit/i }));
 
     await waitFor(() => expect(mockGetFlowpropertyDetail).toHaveBeenCalledWith('fp-1', '1.0.0'));
+    expect(latestFlowpropertyFormProps.formType).toBe('edit');
 
     const nameInput = await screen.findByLabelText(/flow property name/i);
     await userEvent.clear(nameInput);

--- a/tests/unit/pages/Flows/Components/edit.test.tsx
+++ b/tests/unit/pages/Flows/Components/edit.test.tsx
@@ -548,6 +548,7 @@ describe('FlowsEdit', () => {
 
     await waitFor(() => expect(mockGetFlowDetail).toHaveBeenCalledWith('flow-1', '1.0.0'));
     expect(await screen.findByTestId('flow-form')).toBeInTheDocument();
+    expect(latestFlowFormProps.formType).toBe('edit');
 
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
 

--- a/tests/unit/pages/Processes/Components/edit.test.tsx
+++ b/tests/unit/pages/Processes/Components/edit.test.tsx
@@ -497,6 +497,7 @@ describe('ProcessEdit component', () => {
     });
 
     expect(latestProcessFormProps).toBeTruthy();
+    expect(latestProcessFormProps.formType).toBe('edit');
 
     const currentValues = proFormApi?.getFieldsValue() ?? {};
     await act(async () => {

--- a/tests/unit/pages/Sources/SourceEdit.test.tsx
+++ b/tests/unit/pages/Sources/SourceEdit.test.tsx
@@ -590,6 +590,7 @@ describe('SourceEdit component', () => {
     await user.click(screen.getByRole('button', { name: 'Edit' }));
 
     const drawer = await screen.findByRole('dialog', { name: 'Edit Source' });
+    expect(latestSourceFormProps.formType).toBe('edit');
 
     const shortNameInput = within(drawer).getByLabelText('Short Name');
     await user.clear(shortNameInput);

--- a/tests/unit/pages/Unitgroups/Components/edit.test.tsx
+++ b/tests/unit/pages/Unitgroups/Components/edit.test.tsx
@@ -15,6 +15,7 @@ const toText = (node: any): string => {
 };
 
 let latestRefsDrawerProps: any = null;
+let latestUnitGroupFormProps: any = null;
 const mockParentRefCheckContext = { refCheckData: [] as any[] };
 let mockProblemNodes: any = [];
 const mockIntl = {
@@ -313,61 +314,59 @@ jest.mock(
 
 jest.mock('@/pages/Unitgroups/Components/form', () => ({
   __esModule: true,
-  UnitGroupForm: ({
-    unitDataSource,
-    onTabChange,
-    onData,
-    onUnitData,
-    onUnitDataCreate,
-    formRef,
-  }: any) => (
-    <div>
-      <div>{`unit-group-form-${unitDataSource?.length ?? 0}`}</div>
-      <button type='button' onClick={() => onTabChange?.('customTab')}>
-        switch-custom-tab
-      </button>
-      <button type='button' onClick={() => onData?.()}>
-        sync-tab-data
-      </button>
-      <button
-        type='button'
-        onClick={() =>
-          onUnitData?.([
-            {
-              '@dataSetInternalID': '9',
-              name: 'g',
-              quantitativeReference: true,
-            },
-          ])
-        }
-      >
-        replace-units
-      </button>
-      <button
-        type='button'
-        onClick={() =>
-          onUnitDataCreate?.({
-            name: 'lb',
-            quantitativeReference: false,
-          })
-        }
-      >
-        create-unit
-      </button>
-      <button
-        type='button'
-        onClick={() => formRef?.current?.setFieldsValue({ anotherTab: { note: 'x' } })}
-      >
-        push-form-values
-      </button>
-    </div>
-  ),
+  UnitGroupForm: (props: any) => {
+    latestUnitGroupFormProps = props;
+    const { unitDataSource, onTabChange, onData, onUnitData, onUnitDataCreate, formRef } = props;
+    return (
+      <div>
+        <div>{`unit-group-form-${unitDataSource?.length ?? 0}`}</div>
+        <button type='button' onClick={() => onTabChange?.('customTab')}>
+          switch-custom-tab
+        </button>
+        <button type='button' onClick={() => onData?.()}>
+          sync-tab-data
+        </button>
+        <button
+          type='button'
+          onClick={() =>
+            onUnitData?.([
+              {
+                '@dataSetInternalID': '9',
+                name: 'g',
+                quantitativeReference: true,
+              },
+            ])
+          }
+        >
+          replace-units
+        </button>
+        <button
+          type='button'
+          onClick={() =>
+            onUnitDataCreate?.({
+              name: 'lb',
+              quantitativeReference: false,
+            })
+          }
+        >
+          create-unit
+        </button>
+        <button
+          type='button'
+          onClick={() => formRef?.current?.setFieldsValue({ anotherTab: { note: 'x' } })}
+        >
+          push-form-values
+        </button>
+      </div>
+    );
+  },
 }));
 
 describe('UnitGroupEdit', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     latestRefsDrawerProps = null;
+    latestUnitGroupFormProps = null;
     mockProblemNodes = [];
     mockEnrichValidationIssuesWithOwner.mockImplementation(async (issues: any[]) => issues);
     mockGenUnitGroupFromData.mockImplementation(() => generatedUnitGroup);
@@ -403,6 +402,7 @@ describe('UnitGroupEdit', () => {
     await waitFor(() =>
       expect(mockGetUnitGroupDetail).toHaveBeenCalledWith('unitgroup-1', '1.0.0'),
     );
+    expect(latestUnitGroupFormProps.formType).toBe('edit');
     expect(screen.getByText('unit-group-form-1')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

- propagate `formType="edit"` from the Contact, Source, Unit Group, Flow Property, Flow, and Process edit entrypoints
- keep the existing Lifecycle Model path unchanged because it already propagates edit mode correctly
- add entrypoint-level regression assertions so the dataset version field cannot silently become editable again

## Root cause

PR #930 disabled each form's dataset-version control when `formType === "edit"`, but six edit entrypoints did not pass `formType`. Their forms therefore received `undefined`, so the version field remained editable.

## Validation

- 13 focused edit/form suites: 313 tests passed
- `pnpm i18n:audit`
- `pnpm lint`
- `pnpm build`
- Docpact enforce lint: no uncovered, stale, or unreviewed findings
- managed pre-push gate: 433 suites / 5,797 tests passed; 476/476 tracked source files at 100% statements, branches, functions, and lines

## Risk

Low. The runtime change only supplies the existing edit-mode discriminator at the six missing edit boundaries. Create and create-version paths are unchanged.

Closes #929
