### PR TITLE
chore: promote v0.0.86 dev to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-24"
-lastReviewedCommit: "36505f132116e624aa8a5f2409c7651dfa208b5f"
-lastReviewedNote: 'Reviewed for Next Issue #924: React 19 / Ant Design 6 dependency, runtime, fixture, semantic-browser, and generated locale paths remain covered by the existing routing and testing contracts.'
+lastReviewedAt: '2026-08-25'
+lastReviewedCommit: 'f8784672c1b6cd30f07a66c3f0643b8622ba649c'
+lastReviewedNote: 'Added explicit routing for the AI suggestion enqueue/poll service and focused unit proof; existing data-boundary and testing contracts remain authoritative.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.
@@ -190,10 +190,17 @@ routing:
         - config/supabaseEnv.ts
         - src/services/auth/**
         - src/services/general/api.ts
+        - src/services/general/aiSuggestion.ts
         - src/services/general/localeRegistry.ts
         - src/services/general/runtimeLocale.ts
         - src/services/supabase/**
         - docker/**
+    ai-suggestion:
+      paths:
+        - src/components/AISuggestion/**
+        - src/services/general/aiSuggestion.ts
+        - src/services/general/api.ts
+        - tests/unit/services/general/aiSuggestion.test.ts
     testing-gates:
       paths:
         - package.json

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-08-25'
-lastReviewedCommit: 'f8784672c1b6cd30f07a66c3f0643b8622ba649c'
+lastReviewedAt: "2026-08-25"
+lastReviewedCommit: "a24e6eebb28c89cbe33e75bb1de8a207d18728ad"
 lastReviewedNote: 'Added explicit routing for the AI suggestion enqueue/poll service and focused unit proof; existing data-boundary and testing contracts remain authoritative.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedCommit: a24e6eebb28c89cbe33e75bb1de8a207d18728ad
 lastReviewedNote: 'Reviewed for Next Issue #936: authenticated AI suggestion enqueue/poll remains app-side service behavior and does not change repository ownership, branch policy, or UI runtime rules.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,9 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-08-24
-lastReviewedCommit: 36505f132116e624aa8a5f2409c7651dfa208b5f
-lastReviewedNote: 'Reviewed for Next Issue #924: the exact React 19 / Ant Design 6 runtime, App feedback boundary, semantic UI slots, and regenerated locale evidence stay within existing repository ownership and branch policy.'
+lastReviewedAt: 2026-08-25
+lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedNote: 'Reviewed for Next Issue #936: authenticated AI suggestion enqueue/poll remains app-side service behavior and does not change repository ownership, branch policy, or UI runtime rules.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/build.yml
   - .nvmrc
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedCommit: a24e6eebb28c89cbe33e75bb1de8a207d18728ad
 lastReviewedNote: 'Reviewed for Next Issue #936: the AI suggestion service cutover uses the existing focused-test, lint, build, Docpact, and managed-push workflow.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -42,9 +42,9 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .github/workflows/build.yml
   - .nvmrc
-lastReviewedAt: 2026-08-24
-lastReviewedCommit: 36505f132116e624aa8a5f2409c7651dfa208b5f
-lastReviewedNote: 'Reviewed for Next Issue #924: the React 19 / Ant Design 6 migration, semantic browser proof, and no-argument E2E resume parser fix use the existing install, Docpact, build, gate, and managed-push workflow.'
+lastReviewedAt: 2026-08-25
+lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedNote: 'Reviewed for Next Issue #936: the AI suggestion service cutover uses the existing focused-test, lint, build, Docpact, and managed-push workflow.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -43,7 +43,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedCommit: a24e6eebb28c89cbe33e75bb1de8a207d18728ad
 lastReviewedNote: 'Reviewed for Next Issue #936: focused AI suggestion service proof is additive; no pre-push trigger, quality bar, or release-gate policy changes.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -42,9 +42,9 @@ checkPaths:
   - scripts/typescript-native-parser.*
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-08-24
-lastReviewedCommit: 36505f132116e624aa8a5f2409c7651dfa208b5f
-lastReviewedNote: 'Reviewed for Next Issue #924: React 19 / Ant Design 6 focused and browser evidence remains additive to the existing hook-owned full gate; no trigger or quality-bar change is required.'
+lastReviewedAt: 2026-08-25
+lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedNote: 'Reviewed for Next Issue #936: focused AI suggestion service proof is additive; no pre-push trigger, quality bar, or release-gate policy changes.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,9 +25,9 @@ checkPaths:
   - playwright.config.ts
   - config/docs-capture/**
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-08-24
-lastReviewedCommit: 91c3cedca29e7ab3aadf331bd2f177009b4580d2
-lastReviewedNote: 'Reviewed for Next Issue #924: the UI runtime now uses one React 19 / Ant Design 6 / ProComponents 3 generation with Umi-global App, theme, and non-component feedback registration.'
+lastReviewedAt: 2026-08-25
+lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedNote: 'Documented AI校验 as a service-owned enqueue/poll flow over Edge and the generic backend ai-worker while retaining the existing diff UI.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -53,6 +53,7 @@ This repo is a Umi-based React 19 SPA on one native Ant Design 6 / ProComponents
 | `src/components/**` | shared UI and reusable flows |
 | `src/services/**` | app-side Supabase/API access, ordered-dataset shaping, typed locale normalization and runtime fallback for Node-loaded services, explicit anonymous-route policy, and service logic |
 | `src/services/general/tidasScalarStorage.ts` | canonical TIDAS year/percentage scalar normalization and the Process/Flow save-boundary issue format |
+| `src/services/general/aiSuggestion.ts` | authenticated AI suggestion enqueue, bounded polling, terminal validation, and versioned result decoding |
 | `src/services/dataProducts/**` | authenticated data-product commands, closure-check projections, result-package requests, and the curated `task-summary.v2` feed consumed by the global task center |
 | `src/locales/**` | UI strings; every supported locale follows one canonical message manifest, with leaf topology, key ownership, placeholders, and dynamic families kept aligned |
 | `src/global.less`, `src/style/**`, `src/manifest.json`, `src/service-worker.js`, `src/utils/appUrl.ts`, `src/utils/ruleVerification.ts`, `src/typings.d.ts` | browser shell support, global styling, and support utilities |
@@ -82,6 +83,7 @@ Rules:
 - a new locale may land reviewed leaf modules before activation, but it must not gain a top-level `src/locales/<locale>.ts` entry until manifest parity and the locale-specific review gate are complete
 - language behavior is split across typed owners: `localeRegistry.ts` owns UI locale/adapters, `contentLanguageRegistry.ts` owns TIDAS/ILCD reading and authoring plus service-query resolution, `referenceResources/manifest.ts` owns classification/location availability and provenance, and `localeCapabilities.ts` is the derived joined view. The current canonical UI keys are `zh-CN`, `en-US`, `de-DE`, and `fr-FR`; business consumers and parameterized capability tests discover them from the registries. A fixed locale array may appear only in an explicitly labeled fail-closed product-contract test whose purpose is to force deliberate review when that snapshot changes
 - app locale, content language, service-query language, and reference-resource language are separate boundaries. Content reading priorities, backend-query fallbacks, and reference-resource delivery states are declared independently; a native reference overlay exists only after its exact structure/evidence gate passes. Documentation, legal, and public-doc surfaces keep their separately disclosed fallbacks
+- Process and Flow AI校验 keeps the existing `AISuggestion` diff/field-acceptance UI, while `src/services/general/aiSuggestion.ts` owns the asynchronous transport. It submits the current TIDAS JSON to authenticated Edge `ai_suggest`, polls the returned requester-scoped job with a bounded progressive interval, accepts only `ai.tidas_suggestion.result.v1` `complete`/`partial` results, and fails closed on malformed, failed, cancelled, blocked, aborted, or timed-out jobs. Next never reads `worker_jobs` directly and does not receive queue payloads, leases, diagnostics, or model credentials.
 - anonymous SPA access is limited to the explicit login/recovery allowlist. Root/Welcome, every other configured application route, case variants, and unmatched paths require the session guard and redirect anonymous users to the canonical login route; authenticated unmatched paths may render the localized 404. Role gates defer missing-session decisions to that global redirect, then enforce their role only after a user exists, so they cannot replace login with an anonymous 403. Localization route/view coverage records this access context but must never broaden it. Authenticated redirects that drive localized query/hash views must preserve their URL state
 - query-, hash-, path-, loading-, empty-, error-, and retry-driven visible states belong to the locale catalog just like the default page view; pages and reusable components must not hide service failures behind a successful empty state
 - LCIA result transport state and calculation-evidence trust state are separate: a failed or pending result query renders its own state and cannot be reinterpreted as missing or mismatched evidence; only a successfully returned numerical result enters the fail-closed evidence validator

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -43,9 +43,9 @@ checkPaths:
   - scripts/typescript-native-parser.*
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-08-24
-lastReviewedCommit: 36505f132116e624aa8a5f2409c7651dfa208b5f
-lastReviewedNote: 'Reviewed for Next Issue #924: Pro Components proof now closes 121 runtime instances and exercises responsive option strips, nested selectors, forms, layouts, and overlays.'
+lastReviewedAt: 2026-08-25
+lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedNote: 'Added focused proof for AI suggestion authentication, enqueue/poll sequencing, progressive intervals, terminal failures, timeout/abort, and versioned result validation.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -85,6 +85,7 @@ pnpm prepush:gate
 | --- | --- | --- | --- |
 | routes, pages, app runtime, shared UI | `pnpm lint`; focused `pnpm test:ci <jest-args>`; `pnpm build` | `pnpm prepush:gate` | shared UX changes often affect multiple entrypoints; Process LCIA query/evidence state changes include `tests/unit/pages/Processes/Components/processLciaResultsPanel.test.tsx` |
 | services or env selection | `pnpm lint`; focused `pnpm test:ci <jest-args>`; `pnpm build` | `pnpm prepush:gate` | companion proof may live in another repo if schema or Edge runtime changed |
+| Process/Flow AI suggestion transport | `pnpm test:ci --runInBand tests/unit/services/general/aiSuggestion.test.ts`; `pnpm lint`; `pnpm build` | final `pnpm prepush:gate` through `push:checked`; smoke against matching non-production Database, Edge, and generic `ai-worker` revisions when deployed | Assert authenticated enqueue, requester-scoped polling, bounded progressive intervals, timeout/abort, all terminal failures, malformed projections, and exact `ai.tidas_suggestion.result.v1` complete/partial decoding. Keep diff generation and selective acceptance in the existing component; do not expose worker payloads, leases, diagnostics, or provider details. |
 | Process or Flow TIDAS scalar storage normalization | `pnpm lint`; focused general scalar-normalizer, Process/Flow serializer, and Process/Flow API suites; `pnpm build` | final `pnpm prepush:gate` through `push:checked` | Assert Process years persist as integers in `1000..9999`, affected percentage values persist as TIDAS-compatible strings with at most three fractional digits, zero is retained, and create/update/create-version reject non-canonical non-empty values before persistence. |
 | TIDAS package export task identity or recovery | `pnpm test:ci --runInBand tests/unit/services/tidasPackage/taskCenter.test.ts`; `pnpm lint`; `pnpm build` | final `pnpm prepush:gate`; pair with Database package-cache pgTAP proof when enqueue semantics changed | Assert repeated queue responses, persisted aliases, poll completion/failure, and Worker refreshes sharing `workerJobId` or `jobId` produce one visible task; retain the earliest local presentation identity, use backend timestamps/state, and never revive an alias after canonical reconciliation. |
 | Process keyword search service or LCA picker scope | focused `tests/unit/services/processes/api.test.ts` plus the Process full-text data-workflow unit; `pnpm lint`; `pnpm build` | smoke against the exact non-production Database revision that exposes `search_processes`; cover public, personal, and `public_plus_owner_draft` scopes, including actor-owned state-zero rows with non-null team/review metadata | Assert explicit `query_terms`, no direct app-side ILIKE field filter, and `owner_draft_only=true` only for the personal branch of the calculation scope. Database owns latest-version, actor/state eligibility, workflow metadata, and `search_text` index semantics. |

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -44,7 +44,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedCommit: a24e6eebb28c89cbe33e75bb1de8a207d18728ad
 lastReviewedNote: 'Added focused proof for AI suggestion authentication, enqueue/poll sequencing, progressive intervals, terminal failures, timeout/abort, and versioned result validation.'
 related:
   - ../AGENTS.md

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -22,9 +22,9 @@ checkPaths:
   - scripts/e2e/**
   - playwright.config.ts
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-08-22
-lastReviewedCommit: ae01a014
-lastReviewedNote: 'Reviewed for Next Issue #910: canonical TIDAS scalar shaping and its pre-persistence validation remain an app-side service responsibility.'
+lastReviewedAt: 2026-08-25
+lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedNote: 'Documented the AI suggestion app-side polling boundary; Edge owns authentication/API projection, Database owns durable jobs, and Worker owns model execution.'
 ---
 
 # Supabase Environment And Database Workflow
@@ -74,6 +74,7 @@ Rules:
 - national-carbon process-flow graph cache reads go through `src/services/nationalCarbonGraphCache/objects.ts` and its signed object bundle; the frontend no longer owns a public cache base URL override and local direct-read debugging paths should not be reintroduced without a new runtime ownership decision
 - ordered-dataset shaping in `src/services/**` stays an app-side boundary even when it mirrors backend schema names
 - canonical Process/Flow TIDAS scalar shaping also stays in that boundary: serializers convert valid year and percentage form values to their required JSON scalar types, while create/update/create-version reject affected non-empty values that cannot be represented canonically before calling dataset commands
+- AI校验 calls authenticated `ai_suggest` only through `src/services/general/aiSuggestion.ts`: Next enqueues current Process/Flow TIDAS JSON, polls the returned requester-scoped job with a bounded schedule, and consumes only the exact versioned advisory result. Edge owns request validation and public projection, `database-engine` owns durable queue/RPC truth, and the generic Rust `ai-worker` owns rule/model execution. Next never queries worker tables or receives service credentials and internal diagnostics.
 - TIDAS package task reconciliation in `src/services/tidasPackage/taskCenter.ts` may coalesce local aliases by backend `workerJobId` or package `jobId` and adopt backend timestamps, but `database-engine` remains authoritative for mutable-scope cache lifecycle, fresh Worker job creation, package contents, and authorization
 - persisted Calculation Bundle and release readback go through `src/services/lcaReleases/**`: private bundle reads forward the current user session, public current-release and Process projections may be anonymous, and neither path accepts a service-role credential or exposes private object locators
 - ResultSet create/list/get, closure checks, closure artifacts, result-package commands, publication reads, and the unified data-product task feed go through `src/services/dataProducts/**` and authenticated `app_data_product_commands`. Database owns ResultSet identity and ResultSet-to-closure/task joins; Next keeps `resultSetId` as URL/workbench context and derives lifecycle presentation from safe projections without adding a frontend status store. Closure requests preserve exact LCIA method `{ id, version }` identities from the reviewed static catalog, and Next consumes actor-bound curated closure, artifact-lifecycle, signed-download, and `task-summary.v2` projections rather than worker rows or private artifact locators. Signed artifact responses are navigation targets only: Next must not proxy, fetch, or buffer the artifact bytes.

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -43,9 +43,9 @@ checkPaths:
   - pnpm-lock.yaml
   - pnpm-workspace.yaml
   - Dockerfile.app
-lastReviewedAt: 2026-08-24
-lastReviewedCommit: 36505f132116e624aa8a5f2409c7651dfa208b5f
-lastReviewedNote: 'Reviewed for Next Issue #924: React 19 / Ant Design 6 fixture migration, handle-free browser shims, and focused semantic proof extend the maintained validation model without reopening broader strategy work.'
+lastReviewedAt: 2026-08-25
+lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedNote: 'Reviewed for Next Issue #936: service-unit coverage for AI enqueue/poll behavior follows the maintained strategy and does not reopen broader testing work.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -44,7 +44,7 @@ checkPaths:
   - pnpm-workspace.yaml
   - Dockerfile.app
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedCommit: a24e6eebb28c89cbe33e75bb1de8a207d18728ad
 lastReviewedNote: 'Reviewed for Next Issue #936: service-unit coverage for AI enqueue/poll behavior follows the maintained strategy and does not reopen broader testing work.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -41,7 +41,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedCommit: a24e6eebb28c89cbe33e75bb1de8a207d18728ad
 lastReviewedNote: 'Reviewed for Next Issue #936: the new AI suggestion service has focused branch/terminal-state proof and creates no open coverage queue; final full closure remains push-gate owned.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -40,9 +40,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-24
-lastReviewedCommit: 36505f132116e624aa8a5f2409c7651dfa208b5f
-lastReviewedNote: 'Reviewed for Next Issue #924: native Ant Design 6 App, Form.List, fixture, dependency, and semantic-browser proof preserve full-closure maintenance mode and create no compatibility queue.'
+lastReviewedAt: 2026-08-25
+lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedNote: 'Reviewed for Next Issue #936: the new AI suggestion service has focused branch/terminal-state proof and creates no open coverage queue; final full closure remains push-gate owned.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -42,9 +42,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-24
-lastReviewedCommit: 36505f132116e624aa8a5f2409c7651dfa208b5f
-lastReviewedNote: 'Reviewed for Next Issue #924: every shipped Pro Components JSX instance now maps to one explicit surface family with live static or browser evidence.'
+lastReviewedAt: 2026-08-25
+lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedNote: 'Reviewed for Next Issue #936: deterministic mocked Edge envelopes and injected polling clocks follow the existing service-unit and canonical async-task patterns.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedCommit: a24e6eebb28c89cbe33e75bb1de8a207d18728ad
 lastReviewedNote: 'Reviewed for Next Issue #936: deterministic mocked Edge envelopes and injected polling clocks follow the existing service-unit and canonical async-task patterns.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -39,9 +39,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-24
-lastReviewedCommit: 36505f132116e624aa8a5f2409c7651dfa208b5f
-lastReviewedNote: 'Reviewed for Next Issue #924: React 19 timing, App.useApp fixtures, Image/Drawer semantic API drift, MessageChannel handles, and locale artifact refresh now have explicit recovery guidance.'
+lastReviewedAt: 2026-08-25
+lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedNote: 'Reviewed for Next Issue #936: AI polling tests use controlled clocks and leave no new open-handle or gate-recovery troubleshooting path.'
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -40,7 +40,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: f8784672c1b6cd30f07a66c3f0643b8622ba649c
+lastReviewedCommit: a24e6eebb28c89cbe33e75bb1de8a207d18728ad
 lastReviewedNote: 'Reviewed for Next Issue #936: AI polling tests use controlled clocks and leave no new open-handle or gate-recovery troubleshooting path.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a",
-    "auditedInputDigest": "13cc24a019981b3decf8ea5f147355bd4ad5d5b1398cb2acac273d06c5dcc473"
+    "sourceManifestDigest": "2589879c089bb204bf430f70c721286d82fa990743f1f3b83c3030dc5116b144",
+    "auditedInputDigest": "b5b2862231a98e51c503e3a8ddb9e1d7fb3d5d78503859f21f0eb72d6645c3a4"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "4a87832627fe7b25ba0a994608f6597b3dd924dcb1bb617b7295a259ddf93ae5",
+    "dossierDigest": "023aed126540d4ee97aa0c38b2688d65cbebb3cc89569532691fc1d3619e5c15",
     "catalogDigest": "09e1a503bd8add3c0b25f62a2ba1553d8fdeb75a027816ff98c304a9b2c7ad5e",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "ff244a5d18fac5be02e5ba7b28fcf703a255409fcedab59545e47f9a0deaa135"
+  "contextDigest": "dd308f8ef5aa0d51fe9bd17baaafc794e6e8e069f824c482abda909d0b643397"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a"
+    "sourceManifestDigest": "2589879c089bb204bf430f70c721286d82fa990743f1f3b83c3030dc5116b144"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "ff244a5d18fac5be02e5ba7b28fcf703a255409fcedab59545e47f9a0deaa135",
-    "qualityDigest": "39945b26253ec3b6b3455d2e2c310d72c9465f31b41b6bbab24f98eee1d10c25",
+    "contextDigest": "dd308f8ef5aa0d51fe9bd17baaafc794e6e8e069f824c482abda909d0b643397",
+    "qualityDigest": "1a834269e872bc8d5bdb18695408ea381004f28fab9b8e9b028084475c4837e0",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "057dac92963eab8483606885c86f47a1c78edb50a7d54c6957578ad369516b10"
+  "activationDigest": "6c43d100f8cdce50f2b2d2d02310540553a7a7695143760ea957c751ff063a1b"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "13cc24a019981b3decf8ea5f147355bd4ad5d5b1398cb2acac273d06c5dcc473",
+    "auditedInputDigest": "b5b2862231a98e51c503e3a8ddb9e1d7fb3d5d78503859f21f0eb72d6645c3a4",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -74,7 +74,7 @@
     "activeStaticKeyCount": 2140,
     "activeDynamicKeyCount": 306,
     "reservedKeyCount": 762,
-    "productionSourceFileCount": 448,
+    "productionSourceFileCount": 449,
     "literalReferenceCount": 4150,
     "dynamicCallsiteCount": 32,
     "dynamicCallsiteSummaryCount": 32,

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a",
-    "contextDigest": "ff244a5d18fac5be02e5ba7b28fcf703a255409fcedab59545e47f9a0deaa135"
+    "sourceManifestDigest": "2589879c089bb204bf430f70c721286d82fa990743f1f3b83c3030dc5116b144",
+    "contextDigest": "dd308f8ef5aa0d51fe9bd17baaafc794e6e8e069f824c482abda909d0b643397"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "e00dcb2039ed29c3846783bfb076229a4972c4d02d5d23ae656605d6585cc00e",
-    "validationDigest": "97264dd216def5b67c7089d412817b382bbc65bec960801a26f58b41bbbb6f36",
+    "digest": "2e71764a7d95d4e4da8553f0efa22e3ca55e71375766aa0f6d9136c47c936a52",
+    "validationDigest": "bcdf09878ab880643b7a2d175c49e3361b1261a97179b1ac43e8624c955c78c2",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "39945b26253ec3b6b3455d2e2c310d72c9465f31b41b6bbab24f98eee1d10c25"
+  "qualityDigest": "1a834269e872bc8d5bdb18695408ea381004f28fab9b8e9b028084475c4837e0"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "13cc24a019981b3decf8ea5f147355bd4ad5d5b1398cb2acac273d06c5dcc473",
+    "auditedInputDigest": "b5b2862231a98e51c503e3a8ddb9e1d7fb3d5d78503859f21f0eb72d6645c3a4",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "09e1a503bd8add3c0b25f62a2ba1553d8fdeb75a027816ff98c304a9b2c7ad5e",
-    "dossierDigest": "4a87832627fe7b25ba0a994608f6597b3dd924dcb1bb617b7295a259ddf93ae5",
+    "dossierDigest": "023aed126540d4ee97aa0c38b2688d65cbebb3cc89569532691fc1d3619e5c15",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "4a87832627fe7b25ba0a994608f6597b3dd924dcb1bb617b7295a259ddf93ae5",
+        "dossierDigest": "023aed126540d4ee97aa0c38b2688d65cbebb3cc89569532691fc1d3619e5c15",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "97264dd216def5b67c7089d412817b382bbc65bec960801a26f58b41bbbb6f36"
+  "validationDigest": "bcdf09878ab880643b7a2d175c49e3361b1261a97179b1ac43e8624c955c78c2"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a",
-    "auditedInputDigest": "13cc24a019981b3decf8ea5f147355bd4ad5d5b1398cb2acac273d06c5dcc473"
+    "sourceManifestDigest": "2589879c089bb204bf430f70c721286d82fa990743f1f3b83c3030dc5116b144",
+    "auditedInputDigest": "b5b2862231a98e51c503e3a8ddb9e1d7fb3d5d78503859f21f0eb72d6645c3a4"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "31e4298ae38c113b9c1dda8575ce7504f527eb92fd21a3d3c07b5366cb5153b4",
+    "dossierDigest": "a550326998ce8921ca07eefaad4568f62726c519b3749651f422919bda1dcf4c",
     "catalogDigest": "93741a89fe46709918133c289bd4567e9261befb763495e91d6f667bb3595c83",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "36c7c2804e722d31ba345bdf6cdf8e04dbb23b6473d108c163701a4541d5a583"
+  "contextDigest": "a361a88d969818f118e0a3fd6d42e807f2bb016906a87f6e8c99aafc79181f3b"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a"
+    "sourceManifestDigest": "2589879c089bb204bf430f70c721286d82fa990743f1f3b83c3030dc5116b144"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "36c7c2804e722d31ba345bdf6cdf8e04dbb23b6473d108c163701a4541d5a583",
-    "qualityDigest": "8bb044fef67aa561b64fea090de0687cd1f8f91583150a9dd5138fe8ca08aa20",
+    "contextDigest": "a361a88d969818f118e0a3fd6d42e807f2bb016906a87f6e8c99aafc79181f3b",
+    "qualityDigest": "993ea872f8d4a1f9b30aac6754664af3d5387adf8a756f8007f02408bb9f1164",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "8a972688031e300f8918fb495f3f939ebfbed3492974e00ae44473310e214142"
+  "activationDigest": "c1b4d79a71155ecc6478edfe03f16a39238a6bb2f141ebb52dac4ce07d73e474"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a",
-    "contextDigest": "36c7c2804e722d31ba345bdf6cdf8e04dbb23b6473d108c163701a4541d5a583"
+    "sourceManifestDigest": "2589879c089bb204bf430f70c721286d82fa990743f1f3b83c3030dc5116b144",
+    "contextDigest": "a361a88d969818f118e0a3fd6d42e807f2bb016906a87f6e8c99aafc79181f3b"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "614c4587af01e5d50064eb0150e80307ef9b9f728d1f1aee1c2d739180694eb8",
-    "validationDigest": "9c620e1ad002f55db730c0e8e00c468bdf5f647f62ab0016de89deab04910ec3",
+    "digest": "b13aad81fd8eebbbf7a4c29983b1b2749a72edbc314e63f7647448eff1993e25",
+    "validationDigest": "31aee60d3d05620d6f7ca9bbe5b50c75c095eda6b607e2949954165394bbb39e",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "8bb044fef67aa561b64fea090de0687cd1f8f91583150a9dd5138fe8ca08aa20"
+  "qualityDigest": "993ea872f8d4a1f9b30aac6754664af3d5387adf8a756f8007f02408bb9f1164"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "13cc24a019981b3decf8ea5f147355bd4ad5d5b1398cb2acac273d06c5dcc473",
+    "auditedInputDigest": "b5b2862231a98e51c503e3a8ddb9e1d7fb3d5d78503859f21f0eb72d6645c3a4",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "93741a89fe46709918133c289bd4567e9261befb763495e91d6f667bb3595c83",
-    "dossierDigest": "31e4298ae38c113b9c1dda8575ce7504f527eb92fd21a3d3c07b5366cb5153b4",
+    "dossierDigest": "a550326998ce8921ca07eefaad4568f62726c519b3749651f422919bda1dcf4c",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "31e4298ae38c113b9c1dda8575ce7504f527eb92fd21a3d3c07b5366cb5153b4",
+        "dossierDigest": "a550326998ce8921ca07eefaad4568f62726c519b3749651f422919bda1dcf4c",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "9c620e1ad002f55db730c0e8e00c468bdf5f647f62ab0016de89deab04910ec3"
+  "validationDigest": "31aee60d3d05620d6f7ca9bbe5b50c75c095eda6b607e2949954165394bbb39e"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a",
-    "auditedInputDigest": "13cc24a019981b3decf8ea5f147355bd4ad5d5b1398cb2acac273d06c5dcc473"
+    "sourceManifestDigest": "2589879c089bb204bf430f70c721286d82fa990743f1f3b83c3030dc5116b144",
+    "auditedInputDigest": "b5b2862231a98e51c503e3a8ddb9e1d7fb3d5d78503859f21f0eb72d6645c3a4"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "f888ed9ab31ab615292601fe7084c036c3739db03c5cc49ca11067786091724d",
+    "dossierDigest": "11b27c6e0007e2f91e5bc4d42baabfb9efa727618908b2ef2a3953dee8130983",
     "catalogDigest": "24238218499ffff02768ab879d2c55877b656be79221b03b56b8d951d0f0068b",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "02cc16df3a97d0634e719b8df86af13058a86ea4f219a6fd0e9d593491050083"
+  "contextDigest": "f28d72ce0493c1fb2555c384618d438c7fc11a1d8b34b52aaf46b3b8cd2d7f5b"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a"
+    "sourceManifestDigest": "2589879c089bb204bf430f70c721286d82fa990743f1f3b83c3030dc5116b144"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "02cc16df3a97d0634e719b8df86af13058a86ea4f219a6fd0e9d593491050083",
-    "qualityDigest": "91c2d373205a2b119adf454e7733f2c7e8c0eb8bb8aa0fd78f547af297ce51b7",
+    "contextDigest": "f28d72ce0493c1fb2555c384618d438c7fc11a1d8b34b52aaf46b3b8cd2d7f5b",
+    "qualityDigest": "d6d4c7b8cd316045dec90071833d5527792667b520caa6785021414ed216b2a1",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "27a54cb0cd9049f975dbeab09eec1dd091e37ad975b2f8430382a272f8c9a0ad"
+  "activationDigest": "e3204057114689a6d8911dcdcb463f4d18965d813df622d0da212a7a63b6a9eb"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a",
-    "contextDigest": "02cc16df3a97d0634e719b8df86af13058a86ea4f219a6fd0e9d593491050083"
+    "sourceManifestDigest": "2589879c089bb204bf430f70c721286d82fa990743f1f3b83c3030dc5116b144",
+    "contextDigest": "f28d72ce0493c1fb2555c384618d438c7fc11a1d8b34b52aaf46b3b8cd2d7f5b"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "ca08e8958a56590c0c4c1a693393fccdc95828d58aba590d81abfaf7627c5321",
-    "validationDigest": "de254266b14a6bb57c31b2dea255195770d4e0fd9428eb17fae9e0bae732801d",
+    "digest": "3e83d1a08fe8e3eb3f7e7a945a12f9b26834a7194297726eaeb027b50f629264",
+    "validationDigest": "45cce01562d76d0acd7283d346c4e4ef631fa88d982825ee33f1eff58821a9fc",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "91c2d373205a2b119adf454e7733f2c7e8c0eb8bb8aa0fd78f547af297ce51b7"
+  "qualityDigest": "d6d4c7b8cd316045dec90071833d5527792667b520caa6785021414ed216b2a1"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "13cc24a019981b3decf8ea5f147355bd4ad5d5b1398cb2acac273d06c5dcc473",
+    "auditedInputDigest": "b5b2862231a98e51c503e3a8ddb9e1d7fb3d5d78503859f21f0eb72d6645c3a4",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "24238218499ffff02768ab879d2c55877b656be79221b03b56b8d951d0f0068b",
-    "dossierDigest": "f888ed9ab31ab615292601fe7084c036c3739db03c5cc49ca11067786091724d",
+    "dossierDigest": "11b27c6e0007e2f91e5bc4d42baabfb9efa727618908b2ef2a3953dee8130983",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "f888ed9ab31ab615292601fe7084c036c3739db03c5cc49ca11067786091724d",
+        "dossierDigest": "11b27c6e0007e2f91e5bc4d42baabfb9efa727618908b2ef2a3953dee8130983",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "de254266b14a6bb57c31b2dea255195770d4e0fd9428eb17fae9e0bae732801d"
+  "validationDigest": "45cce01562d76d0acd7283d346c4e4ef631fa88d982825ee33f1eff58821a9fc"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a",
-    "auditedInputDigest": "13cc24a019981b3decf8ea5f147355bd4ad5d5b1398cb2acac273d06c5dcc473"
+    "sourceManifestDigest": "2589879c089bb204bf430f70c721286d82fa990743f1f3b83c3030dc5116b144",
+    "auditedInputDigest": "b5b2862231a98e51c503e3a8ddb9e1d7fb3d5d78503859f21f0eb72d6645c3a4"
   },
   "inventory": {
     "sourceMessageCount": 3208,
@@ -47,7 +47,7 @@
     "messageCount": 3208,
     "completeCount": 3208,
     "blockedCount": 0,
-    "dossierDigest": "5f997e16a69f2e59fcb74bb8309060362914cccdd8d85d2093c0599e5c4ce11e",
+    "dossierDigest": "19212169249f1af0bcbca2fab917c9a60d6fcbb8be32fef780463ba0e76792a3",
     "catalogDigest": "a7934690a8abe6e2d5866a0542d6a0df3a9219136af620e7324431f1caf87cff",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "43f389c68fa5025aa095f2bad9cdff25db932620d89a88b523bd617d162ee7a3"
+  "contextDigest": "b11af794abfe0ed69a3003f8cd9997f8db7e746f9b5d09876a617fc7c7dceca7"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a"
+    "sourceManifestDigest": "2589879c089bb204bf430f70c721286d82fa990743f1f3b83c3030dc5116b144"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "43f389c68fa5025aa095f2bad9cdff25db932620d89a88b523bd617d162ee7a3",
-    "qualityDigest": "c895816b5a9788cefe47de1032e6800fb9bdffd810b37df7454f9691bf361431",
+    "contextDigest": "b11af794abfe0ed69a3003f8cd9997f8db7e746f9b5d09876a617fc7c7dceca7",
+    "qualityDigest": "aa673de108adc51ae82bcd6e14155fb52a0a6bbeea55ca10f78c4e36d1eb6b64",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "c382e7388f11edf58716fa0a5e7580225f7acc00c50bdbf0e6dcda1b7b1801df"
+  "activationDigest": "3b091d528aa68d2ddd99999cc5b6b07e319b0c5207bbacf5d554977c825f4396"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "6f6d4f47dd2be6485f5e18c97fcaf8424d1bb6d4d8324ac0ccb501c86375a76a",
-    "contextDigest": "43f389c68fa5025aa095f2bad9cdff25db932620d89a88b523bd617d162ee7a3"
+    "sourceManifestDigest": "2589879c089bb204bf430f70c721286d82fa990743f1f3b83c3030dc5116b144",
+    "contextDigest": "b11af794abfe0ed69a3003f8cd9997f8db7e746f9b5d09876a617fc7c7dceca7"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "7b556d147e42d953cb63315672c4a5f09d12a9bf75ce5c10e70a0a577503490f",
-    "validationDigest": "32846c9513b0a1db839f1a6c68ecf6043c9c4ec8df7a3b6461454d096a17ad35",
+    "digest": "472789c87dd5ab6f74434961445ecdf69848e87def4c5eb992da0b3d30b296c7",
+    "validationDigest": "5e22d98ce07ffd1546abbcd6ed344ff234b582548283437343821213fd29ffa2",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "c895816b5a9788cefe47de1032e6800fb9bdffd810b37df7454f9691bf361431"
+  "qualityDigest": "aa673de108adc51ae82bcd6e14155fb52a0a6bbeea55ca10f78c4e36d1eb6b64"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "13cc24a019981b3decf8ea5f147355bd4ad5d5b1398cb2acac273d06c5dcc473",
+    "auditedInputDigest": "b5b2862231a98e51c503e3a8ddb9e1d7fb3d5d78503859f21f0eb72d6645c3a4",
     "validatedMessageCount": 3208,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1439,
     "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
     "catalogDigest": "a7934690a8abe6e2d5866a0542d6a0df3a9219136af620e7324431f1caf87cff",
-    "dossierDigest": "5f997e16a69f2e59fcb74bb8309060362914cccdd8d85d2093c0599e5c4ce11e",
+    "dossierDigest": "19212169249f1af0bcbca2fab917c9a60d6fcbb8be32fef780463ba0e76792a3",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "0e3e6676aeeeced8fc8863ee26fe2c940f322bb6069efb260ca1728dbd4fe5f8",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "17a6482556654636b754f8bfe3765ec88f012e72fe24aa2e864b322942d7483d",
         "highRiskMessageCount": 1439,
         "highRiskMessageDigest": "242e485b18626071aa4becd095c275fb0453286a5d8fe092257c1089e6151981",
-        "dossierDigest": "5f997e16a69f2e59fcb74bb8309060362914cccdd8d85d2093c0599e5c4ce11e",
+        "dossierDigest": "19212169249f1af0bcbca2fab917c9a60d6fcbb8be32fef780463ba0e76792a3",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "32846c9513b0a1db839f1a6c68ecf6043c9c4ec8df7a3b6461454d096a17ad35"
+  "validationDigest": "5e22d98ce07ffd1546abbcd6ed344ff234b582548283437343821213fd29ffa2"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.85",
+  "version": "0.0.86",
   "packageManager": "pnpm@11.22.0",
   "private": true,
   "description": "An out-of-box LCA Data solution",

--- a/src/services/general/aiSuggestion.ts
+++ b/src/services/general/aiSuggestion.ts
@@ -1,0 +1,153 @@
+import { supabase } from '@/services/supabase';
+import { FunctionRegion } from '@supabase/supabase-js';
+
+export const AI_SUGGESTION_RESULT_SCHEMA_VERSION = 'ai.tidas_suggestion.result.v1';
+export const AI_SUGGESTION_POLL_TIMEOUT_MS = 10 * 60 * 1000;
+export const AI_SUGGESTION_POLL_INTERVALS_MS = [1000, 2000, 3000, 5000] as const;
+
+type JsonRecord = Record<string, unknown>;
+type AiSuggestionDataType = 'process' | 'flow';
+type PendingAiSuggestionStatus = 'queued' | 'running' | 'stale';
+type TerminalAiSuggestionStatus = 'completed' | 'failed' | 'cancelled' | 'blocked';
+
+export type AiSuggestionResult = {
+  schemaVersion: typeof AI_SUGGESTION_RESULT_SCHEMA_VERSION;
+  status: 'complete' | 'partial';
+  dataType: AiSuggestionDataType;
+  data: JsonRecord;
+  [key: string]: unknown;
+};
+
+export type AiSuggestionJobProjection = {
+  jobId: string;
+  status: PendingAiSuggestionStatus | TerminalAiSuggestionStatus;
+  phase?: string | null;
+  progress?: number;
+  resultSchemaVersion?: string;
+  result?: unknown;
+  error?: { code?: string; message?: string; retryable?: boolean };
+};
+
+export type AiSuggestionPollingOptions = {
+  timeoutMs?: number;
+  intervalsMs?: readonly number[];
+  signal?: AbortSignal;
+  onTick?: (job: AiSuggestionJobProjection) => void;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requiredText(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    globalThis.setTimeout(resolve, ms);
+  });
+}
+
+async function getAccessToken(): Promise<string> {
+  const session = await supabase.auth.getSession();
+  const token = session.data.session?.access_token?.trim();
+  if (!token) throw new Error('ai_auth_required');
+  return token;
+}
+
+async function invokeAiSuggest(accessToken: string, body: JsonRecord): Promise<JsonRecord> {
+  const { data, error } = await supabase.functions.invoke('ai_suggest', {
+    headers: { Authorization: `Bearer ${accessToken}` },
+    body,
+    region: FunctionRegion.UsEast1,
+  });
+  if (error) throw new Error(error.message || 'ai_suggest_failed');
+  if (!isRecord(data) || data.ok !== true || !isRecord(data.data)) {
+    throw new Error('ai_suggest_response_invalid');
+  }
+  return data.data;
+}
+
+function parseJobProjection(value: JsonRecord): AiSuggestionJobProjection {
+  const jobId = requiredText(value.jobId);
+  const status = requiredText(value.status);
+  if (!jobId || !status) throw new Error('ai_job_projection_invalid');
+  if (
+    !['queued', 'running', 'stale', 'completed', 'failed', 'cancelled', 'blocked'].includes(status)
+  ) {
+    throw new Error('ai_job_status_invalid');
+  }
+  return value as AiSuggestionJobProjection;
+}
+
+function parseCompletedResult(job: AiSuggestionJobProjection): AiSuggestionResult {
+  if (
+    job.resultSchemaVersion !== AI_SUGGESTION_RESULT_SCHEMA_VERSION ||
+    !isRecord(job.result) ||
+    job.result.schemaVersion !== AI_SUGGESTION_RESULT_SCHEMA_VERSION ||
+    (job.result.status !== 'complete' && job.result.status !== 'partial') ||
+    (job.result.dataType !== 'process' && job.result.dataType !== 'flow') ||
+    !isRecord(job.result.data)
+  ) {
+    throw new Error('ai_result_invalid');
+  }
+  return job.result as AiSuggestionResult;
+}
+
+function terminalError(job: AiSuggestionJobProjection): Error {
+  const code = requiredText(job.error?.code) ?? `ai_job_${job.status}`;
+  return new Error(code);
+}
+
+export async function pollAiSuggestionJob(
+  accessToken: string,
+  jobId: string,
+  options: AiSuggestionPollingOptions = {},
+): Promise<AiSuggestionResult> {
+  const timeoutMs = options.timeoutMs ?? AI_SUGGESTION_POLL_TIMEOUT_MS;
+  const intervals = options.intervalsMs?.length
+    ? options.intervalsMs
+    : AI_SUGGESTION_POLL_INTERVALS_MS;
+  const now = options.now ?? Date.now;
+  const wait = options.sleep ?? sleep;
+  const startedAt = now();
+  let attempt = 0;
+
+  while (true) {
+    if (options.signal?.aborted) throw new Error('ai_poll_aborted');
+
+    const job = parseJobProjection(await invokeAiSuggest(accessToken, { action: 'read', jobId }));
+    options.onTick?.(job);
+
+    if (job.status === 'completed') return parseCompletedResult(job);
+    if (job.status === 'failed' || job.status === 'cancelled' || job.status === 'blocked') {
+      throw terminalError(job);
+    }
+    if (now() - startedAt >= timeoutMs) throw new Error('ai_poll_timeout');
+
+    const interval = intervals[Math.min(attempt, intervals.length - 1)];
+    attempt += 1;
+    await wait(interval);
+  }
+}
+
+export async function getAISuggestion(
+  tidasData: unknown,
+  dataType: string,
+  options: JsonRecord = {},
+  pollingOptions: AiSuggestionPollingOptions = {},
+): Promise<AiSuggestionResult> {
+  const accessToken = await getAccessToken();
+  const queued = parseJobProjection(
+    await invokeAiSuggest(accessToken, {
+      action: 'enqueue',
+      tidasData,
+      dataType,
+      options,
+    }),
+  );
+  return await pollAiSuggestionJob(accessToken, queued.jobId, pollingOptions);
+}

--- a/src/services/general/api.ts
+++ b/src/services/general/api.ts
@@ -1580,23 +1580,7 @@ export async function getAllVersions(
   }
 }
 
-export async function getAISuggestion(tidasData: any, dataType: string, options: any) {
-  let result: any = {};
-  const session = await supabase.auth.getSession();
-  if (session.data.session) {
-    result = await supabase.functions.invoke('ai_suggest', {
-      headers: {
-        Authorization: `Bearer ${session.data.session?.access_token ?? ''}`,
-      },
-      body: { tidasData, dataType, options },
-      region: FunctionRegion.UsEast1,
-    });
-  }
-  if (result.error) {
-    console.log('error', result.error);
-  }
-  return result?.data;
-}
+export { getAISuggestion } from './aiSuggestion';
 
 const JSON_BLOCK_PATTERN = /```(?:json)?\s*([\s\S]*?)```/i;
 

--- a/tests/unit/services/general/aiSuggestion.test.ts
+++ b/tests/unit/services/general/aiSuggestion.test.ts
@@ -1,0 +1,237 @@
+const mockGetSession = jest.fn();
+const mockInvoke = jest.fn();
+
+jest.mock('@/services/supabase', () => ({
+  supabase: {
+    auth: { getSession: (...args: unknown[]) => mockGetSession(...args) },
+    functions: { invoke: (...args: unknown[]) => mockInvoke(...args) },
+  },
+}));
+
+import {
+  AI_SUGGESTION_POLL_INTERVALS_MS,
+  AI_SUGGESTION_RESULT_SCHEMA_VERSION,
+  getAISuggestion,
+  pollAiSuggestionJob,
+} from '@/services/general/aiSuggestion';
+import { FunctionRegion } from '@supabase/supabase-js';
+
+const ACCESS_TOKEN = 'access-token';
+const JOB_ID = '22222222-2222-4222-8222-222222222222';
+
+const completedResult = {
+  schemaVersion: AI_SUGGESTION_RESULT_SCHEMA_VERSION,
+  status: 'complete' as const,
+  dataType: 'process' as const,
+  data: { processDataSet: { name: 'improved' } },
+};
+
+const envelope = (data: Record<string, unknown>) => ({
+  data: { ok: true, data },
+  error: null,
+});
+
+const completedJob = (overrides: Record<string, unknown> = {}) => ({
+  jobId: JOB_ID,
+  status: 'completed',
+  resultSchemaVersion: AI_SUGGESTION_RESULT_SCHEMA_VERSION,
+  result: completedResult,
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.useRealTimers();
+  mockGetSession.mockReset();
+  mockInvoke.mockReset();
+  mockGetSession.mockResolvedValue({
+    data: { session: { access_token: ` ${ACCESS_TOKEN} ` } },
+  });
+});
+
+it('enqueues, polls, and returns the versioned AI Worker result', async () => {
+  const onTick = jest.fn();
+  const wait = jest.fn().mockResolvedValue(undefined);
+  mockInvoke
+    .mockResolvedValueOnce(envelope({ jobId: JOB_ID, status: 'queued' }))
+    .mockResolvedValueOnce(envelope({ jobId: JOB_ID, status: 'running', progress: 25 }))
+    .mockResolvedValueOnce(envelope(completedJob()));
+
+  await expect(
+    getAISuggestion(
+      '{"processDataSet":{}}',
+      'process',
+      { maxRetries: 1 },
+      { intervalsMs: [3], sleep: wait, now: () => 0, onTick },
+    ),
+  ).resolves.toEqual(completedResult);
+
+  expect(mockInvoke.mock.calls).toEqual([
+    [
+      'ai_suggest',
+      {
+        headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
+        body: {
+          action: 'enqueue',
+          tidasData: '{"processDataSet":{}}',
+          dataType: 'process',
+          options: { maxRetries: 1 },
+        },
+        region: FunctionRegion.UsEast1,
+      },
+    ],
+    [
+      'ai_suggest',
+      {
+        headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
+        body: { action: 'read', jobId: JOB_ID },
+        region: FunctionRegion.UsEast1,
+      },
+    ],
+    [
+      'ai_suggest',
+      {
+        headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
+        body: { action: 'read', jobId: JOB_ID },
+        region: FunctionRegion.UsEast1,
+      },
+    ],
+  ]);
+  expect(wait).toHaveBeenCalledTimes(1);
+  expect(onTick).toHaveBeenCalledTimes(2);
+});
+
+it('requires an authenticated session before enqueue', async () => {
+  mockGetSession.mockResolvedValue({ data: { session: null } });
+  await expect(getAISuggestion('{}', 'process')).rejects.toThrow('ai_auth_required');
+  expect(mockInvoke).not.toHaveBeenCalled();
+});
+
+it.each([
+  [{ data: null, error: { message: 'edge unavailable' } }, 'edge unavailable'],
+  [{ data: null, error: { message: '' } }, 'ai_suggest_failed'],
+])('surfaces bounded function invocation failures', async (reply, expected) => {
+  mockInvoke.mockResolvedValue(reply);
+  await expect(getAISuggestion('{}', 'process')).rejects.toThrow(expected);
+});
+
+it.each([[null], [{}], [{ ok: false, data: {} }], [{ ok: true, data: null }]])(
+  'rejects malformed Edge envelopes: %p',
+  async (data) => {
+    mockInvoke.mockResolvedValue({ data, error: null });
+    await expect(getAISuggestion('{}', 'process')).rejects.toThrow('ai_suggest_response_invalid');
+  },
+);
+
+it.each([
+  [{ status: 'queued' }, 'ai_job_projection_invalid'],
+  [{ jobId: JOB_ID }, 'ai_job_projection_invalid'],
+  [{ jobId: JOB_ID, status: 'mystery' }, 'ai_job_status_invalid'],
+])('rejects malformed job projections', async (job, expected) => {
+  mockInvoke.mockResolvedValue(envelope(job));
+  await expect(getAISuggestion('{}', 'process')).rejects.toThrow(expected);
+});
+
+it('uses progressive bounded intervals for queued, running, and stale jobs', async () => {
+  const wait = jest.fn().mockResolvedValue(undefined);
+  const onTick = jest.fn();
+  mockInvoke
+    .mockResolvedValueOnce(envelope({ jobId: JOB_ID, status: 'queued' }))
+    .mockResolvedValueOnce(envelope({ jobId: JOB_ID, status: 'running' }))
+    .mockResolvedValueOnce(envelope({ jobId: JOB_ID, status: 'stale' }))
+    .mockResolvedValueOnce(envelope(completedJob()));
+
+  await pollAiSuggestionJob(ACCESS_TOKEN, JOB_ID, {
+    intervalsMs: [3, 5],
+    sleep: wait,
+    now: () => 0,
+    onTick,
+  });
+
+  expect(wait.mock.calls).toEqual([[3], [5], [5]]);
+  expect(onTick).toHaveBeenCalledTimes(4);
+});
+
+it('uses the default polling timer and interval when no overrides are supplied', async () => {
+  jest.useFakeTimers();
+  mockInvoke
+    .mockResolvedValueOnce(envelope({ jobId: JOB_ID, status: 'queued' }))
+    .mockResolvedValueOnce(envelope(completedJob()));
+
+  const pending = pollAiSuggestionJob(ACCESS_TOKEN, JOB_ID);
+  await jest.advanceTimersByTimeAsync(AI_SUGGESTION_POLL_INTERVALS_MS[0]);
+
+  await expect(pending).resolves.toEqual(completedResult);
+  jest.useRealTimers();
+});
+
+it('aborts before issuing another status request', async () => {
+  const controller = new AbortController();
+  controller.abort();
+
+  await expect(
+    pollAiSuggestionJob(ACCESS_TOKEN, JOB_ID, { signal: controller.signal }),
+  ).rejects.toThrow('ai_poll_aborted');
+  expect(mockInvoke).not.toHaveBeenCalled();
+});
+
+it('times out without sleeping after the timeout boundary', async () => {
+  const wait = jest.fn();
+  const now = jest.fn().mockReturnValueOnce(0).mockReturnValueOnce(10);
+  mockInvoke.mockResolvedValue(envelope({ jobId: JOB_ID, status: 'queued' }));
+
+  await expect(
+    pollAiSuggestionJob(ACCESS_TOKEN, JOB_ID, {
+      timeoutMs: 10,
+      intervalsMs: [1],
+      sleep: wait,
+      now,
+    }),
+  ).rejects.toThrow('ai_poll_timeout');
+  expect(wait).not.toHaveBeenCalled();
+});
+
+it.each([
+  ['failed', { code: 'ai_provider_timeout' }, 'ai_provider_timeout'],
+  ['cancelled', undefined, 'ai_job_cancelled'],
+  ['blocked', { code: '   ' }, 'ai_job_blocked'],
+])('fails closed for terminal %s jobs', async (status, error, expected) => {
+  mockInvoke.mockResolvedValue(envelope({ jobId: JOB_ID, status, error }));
+  await expect(pollAiSuggestionJob(ACCESS_TOKEN, JOB_ID, { now: () => 0 })).rejects.toThrow(
+    expected,
+  );
+});
+
+it.each([
+  { overrides: { resultSchemaVersion: 'wrong' }, label: 'wrong result schema' },
+  { overrides: { result: null }, label: 'missing result' },
+  {
+    overrides: { result: { ...completedResult, schemaVersion: 'wrong' } },
+    label: 'wrong nested schema',
+  },
+  {
+    overrides: { result: { ...completedResult, status: 'failed' } },
+    label: 'failed result state',
+  },
+  {
+    overrides: { result: { ...completedResult, dataType: 'model' } },
+    label: 'wrong data type',
+  },
+  {
+    overrides: { result: { ...completedResult, data: [] } },
+    label: 'non-object result data',
+  },
+])('rejects invalid completed results: $label', async ({ overrides }) => {
+  mockInvoke.mockResolvedValue(envelope(completedJob(overrides as Record<string, unknown>)));
+  await expect(pollAiSuggestionJob(ACCESS_TOKEN, JOB_ID, { now: () => 0 })).rejects.toThrow(
+    'ai_result_invalid',
+  );
+});
+
+it('accepts a valid partial result', async () => {
+  const partial = { ...completedResult, status: 'partial' as const, dataType: 'flow' as const };
+  mockInvoke.mockResolvedValue(envelope(completedJob({ result: partial })));
+
+  await expect(pollAiSuggestionJob(ACCESS_TOKEN, JOB_ID, { now: () => 0 })).resolves.toEqual(
+    partial,
+  );
+});

--- a/tests/unit/services/general/api.test.ts
+++ b/tests/unit/services/general/api.test.ts
@@ -1530,58 +1530,6 @@ describe('getAllVersions', () => {
   });
 });
 
-describe('getAISuggestion', () => {
-  it('should invoke ai_suggest function with serialized payload', async () => {
-    mockAuthGetSession.mockResolvedValue({ data: { session: { access_token: 'token-4' } } });
-    mockFunctionsInvoke.mockResolvedValue({ data: { suggestion: { foo: 'bar' } } });
-    const tidasData = { toJSONString: () => 'serialized' } as any;
-
-    const result = await generalApi.getAISuggestion(tidasData, 'process', { maxRetries: 1 });
-
-    expect(mockFunctionsInvoke).toHaveBeenCalledWith('ai_suggest', {
-      headers: { Authorization: 'Bearer token-4' },
-      body: { tidasData, dataType: 'process', options: { maxRetries: 1 } },
-      region: expect.anything(),
-    });
-    expect(result).toEqual({ suggestion: { foo: 'bar' } });
-  });
-
-  it('should return undefined when session is missing', async () => {
-    mockAuthGetSession.mockResolvedValue({ data: { session: null } });
-
-    const result = await generalApi.getAISuggestion({}, 'flow', {});
-
-    expect(mockFunctionsInvoke).not.toHaveBeenCalled();
-    expect(result).toBeUndefined();
-  });
-
-  it('should handle error response from function', async () => {
-    mockAuthGetSession.mockResolvedValue({ data: { session: { access_token: 'token-5' } } });
-    mockFunctionsInvoke.mockResolvedValue({ error: { message: 'AI service unavailable' } });
-    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
-
-    const result = await generalApi.getAISuggestion({}, 'process', {});
-
-    expect(consoleLogSpy).toHaveBeenCalledWith('error', { message: 'AI service unavailable' });
-    expect(result).toBeUndefined();
-
-    consoleLogSpy.mockRestore();
-  });
-
-  it('should use an empty bearer token for AI suggestions when access token is absent', async () => {
-    mockAuthGetSession.mockResolvedValue({ data: { session: {} } });
-    mockFunctionsInvoke.mockResolvedValue({ data: { suggestion: { foo: 'bar' } } });
-
-    await generalApi.getAISuggestion({}, 'process', {});
-
-    expect(mockFunctionsInvoke).toHaveBeenCalledWith('ai_suggest', {
-      headers: { Authorization: 'Bearer ' },
-      body: { tidasData: {}, dataType: 'process', options: {} },
-      region: expect.anything(),
-    });
-  });
-});
-
 describe('multilingual save normalization', () => {
   it('should normalize payload and auto-fill English translation from AI response', async () => {
     mockAuthGetSession.mockResolvedValue({ data: { session: { access_token: 'token-6' } } });
@@ -4137,7 +4085,7 @@ describe('Edge Cases and Error Handling', () => {
     });
   });
 
-  describe('getAISuggestion', () => {
+  describe('legacy mutation boundary', () => {
     it('returns the structured removed-result envelope for legacy mutation boundaries', () => {
       const result = generalApi.createLegacyMutationRemovedResult('legacyBoundary');
 
@@ -4153,46 +4101,6 @@ describe('Edge Cases and Error Handling', () => {
         status: 410,
         statusText: 'LEGACY_ENDPOINT_REMOVED',
       });
-    });
-
-    it('should get AI suggestion successfully', async () => {
-      const mockResponse = { suggestion: 'AI generated content' };
-      mockAuthGetSession.mockResolvedValue({ data: { session: { access_token: 'token-xyz' } } });
-      mockFunctionsInvoke.mockResolvedValue({ data: mockResponse, error: null });
-
-      const result = await generalApi.getAISuggestion({ name: 'test' }, 'process', { lang: 'en' });
-
-      expect(mockFunctionsInvoke).toHaveBeenCalledWith('ai_suggest', {
-        headers: { Authorization: 'Bearer token-xyz' },
-        body: {
-          tidasData: { name: 'test' },
-          dataType: 'process',
-          options: { lang: 'en' },
-        },
-        region: FunctionRegion.UsEast1,
-      });
-      expect(result).toEqual(mockResponse);
-    });
-
-    it('should return undefined when no session exists', async () => {
-      mockAuthGetSession.mockResolvedValue({ data: { session: null } });
-
-      const result = await generalApi.getAISuggestion({ name: 'test' }, 'process', {});
-
-      expect(result).toBeUndefined();
-    });
-
-    it('should handle edge function error', async () => {
-      mockAuthGetSession.mockResolvedValue({ data: { session: { access_token: 'token-xyz' } } });
-      mockFunctionsInvoke.mockResolvedValue({ data: null, error: { message: 'AI error' } });
-      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
-
-      const result = await generalApi.getAISuggestion({ name: 'test' }, 'flow', {});
-
-      expect(consoleLogSpy).toHaveBeenCalledWith('error', { message: 'AI error' });
-      expect(result).toBeNull();
-
-      consoleLogSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Promotion Contract

- base branch: `main`
- source identity: exact dev commit `649375ff6270fbafd10c0fb5e8452ccfdd960481` from Release PR #939
- back-merge required after merge: No; this is the normal dev-to-main path
- root workspace integration expected: Yes, after promotion

## Linked Issue

Closes #936

## Promotion Facts

- Promote version `0.0.86` from immutable dev candidate `649375ff6270fbafd10c0fb5e8452ccfdd960481`.
- Main baseline bound by the dev Release PR proof: `8d8fe84a678dd4e7bf488584b0e548b31796a18b`.

## Validation Facts

- The promotion branch points exactly at the merged dev candidate.
- The managed promotion push ran only structural/static checks.
- The main PR check verifies the exact dev Release PR proof and tree identity; it does not rerun the full gate or browser E2E.

## Integration And Follow-Up

- After merge, the canonical main release workflow verifies the same proof before tag/publication without repeating candidate acceptance.
