### PR TITLE
chore: prepare v0.0.89 on dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-29"
-lastReviewedCommit: "f61a8699264b10a42c483f85333d42540a394327"
+lastReviewedAt: "2026-08-30"
+lastReviewedCommit: "00d0a8cb1594356a8fab5a397f47bf389e8c18bf"
 lastReviewedNote: 'Reviewed for Next Issue #955: the Processes strict-act synchronization fix remains covered by the existing testing-and-gate route; routing rules are unchanged.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-08-29
-lastReviewedCommit: 5c2f80c865b989753b48cc871ae6eb6892aef45c
+lastReviewedAt: 2026-08-30
+lastReviewedCommit: 00d0a8cb1594356a8fab5a397f47bf389e8c18bf
 lastReviewedNote: 'Reviewed for Next Issue #955: the Processes test-only strict-act repair stays within existing frontend ownership, dependency, and dev-target branch-policy rules.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -42,8 +42,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .github/workflows/build.yml
   - .nvmrc
-lastReviewedAt: 2026-08-29
-lastReviewedCommit: 5c2f80c865b989753b48cc871ae6eb6892aef45c
+lastReviewedAt: 2026-08-30
+lastReviewedCommit: 00d0a8cb1594356a8fab5a397f47bf389e8c18bf
 lastReviewedNote: 'Reviewed for Next Issue #955: focused strict-act proof, lint, Docpact, and the hook-owned full gate cover the release-blocking test synchronization fix.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -42,8 +42,8 @@ checkPaths:
   - scripts/typescript-native-parser.*
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-08-29
-lastReviewedCommit: f61a8699264b10a42c483f85333d42540a394327
+lastReviewedAt: 2026-08-30
+lastReviewedCommit: 00d0a8cb1594356a8fab5a397f47bf389e8c18bf
 lastReviewedNote: 'Reviewed for Next Issue #955: strict React act-warning enforcement correctly caught the Processes test synchronization defect; the hook-owned gate and trigger policy remain unchanged.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -43,8 +43,8 @@ checkPaths:
   - scripts/typescript-native-parser.*
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-08-29
-lastReviewedCommit: f61a8699264b10a42c483f85333d42540a394327
+lastReviewedAt: 2026-08-30
+lastReviewedCommit: 00d0a8cb1594356a8fab5a397f47bf389e8c18bf
 lastReviewedNote: 'Reviewed for Next Issue #955: focused strict-act Processes proof plus lint and the final full gate fit the existing validation matrix; no gate rule changes are needed.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -43,8 +43,8 @@ checkPaths:
   - pnpm-lock.yaml
   - pnpm-workspace.yaml
   - Dockerfile.app
-lastReviewedAt: 2026-08-29
-lastReviewedCommit: f61a8699264b10a42c483f85333d42540a394327
+lastReviewedAt: 2026-08-30
+lastReviewedCommit: 00d0a8cb1594356a8fab5a397f47bf389e8c18bf
 lastReviewedNote: 'Reviewed for Next Issue #955: awaiting direct ProTable request state updates repairs the scoped strict-act defect without reopening broader testing strategy work.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -40,8 +40,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-29
-lastReviewedCommit: f61a8699264b10a42c483f85333d42540a394327
+lastReviewedAt: 2026-08-30
+lastReviewedCommit: 00d0a8cb1594356a8fab5a397f47bf389e8c18bf
 lastReviewedNote: 'Reviewed for Next Issue #955: the scoped strict-act repair adds no open coverage queue; full closure remains owned by the final managed gate.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -42,8 +42,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-29
-lastReviewedCommit: f61a8699264b10a42c483f85333d42540a394327
+lastReviewedAt: 2026-08-30
+lastReviewedCommit: 00d0a8cb1594356a8fab5a397f47bf389e8c18bf
 lastReviewedNote: 'Reviewed for Next Issue #955: wrapping direct mock request callbacks in async act follows the existing state-update synchronization pattern without weakening assertions.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -39,8 +39,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-08-29
-lastReviewedCommit: f61a8699264b10a42c483f85333d42540a394327
+lastReviewedAt: 2026-08-30
+lastReviewedCommit: 00d0a8cb1594356a8fab5a397f47bf389e8c18bf
 lastReviewedNote: 'Reviewed for Next Issue #955: the existing strict act-warning diagnostics and focused-test recovery path identified and verify this defect without new troubleshooting rules.'
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.88",
+  "version": "0.0.89",
   "packageManager": "pnpm@11.24.0",
   "private": true,
   "description": "An out-of-box LCA Data solution",


### PR DESCRIPTION
<!-- tiangong-next-release-automation:v2 issue=950 version=0.0.89 dev-base=00d0a8cb1594356a8fab5a397f47bf389e8c18bf main-base=93d048e05fa96c84a94366920cce25957045d098 candidate=5cfacde56f12d5e2c1a69ef64624fc0fce996d5f -->

## Branch Contract

- base branch: `dev`
- validated environment: exact dev Release PR non-browser gate
- back-merge required after merge: No
- root workspace integration expected: after later dev-to-main promotion

## Linked Issue

Refs #950

## Change Facts

- Prepare version `0.0.89` from exact dev base `00d0a8cb1594356a8fab5a397f47bf389e8c18bf`.
- Change only package.json.version and keep pnpm-lock.yaml byte-for-byte unchanged.
- Keep release proof external to Git and bind it to the exact main/dev bases, candidate SHA/tree, version, workflow run, and artifact.
- Record Docpact review evidence only after the command proves the candidate has no other semantic change.
- Reviewed paths:
  - `.docpact/config.yaml`
  - `AGENTS.md`
  - `DEV.md`
  - `docs/agents/prepush-gate-policy.md`
  - `docs/agents/repo-validation.md`
  - `docs/agents/test_improvement_plan.md`
  - `docs/agents/test_todo_list.md`
  - `docs/agents/testing-patterns.md`
  - `docs/agents/testing-troubleshooting.md`

## Validation Facts

- Candidate: `5cfacde56f12d5e2c1a69ef64624fc0fce996d5f`
- Main baseline: `93d048e05fa96c84a94366920cce25957045d098`
- Release gate: `required_by_dev_release_candidate_gate`; static preflight: `passed`
- Docpact automatic-review status: `completed`
- Docpact checked the complete main-to-candidate promotion range before the dev PR was created.
- The managed candidate push ran only structural/static checks; this PR owns one non-browser full release gate and its exact proof.
- Browser E2E is not evaluated or required by this PR. Run the manual hermetic workflow on the open business PR before release-to-dev when the change risk warrants browser evidence.

## Risks And Follow-Up

- Merge only after the exact Release Candidate release proof succeeds, then run the deterministic dev-to-main promotion command with this PR number.
