### PR TITLE
chore: prepare v0.0.93 on dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-31"
-lastReviewedCommit: "66f3ad0663b137c9d9a61ffde3abde887cd3f847"
+lastReviewedCommit: "dee1cddd1238e135cf9866280676e54715129dfd"
 lastReviewedNote: 'Reviewed for Next Issue #971: existing service-env and testing routes cover Dev selection when Umi preloads main defaults, per-key explicit overrides, and focused regression proof; no routing change is required.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: 66f3ad0663b137c9d9a61ffde3abde887cd3f847
+lastReviewedCommit: dee1cddd1238e135cf9866280676e54715129dfd
 lastReviewedNote: 'Reviewed for Next Issue #971: the standard Dev launcher selects `.env.development*` even after Umi preloads exact main-file defaults, while distinct explicit overrides keep priority.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/build.yml
   - .nvmrc
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: 66f3ad0663b137c9d9a61ffde3abde887cd3f847
+lastReviewedCommit: dee1cddd1238e135cf9866280676e54715129dfd
 lastReviewedNote: 'Reviewed for Next Issue #971: `pnpm start` and `pnpm start:dev` now prove the selected Dev Supabase target despite Umi preloading main `.env`; explicit per-key build overrides remain supported.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -43,7 +43,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: 66f3ad0663b137c9d9a61ffde3abde887cd3f847
+lastReviewedCommit: dee1cddd1238e135cf9866280676e54715129dfd
 lastReviewedNote: 'Reviewed for Next Issue #971: Dev environment decontamination uses focused config proof plus the existing ordinary full gate and real browser smoke; gate ownership and browser trust are unchanged.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -44,7 +44,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: 66f3ad0663b137c9d9a61ffde3abde887cd3f847
+lastReviewedCommit: dee1cddd1238e135cf9866280676e54715129dfd
 lastReviewedNote: 'Reviewed for Next Issue #971: environment proof covers Umi-preloaded main defaults, distinct and partial explicit overrides, the production build, and a real Dev PKCE consent read.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -44,7 +44,7 @@ checkPaths:
   - pnpm-workspace.yaml
   - Dockerfile.app
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: 66f3ad0663b137c9d9a61ffde3abde887cd3f847
+lastReviewedCommit: dee1cddd1238e135cf9866280676e54715129dfd
 lastReviewedNote: 'Reviewed for Next Issue #971: two targeted env-selection regressions protect a live Dev OAuth failure without expanding the maintained testing strategy or browser matrix.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -41,7 +41,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: 66f3ad0663b137c9d9a61ffde3abde887cd3f847
+lastReviewedCommit: dee1cddd1238e135cf9866280676e54715129dfd
 lastReviewedNote: 'Reviewed for Next Issue #971: Umi-loaded main-default and partial explicit-override cases are covered now and create no deferred testing queue.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: 66f3ad0663b137c9d9a61ffde3abde887cd3f847
+lastReviewedCommit: dee1cddd1238e135cf9866280676e54715129dfd
 lastReviewedNote: 'Reviewed for Next Issue #971: config tests distinguish Umi-preloaded main defaults from distinct per-key build overrides without changing service/component/integration patterns.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -40,7 +40,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: 66f3ad0663b137c9d9a61ffde3abde887cd3f847
+lastReviewedCommit: dee1cddd1238e135cf9866280676e54715129dfd
 lastReviewedNote: 'Reviewed for Next Issue #971: a valid Dev OAuth handle returning production feature_disabled now has an exact env-target diagnosis and focused recovery path.'
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.92",
+  "version": "0.0.93",
   "packageManager": "pnpm@11.24.0",
   "private": true,
   "description": "An out-of-box LCA Data solution",


### PR DESCRIPTION
<!-- tiangong-next-release-automation:v2 issue=979 version=0.0.93 dev-base=dee1cddd1238e135cf9866280676e54715129dfd main-base=f858211e3a38eb894005731bd7303dd5e0424f19 candidate=999b1562933c0589ca8ea1bee8dfab5079cf5e02 -->

## Branch Contract

- base branch: `dev`
- validated environment: exact dev Release PR non-browser gate
- back-merge required after merge: No
- root workspace integration expected: after later dev-to-main promotion

## Linked Issue

Refs #979

## Change Facts

- Prepare version `0.0.93` from exact dev base `dee1cddd1238e135cf9866280676e54715129dfd`.
- Change only package.json.version and keep pnpm-lock.yaml byte-for-byte unchanged.
- Keep release proof external to Git and bind it to the exact main/dev bases, candidate SHA/tree, version, workflow run, and artifact.
- Record Docpact review evidence only after the command proves the candidate has no other semantic change.
- Reviewed paths:
  - `.docpact/config.yaml`
  - `AGENTS.md`
  - `DEV.md`
  - `docs/agents/prepush-gate-policy.md`
  - `docs/agents/repo-validation.md`
  - `docs/agents/test_improvement_plan.md`
  - `docs/agents/test_todo_list.md`
  - `docs/agents/testing-patterns.md`
  - `docs/agents/testing-troubleshooting.md`

## Validation Facts

- Candidate: `999b1562933c0589ca8ea1bee8dfab5079cf5e02`
- Main baseline: `f858211e3a38eb894005731bd7303dd5e0424f19`
- Release gate: `required_by_dev_release_candidate_gate`; static preflight: `passed`
- Docpact automatic-review status: `completed`
- Docpact checked the complete main-to-candidate promotion range before the dev PR was created.
- The managed candidate push ran only structural/static checks; this PR owns one non-browser full release gate and its exact proof.
- Browser E2E is not evaluated or required by this PR. Run the manual hermetic workflow on the open business PR before release-to-dev when the change risk warrants browser evidence.

## Risks And Follow-Up

- Merge only after the exact Release Candidate release proof succeeds, then run the deterministic dev-to-main promotion command with this PR number.
