### PR TITLE
chore: prepare v0.0.86 on dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-08-25'
-lastReviewedCommit: 'f8784672c1b6cd30f07a66c3f0643b8622ba649c'
+lastReviewedAt: "2026-08-25"
+lastReviewedCommit: "a24e6eebb28c89cbe33e75bb1de8a207d18728ad"
 lastReviewedNote: 'Added explicit routing for the AI suggestion enqueue/poll service and focused unit proof; existing data-boundary and testing contracts remain authoritative.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedCommit: a24e6eebb28c89cbe33e75bb1de8a207d18728ad
 lastReviewedNote: 'Reviewed for Next Issue #936: authenticated AI suggestion enqueue/poll remains app-side service behavior and does not change repository ownership, branch policy, or UI runtime rules.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/build.yml
   - .nvmrc
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedCommit: a24e6eebb28c89cbe33e75bb1de8a207d18728ad
 lastReviewedNote: 'Reviewed for Next Issue #936: the AI suggestion service cutover uses the existing focused-test, lint, build, Docpact, and managed-push workflow.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -43,7 +43,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedCommit: a24e6eebb28c89cbe33e75bb1de8a207d18728ad
 lastReviewedNote: 'Reviewed for Next Issue #936: focused AI suggestion service proof is additive; no pre-push trigger, quality bar, or release-gate policy changes.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -44,7 +44,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedCommit: a24e6eebb28c89cbe33e75bb1de8a207d18728ad
 lastReviewedNote: 'Added focused proof for AI suggestion authentication, enqueue/poll sequencing, progressive intervals, terminal failures, timeout/abort, and versioned result validation.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -44,7 +44,7 @@ checkPaths:
   - pnpm-workspace.yaml
   - Dockerfile.app
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedCommit: a24e6eebb28c89cbe33e75bb1de8a207d18728ad
 lastReviewedNote: 'Reviewed for Next Issue #936: service-unit coverage for AI enqueue/poll behavior follows the maintained strategy and does not reopen broader testing work.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -41,7 +41,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedCommit: a24e6eebb28c89cbe33e75bb1de8a207d18728ad
 lastReviewedNote: 'Reviewed for Next Issue #936: the new AI suggestion service has focused branch/terminal-state proof and creates no open coverage queue; final full closure remains push-gate owned.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedCommit: a24e6eebb28c89cbe33e75bb1de8a207d18728ad
 lastReviewedNote: 'Reviewed for Next Issue #936: deterministic mocked Edge envelopes and injected polling clocks follow the existing service-unit and canonical async-task patterns.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -40,7 +40,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedCommit: a24e6eebb28c89cbe33e75bb1de8a207d18728ad
 lastReviewedNote: 'Reviewed for Next Issue #936: AI polling tests use controlled clocks and leave no new open-handle or gate-recovery troubleshooting path.'
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.85",
+  "version": "0.0.86",
   "packageManager": "pnpm@11.22.0",
   "private": true,
   "description": "An out-of-box LCA Data solution",


### PR DESCRIPTION
<!-- tiangong-next-release-automation:v2 issue=936 version=0.0.86 dev-base=a24e6eebb28c89cbe33e75bb1de8a207d18728ad main-base=8d8fe84a678dd4e7bf488584b0e548b31796a18b candidate=fef54d12af43c8db1fcc943c8ce67b7bf676e700 -->

## Branch Contract

- base branch: `dev`
- validated environment: exact dev Release PR non-browser gate
- back-merge required after merge: No
- root workspace integration expected: after later dev-to-main promotion

## Linked Issue

Refs #936

## Change Facts

- Prepare version `0.0.86` from exact dev base `a24e6eebb28c89cbe33e75bb1de8a207d18728ad`.
- Change only package.json.version and keep pnpm-lock.yaml byte-for-byte unchanged.
- Keep release proof external to Git and bind it to the exact main/dev bases, candidate SHA/tree, version, workflow run, and artifact.
- Record Docpact review evidence only after the command proves the candidate has no other semantic change.
- Reviewed paths:
  - `.docpact/config.yaml`
  - `AGENTS.md`
  - `DEV.md`
  - `docs/agents/prepush-gate-policy.md`
  - `docs/agents/repo-validation.md`
  - `docs/agents/test_improvement_plan.md`
  - `docs/agents/test_todo_list.md`
  - `docs/agents/testing-patterns.md`
  - `docs/agents/testing-troubleshooting.md`

## Validation Facts

- Candidate: `fef54d12af43c8db1fcc943c8ce67b7bf676e700`
- Main baseline: `8d8fe84a678dd4e7bf488584b0e548b31796a18b`
- Release gate: `required_by_dev_release_candidate_gate`; static preflight: `passed`
- Docpact automatic-review status: `previously_completed`
- Docpact checked the complete main-to-candidate promotion range before the dev PR was created.
- The managed candidate push ran only structural/static checks; this PR owns one non-browser full release gate and its exact proof.
- Browser E2E is not evaluated or required by this PR. Run the manual hermetic workflow on the open business PR before release-to-dev when the change risk warrants browser evidence.

## Risks And Follow-Up

- Merge only after the exact Release Candidate release proof succeeds, then run the deterministic dev-to-main promotion command with this PR number.
