### PR TITLE
chore: prepare v0.0.87 on dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-08-25'
-lastReviewedCommit: '41b791e4760b4b6cd1e18633c32525874f64d60b'
+lastReviewedAt: "2026-08-25"
+lastReviewedCommit: "232a338aea7ae5e0cbfa061a0ba2f77c62bcde99"
 lastReviewedNote: 'Reviewed the merged Issue #938 exact toolchain/SDK consumer and current dev review-validation/i18n changes; existing ownership, routing, and proof rules cover the combined delivery.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: 41b791e4760b4b6cd1e18633c32525874f64d60b
+lastReviewedCommit: 232a338aea7ae5e0cbfa061a0ba2f77c62bcde99
 lastReviewedNote: 'Reviewed after integrating current dev: exact Node/pnpm/TS7, SDK 0.2.0, digest-bound containers, and immutable pnpm setup coexist with the latest review-validation/i18n delivery without changing ownership or branch policy.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/build.yml
   - .nvmrc
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: 41b791e4760b4b6cd1e18633c32525874f64d60b
+lastReviewedCommit: 232a338aea7ae5e0cbfa061a0ba2f77c62bcde99
 lastReviewedNote: 'Reviewed after integrating current dev: bootstrap and gates retain exact Node 24.19.0, pnpm 11.23.0, SDK 0.2.0, and TypeScript 7.0.2 while the normal focused/full workflow remains unchanged.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -43,7 +43,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: 41b791e4760b4b6cd1e18633c32525874f64d60b
+lastReviewedCommit: 232a338aea7ae5e0cbfa061a0ba2f77c62bcde99
 lastReviewedNote: 'Reviewed after integrating current dev: trigger policy is unchanged; hook, CI, container, and receipt identity bind exact Node/pnpm while the merged review-validation/i18n change stays inside the existing full gate.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -44,7 +44,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: 41b791e4760b4b6cd1e18633c32525874f64d60b
+lastReviewedCommit: 232a338aea7ae5e0cbfa061a0ba2f77c62bcde99
 lastReviewedNote: 'Reviewed after integrating current dev: exact Node/pnpm and the unmocked seven-factory SDK 0.2.0 contract join the latest review-validation/i18n tests under the existing proof matrix.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -44,7 +44,7 @@ checkPaths:
   - pnpm-workspace.yaml
   - Dockerfile.app
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: 41b791e4760b4b6cd1e18633c32525874f64d60b
+lastReviewedCommit: 232a338aea7ae5e0cbfa061a0ba2f77c62bcde99
 lastReviewedNote: 'Reviewed the merged SDK package proof and current dev review-validation/i18n coverage; neither reopens broader testing-strategy work.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -41,7 +41,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: 41b791e4760b4b6cd1e18633c32525874f64d60b
+lastReviewedCommit: 232a338aea7ae5e0cbfa061a0ba2f77c62bcde99
 lastReviewedNote: 'Reviewed after integrating current dev: exact-toolchain, SDK 0.2.0, review-validation, and i18n cases create no open queue; full closure remains gate-owned.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: 41b791e4760b4b6cd1e18633c32525874f64d60b
+lastReviewedCommit: 232a338aea7ae5e0cbfa061a0ba2f77c62bcde99
 lastReviewedNote: 'Reviewed after integrating current dev: the real SDK child-process proof, exact toolchain contracts, and latest review-validation cases follow the maintained patterns.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -40,7 +40,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-25
-lastReviewedCommit: 41b791e4760b4b6cd1e18633c32525874f64d60b
+lastReviewedCommit: 232a338aea7ae5e0cbfa061a0ba2f77c62bcde99
 lastReviewedNote: 'Reviewed after integrating current dev: SDK/package-graph, exact Node, review-validation, and i18n failures retain the documented focused recovery paths.'
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.86",
+  "version": "0.0.87",
   "packageManager": "pnpm@11.23.0",
   "private": true,
   "description": "An out-of-box LCA Data solution",


### PR DESCRIPTION
<!-- tiangong-next-release-automation:v2 issue=938 version=0.0.87 dev-base=232a338aea7ae5e0cbfa061a0ba2f77c62bcde99 main-base=9e1bc1acc8a070896b00688ed142f2106009fe1f candidate=3e3fd458fdc5cc398b83b546e4b0ea6811ab582c -->

## Branch Contract

- base branch: `dev`
- validated environment: exact dev Release PR non-browser gate
- back-merge required after merge: No
- root workspace integration expected: after later dev-to-main promotion

## Linked Issue

Closes #938

## Change Facts

- Prepare version `0.0.87` from exact dev base `232a338aea7ae5e0cbfa061a0ba2f77c62bcde99`.
- Change only package.json.version and keep pnpm-lock.yaml byte-for-byte unchanged.
- Keep release proof external to Git and bind it to the exact main/dev bases, candidate SHA/tree, version, workflow run, and artifact.
- Record Docpact review evidence only after the command proves the candidate has no other semantic change.
- Reviewed paths:
  - `.docpact/config.yaml`
  - `AGENTS.md`
  - `DEV.md`
  - `docs/agents/prepush-gate-policy.md`
  - `docs/agents/repo-validation.md`
  - `docs/agents/test_improvement_plan.md`
  - `docs/agents/test_todo_list.md`
  - `docs/agents/testing-patterns.md`
  - `docs/agents/testing-troubleshooting.md`

## Validation Facts

- Candidate: `3e3fd458fdc5cc398b83b546e4b0ea6811ab582c`
- Main baseline: `9e1bc1acc8a070896b00688ed142f2106009fe1f`
- Release gate: `required_by_dev_release_candidate_gate`; static preflight: `passed`
- Docpact automatic-review status: `completed`
- Docpact checked the complete main-to-candidate promotion range before the dev PR was created.
- The managed candidate push ran only structural/static checks; this PR owns one non-browser full release gate and its exact proof.
- Browser E2E is not evaluated or required by this PR. Run the manual hermetic workflow on the open business PR before release-to-dev when the change risk warrants browser evidence.

## Risks And Follow-Up

- Merge only after the exact Release Candidate release proof succeeds, then run the deterministic dev-to-main promotion command with this PR number.
