### PR TITLE
Fix Processes strict act warning blocking v0.0.89 release

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-29"
-lastReviewedCommit: "24f0be95dcd3f77038f97a66f665eb7a6f85aad8"
-lastReviewedNote: 'Reviewed for Next Issue #950: existing frontend-runtime and test routing covers request identity, stale-row clearing, and ProTable race regressions; routing rules remain unchanged.'
+lastReviewedCommit: "f61a8699264b10a42c483f85333d42540a394327"
+lastReviewedNote: 'Reviewed for Next Issue #955: the Processes strict-act synchronization fix remains covered by the existing testing-and-gate route; routing rules are unchanged.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: 24f0be95dcd3f77038f97a66f665eb7a6f85aad8
-lastReviewedNote: 'Reviewed for Next Issue #950: versioned list request identity and stale-row clearing stay within the existing frontend ownership, dependency, and branch-policy contract.'
+lastReviewedCommit: 5c2f80c865b989753b48cc871ae6eb6892aef45c
+lastReviewedNote: 'Reviewed for Next Issue #955: the Processes test-only strict-act repair stays within existing frontend ownership, dependency, and dev-target branch-policy rules.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -43,8 +43,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .nvmrc
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: 24f0be95dcd3f77038f97a66f665eb7a6f85aad8
-lastReviewedNote: 'Reviewed for Next Issue #950: the focused test, lint, build, and hook-owned full-gate workflow already covers the versioned list request-lifecycle fix.'
+lastReviewedCommit: 5c2f80c865b989753b48cc871ae6eb6892aef45c
+lastReviewedNote: 'Reviewed for Next Issue #955: focused strict-act proof, lint, Docpact, and the hook-owned full gate cover the release-blocking test synchronization fix.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -43,8 +43,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: 24f0be95dcd3f77038f97a66f665eb7a6f85aad8
-lastReviewedNote: 'Reviewed for Next Issue #950: the versioned list runtime and regression changes remain covered by the existing hook-owned full gate; trigger policy is unchanged.'
+lastReviewedCommit: f61a8699264b10a42c483f85333d42540a394327
+lastReviewedNote: 'Reviewed for Next Issue #955: strict React act-warning enforcement correctly caught the Processes test synchronization defect; the hook-owned gate and trigger policy remain unchanged.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -44,8 +44,8 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: 24f0be95dcd3f77038f97a66f665eb7a6f85aad8
-lastReviewedNote: 'Reviewed for Next Issue #950: targeted race, route-identity, and 1-to-2-to-1 tests plus lint and build fit the existing validation matrix; no gate rule changes are needed.'
+lastReviewedCommit: f61a8699264b10a42c483f85333d42540a394327
+lastReviewedNote: 'Reviewed for Next Issue #955: focused strict-act Processes proof plus lint and the final full gate fit the existing validation matrix; no gate rule changes are needed.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -44,8 +44,8 @@ checkPaths:
   - pnpm-workspace.yaml
   - Dockerfile.app
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: 24f0be95dcd3f77038f97a66f665eb7a6f85aad8
-lastReviewedNote: 'Reviewed for Next Issue #950: the added deferred-request, route-identity, and pagination regressions close the scoped gap without reopening broader testing work.'
+lastReviewedCommit: f61a8699264b10a42c483f85333d42540a394327
+lastReviewedNote: 'Reviewed for Next Issue #955: awaiting direct ProTable request state updates repairs the scoped strict-act defect without reopening broader testing strategy work.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -41,8 +41,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: 24f0be95dcd3f77038f97a66f665eb7a6f85aad8
-lastReviewedNote: 'Reviewed for Next Issue #950: the scoped versioned-list regression coverage is implemented and adds no open coverage queue; full closure remains gate-owned.'
+lastReviewedCommit: f61a8699264b10a42c483f85333d42540a394327
+lastReviewedNote: 'Reviewed for Next Issue #955: the scoped strict-act repair adds no open coverage queue; full closure remains owned by the final managed gate.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -43,8 +43,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: 24f0be95dcd3f77038f97a66f665eb7a6f85aad8
-lastReviewedNote: 'Reviewed for Next Issue #950: deferred promises, explicit request identity, and visible stale-row assertions follow the existing asynchronous integration-test pattern.'
+lastReviewedCommit: f61a8699264b10a42c483f85333d42540a394327
+lastReviewedNote: 'Reviewed for Next Issue #955: wrapping direct mock request callbacks in async act follows the existing state-update synchronization pattern without weakening assertions.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -40,8 +40,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: 24f0be95dcd3f77038f97a66f665eb7a6f85aad8
-lastReviewedNote: 'Reviewed for Next Issue #950: the existing focused-test and full-gate recovery paths cover versioned list request-lifecycle failures without new troubleshooting rules.'
+lastReviewedCommit: f61a8699264b10a42c483f85333d42540a394327
+lastReviewedNote: 'Reviewed for Next Issue #955: the existing strict act-warning diagnostics and focused-test recovery path identified and verify this defect without new troubleshooting rules.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -604,7 +604,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "df067d1a465f143f8a3f1bd7bfac8d2084f9df26a4aac7f32a91c244f32dce3f",
-          "focusedTestDigest": "d1eec3a76b5a5b93ebb2210774642462678209d207c17507b09d6bc0795a9876",
+          "focusedTestDigest": "7774b4ee8a6ccaf30f2e2f8b6d2ecd13c5cd9aef860b9a7918bf96f3a4fbc309",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -622,7 +622,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "df067d1a465f143f8a3f1bd7bfac8d2084f9df26a4aac7f32a91c244f32dce3f",
-          "focusedTestDigest": "d1eec3a76b5a5b93ebb2210774642462678209d207c17507b09d6bc0795a9876",
+          "focusedTestDigest": "7774b4ee8a6ccaf30f2e2f8b6d2ecd13c5cd9aef860b9a7918bf96f3a4fbc309",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -640,7 +640,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "df067d1a465f143f8a3f1bd7bfac8d2084f9df26a4aac7f32a91c244f32dce3f",
-          "focusedTestDigest": "d1eec3a76b5a5b93ebb2210774642462678209d207c17507b09d6bc0795a9876",
+          "focusedTestDigest": "7774b4ee8a6ccaf30f2e2f8b6d2ecd13c5cd9aef860b9a7918bf96f3a4fbc309",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -658,7 +658,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "df067d1a465f143f8a3f1bd7bfac8d2084f9df26a4aac7f32a91c244f32dce3f",
-          "focusedTestDigest": "d1eec3a76b5a5b93ebb2210774642462678209d207c17507b09d6bc0795a9876",
+          "focusedTestDigest": "7774b4ee8a6ccaf30f2e2f8b6d2ecd13c5cd9aef860b9a7918bf96f3a4fbc309",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "ccceb27145a7edc210de1bc0ed9ad111918e4eaffbd497223e05297c4d990b53",
+      "rowEvidenceDigest": "713ba4b70b131194b4fe0b72a4f27a4e0c3ae299152d776a95efde861d382557",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "602bbab413861302897c217398e81eb50350871cf1d355701944ee47660639a1"
+  "contextDigest": "631116eb2134a1590fff8aeb620e7a7049357fde5e6de453fc04b79fccccef22"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "602bbab413861302897c217398e81eb50350871cf1d355701944ee47660639a1",
-    "qualityDigest": "0f8d928ce50ef2b74fe358e2de12e128cc223ab1eb6b6c2e5e796b7d5a60bb66",
+    "contextDigest": "631116eb2134a1590fff8aeb620e7a7049357fde5e6de453fc04b79fccccef22",
+    "qualityDigest": "55b952b4273f29e8e1b38228a0b02399739690ce5c1b402fa14516c92ac297d3",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "a72c1cb9cfe65d20e829b6b8d9682ef81702631420f46fb0d142a26e5e276a78"
+  "activationDigest": "6c2d5b13be8079ec497eff74fefe2b498876a78b87e034d4ee937610d13c0902"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "330271fd3a4ff03748eb6209e4bef0615b4740fbd0bcea1db588f8016d2b183c",
-    "contextDigest": "602bbab413861302897c217398e81eb50350871cf1d355701944ee47660639a1"
+    "contextDigest": "631116eb2134a1590fff8aeb620e7a7049357fde5e6de453fc04b79fccccef22"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "91315e06ac4e2eece31185711f1250f854877cf106c70ae489414138fedba8f0",
-    "validationDigest": "5842d2d1a3abf090ac579ddae1a97f775df44f8ffadac3a2d96654c1965e522d",
+    "digest": "5b9d7bbb174eff4baddcd3947a6c48a907bd2f72def0069d0816ec20f538afc7",
+    "validationDigest": "8a41a7a80af848cd43a5039e9efeb07ae2a9548f1eafb2108d9a4e20f9825f69",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "0f8d928ce50ef2b74fe358e2de12e128cc223ab1eb6b6c2e5e796b7d5a60bb66"
+  "qualityDigest": "55b952b4273f29e8e1b38228a0b02399739690ce5c1b402fa14516c92ac297d3"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "09e1a503bd8add3c0b25f62a2ba1553d8fdeb75a027816ff98c304a9b2c7ad5e",
     "dossierDigest": "7f1a14d5491160f822f49fc30a53484bc14e58bb03abac26d15a4b0c199da033",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "ccceb27145a7edc210de1bc0ed9ad111918e4eaffbd497223e05297c4d990b53",
+    "routeEvidenceDigest": "713ba4b70b131194b4fe0b72a4f27a4e0c3ae299152d776a95efde861d382557",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "5842d2d1a3abf090ac579ddae1a97f775df44f8ffadac3a2d96654c1965e522d"
+  "validationDigest": "8a41a7a80af848cd43a5039e9efeb07ae2a9548f1eafb2108d9a4e20f9825f69"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -604,7 +604,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "df067d1a465f143f8a3f1bd7bfac8d2084f9df26a4aac7f32a91c244f32dce3f",
-          "focusedTestDigest": "d1eec3a76b5a5b93ebb2210774642462678209d207c17507b09d6bc0795a9876",
+          "focusedTestDigest": "7774b4ee8a6ccaf30f2e2f8b6d2ecd13c5cd9aef860b9a7918bf96f3a4fbc309",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -622,7 +622,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "df067d1a465f143f8a3f1bd7bfac8d2084f9df26a4aac7f32a91c244f32dce3f",
-          "focusedTestDigest": "d1eec3a76b5a5b93ebb2210774642462678209d207c17507b09d6bc0795a9876",
+          "focusedTestDigest": "7774b4ee8a6ccaf30f2e2f8b6d2ecd13c5cd9aef860b9a7918bf96f3a4fbc309",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -640,7 +640,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "df067d1a465f143f8a3f1bd7bfac8d2084f9df26a4aac7f32a91c244f32dce3f",
-          "focusedTestDigest": "d1eec3a76b5a5b93ebb2210774642462678209d207c17507b09d6bc0795a9876",
+          "focusedTestDigest": "7774b4ee8a6ccaf30f2e2f8b6d2ecd13c5cd9aef860b9a7918bf96f3a4fbc309",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -658,7 +658,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "df067d1a465f143f8a3f1bd7bfac8d2084f9df26a4aac7f32a91c244f32dce3f",
-          "focusedTestDigest": "d1eec3a76b5a5b93ebb2210774642462678209d207c17507b09d6bc0795a9876",
+          "focusedTestDigest": "7774b4ee8a6ccaf30f2e2f8b6d2ecd13c5cd9aef860b9a7918bf96f3a4fbc309",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "ccceb27145a7edc210de1bc0ed9ad111918e4eaffbd497223e05297c4d990b53",
+      "rowEvidenceDigest": "713ba4b70b131194b4fe0b72a4f27a4e0c3ae299152d776a95efde861d382557",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "3c9074694a17822a497252c6386bdb332411477d609a6720d12ce33ea358e500"
+  "contextDigest": "89cf9a966a8af90cbb15215907fba5cb642b388bcedb57b184e99dc8fdaca175"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "3c9074694a17822a497252c6386bdb332411477d609a6720d12ce33ea358e500",
-    "qualityDigest": "98a0966a1fc5c830a8d86f309ba5365ff6392ea891aa9aa55164c7e3b5aaedbb",
+    "contextDigest": "89cf9a966a8af90cbb15215907fba5cb642b388bcedb57b184e99dc8fdaca175",
+    "qualityDigest": "4bd5ebb7583f2b1944b37a2797e11f307fc7454bd628577701929a8d76bebac6",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "ddf68c089c256f79aa21f630b06234c989834625c2293bd9c573e2d01d45ae10"
+  "activationDigest": "e7e55ebcf7ee752677dded35a10decac7f28963fc83dd8031e5b11429b4bab11"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "330271fd3a4ff03748eb6209e4bef0615b4740fbd0bcea1db588f8016d2b183c",
-    "contextDigest": "3c9074694a17822a497252c6386bdb332411477d609a6720d12ce33ea358e500"
+    "contextDigest": "89cf9a966a8af90cbb15215907fba5cb642b388bcedb57b184e99dc8fdaca175"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "e289f8d722bd809ed5651508a76a3e490a15376aab7bfe071aaa6ea5fbd08721",
-    "validationDigest": "ee1ba2826f53a3f4acb0868d0eb411bc0f590762431847e32ec5ec293f642075",
+    "digest": "bcbffd672071fb73d88e514e8044da1e07b9809da902f19ab1ed01a01d968591",
+    "validationDigest": "92921b6952e1d6ec562c18206fed33243f676b608e0f80b28f7f7d5d0fd64d60",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "98a0966a1fc5c830a8d86f309ba5365ff6392ea891aa9aa55164c7e3b5aaedbb"
+  "qualityDigest": "4bd5ebb7583f2b1944b37a2797e11f307fc7454bd628577701929a8d76bebac6"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "93741a89fe46709918133c289bd4567e9261befb763495e91d6f667bb3595c83",
     "dossierDigest": "89e9ca52d16a23d1a355780f20a634b19d0c711fd1ed0dda2a8d5ee0669ee79c",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "ccceb27145a7edc210de1bc0ed9ad111918e4eaffbd497223e05297c4d990b53",
+    "routeEvidenceDigest": "713ba4b70b131194b4fe0b72a4f27a4e0c3ae299152d776a95efde861d382557",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "ee1ba2826f53a3f4acb0868d0eb411bc0f590762431847e32ec5ec293f642075"
+  "validationDigest": "92921b6952e1d6ec562c18206fed33243f676b608e0f80b28f7f7d5d0fd64d60"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -604,7 +604,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "df067d1a465f143f8a3f1bd7bfac8d2084f9df26a4aac7f32a91c244f32dce3f",
-          "focusedTestDigest": "d1eec3a76b5a5b93ebb2210774642462678209d207c17507b09d6bc0795a9876",
+          "focusedTestDigest": "7774b4ee8a6ccaf30f2e2f8b6d2ecd13c5cd9aef860b9a7918bf96f3a4fbc309",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -622,7 +622,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "df067d1a465f143f8a3f1bd7bfac8d2084f9df26a4aac7f32a91c244f32dce3f",
-          "focusedTestDigest": "d1eec3a76b5a5b93ebb2210774642462678209d207c17507b09d6bc0795a9876",
+          "focusedTestDigest": "7774b4ee8a6ccaf30f2e2f8b6d2ecd13c5cd9aef860b9a7918bf96f3a4fbc309",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -640,7 +640,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "df067d1a465f143f8a3f1bd7bfac8d2084f9df26a4aac7f32a91c244f32dce3f",
-          "focusedTestDigest": "d1eec3a76b5a5b93ebb2210774642462678209d207c17507b09d6bc0795a9876",
+          "focusedTestDigest": "7774b4ee8a6ccaf30f2e2f8b6d2ecd13c5cd9aef860b9a7918bf96f3a4fbc309",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -658,7 +658,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "df067d1a465f143f8a3f1bd7bfac8d2084f9df26a4aac7f32a91c244f32dce3f",
-          "focusedTestDigest": "d1eec3a76b5a5b93ebb2210774642462678209d207c17507b09d6bc0795a9876",
+          "focusedTestDigest": "7774b4ee8a6ccaf30f2e2f8b6d2ecd13c5cd9aef860b9a7918bf96f3a4fbc309",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "ccceb27145a7edc210de1bc0ed9ad111918e4eaffbd497223e05297c4d990b53",
+      "rowEvidenceDigest": "713ba4b70b131194b4fe0b72a4f27a4e0c3ae299152d776a95efde861d382557",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "909e977bc12c16ada0394616f1980aa17089c4d9d8eae6da412e025e0f410319"
+  "contextDigest": "27f4a2ba4346effd879ceb7048024eeae5ddd4116afe50e22f340b5c689523c3"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "909e977bc12c16ada0394616f1980aa17089c4d9d8eae6da412e025e0f410319",
-    "qualityDigest": "2822211e0174b12b596e09e56bccaacc00570891dc549e269fd01c1c29faeee5",
+    "contextDigest": "27f4a2ba4346effd879ceb7048024eeae5ddd4116afe50e22f340b5c689523c3",
+    "qualityDigest": "67724f75ff5d6224f3f926ab838d4013c048f674340d2acd2f859d2cafd357ac",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "fec90266a89d41d7a868866bb4a8982e88f5de1647169b6f0e34a702526fabb4"
+  "activationDigest": "428b361515456d87a9a0d7cd2e37c2725d9bfe1734f4462ede530786cee37ebc"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "330271fd3a4ff03748eb6209e4bef0615b4740fbd0bcea1db588f8016d2b183c",
-    "contextDigest": "909e977bc12c16ada0394616f1980aa17089c4d9d8eae6da412e025e0f410319"
+    "contextDigest": "27f4a2ba4346effd879ceb7048024eeae5ddd4116afe50e22f340b5c689523c3"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "98d3f2f10c0871f8e6b1e14debb85ab4928058a4058c1e945d178bb39d56b824",
-    "validationDigest": "a93a16cb135e7281558ccf3aabb1b52a6585264f0b76849da810ba55909a667e",
+    "digest": "79f522f0df79d7deeabf65567082f92fa3d49c2f27559c4963539e6589dbae0f",
+    "validationDigest": "1d24be1e3ee3b90328b4dea06d7a42db8762ceb82c0fe938106e272d443f827a",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "2822211e0174b12b596e09e56bccaacc00570891dc549e269fd01c1c29faeee5"
+  "qualityDigest": "67724f75ff5d6224f3f926ab838d4013c048f674340d2acd2f859d2cafd357ac"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "24238218499ffff02768ab879d2c55877b656be79221b03b56b8d951d0f0068b",
     "dossierDigest": "f37608702878ac46f282c75cf162108c9f3de1037d3ecce1f0b83e25bf0a0f4b",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "ccceb27145a7edc210de1bc0ed9ad111918e4eaffbd497223e05297c4d990b53",
+    "routeEvidenceDigest": "713ba4b70b131194b4fe0b72a4f27a4e0c3ae299152d776a95efde861d382557",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "a93a16cb135e7281558ccf3aabb1b52a6585264f0b76849da810ba55909a667e"
+  "validationDigest": "1d24be1e3ee3b90328b4dea06d7a42db8762ceb82c0fe938106e272d443f827a"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -604,7 +604,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "df067d1a465f143f8a3f1bd7bfac8d2084f9df26a4aac7f32a91c244f32dce3f",
-          "focusedTestDigest": "d1eec3a76b5a5b93ebb2210774642462678209d207c17507b09d6bc0795a9876",
+          "focusedTestDigest": "7774b4ee8a6ccaf30f2e2f8b6d2ecd13c5cd9aef860b9a7918bf96f3a4fbc309",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -622,7 +622,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "df067d1a465f143f8a3f1bd7bfac8d2084f9df26a4aac7f32a91c244f32dce3f",
-          "focusedTestDigest": "d1eec3a76b5a5b93ebb2210774642462678209d207c17507b09d6bc0795a9876",
+          "focusedTestDigest": "7774b4ee8a6ccaf30f2e2f8b6d2ecd13c5cd9aef860b9a7918bf96f3a4fbc309",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -640,7 +640,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "df067d1a465f143f8a3f1bd7bfac8d2084f9df26a4aac7f32a91c244f32dce3f",
-          "focusedTestDigest": "d1eec3a76b5a5b93ebb2210774642462678209d207c17507b09d6bc0795a9876",
+          "focusedTestDigest": "7774b4ee8a6ccaf30f2e2f8b6d2ecd13c5cd9aef860b9a7918bf96f3a4fbc309",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -658,7 +658,7 @@
           "viewState": "dataset-list-and-drawers",
           "requiredEvidenceScope": "internal-localization",
           "sourceDigest": "df067d1a465f143f8a3f1bd7bfac8d2084f9df26a4aac7f32a91c244f32dce3f",
-          "focusedTestDigest": "d1eec3a76b5a5b93ebb2210774642462678209d207c17507b09d6bc0795a9876",
+          "focusedTestDigest": "7774b4ee8a6ccaf30f2e2f8b6d2ecd13c5cd9aef860b9a7918bf96f3a4fbc309",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "c1a717241a2262686b0800ebe4da4f59e4dd2e5f00f5e7a036a58f36a79d5b53",
           "derivedMessageCount": 19,
@@ -1089,7 +1089,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "ccceb27145a7edc210de1bc0ed9ad111918e4eaffbd497223e05297c4d990b53",
+      "rowEvidenceDigest": "713ba4b70b131194b4fe0b72a4f27a4e0c3ae299152d776a95efde861d382557",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1113,5 +1113,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "b8ef2ce7cd389a63a6d7e43cf730a60393e3763106407b7d4e03919eaef3c058"
+  "contextDigest": "722ded3d3d2eb3deb8dc42ba270c43dffee27f0d61c8dd3ed23fa19f5bbaf04b"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "b8ef2ce7cd389a63a6d7e43cf730a60393e3763106407b7d4e03919eaef3c058",
-    "qualityDigest": "3b10e8ea89dfa10b69a0e71c86744df2f04898a4846487dace7089f0ef30ca71",
+    "contextDigest": "722ded3d3d2eb3deb8dc42ba270c43dffee27f0d61c8dd3ed23fa19f5bbaf04b",
+    "qualityDigest": "6dedf69d533358e7f16a9077bd6d5f9ecc11e571e3a168a9519cce96fc9b4199",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "af2b0a681f42f4841d592ad99a1f1b7d9b24a893793daffdda408c452786e556",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "e0d3f560dfbe4c7f79bbfec4488a65596cd5c182aeb6aa70ae9d1974fbe84b4f"
+  "activationDigest": "901488fe4b9838a5b8b17aaa19771c3790393db0443948ea0458183a7216f025"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -4,7 +4,7 @@
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestDigest": "330271fd3a4ff03748eb6209e4bef0615b4740fbd0bcea1db588f8016d2b183c",
-    "contextDigest": "b8ef2ce7cd389a63a6d7e43cf730a60393e3763106407b7d4e03919eaef3c058"
+    "contextDigest": "722ded3d3d2eb3deb8dc42ba270c43dffee27f0d61c8dd3ed23fa19f5bbaf04b"
   },
   "catalog": {
     "messageCount": 3208,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "dd3bfb07eb20c9346972b09f3e2968a0bcc0c685b9e7954cafd9cc949e76378c",
-    "validationDigest": "8cff90b66dc5b44e2e120787306f6a40f124ddddfce533cb3cfe362ccc9ddf7c",
+    "digest": "ebee23c7809b9f571fb356d176f72f297fdf3bd9d3badb4fbc36b0b014c22279",
+    "validationDigest": "ecaca2a2f9ec0e180441ddd1904e4026d3e9f556261d607e197ed615553e642a",
     "laneCount": 1,
     "validatedMessageCount": 3208,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "3b10e8ea89dfa10b69a0e71c86744df2f04898a4846487dace7089f0ef30ca71"
+  "qualityDigest": "6dedf69d533358e7f16a9077bd6d5f9ecc11e571e3a168a9519cce96fc9b4199"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -44,7 +44,7 @@
     "catalogDigest": "a7934690a8abe6e2d5866a0542d6a0df3a9219136af620e7324431f1caf87cff",
     "dossierDigest": "adc9e9108bf3d9fcc9bcb31d44f74cdf0e56254a5fb60a46694dc93cfc27fe36",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "ccceb27145a7edc210de1bc0ed9ad111918e4eaffbd497223e05297c4d990b53",
+    "routeEvidenceDigest": "713ba4b70b131194b4fe0b72a4f27a4e0c3ae299152d776a95efde861d382557",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "8cff90b66dc5b44e2e120787306f6a40f124ddddfce533cb3cfe362ccc9ddf7c"
+  "validationDigest": "ecaca2a2f9ec0e180441ddd1904e4026d3e9f556261d607e197ed615553e642a"
 }

--- a/tests/unit/pages/Processes/index.test.tsx
+++ b/tests/unit/pages/Processes/index.test.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import ProcessesPage, { getProcesstypeOfDataSetOptions } from '@/pages/Processes';
 import userEvent from '@testing-library/user-event';
-import { renderWithProviders, screen, waitFor, within } from '../../../helpers/testUtils';
+import { act, renderWithProviders, screen, waitFor, within } from '../../../helpers/testUtils';
 
 jest.mock('@/contexts/AntdAppContext', () => ({
   __esModule: true,
@@ -690,12 +690,18 @@ describe('ProcessesPage', () => {
   it('maps search and table sort fields for pgroonga and table-all requests', async () => {
     renderWithProviders(<ProcessesPage />);
 
+    const requestTable = async (requestParams: any, sort: any) => {
+      await act(async () => {
+        await latestRequest(requestParams, sort);
+      });
+    };
+
     await waitFor(() => expect(mockGetProcessTableAll).toHaveBeenCalled());
 
     await userEvent.click(screen.getByRole('button', { name: /search/i }));
     await waitFor(() => expect(mockGetProcessTablePgroongaSearch).toHaveBeenCalled());
 
-    await latestRequest({ pageSize: 10, current: 1 }, { name: 'ascend' });
+    await requestTable({ pageSize: 10, current: 1 }, { name: 'ascend' });
     expect(mockGetProcessTablePgroongaSearch).toHaveBeenLastCalledWith(
       { pageSize: 10, current: 1 },
       'en',
@@ -708,7 +714,7 @@ describe('ProcessesPage', () => {
       'team-1',
     );
 
-    await latestRequest({ pageSize: 10, current: 1 }, { name: 'descend' });
+    await requestTable({ pageSize: 10, current: 1 }, { name: 'descend' });
     expect(mockGetProcessTablePgroongaSearch).toHaveBeenLastCalledWith(
       { pageSize: 10, current: 1 },
       'en',
@@ -721,7 +727,7 @@ describe('ProcessesPage', () => {
       'team-1',
     );
 
-    await latestRequest({ pageSize: 10, current: 1 }, { classification: 'descend' });
+    await requestTable({ pageSize: 10, current: 1 }, { classification: 'descend' });
     expect(mockGetProcessTablePgroongaSearch).toHaveBeenLastCalledWith(
       { pageSize: 10, current: 1 },
       'en',
@@ -734,7 +740,7 @@ describe('ProcessesPage', () => {
       'team-1',
     );
 
-    await latestRequest({ pageSize: 10, current: 1 }, { classification: 'ascend' });
+    await requestTable({ pageSize: 10, current: 1 }, { classification: 'ascend' });
     expect(mockGetProcessTablePgroongaSearch).toHaveBeenLastCalledWith(
       { pageSize: 10, current: 1 },
       'en',
@@ -754,7 +760,7 @@ describe('ProcessesPage', () => {
     renderWithProviders(<ProcessesPage />);
 
     await waitFor(() => expect(mockGetProcessTableAll).toHaveBeenCalled());
-    await latestRequest({ pageSize: 10, current: 1 }, { name: 'ascend' });
+    await requestTable({ pageSize: 10, current: 1 }, { name: 'ascend' });
     expect(mockGetProcessTableAll).toHaveBeenLastCalledWith(
       { pageSize: 10, current: 1 },
       {
@@ -767,7 +773,7 @@ describe('ProcessesPage', () => {
       'all',
     );
 
-    await latestRequest({ pageSize: 10, current: 1 }, { location: 'descend' });
+    await requestTable({ pageSize: 10, current: 1 }, { location: 'descend' });
     expect(mockGetProcessTableAll).toHaveBeenLastCalledWith(
       { pageSize: 10, current: 1 },
       { location: 'descend' },


### PR DESCRIPTION
## Summary

- wrap direct mocked ProTable request callbacks in async React `act(...)` so state updates settle before assertions
- preserve all existing Processes search and sort mapping assertions
- refresh the four registry locales' generated evidence manifests for the changed focused-test digest
- record the required Docpact testing and repository-workflow reviews

## Why

The v0.0.89 Release PR #954 failed its exact release gate because `tests/unit/pages/Processes/index.test.tsx` emitted six strict React act warnings. The release candidate itself changed only version and bounded governance metadata; the strict-mode defect was deterministic on `dev` and blocked valid `dev -> main` proof.

## Validation

- `FAIL_ON_ACT_WARNING=1 pnpm exec jest tests/unit/pages/Processes/index.test.tsx --runInBand --no-coverage`: 20/20 passed
- `pnpm i18n:locale:artifacts:idempotence`: canonical after two generations
- `pnpm i18n:locale:all:check`: all four registry locales current
- `pnpm docpact:gate`: passed
- managed `pnpm push:checked fork HEAD:feature/issue-955` with exact Node 24.19.0 / pnpm 11.24.0:
  - 435/435 suites passed
  - 5,824/5,824 tests passed
  - 477/477 tracked source files at 100% statements, branches, functions, and lines
- transport completed through the receipt-bound `pnpm run push:retry` continuation after the gate passed

## Release handoff

After this PR merges into `dev`, regenerate the v0.0.89 Release PR from the new exact `dev` head; do not reuse the failed proof from #954.

Closes #955
