### PR TITLE
Fix Process list refresh after creation

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-31"
-lastReviewedCommit: "1bf4840ca333a2ff768db70e475dd6a43144678b"
+lastReviewedCommit: "db1965b0"
 lastReviewedNote: 'Reviewed for Next Issue #964: routing and proof bind the bridge/service to one bounded byte-preserved opaque handle and reject dot-only URL-normalizing segments.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-31"
-lastReviewedCommit: "b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419"
+lastReviewedCommit: "f8c1a2de8446a3b7582998f31c04c461b484a965"
 lastReviewedNote: 'Reviewed for Next Issue #962: routing and proof now cover OAuth consent, EdgeOne hash bridging, safe login/callback redirects, grants, and legacy-key retirement.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-31"
-lastReviewedCommit: "cc36aebfb34950e472e9399ea07a12d78ae0f3a1"
+lastReviewedCommit: "b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419"
 lastReviewedNote: 'Reviewed for Next Issue #962: routing and proof now cover OAuth consent, EdgeOne hash bridging, safe login/callback redirects, grants, and legacy-key retirement.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: 1bf4840ca333a2ff768db70e475dd6a43144678b
+lastReviewedCommit: db1965b0
 lastReviewedNote: 'Reviewed for Next Issue #964: OAuth consent preserves one bounded opaque URL-safe handle byte-for-byte while rejecting dot-only URL-normalizing path segments.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: cc36aebfb34950e472e9399ea07a12d78ae0f3a1
+lastReviewedCommit: b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419
 lastReviewedNote: 'Reviewed for Next Issue #962: OAuth consent uses a hash-history bridge, getClaims identity verification, safe relative login continuation, grant management, and a 50-ID route-view contract.'
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419
+lastReviewedCommit: f8c1a2de8446a3b7582998f31c04c461b484a965
 lastReviewedNote: 'Reviewed for Next Issue #962: OAuth consent uses a hash-history bridge, getClaims identity verification, safe relative login continuation, grant management, and a 50-ID route-view contract.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/build.yml
   - .nvmrc
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: 1bf4840ca333a2ff768db70e475dd6a43144678b
+lastReviewedCommit: db1965b0
 lastReviewedNote: 'Reviewed for Next Issue #964: the opaque authorization-handle repair uses the existing bootstrap, focused OAuth tests, build, and checked-push workflow.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/build.yml
   - .nvmrc
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419
+lastReviewedCommit: f8c1a2de8446a3b7582998f31c04c461b484a965
 lastReviewedNote: 'Reviewed for Next Issue #962: the Supabase JS OAuth API upgrade and consent route use the existing bootstrap, focused-test, build, and checked-push workflow.'
 ---
 

--- a/DEV.md
+++ b/DEV.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/build.yml
   - .nvmrc
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: cc36aebfb34950e472e9399ea07a12d78ae0f3a1
+lastReviewedCommit: b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419
 lastReviewedNote: 'Reviewed for Next Issue #962: the Supabase JS OAuth API upgrade and consent route use the existing bootstrap, focused-test, build, and checked-push workflow.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -43,7 +43,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: 1bf4840ca333a2ff768db70e475dd6a43144678b
+lastReviewedCommit: db1965b0
 lastReviewedNote: 'Reviewed for Next Issue #964: opaque authorization-handle regressions stay inside the existing focused OAuth plus full pre-push gate; gate ownership and browser trust are unchanged.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -43,7 +43,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: cc36aebfb34950e472e9399ea07a12d78ae0f3a1
+lastReviewedCommit: b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419
 lastReviewedNote: 'Reviewed for Next Issue #962: the semantic route contract expands from 49 to 50 IDs without changing gate ownership, browser trust, or release-proof policy.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -43,7 +43,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419
+lastReviewedCommit: f8c1a2de8446a3b7582998f31c04c461b484a965
 lastReviewedNote: 'Reviewed for Next Issue #962: the semantic route contract expands from 49 to 50 IDs without changing gate ownership, browser trust, or release-proof policy.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: cc36aebfb34950e472e9399ea07a12d78ae0f3a1
+lastReviewedCommit: b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419
 lastReviewedNote: 'Reviewed for Next Issue #962: the OAuth consent/grant surface adds a hash-history bridge and page-owned auth boundary while preserving service-first access and route ownership.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419
+lastReviewedCommit: f8c1a2de8446a3b7582998f31c04c461b484a965
 lastReviewedNote: 'Reviewed for Next Issue #962: the OAuth consent/grant surface adds a hash-history bridge and page-owned auth boundary while preserving service-first access and route ownership.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: 1bf4840ca333a2ff768db70e475dd6a43144678b
+lastReviewedCommit: db1965b0
 lastReviewedNote: 'Reviewed for Next Issue #964: the bridge/auth service share one bounded opaque-handle contract and exclude dot-only segments before auth-js path construction.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -44,7 +44,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: cc36aebfb34950e472e9399ea07a12d78ae0f3a1
+lastReviewedCommit: b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419
 lastReviewedNote: 'Reviewed for Next Issue #962: OAuth consent, callback safety, grant revocation, legacy-key retirement, EdgeOne bridging, and the expanded 50-ID semantic route contract have focused proof.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -44,7 +44,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: 1bf4840ca333a2ff768db70e475dd6a43144678b
+lastReviewedCommit: db1965b0
 lastReviewedNote: 'Reviewed for Next Issue #964: OAuth focused proof accepts hosted opaque handles unchanged while rejecting duplicate, delimiter, injection, oversized, and dot-only inputs.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -44,7 +44,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419
+lastReviewedCommit: f8c1a2de8446a3b7582998f31c04c461b484a965
 lastReviewedNote: 'Reviewed for Next Issue #962: OAuth consent, callback safety, grant revocation, legacy-key retirement, EdgeOne bridging, and the expanded 50-ID semantic route contract have focused proof.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -44,7 +44,7 @@ checkPaths:
   - pnpm-workspace.yaml
   - Dockerfile.app
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: cc36aebfb34950e472e9399ea07a12d78ae0f3a1
+lastReviewedCommit: b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419
 lastReviewedNote: 'Reviewed for Next Issue #962: OAuth consent adds one executable route assertion while preserving the bounded semantic E2E and single full-gate strategy.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -44,7 +44,7 @@ checkPaths:
   - pnpm-workspace.yaml
   - Dockerfile.app
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: 1bf4840ca333a2ff768db70e475dd6a43144678b
+lastReviewedCommit: db1965b0
 lastReviewedNote: 'Reviewed for Next Issue #964: bridge, service, page, and redirect tests cover hosted opaque authorization handles without changing the bounded semantic E2E strategy.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -44,7 +44,7 @@ checkPaths:
   - pnpm-workspace.yaml
   - Dockerfile.app
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419
+lastReviewedCommit: f8c1a2de8446a3b7582998f31c04c461b484a965
 lastReviewedNote: 'Reviewed for Next Issue #962: OAuth consent adds one executable route assertion while preserving the bounded semantic E2E and single full-gate strategy.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -41,7 +41,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: 1bf4840ca333a2ff768db70e475dd6a43144678b
+lastReviewedCommit: db1965b0
 lastReviewedNote: 'Reviewed for Next Issue #964: hosted opaque-handle and unsafe-input cases are covered now and create no deferred testing queue.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -41,7 +41,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: cc36aebfb34950e472e9399ea07a12d78ae0f3a1
+lastReviewedCommit: b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419
 lastReviewedNote: 'Reviewed for Next Issue #962: focused OAuth and route-contract proof expands the matrix to 50 IDs without creating a deferred coverage queue.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -41,7 +41,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419
+lastReviewedCommit: f8c1a2de8446a3b7582998f31c04c461b484a965
 lastReviewedNote: 'Reviewed for Next Issue #962: focused OAuth and route-contract proof expands the matrix to 50 IDs without creating a deferred coverage queue.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: cc36aebfb34950e472e9399ea07a12d78ae0f3a1
+lastReviewedCommit: b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419
 lastReviewedNote: 'Reviewed for Next Issue #962: OAuth consent follows service/component/integration patterns and adds one fail-closed route assertion to the 50-ID matrix.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419
+lastReviewedCommit: f8c1a2de8446a3b7582998f31c04c461b484a965
 lastReviewedNote: 'Reviewed for Next Issue #962: OAuth consent follows service/component/integration patterns and adds one fail-closed route assertion to the 50-ID matrix.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: 1bf4840ca333a2ff768db70e475dd6a43144678b
+lastReviewedCommit: db1965b0
 lastReviewedNote: 'Reviewed for Next Issue #964: OAuth service and bridge tests share hosted opaque and unsafe fixtures while preserving existing service/component/integration patterns.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -40,7 +40,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: cc36aebfb34950e472e9399ea07a12d78ae0f3a1
+lastReviewedCommit: b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419
 lastReviewedNote: 'Reviewed for Next Issue #962: semantic evidence troubleshooting now reflects the 50-ID route contract; no recovery or trust-boundary rule changes.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -40,7 +40,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: 1bf4840ca333a2ff768db70e475dd6a43144678b
+lastReviewedCommit: db1965b0
 lastReviewedNote: 'Reviewed for Next Issue #964: opaque authorization-handle failures are diagnosed through the existing focused OAuth fixtures and live Dev flow; no recovery rule changes.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -40,7 +40,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: b4c66b9fdba8a11cd27c3fa7bbb4d9b3eba3c419
+lastReviewedCommit: f8c1a2de8446a3b7582998f31c04c461b484a965
 lastReviewedNote: 'Reviewed for Next Issue #962: semantic evidence troubleshooting now reflects the 50-ID route contract; no recovery or trust-boundary rule changes.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "be054f2d07b8b419755dc4343f6aec34612500fda3862d3e8e039f8f63ab2c7d",
-    "auditedInputDigest": "54184346c9a12eccffab014e680565e94605467016666d17532704f41bf53dc5"
+    "sourceManifestDigest": "f00a051bf8b43a48eac12f468164e7f3d78ed61ee3c2ccf02a3c0132b35017dd",
+    "auditedInputDigest": "de211ce15a6ac781579a03aa944874d8e21716aee6ec4b4411f30d32bd240b20"
   },
   "inventory": {
     "sourceMessageCount": 3252,
@@ -47,7 +47,7 @@
     "messageCount": 3252,
     "completeCount": 3252,
     "blockedCount": 0,
-    "dossierDigest": "bd2f4aa0b7327aecf94628a2a9ff24186e784059d789d43c643769ebfcdb0370",
+    "dossierDigest": "e39737bf32aaa5a93933071303684ae9b2d4357c6d7f6fa170744e66b0416e83",
     "catalogDigest": "34443b2e4dc3a946f642368adc0f46148f1be28903b4c47683df3de7613bc6e4",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1141,5 +1141,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "f257fe5b0c67276f260c51ec1d924581dc3d103ca398e71a45cc63f79c9449a5"
+  "contextDigest": "a0a5269ea62cd5c0a2c3103eeb13eba666fb90120e7ba6beb3472dc066702f8e"
 }

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "c00153b54ef841b30845f02c5570dea606b8303254ef6f85cbf3e8f18d6176e3",
-    "auditedInputDigest": "911cd7913ddc053043a105c1116c2929cd5b85c8b8ca3ea2525cc5e810a1970b"
+    "sourceManifestDigest": "b26a89106c4c753bf1b7fdfe1d467b2df5cb99a468794f397662b5fc48f49efc",
+    "auditedInputDigest": "90d6269219b0456dee08ed10b715721ad3377adfcb7798e2839ae74751ca2615"
   },
   "inventory": {
     "sourceMessageCount": 3252,
@@ -47,7 +47,7 @@
     "messageCount": 3252,
     "completeCount": 3252,
     "blockedCount": 0,
-    "dossierDigest": "40e087b2258c2c4b1096cf7156812477a340adca8ebba2fb5b2b33f774ac10cd",
+    "dossierDigest": "7bc2ace07f272fc0d97d93535826809293e4f2cee6cdb0f16df150f5720a61f3",
     "catalogDigest": "34443b2e4dc3a946f642368adc0f46148f1be28903b4c47683df3de7613bc6e4",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1141,5 +1141,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "a5dd3afa90414b0dcd7d1c7dae6d5d92822aac45a1f31971b148f8aa0a55b3a2"
+  "contextDigest": "0a58c4e8b833588ff5163107cd99e00ba0982dd5199cdb05e630865187bf97e9"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "c00153b54ef841b30845f02c5570dea606b8303254ef6f85cbf3e8f18d6176e3"
+    "sourceManifestDigest": "b26a89106c4c753bf1b7fdfe1d467b2df5cb99a468794f397662b5fc48f49efc"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "a5dd3afa90414b0dcd7d1c7dae6d5d92822aac45a1f31971b148f8aa0a55b3a2",
-    "qualityDigest": "5749ef915c1bf8da6132e90d2590a9f92574a5383bd89722f28b28bc07dcaf83",
+    "contextDigest": "0a58c4e8b833588ff5163107cd99e00ba0982dd5199cdb05e630865187bf97e9",
+    "qualityDigest": "e084cd9fac1718676dc6c286afcb1a78f1ca1f74a1631bbceee3141a1d298ba2",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "05413cb44775e9d17baf7b8d09e2de7fe64742e105d234465dc00071acf5701a"
+  "activationDigest": "ad34c89a131d1b59548fb3fea8219faed30fc5cb76f6839e0ae1a1f4d453d4fc"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "be054f2d07b8b419755dc4343f6aec34612500fda3862d3e8e039f8f63ab2c7d"
+    "sourceManifestDigest": "f00a051bf8b43a48eac12f468164e7f3d78ed61ee3c2ccf02a3c0132b35017dd"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "f257fe5b0c67276f260c51ec1d924581dc3d103ca398e71a45cc63f79c9449a5",
-    "qualityDigest": "4db3f6e5ff7bb3de43b6085cd7983b185cddf3b5413b5ba52a4209cbaf159612",
+    "contextDigest": "a0a5269ea62cd5c0a2c3103eeb13eba666fb90120e7ba6beb3472dc066702f8e",
+    "qualityDigest": "ec41044b74f219ba0a2312c5d4b52b693fb4994f8f09f5866faf27d2f04bdbb2",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "20b8bb3fadef3119a7707161b32c9e04dac5307716db508930be236951ec2fa7"
+  "activationDigest": "6219684463a41c9d941b2924795c0ef1ab40432e75cf1339f15617ffefbdb8c5"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "54184346c9a12eccffab014e680565e94605467016666d17532704f41bf53dc5",
+    "auditedInputDigest": "de211ce15a6ac781579a03aa944874d8e21716aee6ec4b4411f30d32bd240b20",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "911cd7913ddc053043a105c1116c2929cd5b85c8b8ca3ea2525cc5e810a1970b",
+    "auditedInputDigest": "90d6269219b0456dee08ed10b715721ad3377adfcb7798e2839ae74751ca2615",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "be054f2d07b8b419755dc4343f6aec34612500fda3862d3e8e039f8f63ab2c7d",
-    "contextDigest": "f257fe5b0c67276f260c51ec1d924581dc3d103ca398e71a45cc63f79c9449a5"
+    "sourceManifestDigest": "f00a051bf8b43a48eac12f468164e7f3d78ed61ee3c2ccf02a3c0132b35017dd",
+    "contextDigest": "a0a5269ea62cd5c0a2c3103eeb13eba666fb90120e7ba6beb3472dc066702f8e"
   },
   "catalog": {
     "messageCount": 3252,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "b122ab052d0b731d6d7eccee2cc564401bc20f9f64b3a38083cf81533e4bb968",
-    "validationDigest": "b8990f3f2f8637ff06911f18258e2c4e6d9f8693efd7ad4e293ec8953729bc7c",
+    "digest": "08fc950a6efa29e5eaef76f334e542298835153a72809714561274277145b3dd",
+    "validationDigest": "45b599b2cd7779a14db5363d277ca1bd8a29b1b615c4c38769216430731b817e",
     "laneCount": 1,
     "validatedMessageCount": 3252,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "4db3f6e5ff7bb3de43b6085cd7983b185cddf3b5413b5ba52a4209cbaf159612"
+  "qualityDigest": "ec41044b74f219ba0a2312c5d4b52b693fb4994f8f09f5866faf27d2f04bdbb2"
 }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "c00153b54ef841b30845f02c5570dea606b8303254ef6f85cbf3e8f18d6176e3",
-    "contextDigest": "a5dd3afa90414b0dcd7d1c7dae6d5d92822aac45a1f31971b148f8aa0a55b3a2"
+    "sourceManifestDigest": "b26a89106c4c753bf1b7fdfe1d467b2df5cb99a468794f397662b5fc48f49efc",
+    "contextDigest": "0a58c4e8b833588ff5163107cd99e00ba0982dd5199cdb05e630865187bf97e9"
   },
   "catalog": {
     "messageCount": 3252,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "f9ea7d88d7dc5e083a1035361eef76c55f589e4cb5c0141d1704a84b1282104e",
-    "validationDigest": "ae0113c25c61d86e6bd957a78354cb7b18fc0ec6c32feec515acd781284e4189",
+    "digest": "00de066a49c0354e2540bc0554ce79790dfa541e312d06f45befd267e454bc08",
+    "validationDigest": "c54b5a00b5a33be86761aed04c99ae2e7c194c90bd71076502fc9e13ed1ead0d",
     "laneCount": 1,
     "validatedMessageCount": 3252,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "5749ef915c1bf8da6132e90d2590a9f92574a5383bd89722f28b28bc07dcaf83"
+  "qualityDigest": "e084cd9fac1718676dc6c286afcb1a78f1ca1f74a1631bbceee3141a1d298ba2"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "54184346c9a12eccffab014e680565e94605467016666d17532704f41bf53dc5",
+    "auditedInputDigest": "de211ce15a6ac781579a03aa944874d8e21716aee6ec4b4411f30d32bd240b20",
     "validatedMessageCount": 3252,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1483,
     "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
     "catalogDigest": "34443b2e4dc3a946f642368adc0f46148f1be28903b4c47683df3de7613bc6e4",
-    "dossierDigest": "bd2f4aa0b7327aecf94628a2a9ff24186e784059d789d43c643769ebfcdb0370",
+    "dossierDigest": "e39737bf32aaa5a93933071303684ae9b2d4357c6d7f6fa170744e66b0416e83",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "5318b42fd9549c7deb9f05dd685768dd9a17cd45d56b5b4aa8ee22d0d1f31db4",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "9a3030e024e04a1cd65acc04b6fff5b87548e7f4d5db3c2b61bdd354bf345dcd",
         "highRiskMessageCount": 1483,
         "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
-        "dossierDigest": "bd2f4aa0b7327aecf94628a2a9ff24186e784059d789d43c643769ebfcdb0370",
+        "dossierDigest": "e39737bf32aaa5a93933071303684ae9b2d4357c6d7f6fa170744e66b0416e83",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "b8990f3f2f8637ff06911f18258e2c4e6d9f8693efd7ad4e293ec8953729bc7c"
+  "validationDigest": "45b599b2cd7779a14db5363d277ca1bd8a29b1b615c4c38769216430731b817e"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "911cd7913ddc053043a105c1116c2929cd5b85c8b8ca3ea2525cc5e810a1970b",
+    "auditedInputDigest": "90d6269219b0456dee08ed10b715721ad3377adfcb7798e2839ae74751ca2615",
     "validatedMessageCount": 3252,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1483,
     "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
     "catalogDigest": "34443b2e4dc3a946f642368adc0f46148f1be28903b4c47683df3de7613bc6e4",
-    "dossierDigest": "40e087b2258c2c4b1096cf7156812477a340adca8ebba2fb5b2b33f774ac10cd",
+    "dossierDigest": "7bc2ace07f272fc0d97d93535826809293e4f2cee6cdb0f16df150f5720a61f3",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "88bd2233f767c7742a1fdbcf87bace78c1e2ef7250f2de9d4afab9db8c9af7dd",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "9a3030e024e04a1cd65acc04b6fff5b87548e7f4d5db3c2b61bdd354bf345dcd",
         "highRiskMessageCount": 1483,
         "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
-        "dossierDigest": "40e087b2258c2c4b1096cf7156812477a340adca8ebba2fb5b2b33f774ac10cd",
+        "dossierDigest": "7bc2ace07f272fc0d97d93535826809293e4f2cee6cdb0f16df150f5720a61f3",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "ae0113c25c61d86e6bd957a78354cb7b18fc0ec6c32feec515acd781284e4189"
+  "validationDigest": "c54b5a00b5a33be86761aed04c99ae2e7c194c90bd71076502fc9e13ed1ead0d"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "c00153b54ef841b30845f02c5570dea606b8303254ef6f85cbf3e8f18d6176e3",
-    "auditedInputDigest": "911cd7913ddc053043a105c1116c2929cd5b85c8b8ca3ea2525cc5e810a1970b"
+    "sourceManifestDigest": "b26a89106c4c753bf1b7fdfe1d467b2df5cb99a468794f397662b5fc48f49efc",
+    "auditedInputDigest": "90d6269219b0456dee08ed10b715721ad3377adfcb7798e2839ae74751ca2615"
   },
   "inventory": {
     "sourceMessageCount": 3252,
@@ -47,7 +47,7 @@
     "messageCount": 3252,
     "completeCount": 3252,
     "blockedCount": 0,
-    "dossierDigest": "5f44130efea2eec1cfe5014cfb8e58978f75279fa72b202272247593b5483793",
+    "dossierDigest": "4023b92e6a8203a3f7e43bcc8cf0dcfe7eeb721865619a0646867935db1938d6",
     "catalogDigest": "4f2300419e2917ee6953759f56f24f8b13ac271bf99240ca6deeae683f4c34d3",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1141,5 +1141,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "d418c60e2942e9b4bd058972b7de23c763b3027e7f8f9c7cc8dc43dda38be073"
+  "contextDigest": "7e0b96f8d8622c1a2e2ed048bbfef6175658133cf867e8ac12ac1dd1ddef0e2e"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "be054f2d07b8b419755dc4343f6aec34612500fda3862d3e8e039f8f63ab2c7d",
-    "auditedInputDigest": "54184346c9a12eccffab014e680565e94605467016666d17532704f41bf53dc5"
+    "sourceManifestDigest": "f00a051bf8b43a48eac12f468164e7f3d78ed61ee3c2ccf02a3c0132b35017dd",
+    "auditedInputDigest": "de211ce15a6ac781579a03aa944874d8e21716aee6ec4b4411f30d32bd240b20"
   },
   "inventory": {
     "sourceMessageCount": 3252,
@@ -47,7 +47,7 @@
     "messageCount": 3252,
     "completeCount": 3252,
     "blockedCount": 0,
-    "dossierDigest": "2962bf350510c18661209da8707e07ad51741a8af380ab06cbf1c45984851aa9",
+    "dossierDigest": "05230a7deef2fa7d68769556f27ec9c89e729abfbce0d42a2e050e4cd1d638af",
     "catalogDigest": "4f2300419e2917ee6953759f56f24f8b13ac271bf99240ca6deeae683f4c34d3",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1141,5 +1141,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "1c60bb078f22b91ee9ba159a650502b797b472bfa186f4911edc2dbea8db0473"
+  "contextDigest": "cd32edba9888509c3fa6cae0a358e817ab34f20d8d777863f48feae04c977a7b"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "be054f2d07b8b419755dc4343f6aec34612500fda3862d3e8e039f8f63ab2c7d"
+    "sourceManifestDigest": "f00a051bf8b43a48eac12f468164e7f3d78ed61ee3c2ccf02a3c0132b35017dd"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "1c60bb078f22b91ee9ba159a650502b797b472bfa186f4911edc2dbea8db0473",
-    "qualityDigest": "e353df702baf6d4260e0b58c477c108cf3d58f096a1522a2b8b546f44cc0943b",
+    "contextDigest": "cd32edba9888509c3fa6cae0a358e817ab34f20d8d777863f48feae04c977a7b",
+    "qualityDigest": "1a1b5d2b16136a423471d1b6fe3f33ec9b47b82740d564433696236d140f232d",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "699a7d55f60c503d0e60ee9fa04892d351380ab1d8173a1160693306c6961ff3"
+  "activationDigest": "59e09c28ef4e08438cae1436e4f3838291d0749831820ea8d608a74323fdc4d5"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "c00153b54ef841b30845f02c5570dea606b8303254ef6f85cbf3e8f18d6176e3"
+    "sourceManifestDigest": "b26a89106c4c753bf1b7fdfe1d467b2df5cb99a468794f397662b5fc48f49efc"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "d418c60e2942e9b4bd058972b7de23c763b3027e7f8f9c7cc8dc43dda38be073",
-    "qualityDigest": "6e7fbc41b3c329bf601f5641842964c3fc4429aa61129c38a0affa4ceb49b656",
+    "contextDigest": "7e0b96f8d8622c1a2e2ed048bbfef6175658133cf867e8ac12ac1dd1ddef0e2e",
+    "qualityDigest": "fee687db50a5192b732cee69017c84714ee07ff07e0b3bc835d83243c60758eb",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "3956b242e8b85ab01e24ec3598b89bb505c332dbb781fcec70eeced7cf3ea223"
+  "activationDigest": "a8909c341e1d29ac4887810a04d94f2261f424797f5cf859775525c4bc725749"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "be054f2d07b8b419755dc4343f6aec34612500fda3862d3e8e039f8f63ab2c7d",
-    "contextDigest": "1c60bb078f22b91ee9ba159a650502b797b472bfa186f4911edc2dbea8db0473"
+    "sourceManifestDigest": "f00a051bf8b43a48eac12f468164e7f3d78ed61ee3c2ccf02a3c0132b35017dd",
+    "contextDigest": "cd32edba9888509c3fa6cae0a358e817ab34f20d8d777863f48feae04c977a7b"
   },
   "catalog": {
     "messageCount": 3252,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "f6fe3c2d8f381d5b340d1d13e7480b01614cc4cce95d3be5487aba1ff2340dc1",
-    "validationDigest": "13c1750c4342f453e981a04a425703349e701110653e649c6eae2715d80a32fa",
+    "digest": "b2658f4f368884d222118aa28cbb2ddea2373a870b5520d80573e35b91973234",
+    "validationDigest": "fac3f7ffa44f3126a0ec14f2150efce271372b662c343686c66bb32f3e44f924",
     "laneCount": 1,
     "validatedMessageCount": 3252,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "e353df702baf6d4260e0b58c477c108cf3d58f096a1522a2b8b546f44cc0943b"
+  "qualityDigest": "1a1b5d2b16136a423471d1b6fe3f33ec9b47b82740d564433696236d140f232d"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "c00153b54ef841b30845f02c5570dea606b8303254ef6f85cbf3e8f18d6176e3",
-    "contextDigest": "d418c60e2942e9b4bd058972b7de23c763b3027e7f8f9c7cc8dc43dda38be073"
+    "sourceManifestDigest": "b26a89106c4c753bf1b7fdfe1d467b2df5cb99a468794f397662b5fc48f49efc",
+    "contextDigest": "7e0b96f8d8622c1a2e2ed048bbfef6175658133cf867e8ac12ac1dd1ddef0e2e"
   },
   "catalog": {
     "messageCount": 3252,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "447e88ea6c68c14948519073f8e674205a3b88840e428871fd70a157c22e0563",
-    "validationDigest": "87452bd0f9aa398770cbb5864d1116288faa2f0ade30db0c71294890f609e748",
+    "digest": "8e190078243cc0b729fa85805475e94a45640eddd431b20b3b305c5bbc264890",
+    "validationDigest": "5f25b2d2130a9af9338f05f5e98c0c9d2f4d8906d74d2056dda66fe22ffd1a01",
     "laneCount": 1,
     "validatedMessageCount": 3252,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "6e7fbc41b3c329bf601f5641842964c3fc4429aa61129c38a0affa4ceb49b656"
+  "qualityDigest": "fee687db50a5192b732cee69017c84714ee07ff07e0b3bc835d83243c60758eb"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "54184346c9a12eccffab014e680565e94605467016666d17532704f41bf53dc5",
+    "auditedInputDigest": "de211ce15a6ac781579a03aa944874d8e21716aee6ec4b4411f30d32bd240b20",
     "validatedMessageCount": 3252,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1483,
     "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
     "catalogDigest": "4f2300419e2917ee6953759f56f24f8b13ac271bf99240ca6deeae683f4c34d3",
-    "dossierDigest": "2962bf350510c18661209da8707e07ad51741a8af380ab06cbf1c45984851aa9",
+    "dossierDigest": "05230a7deef2fa7d68769556f27ec9c89e729abfbce0d42a2e050e4cd1d638af",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "5318b42fd9549c7deb9f05dd685768dd9a17cd45d56b5b4aa8ee22d0d1f31db4",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "9a3030e024e04a1cd65acc04b6fff5b87548e7f4d5db3c2b61bdd354bf345dcd",
         "highRiskMessageCount": 1483,
         "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
-        "dossierDigest": "2962bf350510c18661209da8707e07ad51741a8af380ab06cbf1c45984851aa9",
+        "dossierDigest": "05230a7deef2fa7d68769556f27ec9c89e729abfbce0d42a2e050e4cd1d638af",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "13c1750c4342f453e981a04a425703349e701110653e649c6eae2715d80a32fa"
+  "validationDigest": "fac3f7ffa44f3126a0ec14f2150efce271372b662c343686c66bb32f3e44f924"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "911cd7913ddc053043a105c1116c2929cd5b85c8b8ca3ea2525cc5e810a1970b",
+    "auditedInputDigest": "90d6269219b0456dee08ed10b715721ad3377adfcb7798e2839ae74751ca2615",
     "validatedMessageCount": 3252,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1483,
     "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
     "catalogDigest": "4f2300419e2917ee6953759f56f24f8b13ac271bf99240ca6deeae683f4c34d3",
-    "dossierDigest": "5f44130efea2eec1cfe5014cfb8e58978f75279fa72b202272247593b5483793",
+    "dossierDigest": "4023b92e6a8203a3f7e43bcc8cf0dcfe7eeb721865619a0646867935db1938d6",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "88bd2233f767c7742a1fdbcf87bace78c1e2ef7250f2de9d4afab9db8c9af7dd",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "9a3030e024e04a1cd65acc04b6fff5b87548e7f4d5db3c2b61bdd354bf345dcd",
         "highRiskMessageCount": 1483,
         "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
-        "dossierDigest": "5f44130efea2eec1cfe5014cfb8e58978f75279fa72b202272247593b5483793",
+        "dossierDigest": "4023b92e6a8203a3f7e43bcc8cf0dcfe7eeb721865619a0646867935db1938d6",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "87452bd0f9aa398770cbb5864d1116288faa2f0ade30db0c71294890f609e748"
+  "validationDigest": "5f25b2d2130a9af9338f05f5e98c0c9d2f4d8906d74d2056dda66fe22ffd1a01"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "be054f2d07b8b419755dc4343f6aec34612500fda3862d3e8e039f8f63ab2c7d",
-    "auditedInputDigest": "54184346c9a12eccffab014e680565e94605467016666d17532704f41bf53dc5"
+    "sourceManifestDigest": "f00a051bf8b43a48eac12f468164e7f3d78ed61ee3c2ccf02a3c0132b35017dd",
+    "auditedInputDigest": "de211ce15a6ac781579a03aa944874d8e21716aee6ec4b4411f30d32bd240b20"
   },
   "inventory": {
     "sourceMessageCount": 3252,
@@ -47,7 +47,7 @@
     "messageCount": 3252,
     "completeCount": 3252,
     "blockedCount": 0,
-    "dossierDigest": "6e84848093203d69985ce7d91f5f12c9ecffc49ebfb6767dd91ecbc7d536d771",
+    "dossierDigest": "c12f4a1f2fd9c43f78cbda6d21e3017cc452bc0f551ab360f9219ed237aa2f91",
     "catalogDigest": "8d63e5b37c6cf032807df34876cc8642a07a6a5fd855bf7006034ea54ee04e29",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1141,5 +1141,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "16fdae1f23df55f358683fc655733d2fb5b030792cbd07516378ba8ae35a3668"
+  "contextDigest": "edcc027ca431358582bca8aaeb60a5cb4e52bd2014c0f8eba5c0390b93862004"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "c00153b54ef841b30845f02c5570dea606b8303254ef6f85cbf3e8f18d6176e3",
-    "auditedInputDigest": "911cd7913ddc053043a105c1116c2929cd5b85c8b8ca3ea2525cc5e810a1970b"
+    "sourceManifestDigest": "b26a89106c4c753bf1b7fdfe1d467b2df5cb99a468794f397662b5fc48f49efc",
+    "auditedInputDigest": "90d6269219b0456dee08ed10b715721ad3377adfcb7798e2839ae74751ca2615"
   },
   "inventory": {
     "sourceMessageCount": 3252,
@@ -47,7 +47,7 @@
     "messageCount": 3252,
     "completeCount": 3252,
     "blockedCount": 0,
-    "dossierDigest": "c372f2a473212d0ff531aa7a82bca292898b46cc9b31d3a3cdba7aaacba7be71",
+    "dossierDigest": "1456e6c40b52f6c5f3e1c47c313aebaab1af2664d7548f1079c9e9c61610781d",
     "catalogDigest": "8d63e5b37c6cf032807df34876cc8642a07a6a5fd855bf7006034ea54ee04e29",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1141,5 +1141,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "59c556874de83c730d4a5f7d01b683edde0c305651da0cfcb21f6bf5657ab567"
+  "contextDigest": "c78d3c3f24dffde78bd0bb00404ca519af0ba3844f18ba6a71dbe8e636c35fa3"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "c00153b54ef841b30845f02c5570dea606b8303254ef6f85cbf3e8f18d6176e3"
+    "sourceManifestDigest": "b26a89106c4c753bf1b7fdfe1d467b2df5cb99a468794f397662b5fc48f49efc"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "59c556874de83c730d4a5f7d01b683edde0c305651da0cfcb21f6bf5657ab567",
-    "qualityDigest": "8892beb84f2b8628bdeeb32b135c7c7a90194d88f7698bcdebca9eb09da5507d",
+    "contextDigest": "c78d3c3f24dffde78bd0bb00404ca519af0ba3844f18ba6a71dbe8e636c35fa3",
+    "qualityDigest": "402e0975ba475c2e8bce549c1105a0fb6bff3ef0c3ad8a56f401bd0e4d13a78f",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "c167dbecd3886da2ed2f63336d2727239265224456ed4328560c1633bd5b315d"
+  "activationDigest": "a25550a1bdca93a9ea9c3d0ede571c04b0c5b3843d9fe773e358319f1fe46889"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "be054f2d07b8b419755dc4343f6aec34612500fda3862d3e8e039f8f63ab2c7d"
+    "sourceManifestDigest": "f00a051bf8b43a48eac12f468164e7f3d78ed61ee3c2ccf02a3c0132b35017dd"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "16fdae1f23df55f358683fc655733d2fb5b030792cbd07516378ba8ae35a3668",
-    "qualityDigest": "1a5f77b2473d5e471203d5c14964414838bf726ff0158c3bc7a779cd818eebb7",
+    "contextDigest": "edcc027ca431358582bca8aaeb60a5cb4e52bd2014c0f8eba5c0390b93862004",
+    "qualityDigest": "f40117f75afe7d89a41bfad6c9b85321570c5e431e943068fcef6584a850908a",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "61d394e143d53c83ffe50176cfdd56d9f749d2bc59afcb52de5949b9cd6971db"
+  "activationDigest": "eded7664231eaa60ea5ce6062c2317772dc1665b67d6e47897c673c173c2cec2"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "c00153b54ef841b30845f02c5570dea606b8303254ef6f85cbf3e8f18d6176e3",
-    "contextDigest": "59c556874de83c730d4a5f7d01b683edde0c305651da0cfcb21f6bf5657ab567"
+    "sourceManifestDigest": "b26a89106c4c753bf1b7fdfe1d467b2df5cb99a468794f397662b5fc48f49efc",
+    "contextDigest": "c78d3c3f24dffde78bd0bb00404ca519af0ba3844f18ba6a71dbe8e636c35fa3"
   },
   "catalog": {
     "messageCount": 3252,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "0af82911ecf8958c7e4de39ead6d5f9f461dec443893c5869ff092721ff30118",
-    "validationDigest": "8f3a24242e1e2ca005aff8fa5636b8bfd327ef839e53eb8c658ef000949a5ebd",
+    "digest": "e01d3afcbb41ed7b6494274655d5fb5e46c80f996ed38d11b7542a5d967fe8ff",
+    "validationDigest": "2135a3c95fe51281055ae5898bb7d7333cf77f771ed2c114d9f4ebfe71380b47",
     "laneCount": 1,
     "validatedMessageCount": 3252,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "8892beb84f2b8628bdeeb32b135c7c7a90194d88f7698bcdebca9eb09da5507d"
+  "qualityDigest": "402e0975ba475c2e8bce549c1105a0fb6bff3ef0c3ad8a56f401bd0e4d13a78f"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "be054f2d07b8b419755dc4343f6aec34612500fda3862d3e8e039f8f63ab2c7d",
-    "contextDigest": "16fdae1f23df55f358683fc655733d2fb5b030792cbd07516378ba8ae35a3668"
+    "sourceManifestDigest": "f00a051bf8b43a48eac12f468164e7f3d78ed61ee3c2ccf02a3c0132b35017dd",
+    "contextDigest": "edcc027ca431358582bca8aaeb60a5cb4e52bd2014c0f8eba5c0390b93862004"
   },
   "catalog": {
     "messageCount": 3252,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "3008f472150f52b7e0512f5a8c05f646c2726b352b27457b2ee69b8510628567",
-    "validationDigest": "bfd5758cc59c42fa543d3c36c25e482d4ceb45e79d565d5a3e96bef89de91b22",
+    "digest": "751b4a42453b88ca5026b2075238e707b36640e54627b0892fb5953c1af74b78",
+    "validationDigest": "79537816b20a3ea482f18ae38f320d6e44a0903c95780c11804b250829bf00f3",
     "laneCount": 1,
     "validatedMessageCount": 3252,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "1a5f77b2473d5e471203d5c14964414838bf726ff0158c3bc7a779cd818eebb7"
+  "qualityDigest": "f40117f75afe7d89a41bfad6c9b85321570c5e431e943068fcef6584a850908a"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "911cd7913ddc053043a105c1116c2929cd5b85c8b8ca3ea2525cc5e810a1970b",
+    "auditedInputDigest": "90d6269219b0456dee08ed10b715721ad3377adfcb7798e2839ae74751ca2615",
     "validatedMessageCount": 3252,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1483,
     "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
     "catalogDigest": "8d63e5b37c6cf032807df34876cc8642a07a6a5fd855bf7006034ea54ee04e29",
-    "dossierDigest": "c372f2a473212d0ff531aa7a82bca292898b46cc9b31d3a3cdba7aaacba7be71",
+    "dossierDigest": "1456e6c40b52f6c5f3e1c47c313aebaab1af2664d7548f1079c9e9c61610781d",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "88bd2233f767c7742a1fdbcf87bace78c1e2ef7250f2de9d4afab9db8c9af7dd",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "9a3030e024e04a1cd65acc04b6fff5b87548e7f4d5db3c2b61bdd354bf345dcd",
         "highRiskMessageCount": 1483,
         "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
-        "dossierDigest": "c372f2a473212d0ff531aa7a82bca292898b46cc9b31d3a3cdba7aaacba7be71",
+        "dossierDigest": "1456e6c40b52f6c5f3e1c47c313aebaab1af2664d7548f1079c9e9c61610781d",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "8f3a24242e1e2ca005aff8fa5636b8bfd327ef839e53eb8c658ef000949a5ebd"
+  "validationDigest": "2135a3c95fe51281055ae5898bb7d7333cf77f771ed2c114d9f4ebfe71380b47"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "54184346c9a12eccffab014e680565e94605467016666d17532704f41bf53dc5",
+    "auditedInputDigest": "de211ce15a6ac781579a03aa944874d8e21716aee6ec4b4411f30d32bd240b20",
     "validatedMessageCount": 3252,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1483,
     "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
     "catalogDigest": "8d63e5b37c6cf032807df34876cc8642a07a6a5fd855bf7006034ea54ee04e29",
-    "dossierDigest": "6e84848093203d69985ce7d91f5f12c9ecffc49ebfb6767dd91ecbc7d536d771",
+    "dossierDigest": "c12f4a1f2fd9c43f78cbda6d21e3017cc452bc0f551ab360f9219ed237aa2f91",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "5318b42fd9549c7deb9f05dd685768dd9a17cd45d56b5b4aa8ee22d0d1f31db4",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "9a3030e024e04a1cd65acc04b6fff5b87548e7f4d5db3c2b61bdd354bf345dcd",
         "highRiskMessageCount": 1483,
         "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
-        "dossierDigest": "6e84848093203d69985ce7d91f5f12c9ecffc49ebfb6767dd91ecbc7d536d771",
+        "dossierDigest": "c12f4a1f2fd9c43f78cbda6d21e3017cc452bc0f551ab360f9219ed237aa2f91",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "bfd5758cc59c42fa543d3c36c25e482d4ceb45e79d565d5a3e96bef89de91b22"
+  "validationDigest": "79537816b20a3ea482f18ae38f320d6e44a0903c95780c11804b250829bf00f3"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "be054f2d07b8b419755dc4343f6aec34612500fda3862d3e8e039f8f63ab2c7d",
-    "auditedInputDigest": "54184346c9a12eccffab014e680565e94605467016666d17532704f41bf53dc5"
+    "sourceManifestDigest": "f00a051bf8b43a48eac12f468164e7f3d78ed61ee3c2ccf02a3c0132b35017dd",
+    "auditedInputDigest": "de211ce15a6ac781579a03aa944874d8e21716aee6ec4b4411f30d32bd240b20"
   },
   "inventory": {
     "sourceMessageCount": 3252,
@@ -47,7 +47,7 @@
     "messageCount": 3252,
     "completeCount": 3252,
     "blockedCount": 0,
-    "dossierDigest": "2363d5df520a4d8da3ef5c543f3a236925edf00818ef82c7f30700ce6edb88a1",
+    "dossierDigest": "c1425673372bc93816d5822284bd1d93b292fc1013be990e36603745be0f0aba",
     "catalogDigest": "5d511ad5a48ecbafeecf43a07b5ef9e8d118984b1e3032583e34cd320a78a2b6",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1141,5 +1141,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "d357b86569fa33d3b801567aaae4d8b8132d5f42d1aaadaa0b31e5de03f2ed6f"
+  "contextDigest": "04b67cca029fda10dbc59cefe8045b1b4b23ce82d08b96827088a37c5a7629de"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "c00153b54ef841b30845f02c5570dea606b8303254ef6f85cbf3e8f18d6176e3",
-    "auditedInputDigest": "911cd7913ddc053043a105c1116c2929cd5b85c8b8ca3ea2525cc5e810a1970b"
+    "sourceManifestDigest": "b26a89106c4c753bf1b7fdfe1d467b2df5cb99a468794f397662b5fc48f49efc",
+    "auditedInputDigest": "90d6269219b0456dee08ed10b715721ad3377adfcb7798e2839ae74751ca2615"
   },
   "inventory": {
     "sourceMessageCount": 3252,
@@ -47,7 +47,7 @@
     "messageCount": 3252,
     "completeCount": 3252,
     "blockedCount": 0,
-    "dossierDigest": "ae8b21ba6ae94b4bed49785f5b8b68faee9e0bc9cf337733060fa75d95d9fd51",
+    "dossierDigest": "3d821c90569fa2f555e159458f87a2186673b4cfe8057aa6e1b56e4e29ddf3e9",
     "catalogDigest": "5d511ad5a48ecbafeecf43a07b5ef9e8d118984b1e3032583e34cd320a78a2b6",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1141,5 +1141,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "17a732bcfaa6ab7ff574b83ba5b203ee671a780ed5079cd683901b6a2e3eaf7c"
+  "contextDigest": "489e376bfda5f2fa90343e22dfafc531f93336c6c7b17bad946870ca610eae0e"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "be054f2d07b8b419755dc4343f6aec34612500fda3862d3e8e039f8f63ab2c7d"
+    "sourceManifestDigest": "f00a051bf8b43a48eac12f468164e7f3d78ed61ee3c2ccf02a3c0132b35017dd"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "d357b86569fa33d3b801567aaae4d8b8132d5f42d1aaadaa0b31e5de03f2ed6f",
-    "qualityDigest": "018cfcee03b6053fc1ab970626e9736cf37c16e1ca6a5adf95cbc179927c8fa5",
+    "contextDigest": "04b67cca029fda10dbc59cefe8045b1b4b23ce82d08b96827088a37c5a7629de",
+    "qualityDigest": "2e1ca795024a766a88d62fd0a4ab12b8210390c0d385eb6fe196c44272258524",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "e577b0cf72651e91cb523f175908c9dd56eff87433ed7a63bfa404855c3dc78b"
+  "activationDigest": "046afa49d877cd5fca2ea5bbb7da5718842ea611af05f18a32f0dfede70657df"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "c00153b54ef841b30845f02c5570dea606b8303254ef6f85cbf3e8f18d6176e3"
+    "sourceManifestDigest": "b26a89106c4c753bf1b7fdfe1d467b2df5cb99a468794f397662b5fc48f49efc"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "17a732bcfaa6ab7ff574b83ba5b203ee671a780ed5079cd683901b6a2e3eaf7c",
-    "qualityDigest": "852002d78e4459bb4c64252c5b98e46ca409305844ed01002199c62d9f25b672",
+    "contextDigest": "489e376bfda5f2fa90343e22dfafc531f93336c6c7b17bad946870ca610eae0e",
+    "qualityDigest": "95a60140eb0a5ab5946eb39fa03642127cd0655c116ada2600c312f1712eeb9b",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
     "routeViewCoverageDigest": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "87a4682f3e2d0515b9d5cd11516aa5f8bce3b4ff0024afd461e9902dd9a06350"
+  "activationDigest": "6b9b0311b755a3a41dc4a2ff48edbc88a03eacb9150d45d13ce446cdd5d497ee"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "c00153b54ef841b30845f02c5570dea606b8303254ef6f85cbf3e8f18d6176e3",
-    "contextDigest": "17a732bcfaa6ab7ff574b83ba5b203ee671a780ed5079cd683901b6a2e3eaf7c"
+    "sourceManifestDigest": "b26a89106c4c753bf1b7fdfe1d467b2df5cb99a468794f397662b5fc48f49efc",
+    "contextDigest": "489e376bfda5f2fa90343e22dfafc531f93336c6c7b17bad946870ca610eae0e"
   },
   "catalog": {
     "messageCount": 3252,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "e5deccb28794da2d0a4c2b728047815866d07ba44a3de82d77c2e4cff9b03c45",
-    "validationDigest": "402d7733953bfa017a40dee0bb25e7bbb3bdfa6a5ccb0a0c0277b9231d875e0b",
+    "digest": "41e136f27bb14c335e3e93cee429a76cbe113858dc50e88f27d82aeffff7aa89",
+    "validationDigest": "1e26b52984a8210ff16873fa2e483a3f67622d8c4e18058eb72306c69d6dadbe",
     "laneCount": 1,
     "validatedMessageCount": 3252,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "852002d78e4459bb4c64252c5b98e46ca409305844ed01002199c62d9f25b672"
+  "qualityDigest": "95a60140eb0a5ab5946eb39fa03642127cd0655c116ada2600c312f1712eeb9b"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "be054f2d07b8b419755dc4343f6aec34612500fda3862d3e8e039f8f63ab2c7d",
-    "contextDigest": "d357b86569fa33d3b801567aaae4d8b8132d5f42d1aaadaa0b31e5de03f2ed6f"
+    "sourceManifestDigest": "f00a051bf8b43a48eac12f468164e7f3d78ed61ee3c2ccf02a3c0132b35017dd",
+    "contextDigest": "04b67cca029fda10dbc59cefe8045b1b4b23ce82d08b96827088a37c5a7629de"
   },
   "catalog": {
     "messageCount": 3252,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "0d170766214e12403b14f35ceb80ae0fc94b9a2b8ddd99fea4218ad8173e9800",
-    "validationDigest": "e11ecfb0cc1b3043bd3e169e17f2c5e602f903ec57aa3bb7e093d8c6cf5f465f",
+    "digest": "b6fc1e65bfd9a32b66fcc80b5c35e4e7959c4e28496500f601697f29d722f513",
+    "validationDigest": "61b0d3705c626e5b0d17b4806a2c6f835b54d94945d4d9fd83ab7d4c175b0408",
     "laneCount": 1,
     "validatedMessageCount": 3252,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "018cfcee03b6053fc1ab970626e9736cf37c16e1ca6a5adf95cbc179927c8fa5"
+  "qualityDigest": "2e1ca795024a766a88d62fd0a4ab12b8210390c0d385eb6fe196c44272258524"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "911cd7913ddc053043a105c1116c2929cd5b85c8b8ca3ea2525cc5e810a1970b",
+    "auditedInputDigest": "90d6269219b0456dee08ed10b715721ad3377adfcb7798e2839ae74751ca2615",
     "validatedMessageCount": 3252,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1483,
     "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
     "catalogDigest": "5d511ad5a48ecbafeecf43a07b5ef9e8d118984b1e3032583e34cd320a78a2b6",
-    "dossierDigest": "ae8b21ba6ae94b4bed49785f5b8b68faee9e0bc9cf337733060fa75d95d9fd51",
+    "dossierDigest": "3d821c90569fa2f555e159458f87a2186673b4cfe8057aa6e1b56e4e29ddf3e9",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "88bd2233f767c7742a1fdbcf87bace78c1e2ef7250f2de9d4afab9db8c9af7dd",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "9a3030e024e04a1cd65acc04b6fff5b87548e7f4d5db3c2b61bdd354bf345dcd",
         "highRiskMessageCount": 1483,
         "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
-        "dossierDigest": "ae8b21ba6ae94b4bed49785f5b8b68faee9e0bc9cf337733060fa75d95d9fd51",
+        "dossierDigest": "3d821c90569fa2f555e159458f87a2186673b4cfe8057aa6e1b56e4e29ddf3e9",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "402d7733953bfa017a40dee0bb25e7bbb3bdfa6a5ccb0a0c0277b9231d875e0b"
+  "validationDigest": "1e26b52984a8210ff16873fa2e483a3f67622d8c4e18058eb72306c69d6dadbe"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "54184346c9a12eccffab014e680565e94605467016666d17532704f41bf53dc5",
+    "auditedInputDigest": "de211ce15a6ac781579a03aa944874d8e21716aee6ec4b4411f30d32bd240b20",
     "validatedMessageCount": 3252,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1483,
     "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
     "catalogDigest": "5d511ad5a48ecbafeecf43a07b5ef9e8d118984b1e3032583e34cd320a78a2b6",
-    "dossierDigest": "2363d5df520a4d8da3ef5c543f3a236925edf00818ef82c7f30700ce6edb88a1",
+    "dossierDigest": "c1425673372bc93816d5822284bd1d93b292fc1013be990e36603745be0f0aba",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "5318b42fd9549c7deb9f05dd685768dd9a17cd45d56b5b4aa8ee22d0d1f31db4",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "9a3030e024e04a1cd65acc04b6fff5b87548e7f4d5db3c2b61bdd354bf345dcd",
         "highRiskMessageCount": 1483,
         "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
-        "dossierDigest": "2363d5df520a4d8da3ef5c543f3a236925edf00818ef82c7f30700ce6edb88a1",
+        "dossierDigest": "c1425673372bc93816d5822284bd1d93b292fc1013be990e36603745be0f0aba",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "e11ecfb0cc1b3043bd3e169e17f2c5e602f903ec57aa3bb7e093d8c6cf5f465f"
+  "validationDigest": "61b0d3705c626e5b0d17b4806a2c6f835b54d94945d4d9fd83ab7d4c175b0408"
 }

--- a/src/pages/Processes/Components/create.tsx
+++ b/src/pages/Processes/Components/create.tsx
@@ -107,8 +107,8 @@ const ProcessCreate: FC<CreateProps> = ({
     }
   };
 
-  const reload = useCallback(() => {
-    actionRef.current?.reload();
+  const reloadFromFirstPage = useCallback(async () => {
+    await actionRef.current?.reload(true);
   }, [actionRef]);
 
   const handletExchangeDataCreate = (data: ProcessExchangeData) => {
@@ -388,7 +388,7 @@ const ProcessCreate: FC<CreateProps> = ({
                 );
                 formRefCreate.current?.resetFields();
                 setDrawerVisible(false);
-                reload();
+                await reloadFromFirstPage();
               } else {
                 message.error(
                   isSupabaseDuplicateKeyError(result.error)

--- a/tests/integration/processes/ProcessesWorkflow.integration.test.tsx
+++ b/tests/integration/processes/ProcessesWorkflow.integration.test.tsx
@@ -8,7 +8,7 @@
  *
  * User journey covered:
  * 1. Owner lands on /mydata processes list, team metadata resolves, and rows render from getProcessTableAll.
- * 2. Owner imports JSON to seed create drawer, triggers create flow, and ProTable reloads.
+ * 2. Owner imports JSON to seed create drawer, triggers create flow, and ProTable reloads page 1.
  * 3. Owner opens inline edit drawer, saves changes, and observes another table reload.
  * 4. Owner expands review detail from the actions dropdown.
  * 5. Owner can jump from the table toolbar to the analysis page.
@@ -246,9 +246,9 @@ jest.mock('@/pages/Processes/Components/create', () => {
           <div data-testid={`process-create-panel-${actionType}`}>
             <button
               type='button'
-              onClick={() => {
+              onClick={async () => {
                 message.success(`${current.trigger} success`);
-                actionRef?.current?.reload?.();
+                await actionRef?.current?.reload?.(true);
                 setOpen(false);
               }}
             >
@@ -614,6 +614,47 @@ describe('Processes workflow integration', () => {
     expect(screen.queryByText('Solar panel manufacturing')).not.toBeInTheDocument();
     expect(getProcessTableAll.mock.calls[1][3]).toBe('tg');
     expect(getProcessTableAll.mock.calls[1][4]).toBe('team-open');
+  });
+
+  it('returns to page one and renders a newly created process without a search', async () => {
+    const user = userEvent.setup();
+    const pageTwoRow = {
+      ...baseRow,
+      id: 'process-page-2',
+      name: 'Existing page two process',
+    };
+    const createdRow = {
+      ...baseRow,
+      id: '4c221a23-4c69-4da6-86e8-6171b9550c88',
+      version: '01.01.000',
+      name: 'Newly created process',
+      modifiedAt: '2026-08-31T08:00:00Z',
+    };
+
+    getProcessTableAll.mockImplementation(async (params: { current?: number }) => {
+      if (params.current === 2) {
+        return { data: [pageTwoRow], page: 2, success: true, total: 20 };
+      }
+      const row = getProcessTableAll.mock.calls.length >= 3 ? createdRow : baseRow;
+      return { data: [row], page: 1, success: true, total: 20 };
+    });
+
+    renderWithProviders(<ProcessesPage />);
+    expect(await screen.findByText('Solar panel manufacturing')).toBeInTheDocument();
+
+    await act(async () => {
+      await proComponentsMocks.lastProTableAction?.setPageInfo({ current: 2 });
+    });
+    expect(await screen.findByText('Existing page two process')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Create Process' }));
+    await user.click(screen.getByRole('button', { name: 'Submit Process' }));
+
+    expect(await screen.findByText('Newly created process')).toBeInTheDocument();
+    expect(screen.queryByText('Existing page two process')).not.toBeInTheDocument();
+    expect(getProcessTableAll.mock.calls.map((call: any[]) => call[0].current)).toEqual([1, 2, 1]);
+    expect(getProcessTablePgroongaSearch).not.toHaveBeenCalled();
+    expect(process_hybrid_search).not.toHaveBeenCalled();
   });
 
   it('keeps page identity, version, and modification time stable across 1 -> 2 -> 1', async () => {

--- a/tests/mocks/proComponents.tsx
+++ b/tests/mocks/proComponents.tsx
@@ -9,7 +9,7 @@ type ProFormContextValue = {
 
 export const proComponentsMocks = {
   lastProTableAction: null as null | {
-    reload: () => Promise<any>;
+    reload: (resetPageIndex?: boolean) => Promise<any>;
     setPageInfo: (info: any) => Promise<any>;
   },
 };
@@ -281,7 +281,7 @@ export const createProComponentsMock = () => {
 
     React.useEffect(() => {
       const handlers = {
-        reload: () => scheduleRun(),
+        reload: (resetPageIndex?: boolean) => scheduleRun(resetPageIndex ? { current: 1 } : {}),
         setPageInfo: (info: any) => scheduleRun(info ?? {}),
       };
       if (actionRef) {

--- a/tests/unit/pages/Processes/Components/create.test.tsx
+++ b/tests/unit/pages/Processes/Components/create.test.tsx
@@ -252,6 +252,7 @@ describe('ProcessCreate component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     actionRef.current.reload.mockClear();
+    actionRef.current.reload.mockResolvedValue(undefined);
     mockCreateProcess.mockResolvedValue({ data: { id: 'generated-id' } });
     mockCreateProcessVersion.mockResolvedValue({ data: { id: 'generated-id' } });
   });
@@ -284,7 +285,38 @@ describe('ProcessCreate component', () => {
 
     expect(mockCreateProcess).toHaveBeenCalledWith('generated-id', expect.any(Object));
     expect(mockAntdMessage.success).toHaveBeenCalled();
-    expect(actionRef.current.reload).toHaveBeenCalled();
+    expect(actionRef.current.reload).toHaveBeenCalledWith(true);
+  });
+
+  it('waits for the first-page reload before completing a successful submission', async () => {
+    let resolveReload!: () => void;
+    actionRef.current.reload.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveReload = resolve;
+        }),
+    );
+
+    render(<ProcessCreate {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: 'create' }));
+
+    let submissionSettled = false;
+    let submission: Promise<void> | undefined;
+    await act(async () => {
+      submission = proFormApi?.submit().then(() => {
+        submissionSettled = true;
+      });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(actionRef.current.reload).toHaveBeenCalledWith(true));
+    expect(submissionSettled).toBe(false);
+
+    await act(async () => {
+      resolveReload();
+      await submission;
+    });
+    expect(submissionSettled).toBe(true);
   });
 
   it('prevents submission when allocated fraction exceeds 100%', async () => {
@@ -462,6 +494,36 @@ describe('ProcessCreate component', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('reloads the first page after a copied process is saved', async () => {
+    mockGetProcessDetail.mockResolvedValue({
+      data: {
+        json: {
+          processDataSet: {},
+        },
+      },
+    });
+    mockGenProcessFromData.mockReturnValue({
+      administrativeInformation: {
+        publicationAndOwnership: {},
+      },
+      exchanges: {
+        exchange: [],
+      },
+    });
+
+    render(<ProcessCreate {...baseProps} actionType='copy' id='process-1' version='01.00.000' />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'copy-icon' }));
+    await waitFor(() => expect(mockGetProcessDetail).toHaveBeenCalled());
+
+    await act(async () => {
+      await proFormApi?.submit();
+    });
+
+    expect(mockCreateProcess).toHaveBeenCalledWith('generated-id', expect.any(Object));
+    expect(actionRef.current.reload).toHaveBeenCalledWith(true);
   });
 
   it('handles tab snapshots, lcia results, and createVersion save errors', async () => {
@@ -656,6 +718,7 @@ describe('ProcessCreate component', () => {
     await waitFor(() =>
       expect(mockCreateProcessVersion).toHaveBeenCalledWith('', '', expect.anything()),
     );
+    expect(actionRef.current.reload).toHaveBeenCalledWith(true);
   });
 
   it('opens automatically from imported data and reuses the imported UUID on submit', async () => {


### PR DESCRIPTION
## Summary

- reset ProTable pagination to page 1 after every successful Process create, copy, or version-create
- await the authoritative list refresh before the successful submission lifecycle completes
- align the shared ProTable test double with `reload(resetPageIndex?: boolean)`
- add component and route-level regressions for the production symptom, including Process `4c221a23-4c69-4da6-86e8-6171b9550c88`
- refresh the derived locale audit artifacts required after the changed frontend source digest

## Root cause

The mutation succeeded, but `ProcessCreate` called `actionRef.current.reload()` without the ProComponents reset flag. When the table was on a later page, it reloaded that same page, so the newly created row on the default `modified_at desc` first page remained invisible until another query such as search changed the table request.

## Behavior

The success path now calls and awaits `actionRef.current.reload(true)`. This returns to page 1 while preserving active query, filter, and sort semantics. It does not optimistically inject a row or bypass the authoritative list response.

## Validation

- RED regression proved the old call had no reset argument and did not await the reload promise
- focused Process component + workflow integration: 2 suites / 23 tests passed with `FAIL_ON_ACT_WARNING=1`
- focused `create.tsx` coverage: 100% statements, branches, functions, and lines
- locale artifact idempotence, all-locale activation, and i18n audit passed
- `pnpm lint` passed
- `pnpm build` passed
- Docpact gate passed
- managed pre-push gate passed after synchronizing with `dev` at `d7bc98fc`: 47 receipt tests plus 440 suites / 5,906 tests; 481/481 tracked source files at 100/100/100/100 coverage

## Risk

Low. The change uses the installed ProComponents public action contract. It intentionally resets only pagination; active filters and sort remain unchanged, so a row excluded by the user's current query is not forced into the table.

Closes #966
