### PR TITLE
chore: prepare v0.0.89 on dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-29"
-lastReviewedCommit: "24f0be95dcd3f77038f97a66f665eb7a6f85aad8"
+lastReviewedCommit: "daee75b4cb370b7a89301489c367a9ae36d8f23d"
 lastReviewedNote: 'Reviewed for Next Issue #950: existing frontend-runtime and test routing covers request identity, stale-row clearing, and ProTable race regressions; routing rules remain unchanged.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: 24f0be95dcd3f77038f97a66f665eb7a6f85aad8
+lastReviewedCommit: daee75b4cb370b7a89301489c367a9ae36d8f23d
 lastReviewedNote: 'Reviewed for Next Issue #950: versioned list request identity and stale-row clearing stay within the existing frontend ownership, dependency, and branch-policy contract.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/build.yml
   - .nvmrc
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: 24f0be95dcd3f77038f97a66f665eb7a6f85aad8
+lastReviewedCommit: daee75b4cb370b7a89301489c367a9ae36d8f23d
 lastReviewedNote: 'Reviewed for Next Issue #950: the focused test, lint, build, and hook-owned full-gate workflow already covers the versioned list request-lifecycle fix.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -43,7 +43,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: 24f0be95dcd3f77038f97a66f665eb7a6f85aad8
+lastReviewedCommit: daee75b4cb370b7a89301489c367a9ae36d8f23d
 lastReviewedNote: 'Reviewed for Next Issue #950: the versioned list runtime and regression changes remain covered by the existing hook-owned full gate; trigger policy is unchanged.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -44,7 +44,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: 24f0be95dcd3f77038f97a66f665eb7a6f85aad8
+lastReviewedCommit: daee75b4cb370b7a89301489c367a9ae36d8f23d
 lastReviewedNote: 'Reviewed for Next Issue #950: targeted race, route-identity, and 1-to-2-to-1 tests plus lint and build fit the existing validation matrix; no gate rule changes are needed.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -44,7 +44,7 @@ checkPaths:
   - pnpm-workspace.yaml
   - Dockerfile.app
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: 24f0be95dcd3f77038f97a66f665eb7a6f85aad8
+lastReviewedCommit: daee75b4cb370b7a89301489c367a9ae36d8f23d
 lastReviewedNote: 'Reviewed for Next Issue #950: the added deferred-request, route-identity, and pagination regressions close the scoped gap without reopening broader testing work.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -41,7 +41,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: 24f0be95dcd3f77038f97a66f665eb7a6f85aad8
+lastReviewedCommit: daee75b4cb370b7a89301489c367a9ae36d8f23d
 lastReviewedNote: 'Reviewed for Next Issue #950: the scoped versioned-list regression coverage is implemented and adds no open coverage queue; full closure remains gate-owned.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: 24f0be95dcd3f77038f97a66f665eb7a6f85aad8
+lastReviewedCommit: daee75b4cb370b7a89301489c367a9ae36d8f23d
 lastReviewedNote: 'Reviewed for Next Issue #950: deferred promises, explicit request identity, and visible stale-row assertions follow the existing asynchronous integration-test pattern.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -40,7 +40,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: 24f0be95dcd3f77038f97a66f665eb7a6f85aad8
+lastReviewedCommit: daee75b4cb370b7a89301489c367a9ae36d8f23d
 lastReviewedNote: 'Reviewed for Next Issue #950: the existing focused-test and full-gate recovery paths cover versioned list request-lifecycle failures without new troubleshooting rules.'
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.88",
+  "version": "0.0.89",
   "packageManager": "pnpm@11.24.0",
   "private": true,
   "description": "An out-of-box LCA Data solution",


### PR DESCRIPTION
<!-- tiangong-next-release-automation:v2 issue=950 version=0.0.89 dev-base=daee75b4cb370b7a89301489c367a9ae36d8f23d main-base=93d048e05fa96c84a94366920cce25957045d098 candidate=8d607e132c191a8c13591f922fe8cc392ec72bd6 -->

## Branch Contract

- base branch: `dev`
- validated environment: exact dev Release PR non-browser gate
- back-merge required after merge: No
- root workspace integration expected: after later dev-to-main promotion

## Linked Issue

Refs #950

## Change Facts

- Prepare version `0.0.89` from exact dev base `daee75b4cb370b7a89301489c367a9ae36d8f23d`.
- Change only package.json.version and keep pnpm-lock.yaml byte-for-byte unchanged.
- Keep release proof external to Git and bind it to the exact main/dev bases, candidate SHA/tree, version, workflow run, and artifact.
- Record Docpact review evidence only after the command proves the candidate has no other semantic change.
- Reviewed paths:
  - `.docpact/config.yaml`
  - `AGENTS.md`
  - `DEV.md`
  - `docs/agents/prepush-gate-policy.md`
  - `docs/agents/repo-validation.md`
  - `docs/agents/test_improvement_plan.md`
  - `docs/agents/test_todo_list.md`
  - `docs/agents/testing-patterns.md`
  - `docs/agents/testing-troubleshooting.md`

## Validation Facts

- Candidate: `8d607e132c191a8c13591f922fe8cc392ec72bd6`
- Main baseline: `93d048e05fa96c84a94366920cce25957045d098`
- Release gate: `required_by_dev_release_candidate_gate`; static preflight: `passed`
- Docpact automatic-review status: `completed`
- Docpact checked the complete main-to-candidate promotion range before the dev PR was created.
- The managed candidate push ran only structural/static checks; this PR owns one non-browser full release gate and its exact proof.
- Browser E2E is not evaluated or required by this PR. Run the manual hermetic workflow on the open business PR before release-to-dev when the change risk warrants browser evidence.

## Risks And Follow-Up

- Merge only after the exact Release Candidate release proof succeeds, then run the deterministic dev-to-main promotion command with this PR number.
