### PR TITLE
chore: promote v0.0.85 dev to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-22"
-lastReviewedCommit: "0047e79e83db054a95843b8ed934da048ad741f7"
+lastReviewedAt: "2026-08-24"
+lastReviewedCommit: "4679f0ff6a34b41a5980376f9a883ddb4629728c"
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 / Ant Design 6 dependency, runtime, fixture, semantic-browser, and generated locale paths remain covered by the existing routing and testing contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-24"
-lastReviewedCommit: "91c3cedca29e7ab3aadf331bd2f177009b4580d2"
+lastReviewedCommit: "36505f132116e624aa8a5f2409c7651dfa208b5f"
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 / Ant Design 6 dependency, runtime, fixture, semantic-browser, and generated locale paths remain covered by the existing routing and testing contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-24"
-lastReviewedCommit: "97bdd539964fb800e52d0ae0625e9783f7337b7a"
+lastReviewedCommit: "91c3cedca29e7ab3aadf331bd2f177009b4580d2"
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 / Ant Design 6 dependency, runtime, fixture, semantic-browser, and generated locale paths remain covered by the existing routing and testing contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-24"
-lastReviewedCommit: "4679f0ff6a34b41a5980376f9a883ddb4629728c"
+lastReviewedCommit: "97bdd539964fb800e52d0ae0625e9783f7337b7a"
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 / Ant Design 6 dependency, runtime, fixture, semantic-browser, and generated locale paths remain covered by the existing routing and testing contracts.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 91c3cedca29e7ab3aadf331bd2f177009b4580d2
+lastReviewedCommit: 36505f132116e624aa8a5f2409c7651dfa208b5f
 lastReviewedNote: 'Reviewed for Next Issue #924: the exact React 19 / Ant Design 6 runtime, App feedback boundary, semantic UI slots, and regenerated locale evidence stay within existing repository ownership and branch policy.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
+lastReviewedCommit: 91c3cedca29e7ab3aadf331bd2f177009b4580d2
 lastReviewedNote: 'Reviewed for Next Issue #924: the exact React 19 / Ant Design 6 runtime, App feedback boundary, semantic UI slots, and regenerated locale evidence stay within existing repository ownership and branch policy.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-08-22
-lastReviewedCommit: 0047e79e83db054a95843b8ed934da048ad741f7
+lastReviewedAt: 2026-08-24
+lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
 lastReviewedNote: 'Reviewed for Next Issue #924: the exact React 19 / Ant Design 6 runtime, App feedback boundary, semantic UI slots, and regenerated locale evidence stay within existing repository ownership and branch policy.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
+lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
 lastReviewedNote: 'Reviewed for Next Issue #924: the exact React 19 / Ant Design 6 runtime, App feedback boundary, semantic UI slots, and regenerated locale evidence stay within existing repository ownership and branch policy.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -42,8 +42,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .github/workflows/build.yml
   - .nvmrc
-lastReviewedAt: 2026-08-22
-lastReviewedCommit: 0047e79e83db054a95843b8ed934da048ad741f7
+lastReviewedAt: 2026-08-24
+lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
 lastReviewedNote: 'Reviewed for Next Issue #924: the React 19 / Ant Design 6 migration, semantic browser proof, and no-argument E2E resume parser fix use the existing install, Docpact, build, gate, and managed-push workflow.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/build.yml
   - .nvmrc
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
+lastReviewedCommit: 91c3cedca29e7ab3aadf331bd2f177009b4580d2
 lastReviewedNote: 'Reviewed for Next Issue #924: the React 19 / Ant Design 6 migration, semantic browser proof, and no-argument E2E resume parser fix use the existing install, Docpact, build, gate, and managed-push workflow.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/build.yml
   - .nvmrc
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 91c3cedca29e7ab3aadf331bd2f177009b4580d2
+lastReviewedCommit: 36505f132116e624aa8a5f2409c7651dfa208b5f
 lastReviewedNote: 'Reviewed for Next Issue #924: the React 19 / Ant Design 6 migration, semantic browser proof, and no-argument E2E resume parser fix use the existing install, Docpact, build, gate, and managed-push workflow.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/build.yml
   - .nvmrc
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
+lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
 lastReviewedNote: 'Reviewed for Next Issue #924: the React 19 / Ant Design 6 migration, semantic browser proof, and no-argument E2E resume parser fix use the existing install, Docpact, build, gate, and managed-push workflow.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -43,7 +43,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 91c3cedca29e7ab3aadf331bd2f177009b4580d2
+lastReviewedCommit: 36505f132116e624aa8a5f2409c7651dfa208b5f
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 / Ant Design 6 focused and browser evidence remains additive to the existing hook-owned full gate; no trigger or quality-bar change is required.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -42,8 +42,8 @@ checkPaths:
   - scripts/typescript-native-parser.*
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-08-22
-lastReviewedCommit: 0047e79e83db054a95843b8ed934da048ad741f7
+lastReviewedAt: 2026-08-24
+lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 / Ant Design 6 focused and browser evidence remains additive to the existing hook-owned full gate; no trigger or quality-bar change is required.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -43,7 +43,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
+lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 / Ant Design 6 focused and browser evidence remains additive to the existing hook-owned full gate; no trigger or quality-bar change is required.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -43,7 +43,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
+lastReviewedCommit: 91c3cedca29e7ab3aadf331bd2f177009b4580d2
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 / Ant Design 6 focused and browser evidence remains additive to the existing hook-owned full gate; no trigger or quality-bar change is required.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
+lastReviewedCommit: 91c3cedca29e7ab3aadf331bd2f177009b4580d2
 lastReviewedNote: 'Reviewed for Next Issue #924: the UI runtime now uses one React 19 / Ant Design 6 / ProComponents 3 generation with Umi-global App, theme, and non-component feedback registration.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
+lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
 lastReviewedNote: 'Reviewed for Next Issue #924: the UI runtime now uses one React 19 / Ant Design 6 / ProComponents 3 generation with Umi-global App, theme, and non-component feedback registration.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - playwright.config.ts
   - config/docs-capture/**
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-08-22
-lastReviewedCommit: a5279243f4c1d22ee00c50ed92787614d585800c
+lastReviewedAt: 2026-08-24
+lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
 lastReviewedNote: 'Reviewed for Next Issue #924: the UI runtime now uses one React 19 / Ant Design 6 / ProComponents 3 generation with Umi-global App, theme, and non-component feedback registration.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -44,7 +44,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
+lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
 lastReviewedNote: 'Reviewed for Next Issue #924: Pro Components proof now closes 121 runtime instances and exercises responsive option strips, nested selectors, forms, layouts, and overlays.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -44,7 +44,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
+lastReviewedCommit: 91c3cedca29e7ab3aadf331bd2f177009b4580d2
 lastReviewedNote: 'Reviewed for Next Issue #924: Pro Components proof now closes 121 runtime instances and exercises responsive option strips, nested selectors, forms, layouts, and overlays.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -43,8 +43,8 @@ checkPaths:
   - scripts/typescript-native-parser.*
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-08-22
-lastReviewedCommit: 0047e79e83db054a95843b8ed934da048ad741f7
+lastReviewedAt: 2026-08-24
+lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
 lastReviewedNote: 'Reviewed for Next Issue #924: Pro Components proof now closes 121 runtime instances and exercises responsive option strips, nested selectors, forms, layouts, and overlays.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -44,7 +44,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 91c3cedca29e7ab3aadf331bd2f177009b4580d2
+lastReviewedCommit: 36505f132116e624aa8a5f2409c7651dfa208b5f
 lastReviewedNote: 'Reviewed for Next Issue #924: Pro Components proof now closes 121 runtime instances and exercises responsive option strips, nested selectors, forms, layouts, and overlays.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -44,7 +44,7 @@ checkPaths:
   - pnpm-workspace.yaml
   - Dockerfile.app
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
+lastReviewedCommit: 91c3cedca29e7ab3aadf331bd2f177009b4580d2
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 / Ant Design 6 fixture migration, handle-free browser shims, and focused semantic proof extend the maintained validation model without reopening broader strategy work.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -43,8 +43,8 @@ checkPaths:
   - pnpm-lock.yaml
   - pnpm-workspace.yaml
   - Dockerfile.app
-lastReviewedAt: 2026-08-22
-lastReviewedCommit: 0047e79e83db054a95843b8ed934da048ad741f7
+lastReviewedAt: 2026-08-24
+lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 / Ant Design 6 fixture migration, handle-free browser shims, and focused semantic proof extend the maintained validation model without reopening broader strategy work.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -44,7 +44,7 @@ checkPaths:
   - pnpm-workspace.yaml
   - Dockerfile.app
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
+lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 / Ant Design 6 fixture migration, handle-free browser shims, and focused semantic proof extend the maintained validation model without reopening broader strategy work.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -44,7 +44,7 @@ checkPaths:
   - pnpm-workspace.yaml
   - Dockerfile.app
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 91c3cedca29e7ab3aadf331bd2f177009b4580d2
+lastReviewedCommit: 36505f132116e624aa8a5f2409c7651dfa208b5f
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 / Ant Design 6 fixture migration, handle-free browser shims, and focused semantic proof extend the maintained validation model without reopening broader strategy work.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -41,7 +41,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
+lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
 lastReviewedNote: 'Reviewed for Next Issue #924: native Ant Design 6 App, Form.List, fixture, dependency, and semantic-browser proof preserve full-closure maintenance mode and create no compatibility queue.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -41,7 +41,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
+lastReviewedCommit: 91c3cedca29e7ab3aadf331bd2f177009b4580d2
 lastReviewedNote: 'Reviewed for Next Issue #924: native Ant Design 6 App, Form.List, fixture, dependency, and semantic-browser proof preserve full-closure maintenance mode and create no compatibility queue.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -40,8 +40,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-22
-lastReviewedCommit: 0047e79e83db054a95843b8ed934da048ad741f7
+lastReviewedAt: 2026-08-24
+lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
 lastReviewedNote: 'Reviewed for Next Issue #924: native Ant Design 6 App, Form.List, fixture, dependency, and semantic-browser proof preserve full-closure maintenance mode and create no compatibility queue.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -41,7 +41,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 91c3cedca29e7ab3aadf331bd2f177009b4580d2
+lastReviewedCommit: 36505f132116e624aa8a5f2409c7651dfa208b5f
 lastReviewedNote: 'Reviewed for Next Issue #924: native Ant Design 6 App, Form.List, fixture, dependency, and semantic-browser proof preserve full-closure maintenance mode and create no compatibility queue.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
+lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
 lastReviewedNote: 'Reviewed for Next Issue #924: every shipped Pro Components JSX instance now maps to one explicit surface family with live static or browser evidence.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -42,8 +42,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-22
-lastReviewedCommit: 0047e79e83db054a95843b8ed934da048ad741f7
+lastReviewedAt: 2026-08-24
+lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
 lastReviewedNote: 'Reviewed for Next Issue #924: every shipped Pro Components JSX instance now maps to one explicit surface family with live static or browser evidence.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 91c3cedca29e7ab3aadf331bd2f177009b4580d2
+lastReviewedCommit: 36505f132116e624aa8a5f2409c7651dfa208b5f
 lastReviewedNote: 'Reviewed for Next Issue #924: every shipped Pro Components JSX instance now maps to one explicit surface family with live static or browser evidence.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
+lastReviewedCommit: 91c3cedca29e7ab3aadf331bd2f177009b4580d2
 lastReviewedNote: 'Reviewed for Next Issue #924: every shipped Pro Components JSX instance now maps to one explicit surface family with live static or browser evidence.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -39,8 +39,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-22
-lastReviewedCommit: 0047e79e83db054a95843b8ed934da048ad741f7
+lastReviewedAt: 2026-08-24
+lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 timing, App.useApp fixtures, Image/Drawer semantic API drift, MessageChannel handles, and locale artifact refresh now have explicit recovery guidance.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -40,7 +40,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 91c3cedca29e7ab3aadf331bd2f177009b4580d2
+lastReviewedCommit: 36505f132116e624aa8a5f2409c7651dfa208b5f
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 timing, App.useApp fixtures, Image/Drawer semantic API drift, MessageChannel handles, and locale artifact refresh now have explicit recovery guidance.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -40,7 +40,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 4679f0ff6a34b41a5980376f9a883ddb4629728c
+lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 timing, App.useApp fixtures, Image/Drawer semantic API drift, MessageChannel handles, and locale artifact refresh now have explicit recovery guidance.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -40,7 +40,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-24
-lastReviewedCommit: 97bdd539964fb800e52d0ae0625e9783f7337b7a
+lastReviewedCommit: 91c3cedca29e7ab3aadf331bd2f177009b4580d2
 lastReviewedNote: 'Reviewed for Next Issue #924: React 19 timing, App.useApp fixtures, Image/Drawer semantic API drift, MessageChannel handles, and locale artifact refresh now have explicit recovery guidance.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
-    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf"
+    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a",
+    "auditedInputDigest": "13cc24a019981b3decf8ea5f147355bd4ad5d5b1398cb2acac273d06c5dcc473"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "fa534f58078993dded15f645ede6935779ca8c2980e0072c41fec073ea8bc701",
+    "dossierDigest": "4a87832627fe7b25ba0a994608f6597b3dd924dcb1bb617b7295a259ddf93ae5",
     "catalogDigest": "09e1a503bd8add3c0b25f62a2ba1553d8fdeb75a027816ff98c304a9b2c7ad5e",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "f399e8844f0bee8d721b8e180b7bbb3727203780c8c7a95fd44d3e1a5940088e"
+  "contextDigest": "ff244a5d18fac5be02e5ba7b28fcf703a255409fcedab59545e47f9a0deaa135"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
-    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
+    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "bf04176d9c21a494c6f4805816fa676c9cba42fa88f7fd1216c898688e916f05",
+    "dossierDigest": "fa534f58078993dded15f645ede6935779ca8c2980e0072c41fec073ea8bc701",
     "catalogDigest": "09e1a503bd8add3c0b25f62a2ba1553d8fdeb75a027816ff98c304a9b2c7ad5e",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "c2c4f78cc1f9f9fab15f4560421ee316d6fab8969cb867982f474421bdc8174e"
+  "contextDigest": "f399e8844f0bee8d721b8e180b7bbb3727203780c8c7a95fd44d3e1a5940088e"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf",
-    "auditedInputDigest": "79845f56bea6cc39301a7f26dae9c52567dedf9bacaa1465bcfe003a4f50d80c"
+    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
+    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "bc8b45fbba753cd69d2db9c79fa514cce500bf703d618e38340fc03cc87e171b",
+    "dossierDigest": "bf04176d9c21a494c6f4805816fa676c9cba42fa88f7fd1216c898688e916f05",
     "catalogDigest": "09e1a503bd8add3c0b25f62a2ba1553d8fdeb75a027816ff98c304a9b2c7ad5e",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "1d769f5f065ac9909d0f0ff6f6c81bc4c7ab41ce1ded21a5cba85ca5b86694ad"
+  "contextDigest": "c2c4f78cc1f9f9fab15f4560421ee316d6fab8969cb867982f474421bdc8174e"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "0e40f2fc8c4f251d89397744e4465cab858189b875f732a92ea3ce7700b96bd9",
-    "auditedInputDigest": "3ef83dc31fb624ac532c00805d67c2da56aac6db36a427afc7d88e211d61afb0"
+    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf",
+    "auditedInputDigest": "79845f56bea6cc39301a7f26dae9c52567dedf9bacaa1465bcfe003a4f50d80c"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "d392e24d8efebe912b4c6e839f3c21e9fef447b5bf6e8f1d0c4b657349573eef",
+    "dossierDigest": "bc8b45fbba753cd69d2db9c79fa514cce500bf703d618e38340fc03cc87e171b",
     "catalogDigest": "09e1a503bd8add3c0b25f62a2ba1553d8fdeb75a027816ff98c304a9b2c7ad5e",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "2b27f88d182d1007ac8a8dbda431bb889cd637fc12175f021037b2a848a3a6a5"
+  "contextDigest": "1d769f5f065ac9909d0f0ff6f6c81bc4c7ab41ce1ded21a5cba85ca5b86694ad"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "c2c4f78cc1f9f9fab15f4560421ee316d6fab8969cb867982f474421bdc8174e",
-    "qualityDigest": "4e2e6929e7ac33ee44ef19ec4cac5cfb3b21ca5e27a58b03edc5efe66eed0f7b",
+    "contextDigest": "f399e8844f0bee8d721b8e180b7bbb3727203780c8c7a95fd44d3e1a5940088e",
+    "qualityDigest": "76d624c43ebde4162b7a42cd17436786394d0e1d011f99e21a1aa85746e41ba0",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "1d6fe925f15b36937aba6fe250e7f11405056b24f74b17e287e031d01f642d35"
+  "activationDigest": "1d742777a3ad4f3e703015fbe4e968b87db72f89b818d080982c8af437b7ee14"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0e40f2fc8c4f251d89397744e4465cab858189b875f732a92ea3ce7700b96bd9"
+    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "2b27f88d182d1007ac8a8dbda431bb889cd637fc12175f021037b2a848a3a6a5",
-    "qualityDigest": "12c9031f62fc72e175e0f1d1f3f9ffd72dadcb63322eab02b76cd393158d7c54",
+    "contextDigest": "1d769f5f065ac9909d0f0ff6f6c81bc4c7ab41ce1ded21a5cba85ca5b86694ad",
+    "qualityDigest": "2f75c2b64faa86c92ab08ef1a49334be19fb9449299a9259aed19044cce5d3c1",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "01ccfb3d3c9520bfaf18b516c36b1777782ba3f7d6d966e6aa516b62fd3d887a"
+  "activationDigest": "361505deefa8f0c22d3437966dfeee818187e47e779969f9800bcf91489059c3"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf"
+    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "1d769f5f065ac9909d0f0ff6f6c81bc4c7ab41ce1ded21a5cba85ca5b86694ad",
-    "qualityDigest": "2f75c2b64faa86c92ab08ef1a49334be19fb9449299a9259aed19044cce5d3c1",
+    "contextDigest": "c2c4f78cc1f9f9fab15f4560421ee316d6fab8969cb867982f474421bdc8174e",
+    "qualityDigest": "4e2e6929e7ac33ee44ef19ec4cac5cfb3b21ca5e27a58b03edc5efe66eed0f7b",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "361505deefa8f0c22d3437966dfeee818187e47e779969f9800bcf91489059c3"
+  "activationDigest": "1d6fe925f15b36937aba6fe250e7f11405056b24f74b17e287e031d01f642d35"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60"
+    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "f399e8844f0bee8d721b8e180b7bbb3727203780c8c7a95fd44d3e1a5940088e",
-    "qualityDigest": "76d624c43ebde4162b7a42cd17436786394d0e1d011f99e21a1aa85746e41ba0",
+    "contextDigest": "ff244a5d18fac5be02e5ba7b28fcf703a255409fcedab59545e47f9a0deaa135",
+    "qualityDigest": "39945b26253ec3b6b3455d2e2c310d72c9465f31b41b6bbab24f98eee1d10c25",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "1d742777a3ad4f3e703015fbe4e968b87db72f89b818d080982c8af437b7ee14"
+  "activationDigest": "057dac92963eab8483606885c86f47a1c78edb50a7d54c6957578ad369516b10"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "79845f56bea6cc39301a7f26dae9c52567dedf9bacaa1465bcfe003a4f50d80c",
+    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048",
+    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf",
+    "auditedInputDigest": "13cc24a019981b3decf8ea5f147355bd4ad5d5b1398cb2acac273d06c5dcc473",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -11988,7 +11988,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/components/RightContent/AvatarDropdown.tsx",
-          "line": 312,
+          "line": 320,
           "column": 16,
           "symbol": "AvatarDropdown",
           "defaultMessage": "All Teams",
@@ -12015,7 +12015,7 @@
             },
             {
               "path": "src/components/RightContent/AvatarDropdown.tsx",
-              "line": 312,
+              "line": 320,
               "column": 16,
               "kind": "FormattedMessage"
             }
@@ -24414,7 +24414,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/components/RightContent/AvatarDropdown.tsx",
-          "line": 283,
+          "line": 291,
           "column": 14,
           "symbol": "menuItems",
           "defaultMessage": "Logout",
@@ -24429,7 +24429,7 @@
           "locations": [
             {
               "path": "src/components/RightContent/AvatarDropdown.tsx",
-              "line": 283,
+              "line": 291,
               "column": 14,
               "kind": "FormattedMessage"
             }
@@ -24615,7 +24615,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/components/RightContent/AvatarDropdown.tsx",
-          "line": 255,
+          "line": 260,
           "column": 14,
           "symbol": "menuItems",
           "defaultMessage": "Account Profile",
@@ -24639,7 +24639,7 @@
           "locations": [
             {
               "path": "src/components/RightContent/AvatarDropdown.tsx",
-              "line": 255,
+              "line": 260,
               "column": 14,
               "kind": "FormattedMessage"
             },
@@ -24713,8 +24713,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/components/RightContent/AvatarDropdown.tsx",
-          "line": 274,
-          "column": 14,
+          "line": 281,
+          "column": 20,
           "symbol": "menuItems",
           "defaultMessage": "Review Management",
           "defaultMessageExpression": null
@@ -24728,8 +24728,8 @@
           "locations": [
             {
               "path": "src/components/RightContent/AvatarDropdown.tsx",
-              "line": 274,
-              "column": 14,
+              "line": 281,
+              "column": 20,
               "kind": "FormattedMessage"
             }
           ]
@@ -24855,7 +24855,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/components/RightContent/AvatarDropdown.tsx",
-          "line": 260,
+          "line": 265,
           "column": 14,
           "symbol": "menuItems",
           "defaultMessage": "My Team",
@@ -24888,7 +24888,7 @@
           "locations": [
             {
               "path": "src/components/RightContent/AvatarDropdown.tsx",
-              "line": 260,
+              "line": 265,
               "column": 14,
               "kind": "FormattedMessage"
             },
@@ -27798,8 +27798,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/components/RightContent/AvatarDropdown.tsx",
-          "line": 265,
-          "column": 14,
+          "line": 272,
+          "column": 20,
           "symbol": "menuItems",
           "defaultMessage": "System Management",
           "defaultMessageExpression": null
@@ -27831,8 +27831,8 @@
           "locations": [
             {
               "path": "src/components/RightContent/AvatarDropdown.tsx",
-              "line": 265,
-              "column": 14,
+              "line": 272,
+              "column": 20,
               "kind": "FormattedMessage"
             },
             {

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "3ef83dc31fb624ac532c00805d67c2da56aac6db36a427afc7d88e211d61afb0",
+    "auditedInputDigest": "79845f56bea6cc39301a7f26dae9c52567dedf9bacaa1465bcfe003a4f50d80c",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -74,7 +74,7 @@
     "activeStaticKeyCount": 2140,
     "activeDynamicKeyCount": 306,
     "reservedKeyCount": 762,
-    "productionSourceFileCount": 447,
+    "productionSourceFileCount": 448,
     "literalReferenceCount": 4150,
     "dynamicCallsiteCount": 32,
     "dynamicCallsiteSummaryCount": 32,
@@ -32735,7 +32735,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Sources/Components/edit.tsx",
-          "line": 332,
+          "line": 333,
           "column": 9,
           "symbol": "handleSubmit",
           "defaultMessage": "Data saved successfully.",
@@ -32750,7 +32750,7 @@
           "locations": [
             {
               "path": "src/pages/Sources/Components/edit.tsx",
-              "line": 332,
+              "line": 333,
               "column": 9,
               "kind": "formatMessage"
             }
@@ -41305,7 +41305,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 669,
+          "line": 671,
           "column": 13,
           "symbol": "handleSyncToOpenData",
           "defaultMessage": "Action failed",
@@ -41326,7 +41326,7 @@
             },
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 669,
+              "line": 671,
               "column": 13,
               "kind": "formatMessage"
             }
@@ -41769,8 +41769,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 768,
-          "column": 15,
+          "line": 771,
+          "column": 17,
           "symbol": "ContactEdit",
           "defaultMessage": "Cancel",
           "defaultMessageExpression": null
@@ -41796,8 +41796,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/Components/edit.tsx",
-          "line": 595,
-          "column": 15,
+          "line": 598,
+          "column": 17,
           "symbol": "FlowpropertiesEdit",
           "defaultMessage": "Cancel",
           "defaultMessageExpression": null
@@ -41823,8 +41823,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flows/Components/edit.tsx",
-          "line": 701,
-          "column": 15,
+          "line": 704,
+          "column": 17,
           "symbol": "FlowsEdit",
           "defaultMessage": "Cancel",
           "defaultMessageExpression": null
@@ -41922,8 +41922,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 1221,
-          "column": 15,
+          "line": 1224,
+          "column": 17,
           "symbol": "ProcessEdit",
           "defaultMessage": "Cancel",
           "defaultMessageExpression": null
@@ -41994,8 +41994,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Sources/Components/edit.tsx",
-          "line": 623,
-          "column": 15,
+          "line": 626,
+          "column": 17,
           "symbol": "SourceEdit",
           "defaultMessage": "Cancel",
           "defaultMessageExpression": null
@@ -42021,8 +42021,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/Components/edit.tsx",
-          "line": 643,
-          "column": 15,
+          "line": 646,
+          "column": 17,
           "symbol": "UnitGroupEdit",
           "defaultMessage": "Cancel",
           "defaultMessageExpression": null
@@ -42081,8 +42081,8 @@
             },
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 768,
-              "column": 15,
+              "line": 771,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
@@ -42099,8 +42099,8 @@
             },
             {
               "path": "src/pages/Flowproperties/Components/edit.tsx",
-              "line": 595,
-              "column": 15,
+              "line": 598,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
@@ -42117,8 +42117,8 @@
             },
             {
               "path": "src/pages/Flows/Components/edit.tsx",
-              "line": 701,
-              "column": 15,
+              "line": 704,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
@@ -42183,8 +42183,8 @@
             },
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 1221,
-              "column": 15,
+              "line": 1224,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
@@ -42231,8 +42231,8 @@
             },
             {
               "path": "src/pages/Sources/Components/edit.tsx",
-              "line": 623,
-              "column": 15,
+              "line": 626,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
@@ -42249,8 +42249,8 @@
             },
             {
               "path": "src/pages/Unitgroups/Components/edit.tsx",
-              "line": 643,
-              "column": 15,
+              "line": 646,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
@@ -42335,8 +42335,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 732,
-          "column": 15,
+          "line": 735,
+          "column": 17,
           "symbol": "ContactEdit",
           "defaultMessage": "Data Check",
           "defaultMessageExpression": null
@@ -42344,8 +42344,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/Components/edit.tsx",
-          "line": 569,
-          "column": 15,
+          "line": 572,
+          "column": 17,
           "symbol": "FlowpropertiesEdit",
           "defaultMessage": "Data Check",
           "defaultMessageExpression": null
@@ -42353,8 +42353,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flows/Components/edit.tsx",
-          "line": 675,
-          "column": 15,
+          "line": 678,
+          "column": 17,
           "symbol": "FlowsEdit",
           "defaultMessage": "Data Check",
           "defaultMessageExpression": null
@@ -42362,8 +42362,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 1896,
-          "column": 16,
+          "line": 1902,
+          "column": 18,
           "symbol": "ToolbarEdit",
           "defaultMessage": "Data Check",
           "defaultMessageExpression": null
@@ -42371,8 +42371,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 1196,
-          "column": 15,
+          "line": 1199,
+          "column": 17,
           "symbol": "ProcessEdit",
           "defaultMessage": "Data Check",
           "defaultMessageExpression": null
@@ -42380,8 +42380,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Sources/Components/edit.tsx",
-          "line": 598,
-          "column": 15,
+          "line": 601,
+          "column": 17,
           "symbol": "SourceEdit",
           "defaultMessage": "Data Check",
           "defaultMessageExpression": null
@@ -42389,8 +42389,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/Components/edit.tsx",
-          "line": 618,
-          "column": 15,
+          "line": 621,
+          "column": 17,
           "symbol": "UnitGroupEdit",
           "defaultMessage": "Data Check",
           "defaultMessageExpression": null
@@ -42404,44 +42404,44 @@
           "locations": [
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 732,
-              "column": 15,
+              "line": 735,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Flowproperties/Components/edit.tsx",
-              "line": 569,
-              "column": 15,
+              "line": 572,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Flows/Components/edit.tsx",
-              "line": 675,
-              "column": 15,
+              "line": 678,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 1896,
-              "column": 16,
+              "line": 1902,
+              "column": 18,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 1196,
-              "column": 15,
+              "line": 1199,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Sources/Components/edit.tsx",
-              "line": 598,
-              "column": 15,
+              "line": 601,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Unitgroups/Components/edit.tsx",
-              "line": 618,
-              "column": 15,
+              "line": 621,
+              "column": 17,
               "kind": "FormattedMessage"
             }
           ]
@@ -42508,7 +42508,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 582,
+          "line": 584,
           "column": 13,
           "symbol": "validationHint",
           "defaultMessage": "Data check failed, please check the data!",
@@ -42517,7 +42517,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Flowproperties/Components/edit.tsx",
-          "line": 501,
+          "line": 503,
           "column": 13,
           "symbol": "validationHint",
           "defaultMessage": "Data check failed, please check the data!",
@@ -42526,7 +42526,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Flows/Components/edit.tsx",
-          "line": 574,
+          "line": 576,
           "column": 28,
           "symbol": "validationHint",
           "defaultMessage": "Data check failed, please check the data!",
@@ -42544,7 +42544,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 829,
+          "line": 830,
           "column": 14,
           "symbol": "getValidationHint",
           "defaultMessage": "Data check failed, please check the data!",
@@ -42553,7 +42553,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Sources/Components/edit.tsx",
-          "line": 529,
+          "line": 531,
           "column": 13,
           "symbol": "validationHint",
           "defaultMessage": "Data check failed, please check the data!",
@@ -42562,7 +42562,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Unitgroups/Components/edit.tsx",
-          "line": 536,
+          "line": 538,
           "column": 28,
           "symbol": "validationHint",
           "defaultMessage": "Data check failed, please check the data!",
@@ -42577,19 +42577,19 @@
           "locations": [
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 582,
+              "line": 584,
               "column": 13,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Flowproperties/Components/edit.tsx",
-              "line": 501,
+              "line": 503,
               "column": 13,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Flows/Components/edit.tsx",
-              "line": 574,
+              "line": 576,
               "column": 28,
               "kind": "formatMessage"
             },
@@ -42601,19 +42601,19 @@
             },
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 829,
+              "line": 830,
               "column": 14,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Sources/Components/edit.tsx",
-              "line": 529,
+              "line": 531,
               "column": 13,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Unitgroups/Components/edit.tsx",
-              "line": 536,
+              "line": 538,
               "column": 28,
               "kind": "formatMessage"
             }
@@ -42764,7 +42764,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 569,
+          "line": 571,
           "column": 11,
           "symbol": "handleCheckData",
           "defaultMessage": "Data validation passed.",
@@ -42773,7 +42773,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Flowproperties/Components/edit.tsx",
-          "line": 488,
+          "line": 490,
           "column": 11,
           "symbol": "handleCheckData",
           "defaultMessage": "Data validation passed.",
@@ -42782,7 +42782,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Flows/Components/edit.tsx",
-          "line": 567,
+          "line": 569,
           "column": 11,
           "symbol": "handleCheckData",
           "defaultMessage": "Data validation passed.",
@@ -42800,7 +42800,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 900,
+          "line": 901,
           "column": 11,
           "symbol": "handleCheckData",
           "defaultMessage": "Data validation passed.",
@@ -42809,7 +42809,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Sources/Components/edit.tsx",
-          "line": 516,
+          "line": 518,
           "column": 11,
           "symbol": "handleCheckData",
           "defaultMessage": "Data validation passed.",
@@ -42818,7 +42818,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Unitgroups/Components/edit.tsx",
-          "line": 529,
+          "line": 531,
           "column": 11,
           "symbol": "handleCheckData",
           "defaultMessage": "Data validation passed.",
@@ -42833,19 +42833,19 @@
           "locations": [
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 569,
+              "line": 571,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Flowproperties/Components/edit.tsx",
-              "line": 488,
+              "line": 490,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Flows/Components/edit.tsx",
-              "line": 567,
+              "line": 569,
               "column": 11,
               "kind": "formatMessage"
             },
@@ -42857,19 +42857,19 @@
             },
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 900,
+              "line": 901,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Sources/Components/edit.tsx",
-              "line": 516,
+              "line": 518,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Unitgroups/Components/edit.tsx",
-              "line": 529,
+              "line": 531,
               "column": 11,
               "kind": "formatMessage"
             }
@@ -43685,7 +43685,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 970,
+          "line": 971,
           "column": 13,
           "symbol": "showMutationError",
           "defaultMessage": "Data with the same ID and version already exists.",
@@ -43745,7 +43745,7 @@
             },
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 970,
+              "line": 971,
               "column": 13,
               "kind": "formatMessage"
             },
@@ -43858,7 +43858,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 1090,
+          "line": 1091,
           "column": 15,
           "symbol": "saveData",
           "defaultMessage": "Created successfully!",
@@ -43918,7 +43918,7 @@
             },
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 1090,
+              "line": 1091,
               "column": 15,
               "kind": "formatMessage"
             },
@@ -45567,7 +45567,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 702,
+          "line": 704,
           "column": 27,
           "symbol": "ContactEdit",
           "defaultMessage": "Edit",
@@ -45576,7 +45576,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 713,
+          "line": 715,
           "column": 13,
           "symbol": "ContactEdit",
           "defaultMessage": "Edit",
@@ -45585,7 +45585,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/Components/edit.tsx",
-          "line": 535,
+          "line": 537,
           "column": 25,
           "symbol": "FlowpropertiesEdit",
           "defaultMessage": "Edit",
@@ -45594,7 +45594,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/Components/edit.tsx",
-          "line": 546,
+          "line": 548,
           "column": 15,
           "symbol": "FlowpropertiesEdit",
           "defaultMessage": "Edit",
@@ -45603,7 +45603,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flows/Components/edit.tsx",
-          "line": 640,
+          "line": 642,
           "column": 25,
           "symbol": "FlowsEdit",
           "defaultMessage": "Edit",
@@ -45612,7 +45612,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flows/Components/edit.tsx",
-          "line": 651,
+          "line": 653,
           "column": 15,
           "symbol": "FlowsEdit",
           "defaultMessage": "Edit",
@@ -45621,7 +45621,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flows/Components/edit.tsx",
-          "line": 659,
+          "line": 661,
           "column": 16,
           "symbol": "FlowsEdit",
           "defaultMessage": "Edit",
@@ -45666,7 +45666,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 1144,
+          "line": 1146,
           "column": 27,
           "symbol": "ProcessEdit",
           "defaultMessage": "Edit",
@@ -45675,7 +45675,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 1155,
+          "line": 1157,
           "column": 17,
           "symbol": "ProcessEdit",
           "defaultMessage": "Edit",
@@ -45720,7 +45720,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Sources/Components/edit.tsx",
-          "line": 568,
+          "line": 570,
           "column": 27,
           "symbol": "SourceEdit",
           "defaultMessage": "Edit",
@@ -45729,7 +45729,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Sources/Components/edit.tsx",
-          "line": 579,
+          "line": 581,
           "column": 13,
           "symbol": "SourceEdit",
           "defaultMessage": "Edit",
@@ -45738,7 +45738,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/Components/edit.tsx",
-          "line": 581,
+          "line": 583,
           "column": 15,
           "symbol": "UnitGroupEdit",
           "defaultMessage": "Edit",
@@ -45747,7 +45747,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/Components/edit.tsx",
-          "line": 594,
+          "line": 596,
           "column": 13,
           "symbol": "UnitGroupEdit",
           "defaultMessage": "Edit",
@@ -45786,43 +45786,43 @@
             },
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 702,
+              "line": 704,
               "column": 27,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 713,
+              "line": 715,
               "column": 13,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Flowproperties/Components/edit.tsx",
-              "line": 535,
+              "line": 537,
               "column": 25,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Flowproperties/Components/edit.tsx",
-              "line": 546,
+              "line": 548,
               "column": 15,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Flows/Components/edit.tsx",
-              "line": 640,
+              "line": 642,
               "column": 25,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Flows/Components/edit.tsx",
-              "line": 651,
+              "line": 653,
               "column": 15,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Flows/Components/edit.tsx",
-              "line": 659,
+              "line": 661,
               "column": 16,
               "kind": "FormattedMessage"
             },
@@ -45852,13 +45852,13 @@
             },
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 1144,
+              "line": 1146,
               "column": 27,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 1155,
+              "line": 1157,
               "column": 17,
               "kind": "FormattedMessage"
             },
@@ -45888,25 +45888,25 @@
             },
             {
               "path": "src/pages/Sources/Components/edit.tsx",
-              "line": 568,
+              "line": 570,
               "column": 27,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Sources/Components/edit.tsx",
-              "line": 579,
+              "line": 581,
               "column": 13,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Unitgroups/Components/edit.tsx",
-              "line": 581,
+              "line": 583,
               "column": 15,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Unitgroups/Components/edit.tsx",
-              "line": 594,
+              "line": 596,
               "column": 13,
               "kind": "FormattedMessage"
             },
@@ -46069,7 +46069,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 207,
+          "line": 208,
           "column": 12,
           "symbol": "edgeLabelText",
           "defaultMessage": "Input",
@@ -46078,7 +46078,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 254,
+          "line": 255,
           "column": 24,
           "symbol": "inputFlowTool",
           "defaultMessage": "Input",
@@ -46120,13 +46120,13 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 207,
+              "line": 208,
               "column": 12,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 254,
+              "line": 255,
               "column": 24,
               "kind": "formatMessage"
             },
@@ -47016,8 +47016,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 1839,
-          "column": 16,
+          "line": 1844,
+          "column": 13,
           "symbol": "ToolbarEdit",
           "defaultMessage": "Delete element",
           "defaultMessageExpression": null
@@ -47031,8 +47031,8 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 1839,
-              "column": 16,
+              "line": 1844,
+              "column": 13,
               "kind": "FormattedMessage"
             }
           ]
@@ -47241,7 +47241,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 195,
+          "line": 196,
           "column": 15,
           "symbol": "edgeLabelText",
           "defaultMessage": "Bal",
@@ -47265,7 +47265,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 195,
+              "line": 196,
               "column": 15,
               "kind": "formatMessage"
             },
@@ -47339,7 +47339,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 199,
+          "line": 200,
           "column": 14,
           "symbol": "edgeLabelText",
           "defaultMessage": "Def",
@@ -47363,7 +47363,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 199,
+              "line": 200,
               "column": 14,
               "kind": "formatMessage"
             },
@@ -47437,7 +47437,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 203,
+          "line": 204,
           "column": 14,
           "symbol": "edgeLabelText",
           "defaultMessage": "Sur",
@@ -47461,7 +47461,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 203,
+              "line": 204,
               "column": 14,
               "kind": "formatMessage"
             },
@@ -47849,7 +47849,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 1095,
+          "line": 1097,
           "column": 15,
           "symbol": "ProcessEdit",
           "defaultMessage": "Process information",
@@ -47873,7 +47873,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 1095,
+              "line": 1097,
               "column": 15,
               "kind": "FormattedMessage"
             },
@@ -48030,7 +48030,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 356,
+          "line": 357,
           "column": 24,
           "symbol": "refTool",
           "defaultMessage": "Reference node",
@@ -48063,7 +48063,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 356,
+              "line": 357,
               "column": 24,
               "kind": "formatMessage"
             },
@@ -48161,7 +48161,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 1114,
+          "line": 1116,
           "column": 15,
           "symbol": "ProcessEdit",
           "defaultMessage": "Model Results",
@@ -48170,7 +48170,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 1130,
+          "line": 1132,
           "column": 15,
           "symbol": "ProcessEdit",
           "defaultMessage": "Model Results",
@@ -48206,13 +48206,13 @@
             },
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 1114,
+              "line": 1116,
               "column": 15,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 1130,
+              "line": 1132,
               "column": 15,
               "kind": "FormattedMessage"
             },
@@ -48286,8 +48286,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 1857,
-          "column": 16,
+          "line": 1863,
+          "column": 18,
           "symbol": "ToolbarEdit",
           "defaultMessage": "Save data",
           "defaultMessageExpression": null
@@ -48301,8 +48301,8 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 1857,
-              "column": 16,
+              "line": 1863,
+              "column": 18,
               "kind": "FormattedMessage"
             }
           ]
@@ -48369,7 +48369,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 398,
+          "line": 399,
           "column": 24,
           "symbol": "nonRefTool",
           "defaultMessage": "Set as reference",
@@ -48384,7 +48384,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 398,
+              "line": 399,
               "column": 24,
               "kind": "formatMessage"
             }
@@ -49025,7 +49025,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 211,
+          "line": 212,
           "column": 13,
           "symbol": "edgeLabelText",
           "defaultMessage": "Output",
@@ -49034,7 +49034,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 300,
+          "line": 301,
           "column": 24,
           "symbol": "outputFlowTool",
           "defaultMessage": "Output",
@@ -49076,13 +49076,13 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 211,
+              "line": 212,
               "column": 13,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 300,
+              "line": 301,
               "column": 24,
               "kind": "formatMessage"
             },
@@ -49370,8 +49370,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/Components/edit.tsx",
-          "line": 599,
-          "column": 15,
+          "line": 602,
+          "column": 17,
           "symbol": "FlowpropertiesEdit",
           "defaultMessage": "Reset",
           "defaultMessageExpression": null
@@ -49385,8 +49385,8 @@
           "locations": [
             {
               "path": "src/pages/Flowproperties/Components/edit.tsx",
-              "line": 599,
-              "column": 15,
+              "line": 602,
+              "column": 17,
               "kind": "FormattedMessage"
             }
           ]
@@ -49453,8 +49453,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 1909,
-          "column": 18,
+          "line": 1915,
+          "column": 20,
           "symbol": "ToolbarEdit",
           "defaultMessage": "Submit for Review",
           "defaultMessageExpression": null
@@ -49462,8 +49462,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 1206,
-          "column": 19,
+          "line": 1209,
+          "column": 21,
           "symbol": "ProcessEdit",
           "defaultMessage": "Submit for Review",
           "defaultMessageExpression": null
@@ -49477,14 +49477,14 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 1909,
-              "column": 18,
+              "line": 1915,
+              "column": 20,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 1206,
-              "column": 19,
+              "line": 1209,
+              "column": 21,
               "kind": "FormattedMessage"
             }
           ]
@@ -49569,8 +49569,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 780,
-          "column": 15,
+          "line": 783,
+          "column": 17,
           "symbol": "ContactEdit",
           "defaultMessage": "Save",
           "defaultMessageExpression": null
@@ -49587,8 +49587,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/Components/edit.tsx",
-          "line": 608,
-          "column": 15,
+          "line": 611,
+          "column": 17,
           "symbol": "FlowpropertiesEdit",
           "defaultMessage": "Save",
           "defaultMessageExpression": null
@@ -49605,8 +49605,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flows/Components/edit.tsx",
-          "line": 714,
-          "column": 15,
+          "line": 717,
+          "column": 17,
           "symbol": "FlowsEdit",
           "defaultMessage": "Save",
           "defaultMessageExpression": null
@@ -49659,8 +49659,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 1235,
-          "column": 15,
+          "line": 1238,
+          "column": 17,
           "symbol": "ProcessEdit",
           "defaultMessage": "Save",
           "defaultMessageExpression": null
@@ -49722,8 +49722,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Sources/Components/edit.tsx",
-          "line": 635,
-          "column": 15,
+          "line": 638,
+          "column": 17,
           "symbol": "SourceEdit",
           "defaultMessage": "Save",
           "defaultMessageExpression": null
@@ -49740,8 +49740,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/Components/edit.tsx",
-          "line": 655,
-          "column": 15,
+          "line": 661,
+          "column": 17,
           "symbol": "UnitGroupEdit",
           "defaultMessage": "Save",
           "defaultMessageExpression": null
@@ -49785,8 +49785,8 @@
             },
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 780,
-              "column": 15,
+              "line": 783,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
@@ -49797,8 +49797,8 @@
             },
             {
               "path": "src/pages/Flowproperties/Components/edit.tsx",
-              "line": 608,
-              "column": 15,
+              "line": 611,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
@@ -49809,8 +49809,8 @@
             },
             {
               "path": "src/pages/Flows/Components/edit.tsx",
-              "line": 714,
-              "column": 15,
+              "line": 717,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
@@ -49845,8 +49845,8 @@
             },
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 1235,
-              "column": 15,
+              "line": 1238,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
@@ -49887,8 +49887,8 @@
             },
             {
               "path": "src/pages/Sources/Components/edit.tsx",
-              "line": 635,
-              "column": 15,
+              "line": 638,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
@@ -49899,8 +49899,8 @@
             },
             {
               "path": "src/pages/Unitgroups/Components/edit.tsx",
-              "line": 655,
-              "column": 15,
+              "line": 661,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
@@ -49979,7 +49979,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 324,
+          "line": 326,
           "column": 11,
           "symbol": "handleSubmit",
           "defaultMessage": "Saved successfully!",
@@ -49988,7 +49988,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Flowproperties/Components/edit.tsx",
-          "line": 323,
+          "line": 325,
           "column": 11,
           "symbol": "handleSubmit",
           "defaultMessage": "Saved successfully!",
@@ -49997,7 +49997,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Flows/Components/edit.tsx",
-          "line": 381,
+          "line": 383,
           "column": 11,
           "symbol": "handleSubmit",
           "defaultMessage": "Saved successfully!",
@@ -50006,7 +50006,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 576,
+          "line": 577,
           "column": 11,
           "symbol": "handleSubmit",
           "defaultMessage": "Saved successfully!",
@@ -50015,7 +50015,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Unitgroups/Components/edit.tsx",
-          "line": 338,
+          "line": 340,
           "column": 11,
           "symbol": "handleSubmit",
           "defaultMessage": "Saved successfully!",
@@ -50030,31 +50030,31 @@
           "locations": [
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 324,
+              "line": 326,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Flowproperties/Components/edit.tsx",
-              "line": 323,
+              "line": 325,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Flows/Components/edit.tsx",
-              "line": 381,
+              "line": 383,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 576,
+              "line": 577,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Unitgroups/Components/edit.tsx",
-              "line": 338,
+              "line": 340,
               "column": 11,
               "kind": "formatMessage"
             }
@@ -50588,8 +50588,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 739,
-          "column": 17,
+          "line": 742,
+          "column": 19,
           "symbol": "ContactEdit",
           "defaultMessage": "Sync to Open Data",
           "defaultMessageExpression": null
@@ -50603,8 +50603,8 @@
           "locations": [
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 739,
-              "column": 17,
+              "line": 742,
+              "column": 19,
               "kind": "FormattedMessage"
             }
           ]
@@ -50778,8 +50778,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 762,
-          "column": 15,
+          "line": 765,
+          "column": 17,
           "symbol": "ContactEdit",
           "defaultMessage": "Update Reference",
           "defaultMessageExpression": null
@@ -50796,8 +50796,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/Components/edit.tsx",
-          "line": 588,
-          "column": 15,
+          "line": 591,
+          "column": 17,
           "symbol": "FlowpropertiesEdit",
           "defaultMessage": "Update Reference",
           "defaultMessageExpression": null
@@ -50814,8 +50814,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flows/Components/edit.tsx",
-          "line": 694,
-          "column": 15,
+          "line": 697,
+          "column": 17,
           "symbol": "FlowsEdit",
           "defaultMessage": "Update Reference",
           "defaultMessageExpression": null
@@ -50832,8 +50832,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 1826,
-          "column": 11,
+          "line": 1830,
+          "column": 13,
           "symbol": "ToolbarEdit",
           "defaultMessage": "Update Reference",
           "defaultMessageExpression": null
@@ -50850,8 +50850,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 1214,
-          "column": 17,
+          "line": 1217,
+          "column": 19,
           "symbol": "ProcessEdit",
           "defaultMessage": "Update Reference",
           "defaultMessageExpression": null
@@ -50859,8 +50859,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Sources/Components/edit.tsx",
-          "line": 617,
-          "column": 15,
+          "line": 620,
+          "column": 17,
           "symbol": "SourceEdit",
           "defaultMessage": "Update Reference",
           "defaultMessageExpression": null
@@ -50877,8 +50877,8 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/Components/edit.tsx",
-          "line": 637,
-          "column": 15,
+          "line": 640,
+          "column": 17,
           "symbol": "UnitGroupEdit",
           "defaultMessage": "Update Reference",
           "defaultMessageExpression": null
@@ -50901,8 +50901,8 @@
           "locations": [
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 762,
-              "column": 15,
+              "line": 765,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
@@ -50913,8 +50913,8 @@
             },
             {
               "path": "src/pages/Flowproperties/Components/edit.tsx",
-              "line": 588,
-              "column": 15,
+              "line": 591,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
@@ -50925,8 +50925,8 @@
             },
             {
               "path": "src/pages/Flows/Components/edit.tsx",
-              "line": 694,
-              "column": 15,
+              "line": 697,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
@@ -50937,8 +50937,8 @@
             },
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 1826,
-              "column": 11,
+              "line": 1830,
+              "column": 13,
               "kind": "FormattedMessage"
             },
             {
@@ -50949,14 +50949,14 @@
             },
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 1214,
-              "column": 17,
+              "line": 1217,
+              "column": 19,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Sources/Components/edit.tsx",
-              "line": 617,
-              "column": 15,
+              "line": 620,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
@@ -50967,8 +50967,8 @@
             },
             {
               "path": "src/pages/Unitgroups/Components/edit.tsx",
-              "line": 637,
-              "column": 15,
+              "line": 640,
+              "column": 17,
               "kind": "FormattedMessage"
             },
             {
@@ -51989,7 +51989,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 464,
+          "line": 466,
           "column": 11,
           "symbol": "handleCheckData",
           "defaultMessage": "This data set is under review and cannot be validated",
@@ -51998,7 +51998,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Flowproperties/Components/edit.tsx",
-          "line": 387,
+          "line": 389,
           "column": 11,
           "symbol": "handleCheckData",
           "defaultMessage": "This data set is under review and cannot be validated",
@@ -52007,7 +52007,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Flows/Components/edit.tsx",
-          "line": 450,
+          "line": 452,
           "column": 11,
           "symbol": "handleCheckData",
           "defaultMessage": "This data set is under review and cannot be validated",
@@ -52016,7 +52016,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Sources/Components/edit.tsx",
-          "line": 412,
+          "line": 414,
           "column": 11,
           "symbol": "handleCheckData",
           "defaultMessage": "This data set is under review and cannot be validated",
@@ -52025,7 +52025,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Unitgroups/Components/edit.tsx",
-          "line": 405,
+          "line": 407,
           "column": 11,
           "symbol": "handleCheckData",
           "defaultMessage": "This data set is under review and cannot be validated",
@@ -52040,31 +52040,31 @@
           "locations": [
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 464,
+              "line": 466,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Flowproperties/Components/edit.tsx",
-              "line": 387,
+              "line": 389,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Flows/Components/edit.tsx",
-              "line": 450,
+              "line": 452,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Sources/Components/edit.tsx",
-              "line": 412,
+              "line": 414,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Unitgroups/Components/edit.tsx",
-              "line": 405,
+              "line": 407,
               "column": 11,
               "kind": "formatMessage"
             }
@@ -53675,7 +53675,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 721,
+          "line": 723,
           "column": 11,
           "symbol": "ContactEdit",
           "defaultMessage": "Edit Contact",
@@ -53690,7 +53690,7 @@
           "locations": [
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 721,
+              "line": 723,
               "column": 11,
               "kind": "FormattedMessage"
             }
@@ -55589,7 +55589,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 406,
+          "line": 408,
           "column": 13,
           "symbol": "validateReferencesForSyncOpenData",
           "defaultMessage": "Contact reference {id}({version}) must match the current contact ID and version.",
@@ -55607,7 +55607,7 @@
           "locations": [
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 406,
+              "line": 408,
               "column": 13,
               "kind": "formatMessage"
             }
@@ -55687,7 +55687,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 437,
+          "line": 439,
           "column": 11,
           "symbol": "validateReferencesForSyncOpenData",
           "defaultMessage": "Referenced data {id}({version}) must be open data.",
@@ -55705,7 +55705,7 @@
           "locations": [
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 437,
+              "line": 439,
               "column": 11,
               "kind": "formatMessage"
             }
@@ -55773,7 +55773,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 625,
+          "line": 627,
           "column": 9,
           "symbol": "handleSyncToOpenData",
           "defaultMessage": "Current contact data is incomplete. Please fill all required fields before syncing.",
@@ -55788,7 +55788,7 @@
           "locations": [
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 625,
+              "line": 627,
               "column": 9,
               "kind": "formatMessage"
             }
@@ -55856,7 +55856,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 682,
+          "line": 684,
           "column": 7,
           "symbol": "handleSyncToOpenData",
           "defaultMessage": "Synchronized to open data successfully!",
@@ -55871,7 +55871,7 @@
           "locations": [
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 682,
+              "line": 684,
               "column": 7,
               "kind": "formatMessage"
             }
@@ -88643,7 +88643,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Flowproperties/Components/edit.tsx",
-          "line": 555,
+          "line": 557,
           "column": 11,
           "symbol": "FlowpropertiesEdit",
           "defaultMessage": "Edit Flow property",
@@ -88667,7 +88667,7 @@
           "locations": [
             {
               "path": "src/pages/Flowproperties/Components/edit.tsx",
-              "line": 555,
+              "line": 557,
               "column": 11,
               "kind": "FormattedMessage"
             },
@@ -89356,7 +89356,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 1026,
+          "line": 1027,
           "column": 15,
           "symbol": "saveData",
           "defaultMessage": "Saved successfully.",
@@ -89371,7 +89371,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 1026,
+              "line": 1027,
               "column": 15,
               "kind": "formatMessage"
             }
@@ -109239,7 +109239,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 1530,
+          "line": 1531,
           "column": 39,
           "symbol": "ToolbarEdit",
           "defaultMessage": "Automatically generated",
@@ -109254,7 +109254,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 1530,
+              "line": 1531,
               "column": 39,
               "kind": "formatMessage"
             }
@@ -125901,7 +125901,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 959,
+          "line": 960,
           "column": 13,
           "symbol": "showMutationError",
           "defaultMessage": "The model is missing reference process information. Complete or rebind the reference process, then try again.",
@@ -125916,7 +125916,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 959,
+              "line": 960,
               "column": 13,
               "kind": "formatMessage"
             }
@@ -125984,7 +125984,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 1480,
+          "line": 1481,
           "column": 13,
           "symbol": "ToolbarEdit",
           "defaultMessage": "Model is not public",
@@ -126008,7 +126008,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 1480,
+              "line": 1481,
               "column": 13,
               "kind": "formatMessage"
             },
@@ -134466,7 +134466,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 741,
+          "line": 742,
           "column": 11,
           "symbol": "handleCheckData",
           "defaultMessage": "This data set is under review and cannot be validated",
@@ -134481,7 +134481,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 741,
+              "line": 742,
               "column": 11,
               "kind": "formatMessage"
             }
@@ -134994,7 +134994,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 1165,
+          "line": 1167,
           "column": 11,
           "symbol": "ProcessEdit",
           "defaultMessage": "Edit process",
@@ -135009,7 +135009,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 1165,
+              "line": 1167,
               "column": 11,
               "kind": "FormattedMessage"
             }
@@ -168949,7 +168949,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 974,
+          "line": 975,
           "column": 13,
           "symbol": "submitReview",
           "defaultMessage": "Review submission failed",
@@ -168964,7 +168964,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 974,
+              "line": 975,
               "column": 13,
               "kind": "formatMessage"
             }
@@ -169050,7 +169050,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 984,
+          "line": 985,
           "column": 9,
           "symbol": "submitReview",
           "defaultMessage": "Review submitted successfully",
@@ -169077,7 +169077,7 @@
             },
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 984,
+              "line": 985,
               "column": 9,
               "kind": "formatMessage"
             }
@@ -178479,7 +178479,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 536,
+          "line": 537,
           "column": 11,
           "symbol": "handleSubmit",
           "defaultMessage": "The total allocated fraction for outputs cannot exceed 100%. Current total: {total}%.",
@@ -178500,7 +178500,7 @@
             },
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 536,
+              "line": 537,
               "column": 11,
               "kind": "formatMessage"
             }
@@ -179760,7 +179760,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 807,
+          "line": 808,
           "column": 34,
           "symbol": "handleCheckData",
           "defaultMessage": "Select exactly one item as the quantitative reference.",
@@ -179775,7 +179775,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 807,
+              "line": 808,
               "column": 34,
               "kind": "formatMessage"
             }
@@ -179843,7 +179843,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 795,
+          "line": 796,
           "column": 34,
           "symbol": "handleCheckData",
           "defaultMessage": "Add at least one exchange",
@@ -179858,7 +179858,7 @@
           "locations": [
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 795,
+              "line": 796,
               "column": 34,
               "kind": "formatMessage"
             }
@@ -214514,7 +214514,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 338,
+          "line": 340,
           "column": 11,
           "symbol": "handleSubmit",
           "defaultMessage": "This data is open data, save failed",
@@ -214523,7 +214523,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 654,
+          "line": 656,
           "column": 11,
           "symbol": "handleSyncToOpenData",
           "defaultMessage": "This data is open data, save failed",
@@ -214532,7 +214532,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Flowproperties/Components/edit.tsx",
-          "line": 338,
+          "line": 340,
           "column": 13,
           "symbol": "handleSubmit",
           "defaultMessage": "This data is open data, save failed",
@@ -214541,7 +214541,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Flows/Components/edit.tsx",
-          "line": 396,
+          "line": 398,
           "column": 13,
           "symbol": "handleSubmit",
           "defaultMessage": "This data is open data, save failed",
@@ -214550,7 +214550,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 980,
+          "line": 981,
           "column": 13,
           "symbol": "showMutationError",
           "defaultMessage": "This data is open data, save failed",
@@ -214559,7 +214559,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 592,
+          "line": 593,
           "column": 13,
           "symbol": "handleSubmit",
           "defaultMessage": "This data is open data, save failed",
@@ -214568,7 +214568,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Sources/Components/edit.tsx",
-          "line": 346,
+          "line": 347,
           "column": 11,
           "symbol": "handleSubmit",
           "defaultMessage": "This data is open data, save failed",
@@ -214577,7 +214577,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Unitgroups/Components/edit.tsx",
-          "line": 353,
+          "line": 355,
           "column": 13,
           "symbol": "handleSubmit",
           "defaultMessage": "This data is open data, save failed",
@@ -214592,49 +214592,49 @@
           "locations": [
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 338,
+              "line": 340,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 654,
+              "line": 656,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Flowproperties/Components/edit.tsx",
-              "line": 338,
+              "line": 340,
               "column": 13,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Flows/Components/edit.tsx",
-              "line": 396,
+              "line": 398,
               "column": 13,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 980,
+              "line": 981,
               "column": 13,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 592,
+              "line": 593,
               "column": 13,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Sources/Components/edit.tsx",
-              "line": 346,
+              "line": 347,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Unitgroups/Components/edit.tsx",
-              "line": 353,
+              "line": 355,
               "column": 13,
               "kind": "formatMessage"
             }
@@ -223646,7 +223646,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 345,
+          "line": 347,
           "column": 11,
           "symbol": "handleSubmit",
           "defaultMessage": "Data is under review, save failed",
@@ -223655,7 +223655,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Contacts/Components/edit.tsx",
-          "line": 661,
+          "line": 663,
           "column": 11,
           "symbol": "handleSyncToOpenData",
           "defaultMessage": "Data is under review, save failed",
@@ -223664,7 +223664,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Flowproperties/Components/edit.tsx",
-          "line": 345,
+          "line": 347,
           "column": 13,
           "symbol": "handleSubmit",
           "defaultMessage": "Data is under review, save failed",
@@ -223673,7 +223673,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Flows/Components/edit.tsx",
-          "line": 403,
+          "line": 405,
           "column": 13,
           "symbol": "handleSubmit",
           "defaultMessage": "Data is under review, save failed",
@@ -223682,7 +223682,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 990,
+          "line": 991,
           "column": 13,
           "symbol": "showMutationError",
           "defaultMessage": "Data is under review, save failed",
@@ -223691,7 +223691,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Processes/Components/edit.tsx",
-          "line": 599,
+          "line": 600,
           "column": 13,
           "symbol": "handleSubmit",
           "defaultMessage": "Data is under review, save failed",
@@ -223700,7 +223700,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Sources/Components/edit.tsx",
-          "line": 353,
+          "line": 354,
           "column": 11,
           "symbol": "handleSubmit",
           "defaultMessage": "Data is under review, save failed",
@@ -223709,7 +223709,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Unitgroups/Components/edit.tsx",
-          "line": 360,
+          "line": 362,
           "column": 13,
           "symbol": "handleSubmit",
           "defaultMessage": "Data is under review, save failed",
@@ -223724,49 +223724,49 @@
           "locations": [
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 345,
+              "line": 347,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Contacts/Components/edit.tsx",
-              "line": 661,
+              "line": 663,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Flowproperties/Components/edit.tsx",
-              "line": 345,
+              "line": 347,
               "column": 13,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Flows/Components/edit.tsx",
-              "line": 403,
+              "line": 405,
               "column": 13,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 990,
+              "line": 991,
               "column": 13,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Processes/Components/edit.tsx",
-              "line": 599,
+              "line": 600,
               "column": 13,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Sources/Components/edit.tsx",
-              "line": 353,
+              "line": 354,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Unitgroups/Components/edit.tsx",
-              "line": 360,
+              "line": 362,
               "column": 13,
               "kind": "formatMessage"
             }
@@ -230312,7 +230312,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Sources/Components/edit.tsx",
-          "line": 587,
+          "line": 589,
           "column": 11,
           "symbol": "SourceEdit",
           "defaultMessage": "Edit Source",
@@ -230327,7 +230327,7 @@
           "locations": [
             {
               "path": "src/pages/Sources/Components/edit.tsx",
-              "line": 587,
+              "line": 589,
               "column": 11,
               "kind": "FormattedMessage"
             }
@@ -243024,7 +243024,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Unitgroups/Components/edit.tsx",
-          "line": 602,
+          "line": 604,
           "column": 11,
           "symbol": "UnitGroupEdit",
           "defaultMessage": "Edit Unit group",
@@ -243039,7 +243039,7 @@
           "locations": [
             {
               "path": "src/pages/Unitgroups/Components/edit.tsx",
-              "line": 602,
+              "line": 604,
               "column": 11,
               "kind": "FormattedMessage"
             }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf",
-    "contextDigest": "1d769f5f065ac9909d0f0ff6f6c81bc4c7ab41ce1ded21a5cba85ca5b86694ad"
+    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
+    "contextDigest": "c2c4f78cc1f9f9fab15f4560421ee316d6fab8969cb867982f474421bdc8174e"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "ebd3bdc37bfaaa143836021b6416896c702a1ef254bb781c69f6100a62311224",
-    "validationDigest": "de16eb4cfaa95842df80299e724c76b6d4781a74e4bf9cf7ee02eb0df5126df2",
+    "digest": "8ea7a866f5373343855d2ac79faefd06808d7d8eec6d04cd66bb0669437bf6c9",
+    "validationDigest": "fe0921fcb4e7ade39c46babe60fdb3dd7327b165d54d9ddf04acf82eb96b6ffa",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "2f75c2b64faa86c92ab08ef1a49334be19fb9449299a9259aed19044cce5d3c1"
+  "qualityDigest": "4e2e6929e7ac33ee44ef19ec4cac5cfb3b21ca5e27a58b03edc5efe66eed0f7b"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
-    "contextDigest": "c2c4f78cc1f9f9fab15f4560421ee316d6fab8969cb867982f474421bdc8174e"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
+    "contextDigest": "f399e8844f0bee8d721b8e180b7bbb3727203780c8c7a95fd44d3e1a5940088e"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "8ea7a866f5373343855d2ac79faefd06808d7d8eec6d04cd66bb0669437bf6c9",
-    "validationDigest": "fe0921fcb4e7ade39c46babe60fdb3dd7327b165d54d9ddf04acf82eb96b6ffa",
+    "digest": "1be40ea60131588e261101dee1141ece2d9473631c640d0e020d0868020cc4c5",
+    "validationDigest": "0aaffaa949544c784c426410ffe5bf9b6bc3e98db60490f2328a01bf277e1182",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "4e2e6929e7ac33ee44ef19ec4cac5cfb3b21ca5e27a58b03edc5efe66eed0f7b"
+  "qualityDigest": "76d624c43ebde4162b7a42cd17436786394d0e1d011f99e21a1aa85746e41ba0"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
-    "contextDigest": "f399e8844f0bee8d721b8e180b7bbb3727203780c8c7a95fd44d3e1a5940088e"
+    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a",
+    "contextDigest": "ff244a5d18fac5be02e5ba7b28fcf703a255409fcedab59545e47f9a0deaa135"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "1be40ea60131588e261101dee1141ece2d9473631c640d0e020d0868020cc4c5",
-    "validationDigest": "0aaffaa949544c784c426410ffe5bf9b6bc3e98db60490f2328a01bf277e1182",
+    "digest": "e00dcb2039ed29c3846783bfb076229a4972c4d02d5d23ae656605d6585cc00e",
+    "validationDigest": "97264dd216def5b67c7089d412817b382bbc65bec960801a26f58b41bbbb6f36",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "76d624c43ebde4162b7a42cd17436786394d0e1d011f99e21a1aa85746e41ba0"
+  "qualityDigest": "39945b26253ec3b6b3455d2e2c310d72c9465f31b41b6bbab24f98eee1d10c25"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0e40f2fc8c4f251d89397744e4465cab858189b875f732a92ea3ce7700b96bd9",
-    "contextDigest": "2b27f88d182d1007ac8a8dbda431bb889cd637fc12175f021037b2a848a3a6a5"
+    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf",
+    "contextDigest": "1d769f5f065ac9909d0f0ff6f6c81bc4c7ab41ce1ded21a5cba85ca5b86694ad"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "b48015530f9fd54c02c217ceb5772d0ec337287c976d37cb8478e014d99562f6",
-    "validationDigest": "8c6f6f5dffb95a01867966a4c985f4b26d95a08f71ccf85d37211fcc55bbd1a6",
+    "digest": "ebd3bdc37bfaaa143836021b6416896c702a1ef254bb781c69f6100a62311224",
+    "validationDigest": "de16eb4cfaa95842df80299e724c76b6d4781a74e4bf9cf7ee02eb0df5126df2",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "12c9031f62fc72e175e0f1d1f3f9ffd72dadcb63322eab02b76cd393158d7c54"
+  "qualityDigest": "2f75c2b64faa86c92ab08ef1a49334be19fb9449299a9259aed19044cce5d3c1"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "79845f56bea6cc39301a7f26dae9c52567dedf9bacaa1465bcfe003a4f50d80c",
+    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "09e1a503bd8add3c0b25f62a2ba1553d8fdeb75a027816ff98c304a9b2c7ad5e",
-    "dossierDigest": "bc8b45fbba753cd69d2db9c79fa514cce500bf703d618e38340fc03cc87e171b",
+    "dossierDigest": "bf04176d9c21a494c6f4805816fa676c9cba42fa88f7fd1216c898688e916f05",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "bc8b45fbba753cd69d2db9c79fa514cce500bf703d618e38340fc03cc87e171b",
+        "dossierDigest": "bf04176d9c21a494c6f4805816fa676c9cba42fa88f7fd1216c898688e916f05",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "de16eb4cfaa95842df80299e724c76b6d4781a74e4bf9cf7ee02eb0df5126df2"
+  "validationDigest": "fe0921fcb4e7ade39c46babe60fdb3dd7327b165d54d9ddf04acf82eb96b6ffa"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf",
+    "auditedInputDigest": "13cc24a019981b3decf8ea5f147355bd4ad5d5b1398cb2acac273d06c5dcc473",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "09e1a503bd8add3c0b25f62a2ba1553d8fdeb75a027816ff98c304a9b2c7ad5e",
-    "dossierDigest": "fa534f58078993dded15f645ede6935779ca8c2980e0072c41fec073ea8bc701",
+    "dossierDigest": "4a87832627fe7b25ba0a994608f6597b3dd924dcb1bb617b7295a259ddf93ae5",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "fa534f58078993dded15f645ede6935779ca8c2980e0072c41fec073ea8bc701",
+        "dossierDigest": "4a87832627fe7b25ba0a994608f6597b3dd924dcb1bb617b7295a259ddf93ae5",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "0aaffaa949544c784c426410ffe5bf9b6bc3e98db60490f2328a01bf277e1182"
+  "validationDigest": "97264dd216def5b67c7089d412817b382bbc65bec960801a26f58b41bbbb6f36"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048",
+    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "09e1a503bd8add3c0b25f62a2ba1553d8fdeb75a027816ff98c304a9b2c7ad5e",
-    "dossierDigest": "bf04176d9c21a494c6f4805816fa676c9cba42fa88f7fd1216c898688e916f05",
+    "dossierDigest": "fa534f58078993dded15f645ede6935779ca8c2980e0072c41fec073ea8bc701",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "bf04176d9c21a494c6f4805816fa676c9cba42fa88f7fd1216c898688e916f05",
+        "dossierDigest": "fa534f58078993dded15f645ede6935779ca8c2980e0072c41fec073ea8bc701",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "fe0921fcb4e7ade39c46babe60fdb3dd7327b165d54d9ddf04acf82eb96b6ffa"
+  "validationDigest": "0aaffaa949544c784c426410ffe5bf9b6bc3e98db60490f2328a01bf277e1182"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "3ef83dc31fb624ac532c00805d67c2da56aac6db36a427afc7d88e211d61afb0",
+    "auditedInputDigest": "79845f56bea6cc39301a7f26dae9c52567dedf9bacaa1465bcfe003a4f50d80c",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "09e1a503bd8add3c0b25f62a2ba1553d8fdeb75a027816ff98c304a9b2c7ad5e",
-    "dossierDigest": "d392e24d8efebe912b4c6e839f3c21e9fef447b5bf6e8f1d0c4b657349573eef",
+    "dossierDigest": "bc8b45fbba753cd69d2db9c79fa514cce500bf703d618e38340fc03cc87e171b",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "d392e24d8efebe912b4c6e839f3c21e9fef447b5bf6e8f1d0c4b657349573eef",
+        "dossierDigest": "bc8b45fbba753cd69d2db9c79fa514cce500bf703d618e38340fc03cc87e171b",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "8c6f6f5dffb95a01867966a4c985f4b26d95a08f71ccf85d37211fcc55bbd1a6"
+  "validationDigest": "de16eb4cfaa95842df80299e724c76b6d4781a74e4bf9cf7ee02eb0df5126df2"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
-    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf"
+    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a",
+    "auditedInputDigest": "13cc24a019981b3decf8ea5f147355bd4ad5d5b1398cb2acac273d06c5dcc473"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "89bef4912e5f812171e55e4cbbc135e8e367bbad58cbe049edf6168fe26cc0ca",
+    "dossierDigest": "31e4298ae38c113b9c1dda8575ce7504f527eb92fd21a3d3c07b5366cb5153b4",
     "catalogDigest": "93741a89fe46709918133c289bd4567e9261befb763495e91d6f667bb3595c83",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "df684ce6d280670ee1ebeb7af69b5e328a76f773a1f813842b04c5f21c2c679e"
+  "contextDigest": "36c7c2804e722d31ba345bdf6cdf8e04dbb23b6473d108c163701a4541d5a583"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
-    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
+    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "35c48fae856f3352c7cedc0be6591ae71d4ae59bea6b42ad470d26dcdfc1355a",
+    "dossierDigest": "89bef4912e5f812171e55e4cbbc135e8e367bbad58cbe049edf6168fe26cc0ca",
     "catalogDigest": "93741a89fe46709918133c289bd4567e9261befb763495e91d6f667bb3595c83",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "4a1d1587226135ddc0e2b0033a3cefb3d19359ad5be07b9dda83b829159c5988"
+  "contextDigest": "df684ce6d280670ee1ebeb7af69b5e328a76f773a1f813842b04c5f21c2c679e"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "0e40f2fc8c4f251d89397744e4465cab858189b875f732a92ea3ce7700b96bd9",
-    "auditedInputDigest": "3ef83dc31fb624ac532c00805d67c2da56aac6db36a427afc7d88e211d61afb0"
+    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf",
+    "auditedInputDigest": "79845f56bea6cc39301a7f26dae9c52567dedf9bacaa1465bcfe003a4f50d80c"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "ea29a390c4538404a99076fdc1a902b2e5091177a0e0d13a56663f4b70a0e0bc",
+    "dossierDigest": "54c657715646c01c13bc2e0bedbcc0dbacc5ba16f7d52607bd064b4dac2b2f38",
     "catalogDigest": "93741a89fe46709918133c289bd4567e9261befb763495e91d6f667bb3595c83",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "3f3f29bc47bdb1d20e79508a9fd6a485453f4ae2889d34d013660644b99664cc"
+  "contextDigest": "79f31148d37f96b97df9cf5393951863a548f2d36ff01349bc74fc59357133d5"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf",
-    "auditedInputDigest": "79845f56bea6cc39301a7f26dae9c52567dedf9bacaa1465bcfe003a4f50d80c"
+    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
+    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "54c657715646c01c13bc2e0bedbcc0dbacc5ba16f7d52607bd064b4dac2b2f38",
+    "dossierDigest": "35c48fae856f3352c7cedc0be6591ae71d4ae59bea6b42ad470d26dcdfc1355a",
     "catalogDigest": "93741a89fe46709918133c289bd4567e9261befb763495e91d6f667bb3595c83",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "79f31148d37f96b97df9cf5393951863a548f2d36ff01349bc74fc59357133d5"
+  "contextDigest": "4a1d1587226135ddc0e2b0033a3cefb3d19359ad5be07b9dda83b829159c5988"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60"
+    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "df684ce6d280670ee1ebeb7af69b5e328a76f773a1f813842b04c5f21c2c679e",
-    "qualityDigest": "e75b67af19fa4369aa58df071b9cacfabfb45d0daab25a79763cdc688e53bdc9",
+    "contextDigest": "36c7c2804e722d31ba345bdf6cdf8e04dbb23b6473d108c163701a4541d5a583",
+    "qualityDigest": "8bb044fef67aa561b64fea090de0687cd1f8f91583150a9dd5138fe8ca08aa20",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "2a2c5a49b9cc10c5a0760817c30179077dedd48b4274a7445ae869c96e3b5b1f"
+  "activationDigest": "8a972688031e300f8918fb495f3f939ebfbed3492974e00ae44473310e214142"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0e40f2fc8c4f251d89397744e4465cab858189b875f732a92ea3ce7700b96bd9"
+    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "3f3f29bc47bdb1d20e79508a9fd6a485453f4ae2889d34d013660644b99664cc",
-    "qualityDigest": "5a45550fdf27f6e2dca1c940878135a89fe464e557bfe7c541f2dd91f4a43658",
+    "contextDigest": "79f31148d37f96b97df9cf5393951863a548f2d36ff01349bc74fc59357133d5",
+    "qualityDigest": "4282e00011e1c065ee71c011ab0e985e7616aa5a3dfb751d17fd06772494dd04",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "bb708059e27c12ca6fe171fd6cd8ef532f89aaad03118f532badbe305574a833"
+  "activationDigest": "6659cd23bf524610eda1a52044838c7696d050c7ba50f07c52cb3092890704dd"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4a1d1587226135ddc0e2b0033a3cefb3d19359ad5be07b9dda83b829159c5988",
-    "qualityDigest": "2cce778a94912ae0988c3907864d4f60f2c9feed31554ef4e68e8b4c48c7bcd5",
+    "contextDigest": "df684ce6d280670ee1ebeb7af69b5e328a76f773a1f813842b04c5f21c2c679e",
+    "qualityDigest": "e75b67af19fa4369aa58df071b9cacfabfb45d0daab25a79763cdc688e53bdc9",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "bb261fc1df53c04859c84e6a719258492f946c477bc4aa48a2a5e839ecfc7d43"
+  "activationDigest": "2a2c5a49b9cc10c5a0760817c30179077dedd48b4274a7445ae869c96e3b5b1f"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf"
+    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "79f31148d37f96b97df9cf5393951863a548f2d36ff01349bc74fc59357133d5",
-    "qualityDigest": "4282e00011e1c065ee71c011ab0e985e7616aa5a3dfb751d17fd06772494dd04",
+    "contextDigest": "4a1d1587226135ddc0e2b0033a3cefb3d19359ad5be07b9dda83b829159c5988",
+    "qualityDigest": "2cce778a94912ae0988c3907864d4f60f2c9feed31554ef4e68e8b4c48c7bcd5",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "6659cd23bf524610eda1a52044838c7696d050c7ba50f07c52cb3092890704dd"
+  "activationDigest": "bb261fc1df53c04859c84e6a719258492f946c477bc4aa48a2a5e839ecfc7d43"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
-    "contextDigest": "4a1d1587226135ddc0e2b0033a3cefb3d19359ad5be07b9dda83b829159c5988"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
+    "contextDigest": "df684ce6d280670ee1ebeb7af69b5e328a76f773a1f813842b04c5f21c2c679e"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "7f4c12d31464c02717fad6b8c9e83f33170d4156a316c8aecd980fdbb6e28649",
-    "validationDigest": "b69d4e05e8ad01baecc0c05e487694c3a0120796b5dcb66817b3e116ee549a60",
+    "digest": "765d556e5ac3d248d7919f294764c99760800d41120ffee2bfad0a6a1ce0936d",
+    "validationDigest": "8ddde266f2ccb852022fc03e68ea8f7a1747d71c2b7b46922d9f9815c5899963",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "2cce778a94912ae0988c3907864d4f60f2c9feed31554ef4e68e8b4c48c7bcd5"
+  "qualityDigest": "e75b67af19fa4369aa58df071b9cacfabfb45d0daab25a79763cdc688e53bdc9"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
-    "contextDigest": "df684ce6d280670ee1ebeb7af69b5e328a76f773a1f813842b04c5f21c2c679e"
+    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a",
+    "contextDigest": "36c7c2804e722d31ba345bdf6cdf8e04dbb23b6473d108c163701a4541d5a583"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "765d556e5ac3d248d7919f294764c99760800d41120ffee2bfad0a6a1ce0936d",
-    "validationDigest": "8ddde266f2ccb852022fc03e68ea8f7a1747d71c2b7b46922d9f9815c5899963",
+    "digest": "614c4587af01e5d50064eb0150e80307ef9b9f728d1f1aee1c2d739180694eb8",
+    "validationDigest": "9c620e1ad002f55db730c0e8e00c468bdf5f647f62ab0016de89deab04910ec3",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "e75b67af19fa4369aa58df071b9cacfabfb45d0daab25a79763cdc688e53bdc9"
+  "qualityDigest": "8bb044fef67aa561b64fea090de0687cd1f8f91583150a9dd5138fe8ca08aa20"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0e40f2fc8c4f251d89397744e4465cab858189b875f732a92ea3ce7700b96bd9",
-    "contextDigest": "3f3f29bc47bdb1d20e79508a9fd6a485453f4ae2889d34d013660644b99664cc"
+    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf",
+    "contextDigest": "79f31148d37f96b97df9cf5393951863a548f2d36ff01349bc74fc59357133d5"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "346c3d4d4db73b98ad712ba18f09282e1d320c3a4acf0e510947816968ced3ee",
-    "validationDigest": "85f25f4e8c0f52b24f5b79cccb7302163bd13c872e18a72963e7412335d45248",
+    "digest": "aab2ebca722b83eb62ad325fec8dc96ace9739589d0a1bb31ad7dd8c6d89d7ee",
+    "validationDigest": "ba1f4189f2b316895daf3c3cd9afd0b82e4ff2b03cd9d4bb62440be51c2e240c",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "5a45550fdf27f6e2dca1c940878135a89fe464e557bfe7c541f2dd91f4a43658"
+  "qualityDigest": "4282e00011e1c065ee71c011ab0e985e7616aa5a3dfb751d17fd06772494dd04"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf",
-    "contextDigest": "79f31148d37f96b97df9cf5393951863a548f2d36ff01349bc74fc59357133d5"
+    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
+    "contextDigest": "4a1d1587226135ddc0e2b0033a3cefb3d19359ad5be07b9dda83b829159c5988"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "aab2ebca722b83eb62ad325fec8dc96ace9739589d0a1bb31ad7dd8c6d89d7ee",
-    "validationDigest": "ba1f4189f2b316895daf3c3cd9afd0b82e4ff2b03cd9d4bb62440be51c2e240c",
+    "digest": "7f4c12d31464c02717fad6b8c9e83f33170d4156a316c8aecd980fdbb6e28649",
+    "validationDigest": "b69d4e05e8ad01baecc0c05e487694c3a0120796b5dcb66817b3e116ee549a60",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "4282e00011e1c065ee71c011ab0e985e7616aa5a3dfb751d17fd06772494dd04"
+  "qualityDigest": "2cce778a94912ae0988c3907864d4f60f2c9feed31554ef4e68e8b4c48c7bcd5"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf",
+    "auditedInputDigest": "13cc24a019981b3decf8ea5f147355bd4ad5d5b1398cb2acac273d06c5dcc473",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "93741a89fe46709918133c289bd4567e9261befb763495e91d6f667bb3595c83",
-    "dossierDigest": "89bef4912e5f812171e55e4cbbc135e8e367bbad58cbe049edf6168fe26cc0ca",
+    "dossierDigest": "31e4298ae38c113b9c1dda8575ce7504f527eb92fd21a3d3c07b5366cb5153b4",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "89bef4912e5f812171e55e4cbbc135e8e367bbad58cbe049edf6168fe26cc0ca",
+        "dossierDigest": "31e4298ae38c113b9c1dda8575ce7504f527eb92fd21a3d3c07b5366cb5153b4",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "8ddde266f2ccb852022fc03e68ea8f7a1747d71c2b7b46922d9f9815c5899963"
+  "validationDigest": "9c620e1ad002f55db730c0e8e00c468bdf5f647f62ab0016de89deab04910ec3"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "3ef83dc31fb624ac532c00805d67c2da56aac6db36a427afc7d88e211d61afb0",
+    "auditedInputDigest": "79845f56bea6cc39301a7f26dae9c52567dedf9bacaa1465bcfe003a4f50d80c",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "93741a89fe46709918133c289bd4567e9261befb763495e91d6f667bb3595c83",
-    "dossierDigest": "ea29a390c4538404a99076fdc1a902b2e5091177a0e0d13a56663f4b70a0e0bc",
+    "dossierDigest": "54c657715646c01c13bc2e0bedbcc0dbacc5ba16f7d52607bd064b4dac2b2f38",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "ea29a390c4538404a99076fdc1a902b2e5091177a0e0d13a56663f4b70a0e0bc",
+        "dossierDigest": "54c657715646c01c13bc2e0bedbcc0dbacc5ba16f7d52607bd064b4dac2b2f38",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "85f25f4e8c0f52b24f5b79cccb7302163bd13c872e18a72963e7412335d45248"
+  "validationDigest": "ba1f4189f2b316895daf3c3cd9afd0b82e4ff2b03cd9d4bb62440be51c2e240c"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048",
+    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "93741a89fe46709918133c289bd4567e9261befb763495e91d6f667bb3595c83",
-    "dossierDigest": "35c48fae856f3352c7cedc0be6591ae71d4ae59bea6b42ad470d26dcdfc1355a",
+    "dossierDigest": "89bef4912e5f812171e55e4cbbc135e8e367bbad58cbe049edf6168fe26cc0ca",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "35c48fae856f3352c7cedc0be6591ae71d4ae59bea6b42ad470d26dcdfc1355a",
+        "dossierDigest": "89bef4912e5f812171e55e4cbbc135e8e367bbad58cbe049edf6168fe26cc0ca",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "b69d4e05e8ad01baecc0c05e487694c3a0120796b5dcb66817b3e116ee549a60"
+  "validationDigest": "8ddde266f2ccb852022fc03e68ea8f7a1747d71c2b7b46922d9f9815c5899963"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "79845f56bea6cc39301a7f26dae9c52567dedf9bacaa1465bcfe003a4f50d80c",
+    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "93741a89fe46709918133c289bd4567e9261befb763495e91d6f667bb3595c83",
-    "dossierDigest": "54c657715646c01c13bc2e0bedbcc0dbacc5ba16f7d52607bd064b4dac2b2f38",
+    "dossierDigest": "35c48fae856f3352c7cedc0be6591ae71d4ae59bea6b42ad470d26dcdfc1355a",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "54c657715646c01c13bc2e0bedbcc0dbacc5ba16f7d52607bd064b4dac2b2f38",
+        "dossierDigest": "35c48fae856f3352c7cedc0be6591ae71d4ae59bea6b42ad470d26dcdfc1355a",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "ba1f4189f2b316895daf3c3cd9afd0b82e4ff2b03cd9d4bb62440be51c2e240c"
+  "validationDigest": "b69d4e05e8ad01baecc0c05e487694c3a0120796b5dcb66817b3e116ee549a60"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
-    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
+    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "14e636b03791f59dc4aa9306f792e83939fb8631a03a904d453d3b9af1a9baa6",
+    "dossierDigest": "3a42aab00878ab536c7bf36c5b6e002c04ca95c98979c8cbdefe0457a82f5526",
     "catalogDigest": "24238218499ffff02768ab879d2c55877b656be79221b03b56b8d951d0f0068b",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "3ebc21810992cf565de4f920646be28a0fbc67cda9996f93dbfc55d44b810651"
+  "contextDigest": "8fd7559f292494a345765a3158204163ff97635ae5a796e961f01a12e604589e"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
-    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf"
+    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a",
+    "auditedInputDigest": "13cc24a019981b3decf8ea5f147355bd4ad5d5b1398cb2acac273d06c5dcc473"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "3a42aab00878ab536c7bf36c5b6e002c04ca95c98979c8cbdefe0457a82f5526",
+    "dossierDigest": "f888ed9ab31ab615292601fe7084c036c3739db03c5cc49ca11067786091724d",
     "catalogDigest": "24238218499ffff02768ab879d2c55877b656be79221b03b56b8d951d0f0068b",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "8fd7559f292494a345765a3158204163ff97635ae5a796e961f01a12e604589e"
+  "contextDigest": "02cc16df3a97d0634e719b8df86af13058a86ea4f219a6fd0e9d593491050083"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "0e40f2fc8c4f251d89397744e4465cab858189b875f732a92ea3ce7700b96bd9",
-    "auditedInputDigest": "3ef83dc31fb624ac532c00805d67c2da56aac6db36a427afc7d88e211d61afb0"
+    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf",
+    "auditedInputDigest": "79845f56bea6cc39301a7f26dae9c52567dedf9bacaa1465bcfe003a4f50d80c"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "42897b6143d5489c01c31024adba34a134b1a5e6634aab2fbe50f26fa8e1d77c",
+    "dossierDigest": "1df1a089ad52c184c626dff04e4aaa7bd6ce209a13dcb4e7403d12988e671fd8",
     "catalogDigest": "24238218499ffff02768ab879d2c55877b656be79221b03b56b8d951d0f0068b",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "a3350692f63855a586f8b027860ff3fe60c054b0aaeec80fe1fb3a9615bc1ce8"
+  "contextDigest": "57392d1f737af0b5a2e60194da2e510bbdd2bba478a87307af83852c5704f353"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf",
-    "auditedInputDigest": "79845f56bea6cc39301a7f26dae9c52567dedf9bacaa1465bcfe003a4f50d80c"
+    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
+    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "1df1a089ad52c184c626dff04e4aaa7bd6ce209a13dcb4e7403d12988e671fd8",
+    "dossierDigest": "14e636b03791f59dc4aa9306f792e83939fb8631a03a904d453d3b9af1a9baa6",
     "catalogDigest": "24238218499ffff02768ab879d2c55877b656be79221b03b56b8d951d0f0068b",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "57392d1f737af0b5a2e60194da2e510bbdd2bba478a87307af83852c5704f353"
+  "contextDigest": "3ebc21810992cf565de4f920646be28a0fbc67cda9996f93dbfc55d44b810651"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "3ebc21810992cf565de4f920646be28a0fbc67cda9996f93dbfc55d44b810651",
-    "qualityDigest": "999c6f191afc4ee0421b3706f52f7706fbb94e4a91241d9ecfa74396654f1cd6",
+    "contextDigest": "8fd7559f292494a345765a3158204163ff97635ae5a796e961f01a12e604589e",
+    "qualityDigest": "458ad10f6f3e1807d19101d3d8a0a6cb7aafa550dbe41cb9daf8d311fe451c79",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "e1ccbc815b688359b056553d8b238ce30539112e40b6eb18296f51ddffe445a1"
+  "activationDigest": "55afaa3f63df3d754b6473012bb39beba04f7f59e1d1c4d94cbe9498f49f6ae2"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0e40f2fc8c4f251d89397744e4465cab858189b875f732a92ea3ce7700b96bd9"
+    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "a3350692f63855a586f8b027860ff3fe60c054b0aaeec80fe1fb3a9615bc1ce8",
-    "qualityDigest": "509ed091962cb6e6e2b0af70697f7f5667612dbf0f2ed2a96edcd9eeece35b88",
+    "contextDigest": "57392d1f737af0b5a2e60194da2e510bbdd2bba478a87307af83852c5704f353",
+    "qualityDigest": "da7664c1f87de7fec0be0d7dbda2daf49efdc9c0afa6315c6aa716962a00a155",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "0e0cbfe72f14fcf18b00f8a90f7f54aa12cd7aa00683c2d3dad4b1cd0ab3c3fa"
+  "activationDigest": "9ed32bc7b3b32f2a4e1066e7c43b7f29dae8a3cafe777cf060be18df1416cef1"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf"
+    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "57392d1f737af0b5a2e60194da2e510bbdd2bba478a87307af83852c5704f353",
-    "qualityDigest": "da7664c1f87de7fec0be0d7dbda2daf49efdc9c0afa6315c6aa716962a00a155",
+    "contextDigest": "3ebc21810992cf565de4f920646be28a0fbc67cda9996f93dbfc55d44b810651",
+    "qualityDigest": "999c6f191afc4ee0421b3706f52f7706fbb94e4a91241d9ecfa74396654f1cd6",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "9ed32bc7b3b32f2a4e1066e7c43b7f29dae8a3cafe777cf060be18df1416cef1"
+  "activationDigest": "e1ccbc815b688359b056553d8b238ce30539112e40b6eb18296f51ddffe445a1"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60"
+    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "8fd7559f292494a345765a3158204163ff97635ae5a796e961f01a12e604589e",
-    "qualityDigest": "458ad10f6f3e1807d19101d3d8a0a6cb7aafa550dbe41cb9daf8d311fe451c79",
+    "contextDigest": "02cc16df3a97d0634e719b8df86af13058a86ea4f219a6fd0e9d593491050083",
+    "qualityDigest": "91c2d373205a2b119adf454e7733f2c7e8c0eb8bb8aa0fd78f547af297ce51b7",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "55afaa3f63df3d754b6473012bb39beba04f7f59e1d1c4d94cbe9498f49f6ae2"
+  "activationDigest": "27a54cb0cd9049f975dbeab09eec1dd091e37ad975b2f8430382a272f8c9a0ad"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
-    "contextDigest": "8fd7559f292494a345765a3158204163ff97635ae5a796e961f01a12e604589e"
+    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a",
+    "contextDigest": "02cc16df3a97d0634e719b8df86af13058a86ea4f219a6fd0e9d593491050083"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "8dc723588f88a58a0897163574902cef0c17661cb8c9b493aaaced5cd72da45d",
-    "validationDigest": "95be742c64f8f9f0a135612bbcc27291a521bd3c1dfbcfca6b72f831775f520e",
+    "digest": "ca08e8958a56590c0c4c1a693393fccdc95828d58aba590d81abfaf7627c5321",
+    "validationDigest": "de254266b14a6bb57c31b2dea255195770d4e0fd9428eb17fae9e0bae732801d",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "458ad10f6f3e1807d19101d3d8a0a6cb7aafa550dbe41cb9daf8d311fe451c79"
+  "qualityDigest": "91c2d373205a2b119adf454e7733f2c7e8c0eb8bb8aa0fd78f547af297ce51b7"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf",
-    "contextDigest": "57392d1f737af0b5a2e60194da2e510bbdd2bba478a87307af83852c5704f353"
+    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
+    "contextDigest": "3ebc21810992cf565de4f920646be28a0fbc67cda9996f93dbfc55d44b810651"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "9253684222c018125751dfefcae9cd6ae37885caf351edacd466c7c8dd653e42",
-    "validationDigest": "9db08a0477aa8e30a2b56a884e962abfb9d22154eb05ff7eb5e733bb01a3e1bb",
+    "digest": "967b196ffbcf799fbd4aaa2f7fb57ede8b876a4ed91d9de514dd889acc4b2fa8",
+    "validationDigest": "921df1314634444420fd3bd769f98ae6055dcccfabd75e3b011a8105800b84b7",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "da7664c1f87de7fec0be0d7dbda2daf49efdc9c0afa6315c6aa716962a00a155"
+  "qualityDigest": "999c6f191afc4ee0421b3706f52f7706fbb94e4a91241d9ecfa74396654f1cd6"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0e40f2fc8c4f251d89397744e4465cab858189b875f732a92ea3ce7700b96bd9",
-    "contextDigest": "a3350692f63855a586f8b027860ff3fe60c054b0aaeec80fe1fb3a9615bc1ce8"
+    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf",
+    "contextDigest": "57392d1f737af0b5a2e60194da2e510bbdd2bba478a87307af83852c5704f353"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "b823b322f6e3151ad1ce0b8187cbb064dbcf824cbdbcadbfb58ddafa88b51bcc",
-    "validationDigest": "96006ada649c556be2069662b6254f7ef7c8684eb36b485edee3fbe7d91c0305",
+    "digest": "9253684222c018125751dfefcae9cd6ae37885caf351edacd466c7c8dd653e42",
+    "validationDigest": "9db08a0477aa8e30a2b56a884e962abfb9d22154eb05ff7eb5e733bb01a3e1bb",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "509ed091962cb6e6e2b0af70697f7f5667612dbf0f2ed2a96edcd9eeece35b88"
+  "qualityDigest": "da7664c1f87de7fec0be0d7dbda2daf49efdc9c0afa6315c6aa716962a00a155"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
-    "contextDigest": "3ebc21810992cf565de4f920646be28a0fbc67cda9996f93dbfc55d44b810651"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
+    "contextDigest": "8fd7559f292494a345765a3158204163ff97635ae5a796e961f01a12e604589e"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "967b196ffbcf799fbd4aaa2f7fb57ede8b876a4ed91d9de514dd889acc4b2fa8",
-    "validationDigest": "921df1314634444420fd3bd769f98ae6055dcccfabd75e3b011a8105800b84b7",
+    "digest": "8dc723588f88a58a0897163574902cef0c17661cb8c9b493aaaced5cd72da45d",
+    "validationDigest": "95be742c64f8f9f0a135612bbcc27291a521bd3c1dfbcfca6b72f831775f520e",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "999c6f191afc4ee0421b3706f52f7706fbb94e4a91241d9ecfa74396654f1cd6"
+  "qualityDigest": "458ad10f6f3e1807d19101d3d8a0a6cb7aafa550dbe41cb9daf8d311fe451c79"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "3ef83dc31fb624ac532c00805d67c2da56aac6db36a427afc7d88e211d61afb0",
+    "auditedInputDigest": "79845f56bea6cc39301a7f26dae9c52567dedf9bacaa1465bcfe003a4f50d80c",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "24238218499ffff02768ab879d2c55877b656be79221b03b56b8d951d0f0068b",
-    "dossierDigest": "42897b6143d5489c01c31024adba34a134b1a5e6634aab2fbe50f26fa8e1d77c",
+    "dossierDigest": "1df1a089ad52c184c626dff04e4aaa7bd6ce209a13dcb4e7403d12988e671fd8",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "42897b6143d5489c01c31024adba34a134b1a5e6634aab2fbe50f26fa8e1d77c",
+        "dossierDigest": "1df1a089ad52c184c626dff04e4aaa7bd6ce209a13dcb4e7403d12988e671fd8",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "96006ada649c556be2069662b6254f7ef7c8684eb36b485edee3fbe7d91c0305"
+  "validationDigest": "9db08a0477aa8e30a2b56a884e962abfb9d22154eb05ff7eb5e733bb01a3e1bb"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf",
+    "auditedInputDigest": "13cc24a019981b3decf8ea5f147355bd4ad5d5b1398cb2acac273d06c5dcc473",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "24238218499ffff02768ab879d2c55877b656be79221b03b56b8d951d0f0068b",
-    "dossierDigest": "3a42aab00878ab536c7bf36c5b6e002c04ca95c98979c8cbdefe0457a82f5526",
+    "dossierDigest": "f888ed9ab31ab615292601fe7084c036c3739db03c5cc49ca11067786091724d",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "3a42aab00878ab536c7bf36c5b6e002c04ca95c98979c8cbdefe0457a82f5526",
+        "dossierDigest": "f888ed9ab31ab615292601fe7084c036c3739db03c5cc49ca11067786091724d",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "95be742c64f8f9f0a135612bbcc27291a521bd3c1dfbcfca6b72f831775f520e"
+  "validationDigest": "de254266b14a6bb57c31b2dea255195770d4e0fd9428eb17fae9e0bae732801d"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048",
+    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "24238218499ffff02768ab879d2c55877b656be79221b03b56b8d951d0f0068b",
-    "dossierDigest": "14e636b03791f59dc4aa9306f792e83939fb8631a03a904d453d3b9af1a9baa6",
+    "dossierDigest": "3a42aab00878ab536c7bf36c5b6e002c04ca95c98979c8cbdefe0457a82f5526",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "14e636b03791f59dc4aa9306f792e83939fb8631a03a904d453d3b9af1a9baa6",
+        "dossierDigest": "3a42aab00878ab536c7bf36c5b6e002c04ca95c98979c8cbdefe0457a82f5526",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "921df1314634444420fd3bd769f98ae6055dcccfabd75e3b011a8105800b84b7"
+  "validationDigest": "95be742c64f8f9f0a135612bbcc27291a521bd3c1dfbcfca6b72f831775f520e"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "79845f56bea6cc39301a7f26dae9c52567dedf9bacaa1465bcfe003a4f50d80c",
+    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "24238218499ffff02768ab879d2c55877b656be79221b03b56b8d951d0f0068b",
-    "dossierDigest": "1df1a089ad52c184c626dff04e4aaa7bd6ce209a13dcb4e7403d12988e671fd8",
+    "dossierDigest": "14e636b03791f59dc4aa9306f792e83939fb8631a03a904d453d3b9af1a9baa6",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "1df1a089ad52c184c626dff04e4aaa7bd6ce209a13dcb4e7403d12988e671fd8",
+        "dossierDigest": "14e636b03791f59dc4aa9306f792e83939fb8631a03a904d453d3b9af1a9baa6",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "9db08a0477aa8e30a2b56a884e962abfb9d22154eb05ff7eb5e733bb01a3e1bb"
+  "validationDigest": "921df1314634444420fd3bd769f98ae6055dcccfabd75e3b011a8105800b84b7"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "0e40f2fc8c4f251d89397744e4465cab858189b875f732a92ea3ce7700b96bd9",
-    "auditedInputDigest": "3ef83dc31fb624ac532c00805d67c2da56aac6db36a427afc7d88e211d61afb0"
+    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf",
+    "auditedInputDigest": "79845f56bea6cc39301a7f26dae9c52567dedf9bacaa1465bcfe003a4f50d80c"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "17b1095b840c9f059845732af8b15f407a1374ae4d235302ebff9b5d515a8770",
+    "dossierDigest": "a451fad9791339c333212255bfd122b24551b14ab0f325f993a108b52f582790",
     "catalogDigest": "a7934690a8abe6e2d5866a0542d6a0df3a9219136af620e7324431f1caf87cff",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "de843f5d7353c0f9f50ee263e7293543a73e99458c70c6c3e5eef46eee3a468f"
+  "contextDigest": "6416a838d13770abc324e727ed4a8ae6979f550c3c4d91315627a676d76ed23f"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
-    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
+    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "f13b23880c443c15fac8e49abb6c9b1acb3580f5774e29c33264de92d52a6d9e",
+    "dossierDigest": "7a45e6ac1777353ccfc0ac886f659b00424365489a67ff41e1fe545122bea688",
     "catalogDigest": "a7934690a8abe6e2d5866a0542d6a0df3a9219136af620e7324431f1caf87cff",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "05f47b76918b5642761d51a591866e3a706c21f28e0c5dc5241a0316fb053053"
+  "contextDigest": "b875dd5e612f7800b1936a45978d0176cb8a4feb1ce030a4211c84dfeb9f9e1b"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf",
-    "auditedInputDigest": "79845f56bea6cc39301a7f26dae9c52567dedf9bacaa1465bcfe003a4f50d80c"
+    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
+    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "a451fad9791339c333212255bfd122b24551b14ab0f325f993a108b52f582790",
+    "dossierDigest": "f13b23880c443c15fac8e49abb6c9b1acb3580f5774e29c33264de92d52a6d9e",
     "catalogDigest": "a7934690a8abe6e2d5866a0542d6a0df3a9219136af620e7324431f1caf87cff",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "6416a838d13770abc324e727ed4a8ae6979f550c3c4d91315627a676d76ed23f"
+  "contextDigest": "05f47b76918b5642761d51a591866e3a706c21f28e0c5dc5241a0316fb053053"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
-    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf"
+    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a",
+    "auditedInputDigest": "13cc24a019981b3decf8ea5f147355bd4ad5d5b1398cb2acac273d06c5dcc473"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "7a45e6ac1777353ccfc0ac886f659b00424365489a67ff41e1fe545122bea688",
+    "dossierDigest": "5f997e16a69f2e59fcb74bb8309060362914cccdd8d85d2093c0599e5c4ce11e",
     "catalogDigest": "a7934690a8abe6e2d5866a0542d6a0df3a9219136af620e7324431f1caf87cff",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "b875dd5e612f7800b1936a45978d0176cb8a4feb1ce030a4211c84dfeb9f9e1b"
+  "contextDigest": "43f389c68fa5025aa095f2bad9cdff25db932620d89a88b523bd617d162ee7a3"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0e40f2fc8c4f251d89397744e4465cab858189b875f732a92ea3ce7700b96bd9"
+    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "de843f5d7353c0f9f50ee263e7293543a73e99458c70c6c3e5eef46eee3a468f",
-    "qualityDigest": "4ba8927bb362d81fd79e71b7925ae9cf4cad363ccd0cc6d7c20dbd2ad2bf1fbb",
+    "contextDigest": "6416a838d13770abc324e727ed4a8ae6979f550c3c4d91315627a676d76ed23f",
+    "qualityDigest": "118f7ade29c3869a613310656ab62ef360fc93fdbb1118347998f52260b6f99e",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "038c7e1584aaaf4206250e7d705d93366e796fc00b2d3743401ec6bfec97a247"
+  "activationDigest": "1505e8d04292a26e273f45f422d7356706aad63b48998617ebf333235a372cbb"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60"
+    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "b875dd5e612f7800b1936a45978d0176cb8a4feb1ce030a4211c84dfeb9f9e1b",
-    "qualityDigest": "3fa390ff9c10ea649e33d6fa07ec8cd6f1227ce6660ee726533a0c7785df0624",
+    "contextDigest": "43f389c68fa5025aa095f2bad9cdff25db932620d89a88b523bd617d162ee7a3",
+    "qualityDigest": "c895816b5a9788cefe47de1032e6800fb9bdffd810b37df7454f9691bf361431",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "f9c88f7d498412f7a1e1dafa1a915f4e5af5cda4e984ad31e03ff866c7e686ff"
+  "activationDigest": "c382e7388f11edf58716fa0a5e7580225f7acc00c50bdbf0e6dcda1b7b1801df"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf"
+    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "6416a838d13770abc324e727ed4a8ae6979f550c3c4d91315627a676d76ed23f",
-    "qualityDigest": "118f7ade29c3869a613310656ab62ef360fc93fdbb1118347998f52260b6f99e",
+    "contextDigest": "05f47b76918b5642761d51a591866e3a706c21f28e0c5dc5241a0316fb053053",
+    "qualityDigest": "9abf1ebd7a09ca9559ea3875520b0afba4975750e82b46d6d855ca86556d556f",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "1505e8d04292a26e273f45f422d7356706aad63b48998617ebf333235a372cbb"
+  "activationDigest": "07cf92451e944d4733ec55b06eb24069873d4073e256da042c0fc96136b69238"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "05f47b76918b5642761d51a591866e3a706c21f28e0c5dc5241a0316fb053053",
-    "qualityDigest": "9abf1ebd7a09ca9559ea3875520b0afba4975750e82b46d6d855ca86556d556f",
+    "contextDigest": "b875dd5e612f7800b1936a45978d0176cb8a4feb1ce030a4211c84dfeb9f9e1b",
+    "qualityDigest": "3fa390ff9c10ea649e33d6fa07ec8cd6f1227ce6660ee726533a0c7785df0624",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "07cf92451e944d4733ec55b06eb24069873d4073e256da042c0fc96136b69238"
+  "activationDigest": "f9c88f7d498412f7a1e1dafa1a915f4e5af5cda4e984ad31e03ff866c7e686ff"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
-    "contextDigest": "b875dd5e612f7800b1936a45978d0176cb8a4feb1ce030a4211c84dfeb9f9e1b"
+    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a",
+    "contextDigest": "43f389c68fa5025aa095f2bad9cdff25db932620d89a88b523bd617d162ee7a3"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "bbe1b3bf0e50ce367203c8bb6bbf25d2bf530c3147e4e20b624da1b8bb7eed3f",
-    "validationDigest": "3fb3ef57b23a2b2d5c4137f2781e759ceae737804d4131bb7ab7ae3b3e146bd8",
+    "digest": "7b556d147e42d953cb63315672c4a5f09d12a9bf75ce5c10e70a0a577503490f",
+    "validationDigest": "32846c9513b0a1db839f1a6c68ecf6043c9c4ec8df7a3b6461454d096a17ad35",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "3fa390ff9c10ea649e33d6fa07ec8cd6f1227ce6660ee726533a0c7785df0624"
+  "qualityDigest": "c895816b5a9788cefe47de1032e6800fb9bdffd810b37df7454f9691bf361431"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf",
-    "contextDigest": "6416a838d13770abc324e727ed4a8ae6979f550c3c4d91315627a676d76ed23f"
+    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
+    "contextDigest": "05f47b76918b5642761d51a591866e3a706c21f28e0c5dc5241a0316fb053053"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "fe8c4c2b25c33d12732b00ec35fc1ac47b43ccf3d0b38c749226890ec5b45ea6",
-    "validationDigest": "937cc46c57bb727bcec5d212ca496c661ab5d7ad785ac09849812deb85a20d4a",
+    "digest": "bfc93617da9c196c43c39652f1d2526c0cf72cf6c6d3a231e7e19131f6b77a1a",
+    "validationDigest": "8421ca9d1c3cf87ef75a6cc951ef3bbb8e3ec9868108b3c7e90315156f1a02c7",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "118f7ade29c3869a613310656ab62ef360fc93fdbb1118347998f52260b6f99e"
+  "qualityDigest": "9abf1ebd7a09ca9559ea3875520b0afba4975750e82b46d6d855ca86556d556f"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "7d203a37cd30f873909668a1a3cfbb3da8a0a9cdc190b85d9863271dad3350d0",
-    "contextDigest": "05f47b76918b5642761d51a591866e3a706c21f28e0c5dc5241a0316fb053053"
+    "sourceManifestDigest": "fe3567e36214a28034bfb13263f6089dd80b9a63ea94223b632cbb561814dc60",
+    "contextDigest": "b875dd5e612f7800b1936a45978d0176cb8a4feb1ce030a4211c84dfeb9f9e1b"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "bfc93617da9c196c43c39652f1d2526c0cf72cf6c6d3a231e7e19131f6b77a1a",
-    "validationDigest": "8421ca9d1c3cf87ef75a6cc951ef3bbb8e3ec9868108b3c7e90315156f1a02c7",
+    "digest": "bbe1b3bf0e50ce367203c8bb6bbf25d2bf530c3147e4e20b624da1b8bb7eed3f",
+    "validationDigest": "3fb3ef57b23a2b2d5c4137f2781e759ceae737804d4131bb7ab7ae3b3e146bd8",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "9abf1ebd7a09ca9559ea3875520b0afba4975750e82b46d6d855ca86556d556f"
+  "qualityDigest": "3fa390ff9c10ea649e33d6fa07ec8cd6f1227ce6660ee726533a0c7785df0624"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "0e40f2fc8c4f251d89397744e4465cab858189b875f732a92ea3ce7700b96bd9",
-    "contextDigest": "de843f5d7353c0f9f50ee263e7293543a73e99458c70c6c3e5eef46eee3a468f"
+    "sourceManifestDigest": "e0181efb731078ac9500e4179a5906ee8c6ac51be25dd939310e5919f9a95baf",
+    "contextDigest": "6416a838d13770abc324e727ed4a8ae6979f550c3c4d91315627a676d76ed23f"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "0e17d5e4fc113241e0f842d8f6f5b68ba878fb527a659542081a88c95e1b8a81",
-    "validationDigest": "30721c0863abbff5d763654b11316fa30eb4faff433ed4e10b6af3217fcd6c3e",
+    "digest": "fe8c4c2b25c33d12732b00ec35fc1ac47b43ccf3d0b38c749226890ec5b45ea6",
+    "validationDigest": "937cc46c57bb727bcec5d212ca496c661ab5d7ad785ac09849812deb85a20d4a",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "4ba8927bb362d81fd79e71b7925ae9cf4cad363ccd0cc6d7c20dbd2ad2bf1fbb"
+  "qualityDigest": "118f7ade29c3869a613310656ab62ef360fc93fdbb1118347998f52260b6f99e"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048",
+    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "a7934690a8abe6e2d5866a0542d6a0df3a9219136af620e7324431f1caf87cff",
-    "dossierDigest": "f13b23880c443c15fac8e49abb6c9b1acb3580f5774e29c33264de92d52a6d9e",
+    "dossierDigest": "7a45e6ac1777353ccfc0ac886f659b00424365489a67ff41e1fe545122bea688",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "f13b23880c443c15fac8e49abb6c9b1acb3580f5774e29c33264de92d52a6d9e",
+        "dossierDigest": "7a45e6ac1777353ccfc0ac886f659b00424365489a67ff41e1fe545122bea688",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "8421ca9d1c3cf87ef75a6cc951ef3bbb8e3ec9868108b3c7e90315156f1a02c7"
+  "validationDigest": "3fb3ef57b23a2b2d5c4137f2781e759ceae737804d4131bb7ab7ae3b3e146bd8"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "79845f56bea6cc39301a7f26dae9c52567dedf9bacaa1465bcfe003a4f50d80c",
+    "auditedInputDigest": "c2a281f6a478bb0052ac1b3314ebb150cba8c68e680b783a86077875b1a46048",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "a7934690a8abe6e2d5866a0542d6a0df3a9219136af620e7324431f1caf87cff",
-    "dossierDigest": "a451fad9791339c333212255bfd122b24551b14ab0f325f993a108b52f582790",
+    "dossierDigest": "f13b23880c443c15fac8e49abb6c9b1acb3580f5774e29c33264de92d52a6d9e",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "a451fad9791339c333212255bfd122b24551b14ab0f325f993a108b52f582790",
+        "dossierDigest": "f13b23880c443c15fac8e49abb6c9b1acb3580f5774e29c33264de92d52a6d9e",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "937cc46c57bb727bcec5d212ca496c661ab5d7ad785ac09849812deb85a20d4a"
+  "validationDigest": "8421ca9d1c3cf87ef75a6cc951ef3bbb8e3ec9868108b3c7e90315156f1a02c7"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "31b8f6b2534a2b94eae67273daaace1622e5efd9d14d3174f502c487a7460cdf",
+    "auditedInputDigest": "13cc24a019981b3decf8ea5f147355bd4ad5d5b1398cb2acac273d06c5dcc473",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "a7934690a8abe6e2d5866a0542d6a0df3a9219136af620e7324431f1caf87cff",
-    "dossierDigest": "7a45e6ac1777353ccfc0ac886f659b00424365489a67ff41e1fe545122bea688",
+    "dossierDigest": "5f997e16a69f2e59fcb74bb8309060362914cccdd8d85d2093c0599e5c4ce11e",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "7a45e6ac1777353ccfc0ac886f659b00424365489a67ff41e1fe545122bea688",
+        "dossierDigest": "5f997e16a69f2e59fcb74bb8309060362914cccdd8d85d2093c0599e5c4ce11e",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "3fb3ef57b23a2b2d5c4137f2781e759ceae737804d4131bb7ab7ae3b3e146bd8"
+  "validationDigest": "32846c9513b0a1db839f1a6c68ecf6043c9c4ec8df7a3b6461454d096a17ad35"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "3ef83dc31fb624ac532c00805d67c2da56aac6db36a427afc7d88e211d61afb0",
+    "auditedInputDigest": "79845f56bea6cc39301a7f26dae9c52567dedf9bacaa1465bcfe003a4f50d80c",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "a7934690a8abe6e2d5866a0542d6a0df3a9219136af620e7324431f1caf87cff",
-    "dossierDigest": "17b1095b840c9f059845732af8b15f407a1374ae4d235302ebff9b5d515a8770",
+    "dossierDigest": "a451fad9791339c333212255bfd122b24551b14ab0f325f993a108b52f582790",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "17b1095b840c9f059845732af8b15f407a1374ae4d235302ebff9b5d515a8770",
+        "dossierDigest": "a451fad9791339c333212255bfd122b24551b14ab0f325f993a108b52f582790",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "30721c0863abbff5d763654b11316fa30eb4faff433ed4e10b6af3217fcd6c3e"
+  "validationDigest": "937cc46c57bb727bcec5d212ca496c661ab5d7ad785ac09849812deb85a20d4a"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.84",
+  "version": "0.0.85",
   "packageManager": "pnpm@11.22.0",
   "private": true,
   "description": "An out-of-box LCA Data solution",

--- a/src/components/LoadingDisabledActionGroup/index.tsx
+++ b/src/components/LoadingDisabledActionGroup/index.tsx
@@ -1,0 +1,25 @@
+import type { CSSProperties, FC, PropsWithChildren } from 'react';
+
+type Props = PropsWithChildren<{
+  loading: boolean;
+  style?: CSSProperties;
+}>;
+
+const fieldsetStyle: CSSProperties = {
+  border: 0,
+  margin: 0,
+  minInlineSize: 0,
+  padding: 0,
+};
+
+const LoadingDisabledActionGroup: FC<Props> = ({ children, loading, style }) => (
+  <fieldset
+    aria-busy={loading}
+    disabled={loading}
+    style={style ? { ...fieldsetStyle, ...style } : fieldsetStyle}
+  >
+    {children}
+  </fieldset>
+);
+
+export default LoadingDisabledActionGroup;

--- a/src/components/RightContent/AvatarDropdown.tsx
+++ b/src/components/RightContent/AvatarDropdown.tsx
@@ -248,7 +248,12 @@ export const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({ children }) =
     return loading;
   }
 
-  const menuItems = [
+  const canViewSystemManagement = ['admin', 'owner', 'member'].includes(systemUserData?.role ?? '');
+  const canViewReviewManagement = ['review-admin', 'review-member'].includes(
+    reviewUserData?.role ?? '',
+  );
+
+  const menuItems: MenuProps['items'] = [
     {
       key: 'profile',
       icon: <UserOutlined />,
@@ -259,21 +264,24 @@ export const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({ children }) =
       icon: <TeamOutlined />,
       label: <FormattedMessage id='menu.account.team' defaultMessage='My Team' />,
     },
-    {
-      key: 'system',
-      icon: <SettingOutlined />,
-      label: <FormattedMessage id='menu.manageSystem' defaultMessage='System Management' />,
-      hidden:
-        systemUserData?.role !== 'admin' &&
-        systemUserData?.role !== 'owner' &&
-        systemUserData?.role !== 'member',
-    },
-    {
-      key: 'review',
-      icon: <AuditOutlined />,
-      label: <FormattedMessage id='menu.account.review' defaultMessage='Review Management' />,
-      hidden: reviewUserData?.role !== 'review-admin' && reviewUserData?.role !== 'review-member',
-    },
+    ...(canViewSystemManagement
+      ? [
+          {
+            key: 'system',
+            icon: <SettingOutlined />,
+            label: <FormattedMessage id='menu.manageSystem' defaultMessage='System Management' />,
+          },
+        ]
+      : []),
+    ...(canViewReviewManagement
+      ? [
+          {
+            key: 'review',
+            icon: <AuditOutlined />,
+            label: <FormattedMessage id='menu.account.review' defaultMessage='Review Management' />,
+          },
+        ]
+      : []),
     {
       type: 'divider' as const,
     },

--- a/src/pages/Contacts/Components/edit.tsx
+++ b/src/pages/Contacts/Components/edit.tsx
@@ -808,6 +808,7 @@ const ContactEdit: FC<Props> = ({
               }}
             >
               <ContactForm
+                formType='edit'
                 lang={lang}
                 activeTabKey={activeTabKey}
                 formRef={formRefEdit}

--- a/src/pages/Contacts/Components/edit.tsx
+++ b/src/pages/Contacts/Components/edit.tsx
@@ -1,5 +1,6 @@
 /* istanbul ignore file -- drawer orchestration is covered by behavioral tests; remaining branches are UI scheduling only */
 import DatasetSubmitReviewButton from '@/components/DatasetSubmitReviewButton';
+import LoadingDisabledActionGroup from '@/components/LoadingDisabledActionGroup';
 import RefsOfNewVersionDrawer, { RefVersionItem } from '@/components/RefsOfNewVersionDrawer';
 import { showValidationIssueModal } from '@/components/ValidationIssueModal';
 import { RefCheckContext, RefCheckType, useRefCheckContext } from '@/contexts/refCheckContext';
@@ -260,6 +261,7 @@ const ContactEdit: FC<Props> = ({
 
   useEffect(() => {
     if (!drawerVisible) {
+      setInitData(undefined);
       setCurrentStateCode(undefined);
       setShowRules(false);
       setSdkValidationDetails([]);
@@ -727,59 +729,61 @@ const ContactEdit: FC<Props> = ({
         open={drawerVisible}
         onClose={closeDrawer}
         footer={
-          <Space size={'middle'} className={styles.footer_right}>
-            <Button onClick={() => void handleCheckData()}>
-              <FormattedMessage id='pages.button.check' defaultMessage='Data Check' />
-            </Button>
-            {showSyncOpenDataButton && isReviewAdmin && (
+          <LoadingDisabledActionGroup loading={spinning || !initData}>
+            <Space size={'middle'} className={styles.footer_right}>
+              <Button onClick={() => void handleCheckData()}>
+                <FormattedMessage id='pages.button.check' defaultMessage='Data Check' />
+              </Button>
+              {showSyncOpenDataButton && isReviewAdmin && (
+                <Button
+                  disabled={spinning || currentStateCode === 100}
+                  onClick={handleSyncToOpenData}
+                >
+                  <FormattedMessage
+                    id='pages.button.syncToOpenData'
+                    defaultMessage='Sync to Open Data'
+                  />
+                </Button>
+              )}
+              <DatasetSubmitReviewButton
+                table='contacts'
+                id={id}
+                version={version}
+                disabled={spinning || currentStateCode !== 0}
+                beforeSubmit={() => handleCheckData({ actionFrom: 'review' })}
+                onSuccess={() => {
+                  setCurrentStateCode(20);
+                  actionRef?.current?.reload();
+                  closeDrawer();
+                }}
+              />
               <Button
-                disabled={spinning || currentStateCode === 100}
-                onClick={handleSyncToOpenData}
+                onClick={() => {
+                  handleUpdateReference();
+                }}
               >
                 <FormattedMessage
-                  id='pages.button.syncToOpenData'
-                  defaultMessage='Sync to Open Data'
+                  id='pages.button.updateReference'
+                  defaultMessage='Update Reference'
                 />
               </Button>
-            )}
-            <DatasetSubmitReviewButton
-              table='contacts'
-              id={id}
-              version={version}
-              disabled={spinning || currentStateCode !== 0}
-              beforeSubmit={() => handleCheckData({ actionFrom: 'review' })}
-              onSuccess={() => {
-                setCurrentStateCode(20);
-                actionRef?.current?.reload();
-                closeDrawer();
-              }}
-            />
-            <Button
-              onClick={() => {
-                handleUpdateReference();
-              }}
-            >
-              <FormattedMessage
-                id='pages.button.updateReference'
-                defaultMessage='Update Reference'
-              />
-            </Button>
-            <Button onClick={closeDrawer}>
-              <FormattedMessage id='pages.button.cancel' defaultMessage='Cancel' />
-            </Button>
-            {/* <Button onClick={onReset}>
+              <Button onClick={closeDrawer}>
+                <FormattedMessage id='pages.button.cancel' defaultMessage='Cancel' />
+              </Button>
+              {/* <Button onClick={onReset}>
               <FormattedMessage id="pages.button.reset" defaultMessage="Reset" />
             </Button> */}
-            <Button
-              onClick={async () => {
-                setShowRules(false);
-                await handleSubmit(true);
-              }}
-              type='primary'
-            >
-              <FormattedMessage id='pages.button.save' defaultMessage='Save' />
-            </Button>
-          </Space>
+              <Button
+                onClick={async () => {
+                  setShowRules(false);
+                  await handleSubmit(true);
+                }}
+                type='primary'
+              >
+                <FormattedMessage id='pages.button.save' defaultMessage='Save' />
+              </Button>
+            </Space>
+          </LoadingDisabledActionGroup>
         }
       >
         <Spin spinning={spinning}>

--- a/src/pages/Contacts/Components/form.tsx
+++ b/src/pages/Contacts/Components/form.tsx
@@ -462,7 +462,7 @@ export const ContactForm: FC<Props> = ({
                 ]['rules'] ?? [],
               )}
             >
-              <Input />
+              <Input disabled={formType === 'edit'} />
             </DatasetCreateVersionFormItem>
             <ContactSelectForm
               label={

--- a/src/pages/Flowproperties/Components/edit.tsx
+++ b/src/pages/Flowproperties/Components/edit.tsx
@@ -1,5 +1,6 @@
 /* istanbul ignore file -- drawer orchestration is covered by behavioral tests; remaining branches are UI scheduling only */
 import DatasetSubmitReviewButton from '@/components/DatasetSubmitReviewButton';
+import LoadingDisabledActionGroup from '@/components/LoadingDisabledActionGroup';
 import RefsOfNewVersionDrawer, { RefVersionItem } from '@/components/RefsOfNewVersionDrawer';
 import { showValidationIssueModal } from '@/components/ValidationIssueModal';
 import { RefCheckContext, RefCheckType, useRefCheckContext } from '@/contexts/refCheckContext';
@@ -279,6 +280,7 @@ const FlowpropertiesEdit: FC<Props> = ({
 
   useEffect(() => {
     if (!drawerVisible) {
+      setInitData(undefined);
       setDetailStateCode(undefined);
       setRefCheckContextValue({ refCheckData: [] });
       setShowRules(false);
@@ -564,50 +566,52 @@ const FlowpropertiesEdit: FC<Props> = ({
         open={drawerVisible}
         onClose={closeDrawer}
         footer={
-          <Space size={'middle'} className={styles.footer_right}>
-            <Button onClick={() => void handleCheckData()}>
-              <FormattedMessage id='pages.button.check' defaultMessage='Data Check' />
-            </Button>
-            <DatasetSubmitReviewButton
-              table='flowproperties'
-              id={id}
-              version={version}
-              disabled={spinning || detailStateCode !== 0}
-              beforeSubmit={() => handleCheckData()}
-              onSuccess={() => {
-                setDetailStateCode(20);
-                actionRef?.current?.reload();
-                closeDrawer();
-              }}
-            />
-            <Button
-              onClick={() => {
-                handleUpdateReference();
-              }}
-            >
-              <FormattedMessage
-                id='pages.button.updateReference'
-                defaultMessage='Update Reference'
+          <LoadingDisabledActionGroup loading={spinning || !initData}>
+            <Space size={'middle'} className={styles.footer_right}>
+              <Button onClick={() => void handleCheckData()}>
+                <FormattedMessage id='pages.button.check' defaultMessage='Data Check' />
+              </Button>
+              <DatasetSubmitReviewButton
+                table='flowproperties'
+                id={id}
+                version={version}
+                disabled={spinning || detailStateCode !== 0}
+                beforeSubmit={() => handleCheckData()}
+                onSuccess={() => {
+                  setDetailStateCode(20);
+                  actionRef?.current?.reload();
+                  closeDrawer();
+                }}
               />
-            </Button>
-            <Button onClick={closeDrawer}>
-              {' '}
-              <FormattedMessage id='pages.button.cancel' defaultMessage='Cancel' />
-            </Button>
-            <Button onClick={onReset}>
-              {' '}
-              <FormattedMessage id='pages.button.reset' defaultMessage='Reset' />
-            </Button>
-            <Button
-              onClick={async () => {
-                setShowRules(false);
-                await handleSubmit(true);
-              }}
-              type='primary'
-            >
-              <FormattedMessage id='pages.button.save' defaultMessage='Save' />
-            </Button>
-          </Space>
+              <Button
+                onClick={() => {
+                  handleUpdateReference();
+                }}
+              >
+                <FormattedMessage
+                  id='pages.button.updateReference'
+                  defaultMessage='Update Reference'
+                />
+              </Button>
+              <Button onClick={closeDrawer}>
+                {' '}
+                <FormattedMessage id='pages.button.cancel' defaultMessage='Cancel' />
+              </Button>
+              <Button onClick={onReset}>
+                {' '}
+                <FormattedMessage id='pages.button.reset' defaultMessage='Reset' />
+              </Button>
+              <Button
+                onClick={async () => {
+                  setShowRules(false);
+                  await handleSubmit(true);
+                }}
+                type='primary'
+              >
+                <FormattedMessage id='pages.button.save' defaultMessage='Save' />
+              </Button>
+            </Space>
+          </LoadingDisabledActionGroup>
         }
       >
         <Spin spinning={spinning}>

--- a/src/pages/Flowproperties/Components/edit.tsx
+++ b/src/pages/Flowproperties/Components/edit.tsx
@@ -636,6 +636,7 @@ const FlowpropertiesEdit: FC<Props> = ({
               }}
             >
               <FlowpropertyForm
+                formType='edit'
                 lang={lang}
                 activeTabKey={activeTabKey}
                 drawerVisible={drawerVisible}

--- a/src/pages/Flowproperties/Components/form.tsx
+++ b/src/pages/Flowproperties/Components/form.tsx
@@ -433,7 +433,7 @@ export const FlowpropertyForm: FC<Props> = ({
               ]['rules'],
             )}
           >
-            <Input />
+            <Input disabled={formType === 'edit'} />
           </DatasetCreateVersionFormItem>
           {/* <FlowpropertiesSelectForm
             name={[

--- a/src/pages/Flows/Components/edit.tsx
+++ b/src/pages/Flows/Components/edit.tsx
@@ -1,6 +1,7 @@
 /* istanbul ignore file -- drawer orchestration is covered by behavioral tests; remaining branches are UI scheduling only */
 import AISuggestion from '@/components/AISuggestion';
 import DatasetSubmitReviewButton from '@/components/DatasetSubmitReviewButton';
+import LoadingDisabledActionGroup from '@/components/LoadingDisabledActionGroup';
 import RefsOfNewVersionDrawer, { RefVersionItem } from '@/components/RefsOfNewVersionDrawer';
 import { showValidationIssueModal } from '@/components/ValidationIssueModal';
 import { RefCheckContext, RefCheckType, useRefCheckContext } from '@/contexts/refCheckContext';
@@ -325,6 +326,7 @@ const FlowsEdit: FC<Props> = ({
 
   useEffect(() => {
     if (!drawerVisible) {
+      setInitData(undefined);
       setDetailStateCode(undefined);
       setRefCheckContextValue({ refCheckData: [] });
       setShowRules(false);
@@ -664,56 +666,58 @@ const FlowsEdit: FC<Props> = ({
         open={drawerVisible}
         onClose={closeDrawer}
         footer={
-          <Space size={'middle'} className={styles.footer_right}>
-            <AISuggestion
-              type='flow'
-              onLatestJsonChange={handleLatestJsonChange}
-              onClose={handleAISuggestionClose}
-              originJson={originJson}
-            />
-            <Button onClick={() => void handleCheckData()}>
-              <FormattedMessage id='pages.button.check' defaultMessage='Data Check' />
-            </Button>
-            <DatasetSubmitReviewButton
-              table='flows'
-              id={id}
-              version={version}
-              disabled={spinning || detailStateCode !== 0}
-              beforeSubmit={() => handleCheckData({ actionFrom: 'review' })}
-              onSuccess={() => {
-                setDetailStateCode(20);
-                actionRef?.current?.reload();
-                closeDrawer();
-              }}
-            />
-            <Button
-              onClick={() => {
-                handleUpdateReference();
-              }}
-            >
-              <FormattedMessage
-                id='pages.button.updateReference'
-                defaultMessage='Update Reference'
+          <LoadingDisabledActionGroup loading={spinning || !initData}>
+            <Space size={'middle'} className={styles.footer_right}>
+              <AISuggestion
+                type='flow'
+                onLatestJsonChange={handleLatestJsonChange}
+                onClose={handleAISuggestionClose}
+                originJson={originJson}
               />
-            </Button>
-            <Button onClick={closeDrawer}>
-              {' '}
-              <FormattedMessage id='pages.button.cancel' defaultMessage='Cancel' />
-            </Button>
-            {/* <Button onClick={onReset}>
+              <Button onClick={() => void handleCheckData()}>
+                <FormattedMessage id='pages.button.check' defaultMessage='Data Check' />
+              </Button>
+              <DatasetSubmitReviewButton
+                table='flows'
+                id={id}
+                version={version}
+                disabled={spinning || detailStateCode !== 0}
+                beforeSubmit={() => handleCheckData({ actionFrom: 'review' })}
+                onSuccess={() => {
+                  setDetailStateCode(20);
+                  actionRef?.current?.reload();
+                  closeDrawer();
+                }}
+              />
+              <Button
+                onClick={() => {
+                  handleUpdateReference();
+                }}
+              >
+                <FormattedMessage
+                  id='pages.button.updateReference'
+                  defaultMessage='Update Reference'
+                />
+              </Button>
+              <Button onClick={closeDrawer}>
+                {' '}
+                <FormattedMessage id='pages.button.cancel' defaultMessage='Cancel' />
+              </Button>
+              {/* <Button onClick={onReset}>
               {' '}
               <FormattedMessage id="pages.button.reset" defaultMessage="Reset" />
             </Button> */}
-            <Button
-              onClick={async () => {
-                setShowRules(false);
-                await handleSubmit(true);
-              }}
-              type='primary'
-            >
-              <FormattedMessage id='pages.button.save' defaultMessage='Save' />
-            </Button>
-          </Space>
+              <Button
+                onClick={async () => {
+                  setShowRules(false);
+                  await handleSubmit(true);
+                }}
+                type='primary'
+              >
+                <FormattedMessage id='pages.button.save' defaultMessage='Save' />
+              </Button>
+            </Space>
+          </LoadingDisabledActionGroup>
         }
       >
         <Spin spinning={spinning}>

--- a/src/pages/Flows/Components/edit.tsx
+++ b/src/pages/Flows/Components/edit.tsx
@@ -742,6 +742,7 @@ const FlowsEdit: FC<Props> = ({
               }}
             >
               <FlowForm
+                formType='edit'
                 lang={lang}
                 activeTabKey={activeTabKey}
                 drawerVisible={drawerVisible}

--- a/src/pages/Flows/Components/form.tsx
+++ b/src/pages/Flows/Components/form.tsx
@@ -1088,7 +1088,7 @@ export const FlowForm: FC<Props> = ({
               ]['rules'],
             )}
           >
-            <Input />
+            <Input disabled={formType === 'edit'} />
           </DatasetCreateVersionFormItem>
           {/* <FlowsSelectForm
             name={[

--- a/src/pages/LifeCycleModels/Components/form.tsx
+++ b/src/pages/LifeCycleModels/Components/form.tsx
@@ -717,7 +717,7 @@ export const LifeCycleModelForm: FC<Props> = ({
               ]['common:dataSetVersion']['rules'],
             )}
           >
-            <Input />
+            <Input disabled={formType === 'edit'} />
           </DatasetCreateVersionFormItem>
           <Form.Item
             required={false}

--- a/src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx
+++ b/src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx
@@ -53,6 +53,7 @@ import {
   SaveOutlined,
   SendOutlined,
 } from '@ant-design/icons';
+import LoadingDisabledActionGroup from '@/components/LoadingDisabledActionGroup';
 import type { Edge as X6Edge, Node as X6Node } from '@antv/x6';
 import { App, Button, Space, Spin, theme, Tooltip } from 'antd';
 import { FC, useCallback, useEffect, useRef, useState } from 'react';
@@ -1772,37 +1773,40 @@ const ToolbarEdit: FC<Props> = ({
     nodes.some((node) => node.selected) || edges.some((edge) => edge.selected);
 
   return (
-    <Space
-      orientation='vertical'
-      size={'middle'}
-      style={{ height: '70vh', overflowY: 'auto', paddingRight: 10, paddingLeft: 10 }}
+    <LoadingDisabledActionGroup
+      loading={spinning || (drawerVisible && Object.keys(infoData ?? {}).length === 0)}
     >
-      <ToolbarEditInfo
-        ref={editInfoRef}
-        action={thisAction}
-        actionType={actionType}
-        data={infoData}
-        onData={updateInfoData}
-        lang={lang}
-        onNavigateProcessInstance={handleNavigateProcessInstance}
-        onProcessInstanceValidationChange={handleProcessInstanceValidationChange}
-      />
-      {getShowResult()}
-      <EdgeExhange
-        lang={lang}
-        disabled={!selectedEdge}
-        edge={selectedEdge as LifeCycleModelGraphEdge}
-      />
-      <TargetAmount
-        refNode={quantitativeReferenceNode as LifeCycleModelGraphNode}
-        drawerVisible={targetAmountDrawerVisible}
-        lang={lang}
-        setDrawerVisible={setTargetAmountDrawerVisible}
-        onData={updateTargetAmount}
-      />
+      <Space
+        orientation='vertical'
+        size={'middle'}
+        style={{ height: '70vh', overflowY: 'auto', paddingRight: 10, paddingLeft: 10 }}
+      >
+        <ToolbarEditInfo
+          ref={editInfoRef}
+          action={thisAction}
+          actionType={actionType}
+          data={infoData}
+          onData={updateInfoData}
+          lang={lang}
+          onNavigateProcessInstance={handleNavigateProcessInstance}
+          onProcessInstanceValidationChange={handleProcessInstanceValidationChange}
+        />
+        {getShowResult()}
+        <EdgeExhange
+          lang={lang}
+          disabled={!selectedEdge}
+          edge={selectedEdge as LifeCycleModelGraphEdge}
+        />
+        <TargetAmount
+          refNode={quantitativeReferenceNode as LifeCycleModelGraphNode}
+          drawerVisible={targetAmountDrawerVisible}
+          lang={lang}
+          setDrawerVisible={setTargetAmountDrawerVisible}
+          onData={updateTargetAmount}
+        />
 
-      <ModelToolbarAdd buttonType={'icon'} lang={lang} onData={addProcessNodes} />
-      {/* <Tooltip
+        <ModelToolbarAdd buttonType={'icon'} lang={lang} onData={addProcessNodes} />
+        {/* <Tooltip
             title={
               <FormattedMessage
                 id="pages.button.model.design"
@@ -1821,60 +1825,62 @@ const ToolbarEdit: FC<Props> = ({
               }
             />
           </Tooltip> */}
-      <Tooltip
-        title={
-          <FormattedMessage id='pages.button.updateReference' defaultMessage='Update Reference' />
-        }
-        placement='left'
-      >
-        <Button
-          type='primary'
-          size='small'
-          icon={<CopyOutlined />}
-          style={{ boxShadow: 'none' }}
-          onClick={() => updateReference(true)}
-        />
-      </Tooltip>
-      <Tooltip
-        title={<FormattedMessage id='pages.button.model.delete' defaultMessage='Delete element' />}
-        placement='left'
-      >
-        <Button
-          type='primary'
-          size='small'
-          icon={<DeleteOutlined />}
-          style={{ boxShadow: 'none' }}
-          disabled={
-            nodes.filter((node) => node.selected).length === 0 &&
-            edges.filter((edge) => edge.selected).length === 0
+        <Tooltip
+          title={
+            <FormattedMessage id='pages.button.updateReference' defaultMessage='Update Reference' />
           }
-          onClick={deleteCell}
-        />
-      </Tooltip>
-      <br />
+          placement='left'
+        >
+          <Button
+            type='primary'
+            size='small'
+            icon={<CopyOutlined />}
+            style={{ boxShadow: 'none' }}
+            onClick={() => updateReference(true)}
+          />
+        </Tooltip>
+        <Tooltip
+          title={
+            <FormattedMessage id='pages.button.model.delete' defaultMessage='Delete element' />
+          }
+          placement='left'
+        >
+          <Button
+            type='primary'
+            size='small'
+            icon={<DeleteOutlined />}
+            style={{ boxShadow: 'none' }}
+            disabled={
+              nodes.filter((node) => node.selected).length === 0 &&
+              edges.filter((edge) => edge.selected).length === 0
+            }
+            onClick={deleteCell}
+          />
+        </Tooltip>
+        <br />
 
-      <Tooltip
-        title={<FormattedMessage id='pages.button.model.save' defaultMessage='Save data' />}
-        placement='left'
-      >
-        <Button
-          type='primary'
-          size='small'
-          icon={<SaveOutlined />}
-          style={{ boxShadow: 'none' }}
-          onClick={() => {
-            saveData(true);
-            updateNodeCb({
-              '@refObjectId': id,
-              '@version': version,
-              '@type': 'lifeCycleModel data set',
-            });
-          }}
-        />
-      </Tooltip>
-      <br />
+        <Tooltip
+          title={<FormattedMessage id='pages.button.model.save' defaultMessage='Save data' />}
+          placement='left'
+        >
+          <Button
+            type='primary'
+            size='small'
+            icon={<SaveOutlined />}
+            style={{ boxShadow: 'none' }}
+            onClick={() => {
+              saveData(true);
+              updateNodeCb({
+                '@refObjectId': id,
+                '@version': version,
+                '@type': 'lifeCycleModel data set',
+              });
+            }}
+          />
+        </Tooltip>
+        <br />
 
-      {/* <ProcessView
+        {/* <ProcessView
         id={id ?? ''}
         version={version ?? ''}
         lang={lang}
@@ -1882,81 +1888,82 @@ const ToolbarEdit: FC<Props> = ({
         actionRef={undefined}
         disabled={false}
       /> */}
-      <ModelResult
-        submodels={(jsonTg?.submodels ?? []).map((submodel) => ({
-          id: submodel.id,
-          version: submodel.version ?? thisVersion,
-        }))}
-        modelId={thisId}
-        modelVersion={thisVersion}
-        lang={lang}
-        actionType='edit'
-      />
-      <Tooltip
-        title={<FormattedMessage id='pages.button.check' defaultMessage='Data Check' />}
-        placement='left'
-      >
-        <Button
-          type='primary'
-          size='small'
-          icon={<CheckCircleOutlined />}
-          style={{ boxShadow: 'none' }}
-          onClick={() => void handleCheckData()}
+        <ModelResult
+          submodels={(jsonTg?.submodels ?? []).map((submodel) => ({
+            id: submodel.id,
+            version: submodel.version ?? thisVersion,
+          }))}
+          modelId={thisId}
+          modelVersion={thisVersion}
+          lang={lang}
+          actionType='edit'
         />
-      </Tooltip>
-      {!hideReviewButton ? (
         <Tooltip
-          title={<FormattedMessage id='pages.button.review' defaultMessage='Submit for Review' />}
+          title={<FormattedMessage id='pages.button.check' defaultMessage='Data Check' />}
           placement='left'
         >
           <Button
             type='primary'
             size='small'
-            icon={<SendOutlined />}
+            icon={<CheckCircleOutlined />}
             style={{ boxShadow: 'none' }}
-            onClick={handelSubmitReview}
+            onClick={() => void handleCheckData()}
           />
         </Tooltip>
-      ) : null}
-      <Control
-        items={[
-          'undo',
-          'redo',
-          'paste',
-          'duplicate',
-          'zoomOut',
-          'zoomTo',
-          'zoomIn',
-          'zoomToFit',
-          'zoomToOrigin',
-          'autoLayoutLR',
-        ]}
-        editorActions={{
-          undo: undoGraph,
-          redo: redoGraph,
-          paste: pasteSelection,
-          duplicate: duplicateSelection,
-        }}
-        canDuplicate={hasSelectedCells}
-      />
-      <Spin className='tg-fullscreen-spin' spinning={spinning} fullscreen />
-      <IoPortSelect
-        lang={lang}
-        node={ioPortSelectorNode as LifeCycleModelGraphNode}
-        direction={ioPortSelectorDirection}
-        drawerVisible={ioPortSelectorDrawerVisible}
-        onData={updateNodePorts}
-        onDrawerVisible={setIoPortSelectorDrawerVisible}
-      />
-      <ConnectableProcesses
-        lang={lang}
-        drawerVisible={connectableProcessesDrawerVisible}
-        setDrawerVisible={setConnectableProcessesDrawerVisible}
-        portId={connectableProcessesPortId}
-        flowVersion={connectableProcessesFlowVersion}
-        onData={addProcessNodes}
-      />
-    </Space>
+        {!hideReviewButton ? (
+          <Tooltip
+            title={<FormattedMessage id='pages.button.review' defaultMessage='Submit for Review' />}
+            placement='left'
+          >
+            <Button
+              type='primary'
+              size='small'
+              icon={<SendOutlined />}
+              style={{ boxShadow: 'none' }}
+              onClick={handelSubmitReview}
+            />
+          </Tooltip>
+        ) : null}
+        <Control
+          items={[
+            'undo',
+            'redo',
+            'paste',
+            'duplicate',
+            'zoomOut',
+            'zoomTo',
+            'zoomIn',
+            'zoomToFit',
+            'zoomToOrigin',
+            'autoLayoutLR',
+          ]}
+          editorActions={{
+            undo: undoGraph,
+            redo: redoGraph,
+            paste: pasteSelection,
+            duplicate: duplicateSelection,
+          }}
+          canDuplicate={hasSelectedCells}
+        />
+        <Spin className='tg-fullscreen-spin' spinning={spinning} fullscreen />
+        <IoPortSelect
+          lang={lang}
+          node={ioPortSelectorNode as LifeCycleModelGraphNode}
+          direction={ioPortSelectorDirection}
+          drawerVisible={ioPortSelectorDrawerVisible}
+          onData={updateNodePorts}
+          onDrawerVisible={setIoPortSelectorDrawerVisible}
+        />
+        <ConnectableProcesses
+          lang={lang}
+          drawerVisible={connectableProcessesDrawerVisible}
+          setDrawerVisible={setConnectableProcessesDrawerVisible}
+          portId={connectableProcessesPortId}
+          flowVersion={connectableProcessesFlowVersion}
+          onData={addProcessNodes}
+        />
+      </Space>
+    </LoadingDisabledActionGroup>
   );
 };
 

--- a/src/pages/Processes/Components/edit.tsx
+++ b/src/pages/Processes/Components/edit.tsx
@@ -1292,6 +1292,7 @@ const ProcessEdit: FC<Props> = ({
               }}
             >
               <ProcessForm
+                formType='edit'
                 lang={lang}
                 activeTabKey={activeTabKey}
                 actionFrom={actionFrom}

--- a/src/pages/Processes/Components/edit.tsx
+++ b/src/pages/Processes/Components/edit.tsx
@@ -1,5 +1,6 @@
 /* istanbul ignore file -- process editor orchestration is covered by behavioral tests; remaining misses are UI scheduling only */
 import AISuggestion from '@/components/AISuggestion';
+import LoadingDisabledActionGroup from '@/components/LoadingDisabledActionGroup';
 import { showValidationIssueModal } from '@/components/ValidationIssueModal';
 import { RefCheckContext, RefCheckType } from '@/contexts/refCheckContext';
 import {
@@ -1038,6 +1039,7 @@ const ProcessEdit: FC<Props> = ({
 
   useEffect(() => {
     if (!drawerVisible) {
+      setInitData(undefined);
       setShowRules(false);
       setRefCheckData([]);
       setValidationIssueTabNames([]);
@@ -1181,60 +1183,62 @@ const ProcessEdit: FC<Props> = ({
         open={drawerVisible}
         onClose={() => setDrawerVisible(false)}
         footer={
-          <Space size={'middle'} className={styles.footer_right}>
-            <AISuggestion
-              type='process'
-              onLatestJsonChange={handleLatestJsonChange}
-              onClose={handleAISuggestionClose}
-              originJson={originJson}
-            />
-            <Button
-              onClick={async () => {
-                await runCheckData();
-              }}
-            >
-              <FormattedMessage id='pages.button.check' defaultMessage='Data Check' />
-            </Button>
-            <>
-              {!hideReviewButton && (
-                <Button
-                  disabled={spinning}
-                  onClick={() => {
-                    submitReview();
-                  }}
-                >
-                  <FormattedMessage id='pages.button.review' defaultMessage='Submit for Review' />
-                </Button>
-              )}
+          <LoadingDisabledActionGroup loading={spinning || !initData}>
+            <Space size={'middle'} className={styles.footer_right}>
+              <AISuggestion
+                type='process'
+                onLatestJsonChange={handleLatestJsonChange}
+                onClose={handleAISuggestionClose}
+                originJson={originJson}
+              />
               <Button
-                onClick={() => {
-                  handleUpdateReference();
+                onClick={async () => {
+                  await runCheckData();
                 }}
               >
-                <FormattedMessage
-                  id='pages.button.updateReference'
-                  defaultMessage='Update Reference'
-                />
+                <FormattedMessage id='pages.button.check' defaultMessage='Data Check' />
               </Button>
-            </>
-            <Button onClick={() => setDrawerVisible(false)}>
-              <FormattedMessage id='pages.button.cancel' defaultMessage='Cancel' />
-            </Button>
-            {/* <Button onClick={onReset}>
+              <>
+                {!hideReviewButton && (
+                  <Button
+                    disabled={spinning}
+                    onClick={() => {
+                      submitReview();
+                    }}
+                  >
+                    <FormattedMessage id='pages.button.review' defaultMessage='Submit for Review' />
+                  </Button>
+                )}
+                <Button
+                  onClick={() => {
+                    handleUpdateReference();
+                  }}
+                >
+                  <FormattedMessage
+                    id='pages.button.updateReference'
+                    defaultMessage='Update Reference'
+                  />
+                </Button>
+              </>
+              <Button onClick={() => setDrawerVisible(false)}>
+                <FormattedMessage id='pages.button.cancel' defaultMessage='Cancel' />
+              </Button>
+              {/* <Button onClick={onReset}>
               {' '}
               <FormattedMessage id="pages.button.reset" defaultMessage="Reset" />
             </Button> */}
 
-            <Button
-              onClick={() => {
-                setShowRules(false);
-                formRefEdit.current?.submit();
-              }}
-              type='primary'
-            >
-              <FormattedMessage id='pages.button.save' defaultMessage='Save' />
-            </Button>
-          </Space>
+              <Button
+                onClick={() => {
+                  setShowRules(false);
+                  formRefEdit.current?.submit();
+                }}
+                type='primary'
+              >
+                <FormattedMessage id='pages.button.save' defaultMessage='Save' />
+              </Button>
+            </Space>
+          </LoadingDisabledActionGroup>
         }
       >
         <span

--- a/src/pages/Processes/Components/form.tsx
+++ b/src/pages/Processes/Components/form.tsx
@@ -2389,7 +2389,7 @@ export const ProcessForm: FC<Props> = ({
               ]['rules'],
             )}
           >
-            <Input disabled={actionFrom === 'modelResult'} />
+            <Input disabled={formType === 'edit' || actionFrom === 'modelResult'} />
           </DatasetCreateVersionFormItem>
 
           <Form.Item

--- a/src/pages/Sources/Components/edit.tsx
+++ b/src/pages/Sources/Components/edit.tsx
@@ -1,5 +1,6 @@
 /* istanbul ignore file -- drawer orchestration is covered by behavioral tests; remaining branches are UI scheduling only */
 import DatasetSubmitReviewButton from '@/components/DatasetSubmitReviewButton';
+import LoadingDisabledActionGroup from '@/components/LoadingDisabledActionGroup';
 import RefsOfNewVersionDrawer, { RefVersionItem } from '@/components/RefsOfNewVersionDrawer';
 import { showValidationIssueModal } from '@/components/ValidationIssueModal';
 import { RefCheckContext, RefCheckType, useRefCheckContext } from '@/contexts/refCheckContext';
@@ -388,6 +389,7 @@ const SourceEdit: FC<Props> = ({
 
   useEffect(() => {
     if (!drawerVisible) {
+      setInitData(undefined);
       setDetailStateCode(undefined);
       setRefCheckContextValue({ refCheckData: [] });
       setShowRules(false);
@@ -593,48 +595,50 @@ const SourceEdit: FC<Props> = ({
         open={drawerVisible}
         onClose={closeDrawer}
         footer={
-          <Space size={'middle'} className={styles.footer_right}>
-            <Button onClick={() => void handleCheckData()}>
-              <FormattedMessage id='pages.button.check' defaultMessage='Data Check' />
-            </Button>
-            <DatasetSubmitReviewButton
-              table='sources'
-              id={id}
-              version={version}
-              disabled={spinning || detailStateCode !== 0}
-              beforeSubmit={() => handleCheckData({ actionFrom: 'review' })}
-              onSuccess={() => {
-                setDetailStateCode(20);
-                reload();
-                closeDrawer();
-              }}
-            />
-            <Button
-              onClick={() => {
-                handleUpdateReference();
-              }}
-            >
-              <FormattedMessage
-                id='pages.button.updateReference'
-                defaultMessage='Update Reference'
+          <LoadingDisabledActionGroup loading={spinning || !initData}>
+            <Space size={'middle'} className={styles.footer_right}>
+              <Button onClick={() => void handleCheckData()}>
+                <FormattedMessage id='pages.button.check' defaultMessage='Data Check' />
+              </Button>
+              <DatasetSubmitReviewButton
+                table='sources'
+                id={id}
+                version={version}
+                disabled={spinning || detailStateCode !== 0}
+                beforeSubmit={() => handleCheckData({ actionFrom: 'review' })}
+                onSuccess={() => {
+                  setDetailStateCode(20);
+                  reload();
+                  closeDrawer();
+                }}
               />
-            </Button>
-            <Button onClick={closeDrawer}>
-              <FormattedMessage id='pages.button.cancel' defaultMessage='Cancel' />
-            </Button>
-            {/* <Button onClick={onReset}>
+              <Button
+                onClick={() => {
+                  handleUpdateReference();
+                }}
+              >
+                <FormattedMessage
+                  id='pages.button.updateReference'
+                  defaultMessage='Update Reference'
+                />
+              </Button>
+              <Button onClick={closeDrawer}>
+                <FormattedMessage id='pages.button.cancel' defaultMessage='Cancel' />
+              </Button>
+              {/* <Button onClick={onReset}>
               <FormattedMessage id="pages.button.reset" defaultMessage="Reset" />
             </Button> */}
-            <Button
-              onClick={async () => {
-                setShowRules(false);
-                await handleSubmit(true);
-              }}
-              type='primary'
-            >
-              <FormattedMessage id='pages.button.save' defaultMessage='Save' />
-            </Button>
-          </Space>
+              <Button
+                onClick={async () => {
+                  setShowRules(false);
+                  await handleSubmit(true);
+                }}
+                type='primary'
+              >
+                <FormattedMessage id='pages.button.save' defaultMessage='Save' />
+              </Button>
+            </Space>
+          </LoadingDisabledActionGroup>
         }
       >
         <Spin spinning={spinning}>

--- a/src/pages/Sources/Components/edit.tsx
+++ b/src/pages/Sources/Components/edit.tsx
@@ -663,6 +663,7 @@ const SourceEdit: FC<Props> = ({
               }}
             >
               <SourceForm
+                formType='edit'
                 lang={lang}
                 activeTabKey={activeTabKey}
                 formRef={formRefEdit}

--- a/src/pages/Sources/Components/form.tsx
+++ b/src/pages/Sources/Components/form.tsx
@@ -415,7 +415,7 @@ export const SourceForm: FC<Props> = ({
               ]['rules'] ?? [],
             )}
           >
-            <Input />
+            <Input disabled={formType === 'edit'} />
           </DatasetCreateVersionFormItem>
           <ContactSelectForm
             label={

--- a/src/pages/Unitgroups/Components/edit.tsx
+++ b/src/pages/Unitgroups/Components/edit.tsx
@@ -1,5 +1,6 @@
 /* istanbul ignore file -- drawer orchestration is covered by behavioral tests; remaining branches are UI scheduling only */
 import DatasetSubmitReviewButton from '@/components/DatasetSubmitReviewButton';
+import LoadingDisabledActionGroup from '@/components/LoadingDisabledActionGroup';
 import RefsOfNewVersionDrawer, { RefVersionItem } from '@/components/RefsOfNewVersionDrawer';
 import { showValidationIssueModal } from '@/components/ValidationIssueModal';
 import { RefCheckContext, RefCheckType, useRefCheckContext } from '@/contexts/refCheckContext';
@@ -272,6 +273,7 @@ const UnitGroupEdit: FC<Props> = ({
 
   useEffect(() => {
     if (!drawerVisible) {
+      setInitData(undefined);
       setDetailStateCode(undefined);
       setRefCheckContextValue({ refCheckData: [] });
       setShowRules(false);
@@ -613,48 +615,53 @@ const UnitGroupEdit: FC<Props> = ({
         open={drawerVisible}
         onClose={closeDrawer}
         footer={
-          <Space size={'middle'} className={styles.footer_right}>
-            <Button onClick={() => void handleCheckData()}>
-              <FormattedMessage id='pages.button.check' defaultMessage='Data Check' />
-            </Button>
-            <DatasetSubmitReviewButton
-              table='unitgroups'
-              id={id}
-              version={version}
-              disabled={spinning || detailStateCode !== 0}
-              beforeSubmit={() => handleCheckData()}
-              onSuccess={() => {
-                setDetailStateCode(20);
-                actionRef?.current?.reload();
-                closeDrawer();
-              }}
-            />
-            <Button
-              onClick={() => {
-                handleUpdateReference();
-              }}
-            >
-              <FormattedMessage
-                id='pages.button.updateReference'
-                defaultMessage='Update Reference'
+          <LoadingDisabledActionGroup loading={spinning || !initData}>
+            <Space size={'middle'} className={styles.footer_right}>
+              <Button onClick={() => void handleCheckData()}>
+                <FormattedMessage id='pages.button.check' defaultMessage='Data Check' />
+              </Button>
+              <DatasetSubmitReviewButton
+                table='unitgroups'
+                id={id}
+                version={version}
+                disabled={spinning || detailStateCode !== 0}
+                beforeSubmit={() => handleCheckData()}
+                onSuccess={() => {
+                  setDetailStateCode(20);
+                  actionRef?.current?.reload();
+                  closeDrawer();
+                }}
               />
-            </Button>
-            <Button onClick={closeDrawer}>
-              <FormattedMessage id='pages.button.cancel' defaultMessage='Cancel'></FormattedMessage>
-            </Button>
-            {/* <Button onClick={onReset}>
+              <Button
+                onClick={() => {
+                  handleUpdateReference();
+                }}
+              >
+                <FormattedMessage
+                  id='pages.button.updateReference'
+                  defaultMessage='Update Reference'
+                />
+              </Button>
+              <Button onClick={closeDrawer}>
+                <FormattedMessage
+                  id='pages.button.cancel'
+                  defaultMessage='Cancel'
+                ></FormattedMessage>
+              </Button>
+              {/* <Button onClick={onReset}>
               <FormattedMessage id="pages.button.reset" defaultMessage="Reset"></FormattedMessage>
             </Button> */}
-            <Button
-              onClick={async () => {
-                setShowRules(false);
-                await handleSubmit(true);
-              }}
-              type='primary'
-            >
-              <FormattedMessage id='pages.button.save' defaultMessage='Save'></FormattedMessage>
-            </Button>
-          </Space>
+              <Button
+                onClick={async () => {
+                  setShowRules(false);
+                  await handleSubmit(true);
+                }}
+                type='primary'
+              >
+                <FormattedMessage id='pages.button.save' defaultMessage='Save'></FormattedMessage>
+              </Button>
+            </Space>
+          </LoadingDisabledActionGroup>
         }
       >
         <Spin spinning={spinning}>

--- a/src/pages/Unitgroups/Components/edit.tsx
+++ b/src/pages/Unitgroups/Components/edit.tsx
@@ -686,6 +686,7 @@ const UnitGroupEdit: FC<Props> = ({
               }}
             >
               <UnitGroupForm
+                formType='edit'
                 lang={lang}
                 activeTabKey={activeTabKey}
                 formRef={formRefEdit}

--- a/src/pages/Unitgroups/Components/form.tsx
+++ b/src/pages/Unitgroups/Components/form.tsx
@@ -574,7 +574,7 @@ export const UnitGroupForm: FC<Props> = ({
             ]['rules'] ?? [],
           )}
         >
-          <Input />
+          <Input disabled={formType === 'edit'} />
         </DatasetCreateVersionFormItem>
         <ContactSelectForm
           lang={lang}

--- a/tests/unit/components/AvatarDropdown.test.tsx
+++ b/tests/unit/components/AvatarDropdown.test.tsx
@@ -153,8 +153,7 @@ const setupModuleMocks = () => {
     () => ({
       __esModule: true,
       default: function HeaderDropdown({ menu, children, trigger }: any) {
-        const items =
-          menu.items?.filter((item: any) => !item.hidden && item.type !== 'divider') ?? [];
+        const items = menu.items?.filter((item: any) => item.type !== 'divider') ?? [];
         return (
           <div>
             <div data-testid='header-trigger' data-trigger={trigger?.join(',')}>
@@ -404,6 +403,25 @@ describe('AvatarDropdown', () => {
     });
 
     mockedGetSystemUserRoleApi.mockResolvedValue(null);
+    mockedGetReviewUserRoleApi.mockResolvedValue(null);
+
+    render(<AvatarDropdown>avatar</AvatarDropdown>);
+
+    expect(await screen.findByRole('button', { name: 'Account Profile' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'System Management' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Review Management' })).not.toBeInTheDocument();
+  });
+
+  it('hides system management from data product managers without a management role', async () => {
+    const setInitialState = jest.fn();
+    mockUseModel.mockImplementation((model: string) => {
+      if (model === '@@initialState') {
+        return { initialState: { currentUser: { name: 'Morgan' } }, setInitialState };
+      }
+      return {};
+    });
+
+    mockedGetSystemUserRoleApi.mockResolvedValue({ role: 'data_product_manager' });
     mockedGetReviewUserRoleApi.mockResolvedValue(null);
 
     render(<AvatarDropdown>avatar</AvatarDropdown>);

--- a/tests/unit/components/LoadingDisabledActionGroup.test.tsx
+++ b/tests/unit/components/LoadingDisabledActionGroup.test.tsx
@@ -1,0 +1,31 @@
+import LoadingDisabledActionGroup from '@/components/LoadingDisabledActionGroup';
+import { render, screen } from '../../helpers/testUtils';
+
+describe('LoadingDisabledActionGroup', () => {
+  it('disables every nested action until loading finishes', () => {
+    const { rerender } = render(
+      <LoadingDisabledActionGroup loading style={{ width: 240 }}>
+        <button type='button'>Data Check</button>
+        <button type='button' disabled={false}>
+          Save
+        </button>
+      </LoadingDisabledActionGroup>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Data Check' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(screen.getByRole('group')).toHaveStyle({ width: '240px' });
+
+    rerender(
+      <LoadingDisabledActionGroup loading={false}>
+        <button type='button'>Data Check</button>
+        <button type='button' disabled={false}>
+          Save
+        </button>
+      </LoadingDisabledActionGroup>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Data Check' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+  });
+});

--- a/tests/unit/pages/Contacts/ContactEdit.test.tsx
+++ b/tests/unit/pages/Contacts/ContactEdit.test.tsx
@@ -591,6 +591,7 @@ describe('ContactEdit component', () => {
     await waitFor(() =>
       expect(mockGetContactDetail).toHaveBeenCalledWith('contact-123', '01.00.000'),
     );
+    expect(latestContactFormProps.formType).toBe('edit');
 
     const shortNameInput = within(drawer).getByDisplayValue('Original contact');
     await user.clear(shortNameInput);

--- a/tests/unit/pages/Contacts/ContactForm.test.tsx
+++ b/tests/unit/pages/Contacts/ContactForm.test.tsx
@@ -10,6 +10,7 @@ const toText = (node: any): string => {
   if (Array.isArray(node)) return node.map(toText).join('');
   if (node?.props?.defaultMessage) return node.props.defaultMessage;
   if (node?.props?.id) return node.props.id;
+  if (node?.props?.label) return toText(node.props.label);
   if (node?.props?.children) return toText(node.props.children);
   return '';
 };
@@ -238,7 +239,7 @@ describe('ContactForm component', () => {
   });
 
   it('does not inject the default source name outside create mode', () => {
-    renderForm({ formType: 'edit' });
+    renderForm({ activeTabKey: 'administrativeInformation', formType: 'edit' });
 
     const dataSetFormatCall = mockSourceSelectForm.mock.calls.find(
       ([props]: any[]) =>
@@ -248,6 +249,7 @@ describe('ContactForm component', () => {
     );
 
     expect(dataSetFormatCall?.[0]?.defaultSourceName).toBeUndefined();
+    expect(screen.getByRole('textbox', { name: 'Data set version' })).toBeDisabled();
   });
 
   it('applies validation rules when showRules is true', () => {

--- a/tests/unit/pages/Flowproperties/edit.test.tsx
+++ b/tests/unit/pages/Flowproperties/edit.test.tsx
@@ -436,6 +436,7 @@ describe('FlowpropertiesEdit', () => {
     await userEvent.click(screen.getByRole('button', { name: /edit/i }));
 
     await waitFor(() => expect(mockGetFlowpropertyDetail).toHaveBeenCalledWith('fp-1', '1.0.0'));
+    expect(latestFlowpropertyFormProps.formType).toBe('edit');
 
     const nameInput = await screen.findByLabelText(/flow property name/i);
     await userEvent.clear(nameInput);

--- a/tests/unit/pages/Flowproperties/form.test.tsx
+++ b/tests/unit/pages/Flowproperties/form.test.tsx
@@ -9,6 +9,7 @@ const toText = (node: any): string => {
   if (Array.isArray(node)) return node.map(toText).join('');
   if (node?.props?.defaultMessage) return node.props.defaultMessage;
   if (node?.props?.id) return node.props.id;
+  if (node?.props?.label) return toText(node.props.label);
   if (node?.props?.children) return toText(node.props.children);
   return '';
 };
@@ -327,6 +328,20 @@ describe('FlowpropertyForm', () => {
     expect(
       screen.getAllByRole('textbox').some((element) => !element.hasAttribute('disabled')),
     ).toBe(true);
+
+    rerender(
+      <FlowpropertyForm
+        lang='en'
+        activeTabKey='administrativeInformation'
+        drawerVisible={true}
+        formRef={formRef as any}
+        onData={jest.fn()}
+        onTabChange={jest.fn()}
+        formType='edit'
+      />,
+    );
+
+    expect(screen.getByRole('textbox', { name: /Data set version/i })).toBeDisabled();
   });
 
   it('derives schema rules when showRules is enabled', async () => {

--- a/tests/unit/pages/Flows/Components/edit.test.tsx
+++ b/tests/unit/pages/Flows/Components/edit.test.tsx
@@ -548,6 +548,7 @@ describe('FlowsEdit', () => {
 
     await waitFor(() => expect(mockGetFlowDetail).toHaveBeenCalledWith('flow-1', '1.0.0'));
     expect(await screen.findByTestId('flow-form')).toBeInTheDocument();
+    expect(latestFlowFormProps.formType).toBe('edit');
 
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
 

--- a/tests/unit/pages/Flows/Components/form.test.tsx
+++ b/tests/unit/pages/Flows/Components/form.test.tsx
@@ -10,6 +10,7 @@ const toText = (node: any): string => {
   if (Array.isArray(node)) return node.map(toText).join('');
   if (node?.props?.defaultMessage) return node.props.defaultMessage;
   if (node?.props?.id) return node.props.id;
+  if (node?.props?.label) return toText(node.props.label);
   if (node?.props?.children) return toText(node.props.children);
   return '';
 };
@@ -91,8 +92,8 @@ jest.mock('antd', () => {
       {children}
     </label>
   );
-  const Input = ({ value = '', onChange }: any) => (
-    <input value={value} onChange={(e) => onChange?.(e)} />
+  const Input = ({ value = '', onChange, ...rest }: any) => (
+    <input value={value} onChange={(e) => onChange?.(e)} {...rest} />
   );
   const Select = (props: any) => {
     mockSelectProps.push(props);
@@ -413,6 +414,16 @@ describe('FlowForm (src/pages/Flows/Components/form.tsx)', () => {
         (call) => Array.isArray(call.name) && call.name.includes('common:referenceToDataSetFormat'),
       )?.defaultSourceName,
     ).toBeUndefined();
+  });
+
+  it('locks the dataset version in edit mode', async () => {
+    await act(async () => {
+      render(
+        <FlowForm {...baseProps()} activeTabKey='administrativeInformation' formType='edit' />,
+      );
+    });
+
+    expect(screen.getByRole('textbox', { name: /Data set version/i })).toBeDisabled();
   });
 
   it('passes sdk row highlights to property drawers and marks the focused row', async () => {

--- a/tests/unit/pages/LifeCycleModels/Components/form.test.tsx
+++ b/tests/unit/pages/LifeCycleModels/Components/form.test.tsx
@@ -9,6 +9,7 @@ const toText = (node: any): string => {
   if (Array.isArray(node)) return node.map(toText).join('');
   if (node?.props?.defaultMessage) return node.props.defaultMessage;
   if (node?.props?.id) return node.props.id;
+  if (node?.props?.label) return toText(node.props.label);
   if (node?.props?.children) return toText(node.props.children);
   return '';
 };
@@ -248,7 +249,7 @@ describe('LifeCycleModelForm', () => {
     );
   });
 
-  it('keeps dataset version editable and does not inject the create default source otherwise', () => {
+  it('locks dataset version in edit mode and does not inject the create default source', () => {
     renderWithProviders(
       <LifeCycleModelForm
         {...baseProps}
@@ -257,7 +258,7 @@ describe('LifeCycleModelForm', () => {
       />,
     );
 
-    expect(screen.getAllByRole('textbox')[1]).not.toBeDisabled();
+    expect(screen.getByRole('textbox', { name: 'Data set version' })).toBeDisabled();
     expect(
       getSourceSelects().every(
         (sourceSelect) => !sourceSelect.textContent?.includes('ILCD format'),

--- a/tests/unit/pages/Processes/Components/edit.test.tsx
+++ b/tests/unit/pages/Processes/Components/edit.test.tsx
@@ -497,6 +497,7 @@ describe('ProcessEdit component', () => {
     });
 
     expect(latestProcessFormProps).toBeTruthy();
+    expect(latestProcessFormProps.formType).toBe('edit');
 
     const currentValues = proFormApi?.getFieldsValue() ?? {};
     await act(async () => {

--- a/tests/unit/pages/Processes/Components/form.test.tsx
+++ b/tests/unit/pages/Processes/Components/form.test.tsx
@@ -1701,6 +1701,14 @@ describe('ProcessForm component', () => {
         expect.objectContaining({ defaultSourceName: '' }),
       );
     });
+
+    expect(
+      within(
+        screen.getByTestId(
+          'form-item-administrativeInformation.publicationAndOwnership.common:dataSetVersion',
+        ),
+      ).getByRole('textbox'),
+    ).toBeDisabled();
   });
 
   it('marks output rows with issues and enriches output exchanges with flow state metadata', async () => {

--- a/tests/unit/pages/Sources/SourceEdit.test.tsx
+++ b/tests/unit/pages/Sources/SourceEdit.test.tsx
@@ -590,6 +590,7 @@ describe('SourceEdit component', () => {
     await user.click(screen.getByRole('button', { name: 'Edit' }));
 
     const drawer = await screen.findByRole('dialog', { name: 'Edit Source' });
+    expect(latestSourceFormProps.formType).toBe('edit');
 
     const shortNameInput = within(drawer).getByLabelText('Short Name');
     await user.clear(shortNameInput);

--- a/tests/unit/pages/Sources/SourceForm.test.tsx
+++ b/tests/unit/pages/Sources/SourceForm.test.tsx
@@ -9,6 +9,7 @@ const toText = (node: any): string => {
   if (Array.isArray(node)) return node.map(toText).join('');
   if (node?.props?.defaultMessage) return node.props.defaultMessage;
   if (node?.props?.id) return node.props.id;
+  if (node?.props?.label) return toText(node.props.label);
   if (node?.props?.children) return toText(node.props.children);
   return '';
 };
@@ -428,7 +429,7 @@ describe('SourceForm component', () => {
   });
 
   it('does not inject the default source name outside create mode', () => {
-    renderForm({ formType: 'edit' });
+    renderForm({ activeTabKey: 'administrativeInformation', formType: 'edit' });
 
     const dataSetFormatCall = mockSourceSelectForm.mock.calls.find(
       ([props]: any[]) =>
@@ -438,6 +439,7 @@ describe('SourceForm component', () => {
     );
 
     expect(dataSetFormatCall?.[0]?.defaultSourceName).toBeUndefined();
+    expect(screen.getByRole('textbox', { name: 'Data set version' })).toBeDisabled();
   });
 
   it('highlights tabs with sdk validation issues using the error color token', () => {

--- a/tests/unit/pages/Unitgroups/Components/edit.test.tsx
+++ b/tests/unit/pages/Unitgroups/Components/edit.test.tsx
@@ -15,6 +15,7 @@ const toText = (node: any): string => {
 };
 
 let latestRefsDrawerProps: any = null;
+let latestUnitGroupFormProps: any = null;
 const mockParentRefCheckContext = { refCheckData: [] as any[] };
 let mockProblemNodes: any = [];
 const mockIntl = {
@@ -313,61 +314,59 @@ jest.mock(
 
 jest.mock('@/pages/Unitgroups/Components/form', () => ({
   __esModule: true,
-  UnitGroupForm: ({
-    unitDataSource,
-    onTabChange,
-    onData,
-    onUnitData,
-    onUnitDataCreate,
-    formRef,
-  }: any) => (
-    <div>
-      <div>{`unit-group-form-${unitDataSource?.length ?? 0}`}</div>
-      <button type='button' onClick={() => onTabChange?.('customTab')}>
-        switch-custom-tab
-      </button>
-      <button type='button' onClick={() => onData?.()}>
-        sync-tab-data
-      </button>
-      <button
-        type='button'
-        onClick={() =>
-          onUnitData?.([
-            {
-              '@dataSetInternalID': '9',
-              name: 'g',
-              quantitativeReference: true,
-            },
-          ])
-        }
-      >
-        replace-units
-      </button>
-      <button
-        type='button'
-        onClick={() =>
-          onUnitDataCreate?.({
-            name: 'lb',
-            quantitativeReference: false,
-          })
-        }
-      >
-        create-unit
-      </button>
-      <button
-        type='button'
-        onClick={() => formRef?.current?.setFieldsValue({ anotherTab: { note: 'x' } })}
-      >
-        push-form-values
-      </button>
-    </div>
-  ),
+  UnitGroupForm: (props: any) => {
+    latestUnitGroupFormProps = props;
+    const { unitDataSource, onTabChange, onData, onUnitData, onUnitDataCreate, formRef } = props;
+    return (
+      <div>
+        <div>{`unit-group-form-${unitDataSource?.length ?? 0}`}</div>
+        <button type='button' onClick={() => onTabChange?.('customTab')}>
+          switch-custom-tab
+        </button>
+        <button type='button' onClick={() => onData?.()}>
+          sync-tab-data
+        </button>
+        <button
+          type='button'
+          onClick={() =>
+            onUnitData?.([
+              {
+                '@dataSetInternalID': '9',
+                name: 'g',
+                quantitativeReference: true,
+              },
+            ])
+          }
+        >
+          replace-units
+        </button>
+        <button
+          type='button'
+          onClick={() =>
+            onUnitDataCreate?.({
+              name: 'lb',
+              quantitativeReference: false,
+            })
+          }
+        >
+          create-unit
+        </button>
+        <button
+          type='button'
+          onClick={() => formRef?.current?.setFieldsValue({ anotherTab: { note: 'x' } })}
+        >
+          push-form-values
+        </button>
+      </div>
+    );
+  },
 }));
 
 describe('UnitGroupEdit', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     latestRefsDrawerProps = null;
+    latestUnitGroupFormProps = null;
     mockProblemNodes = [];
     mockEnrichValidationIssuesWithOwner.mockImplementation(async (issues: any[]) => issues);
     mockGenUnitGroupFromData.mockImplementation(() => generatedUnitGroup);
@@ -403,6 +402,7 @@ describe('UnitGroupEdit', () => {
     await waitFor(() =>
       expect(mockGetUnitGroupDetail).toHaveBeenCalledWith('unitgroup-1', '1.0.0'),
     );
+    expect(latestUnitGroupFormProps.formType).toBe('edit');
     expect(screen.getByText('unit-group-form-1')).toBeInTheDocument();
   });
 

--- a/tests/unit/pages/Unitgroups/Components/form.test.tsx
+++ b/tests/unit/pages/Unitgroups/Components/form.test.tsx
@@ -10,6 +10,7 @@ const toText = (node: any): string => {
   if (Array.isArray(node)) return node.map(toText).join('');
   if (node?.props?.defaultMessage) return node.props.defaultMessage;
   if (node?.props?.id) return node.props.id;
+  if (node?.props?.label) return toText(node.props.label);
   if (node?.props?.children) return toText(node.props.children);
   return '';
 };
@@ -449,7 +450,7 @@ describe('UnitGroupForm', () => {
     expect(screen.getByTestId('contact-select')).toHaveTextContent('"showRequiredLabel":true');
   });
 
-  it('keeps non-create administrative fields editable and skips create-only default sources', () => {
+  it('locks the dataset version in edit mode and skips create-only default sources', () => {
     const { rerender } = renderWithProviders(
       <UnitGroupForm {...baseProps} activeTabKey='modellingAndValidation' formType='edit' />,
     );
@@ -462,7 +463,7 @@ describe('UnitGroupForm', () => {
       <UnitGroupForm {...baseProps} activeTabKey='administrativeInformation' formType='edit' />,
     );
 
-    expect(screen.getAllByRole('textbox')[1]).not.toBeDisabled();
+    expect(screen.getByRole('textbox', { name: 'Data set version' })).toBeDisabled();
     expect(screen.getAllByTestId('source-select')[0]).not.toHaveTextContent('ILCD format');
   });
 

--- a/tests/unit/pages/editLoadingActionsContract.test.ts
+++ b/tests/unit/pages/editLoadingActionsContract.test.ts
@@ -1,0 +1,34 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const editorCases = [
+  'Contacts/Components/edit.tsx',
+  'Sources/Components/edit.tsx',
+  'Unitgroups/Components/edit.tsx',
+  'Flowproperties/Components/edit.tsx',
+  'Flows/Components/edit.tsx',
+  'Processes/Components/edit.tsx',
+];
+
+describe('dataset edit loading actions contract', () => {
+  it.each(editorCases)('disables every %s footer action until detail data is ready', (file) => {
+    const source = fs.readFileSync(path.join(process.cwd(), 'src/pages', file), 'utf8');
+
+    expect(source).toContain(
+      "import LoadingDisabledActionGroup from '@/components/LoadingDisabledActionGroup';",
+    );
+    expect(source).toContain('<LoadingDisabledActionGroup loading={spinning || !initData}>');
+    expect(source).toContain('setInitData(undefined);');
+  });
+
+  it('disables lifecycle model toolbar actions until model detail is ready', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx'),
+      'utf8',
+    );
+
+    expect(source).toContain(
+      'loading={spinning || (drawerVisible && Object.keys(infoData ?? {}).length === 0)}',
+    );
+  });
+});


### PR DESCRIPTION
## Promotion Contract

- base branch: `main`
- source identity: exact dev commit `f8784672c1b6cd30f07a66c3f0643b8622ba649c` from Release PR #934
- back-merge required after merge: No; this is the normal dev-to-main path
- root workspace integration expected: Yes, after promotion

## Linked Issue

Closes #932

## Promotion Facts

- Promote version `0.0.85` from immutable dev candidate `f8784672c1b6cd30f07a66c3f0643b8622ba649c`.
- Main baseline bound by the dev Release PR proof: `a4bd60aca89cc6903a9fd90bb7065bec735c9bfc`.

## Validation Facts

- The promotion branch points exactly at the merged dev candidate.
- The managed promotion push ran only structural/static checks.
- The main PR check verifies the exact dev Release PR proof and tree identity; it does not rerun the full gate or browser E2E.

## Integration And Follow-Up

- After merge, the canonical main release workflow verifies the same proof before tag/publication without repeating candidate acceptance.
