### PR TITLE
fix: close v0.0.95 release preflight contracts

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-09-01"
-lastReviewedCommit: "45ad89afb41d6185ed7419c4ccba3967bea71787"
+lastReviewedCommit: "6ff84d2eeeaf5398cf72838f8f4952a56648c35c"
 lastReviewedNote: 'Reviewed while integrating Next Issues #982 and #983: frontend-runtime and testing routes cover the Jest/browser migration and optional organization profile metadata; the exact browser-navigation trigger remains explicit.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-09-01
-lastReviewedCommit: 45ad89afb41d6185ed7419c4ccba3967bea71787
+lastReviewedCommit: 6ff84d2eeeaf5398cf72838f8f4952a56648c35c
 lastReviewedNote: 'Reviewed while integrating Next Issues #982 and #983: Jest 30 browser/runtime boundaries and descriptive account organization metadata do not change repository ownership, authorization, delivery, or modified-at-desc Process behavior.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/build.yml
   - .nvmrc
 lastReviewedAt: 2026-09-01
-lastReviewedCommit: 45ad89afb41d6185ed7419c4ccba3967bea71787
+lastReviewedCommit: 6ff84d2eeeaf5398cf72838f8f4952a56648c35c
 lastReviewedNote: 'Reviewed while integrating Next Issues #982 and #983: bootstrap/proof commands cover the upgraded Jest/Umi/Electron/Playwright stack, while account organization keeps existing startup, Supabase Auth, and environment workflows.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -43,7 +43,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-09-01
-lastReviewedCommit: 45ad89afb41d6185ed7419c4ccba3967bea71787
+lastReviewedCommit: 6ff84d2eeeaf5398cf72838f8f4952a56648c35c
 lastReviewedNote: 'Reviewed while integrating Next Issues #982 and #983: source-mapped Jest 30 coverage and organization profile regressions retain one full-gate owner and unchanged 100% enforcement.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-09-01
-lastReviewedCommit: 45ad89afb41d6185ed7419c4ccba3967bea71787
+lastReviewedCommit: 6ff84d2eeeaf5398cf72838f8f4952a56648c35c
 lastReviewedNote: 'Reviewed for Next Issue #982: the stable frontend/service map includes the explicit browser-navigation boundary required by Jest 30/jsdom 26 without changing runtime behavior.'
 related:
   - ../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -44,7 +44,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-09-01
-lastReviewedCommit: 45ad89afb41d6185ed7419c4ccba3967bea71787
+lastReviewedCommit: 6ff84d2eeeaf5398cf72838f8f4952a56648c35c
 lastReviewedNote: 'Reviewed while integrating Next Issues #982 and #983: Jest 30 keeps 100% source-mapped coverage, and profile service/account regressions cover organization read, trim, clear, refresh fallback, and UI state.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -44,7 +44,7 @@ checkPaths:
   - pnpm-workspace.yaml
   - Dockerfile.app
 lastReviewedAt: 2026-09-01
-lastReviewedCommit: 45ad89afb41d6185ed7419c4ccba3967bea71787
+lastReviewedCommit: 6ff84d2eeeaf5398cf72838f8f4952a56648c35c
 lastReviewedNote: 'Reviewed while integrating Next Issues #982 and #983: browser, continuation, jsdom, coverage, profile-service, and account-page findings close through existing strategy without a new queue or browser matrix.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -41,7 +41,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-09-01
-lastReviewedCommit: 45ad89afb41d6185ed7419c4ccba3967bea71787
+lastReviewedCommit: 6ff84d2eeeaf5398cf72838f8f4952a56648c35c
 lastReviewedNote: 'Reviewed while integrating Next Issues #982 and #983: Jest/browser migration and organization load/update/clear/refresh/missing-profile paths are closed with no deferred testing queue.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-09-01
-lastReviewedCommit: 45ad89afb41d6185ed7419c4ccba3967bea71787
+lastReviewedCommit: 6ff84d2eeeaf5398cf72838f8f4952a56648c35c
 lastReviewedNote: 'Reviewed while integrating Next Issues #982 and #983: atomic geometry, explicit runtime inputs, fail-closed coverage, and organization profile proof all reuse existing service/page/integration patterns.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -40,7 +40,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-09-01
-lastReviewedCommit: 45ad89afb41d6185ed7419c4ccba3967bea71787
+lastReviewedCommit: 6ff84d2eeeaf5398cf72838f8f4952a56648c35c
 lastReviewedNote: 'Reviewed while integrating Next Issues #982 and #983: service defaults, geometry, browser globals, source-mapped coverage, and organization failures use existing fail-closed diagnostics.'
 ---
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "b78ee928718894b3c2b725c00d140600be2eeeb08deb82a11a1fa93a7c06a95b",
-    "auditedInputDigest": "cc9cdad1ad0ad2149d560a591627e0c31ed015052e239f57737e4674c23ac998"
+    "sourceManifestDigest": "f54ab67d3ae00d351ca44b98e07012eae5776e16e9d98e518adf67fc324ec243",
+    "auditedInputDigest": "a4d0f503df21a95c502b60a4339c01b6b47d0f17648a055e38d741a01b69a539"
   },
   "inventory": {
-    "sourceMessageCount": 3256,
-    "localeMessageCount": 3256,
+    "sourceMessageCount": 3295,
+    "localeMessageCount": 3295,
     "leafModuleCount": 31,
     "dynamicFamilyCount": 15,
     "dynamicCallsiteCount": 32,
@@ -44,36 +44,36 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3256,
-    "completeCount": 3256,
+    "messageCount": 3295,
+    "completeCount": 3295,
     "blockedCount": 0,
-    "dossierDigest": "47842f3cdb6acd938d6b7a1ab4752c5c62ec98aaf68fd4f6571e7e3b41f101e9",
-    "catalogDigest": "6a1499d3ed5cdce28c0b4a0e44f3e3ed4f0ff47c1cbd90378db62a8a07d878c6",
+    "dossierDigest": "25febae5692b71ba65a0434115e9398fb7f63a0b42eb7c3a82f121e2cf676324",
+    "catalogDigest": "1fcabf2dee927bac49006bd93af3a03b379c084ae57454fe61f741164033c499",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
     "roleCounts": {
-      "error-or-validation": 377,
-      "explanatory-copy": 121,
+      "error-or-validation": 379,
+      "explanatory-copy": 122,
       "field-guidance": 53,
-      "label-or-body-copy": 1311,
+      "label-or-body-copy": 1338,
       "navigation-or-tab": 228,
-      "reserved-catalog-copy": 288,
-      "status-or-empty-state": 114,
+      "reserved-catalog-copy": 292,
+      "status-or-empty-state": 116,
       "success-notification": 187,
-      "title-or-heading": 249,
-      "user-action": 328
+      "title-or-heading": 251,
+      "user-action": 329
     },
     "stateCounts": {
       "destructive-or-rejecting-action": 47,
-      "failure-or-invalid-input": 377,
-      "interactive-ready": 539,
-      "retained-not-currently-reachable": 396,
+      "failure-or-invalid-input": 379,
+      "interactive-ready": 540,
+      "retained-not-currently-reachable": 402,
       "successful-completion": 187,
-      "visible": 1710
+      "visible": 1740
     },
-    "riskCounts": { "high": 1483, "low": 1546, "medium": 227 },
-    "highRiskMessageCount": 1483,
-    "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf"
+    "riskCounts": { "high": 1493, "low": 1575, "medium": 227 },
+    "highRiskMessageCount": 1493,
+    "highRiskMessageDigest": "5bd9a96def8097e8d66b6e34e4797036a465eb50cb41818ea298554b8c612eea"
   },
   "typedContentDossiers": {
     "sourcePath": "src/components/ImportTidasPackage/reportContent.ts",
@@ -88,14 +88,14 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4188,
+    "literalReferenceCount": 4223,
     "dynamicCallsiteCount": 32,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "pnpm i18n:context:dossier --locale de-DE --message <MESSAGE_ID>"
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
+    "digest": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -111,7 +111,7 @@
         "evidenceSchemaVersion": "tiangong.i18n-semantic-e2e-evidence.v2",
         "proofStorage": "ignored-local-or-github-actions-artifact",
         "requiredAt": "dev-release-candidate-gate",
-        "routeCoverageContractDigest": "56b08f4e25b3cb7ae275b449914a368d73d6f8b5cd0e00533fce5ac2aeed8705",
+        "routeCoverageContractDigest": "466465f8b1ab300ee23eb7208624c92564ce749aea0317c574d3a2c0de1f5d4b",
         "requiredAssertionCount": 50,
         "executionEvidence": null,
         "contractReady": true,
@@ -132,20 +132,20 @@
       "viewStateRegistry": {
         "schemaVersion": "tiangong.route-view-state-registry.v1",
         "sourcePath": "src/services/general/routeViewStateRegistry.json",
-        "sourceDigest": "e296972fc135327906352bfea38dc3ccd614bd1ab81d4053ed21f5ba65f2f170",
+        "sourceDigest": "9476fa2b88f62781a562626f39b92809be264ca1775c0bb7ac576de46295d832",
         "registryCount": 7,
         "executableVariantCount": 12,
-        "focusedVariantCount": 7
+        "focusedVariantCount": 8
       },
       "sourceFileCount": 37,
-      "sourceEvidenceDigest": "d552e299d9488180894072558ffb18b8760a53548ce04b25e582f0d0b74d225a",
+      "sourceEvidenceDigest": "5a99925398a47b16736c00c3393e9348ed650b32427d6b2ddd9ed2198839369d",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
           "route": "/",
           "viewState": "redirect-to-welcome",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "01d2189592b68f84eb5b2b9293c099fc8b175961ca037300f33079773f19a99f",
+          "sourceDigest": "46c37fb26697ce00ef06fc3025f9c575f97a0a091dec90f5dec777626b0b1c13",
           "focusedTestDigest": "2db96025ec564871cc9ebdfbd9e106b0cd6d0907f7f765574cc56a93122a4c24",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "d4754f0ac91aaabda0250ca6a0977f131654b0900d1b14b36a4c840aa42f6825",
@@ -172,7 +172,7 @@
           "route": "/welcome",
           "viewState": "overview",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "fd26650a765321bf70a703d4f841aa053a64ac5905dc8d425a034cf768c65b51",
+          "sourceDigest": "66c3c1b6d08088d3d019c30156034ffcf16338e94d39e68bc316fe426ad4359e",
           "focusedTestDigest": "5565e087364aeec68560016fed1de6dde3d6033b550a7b42578133ffdb6a94da",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "811949b6e0dccca1b6aa510e63afebb8839888cf24907b1dc2bae6a1755bf3d3",
@@ -199,7 +199,7 @@
           "route": "/welcome?view=carbon-footprint",
           "viewState": "carbon-footprint-guide",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "fd26650a765321bf70a703d4f841aa053a64ac5905dc8d425a034cf768c65b51",
+          "sourceDigest": "66c3c1b6d08088d3d019c30156034ffcf16338e94d39e68bc316fe426ad4359e",
           "focusedTestDigest": "5b5148760307f23e143c255ac0e71c63cef7b29498da1ded43e06e01659cb9c9",
           "plannedBrowserAssertionCount": 3,
           "plannedBrowserAssertionDigest": "7dce46b0e253c9000c52c96a89b772057bc78fbf5d13a1db1094e52d13b71be3",
@@ -319,13 +319,22 @@
           "route": "/dashboard/national-carbon",
           "viewState": "national-carbon-dashboard",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "bc85d65819e9ad6b0c4e544f7a05b8594a7ec715dc2f03c5635e35fd899f7aa9",
-          "focusedTestDigest": "dcdc78e899dbb0901df2ba3b74c013a4c6e0a6459de5910ebdb18f06e167a2d9",
+          "sourceDigest": "44c36ae7d1280d2fd8f9b0386f8167ef63d61a7bd7f15e597ab5eb65fbb702e6",
+          "focusedTestDigest": "c60f0433ae97c5b053a8600e61874da509a3064cc159bcf5955c6a345ccddd36",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "95b95698b9168443cacad5913312e98989fb251f09feee48fbaf5f7203c57587",
-          "derivedMessageCount": 269,
-          "derivedMessageDigest": "f8add4900da9ffe9333a7a5d7bed82008a76673a7db22cf08e295298ec4ea8e3",
-          "stateSignals": ["empty", "error", "loading", "modal", "retry", "success", "unavailable"],
+          "derivedMessageCount": 308,
+          "derivedMessageDigest": "4e864160bd7131da204bdaa6f62d80859097cbed140f499f20e231d191d7a2bd",
+          "stateSignals": [
+            "empty",
+            "error",
+            "loading",
+            "modal",
+            "ready",
+            "retry",
+            "success",
+            "unavailable"
+          ],
           "queryParameters": ["autoplay", "screen", "tid"],
           "navigationTargets": [
             "/dashboard/national-carbon",
@@ -333,7 +342,7 @@
             "/umi/plugin/openapi",
             "/user/login/password_reset"
           ],
-          "interactionKinds": [],
+          "interactionKinds": ["tooltip"],
           "acceptedTechnicalLiteralCount": 0,
           "unownedVisibleLiteralCount": 0
         },
@@ -1117,7 +1126,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "d83a5ca4985d045c0853d1eb33985d2bf029ca17c1c24908371d19d3511bed74",
+      "rowEvidenceDigest": "e0e74bcc62c376f54d13f1fc6471c827b9a41b727aa6e4c239a01bd9d11e7334",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1135,11 +1144,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "39d86ee63e4a85cb6f555c127d1903b79c661c3ed6b9fe59924e6bac7ffc6157",
-    "docs/plans/i18n/route-view-coverage.json": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
+    "docs/plans/i18n/route-view-coverage.json": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-de-DE/glossary.json": "a5fd4e759af2713fbec83f2b95171c7b32206d7218da0401d28d2eecefccce3a",
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "0075f37ef444d1581d16d72dff96f9d363b724aece079b155456a356f0355ac4"
+  "contextDigest": "2bcbcdee14d054dcedc4f4f9c4d56bb6b6cf791092071220a819bfe5b6eeda2e"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "b78ee928718894b3c2b725c00d140600be2eeeb08deb82a11a1fa93a7c06a95b"
+    "sourceManifestDigest": "f54ab67d3ae00d351ca44b98e07012eae5776e16e9d98e518adf67fc324ec243"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "0075f37ef444d1581d16d72dff96f9d363b724aece079b155456a356f0355ac4",
-    "qualityDigest": "e94068b83148bd82dcecd2951eda3721dc87daa54cbc03ecb0abb1c6e8752af5",
+    "contextDigest": "2bcbcdee14d054dcedc4f4f9c4d56bb6b6cf791092071220a819bfe5b6eeda2e",
+    "qualityDigest": "e7f1d9920df6b3c7a14429cd8d4be9a5031e06a969ff9db8ec37d85e5dbff4c0",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
-    "routeViewCoverageDigest": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
+    "routeViewCoverageDigest": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "5ca2b239da4622af88ff5c8a7469b45c730f24ae4232302db662cb15a5809c74"
+  "activationDigest": "52c06b189bdf0ed53e22e8b690cb23e85dcc5a170d511962087091f657632bd4"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": "tiangong.i18n-manifest.v1",
   "source": {
-    "baseRef": "origin/dev",
-    "baseCommit": "f92522afb8bdcd7681d004d5792e108528ec86a9",
-    "auditedInputDigest": "5b9507fd4ec252f056dfc9ef807fe3f35308ec321666f8b72b1b26a68852880d",
+    "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
+    "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
+    "auditedInputDigest": "a4d0f503df21a95c502b60a4339c01b6b47d0f17648a055e38d741a01b69a539",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -71,11 +71,11 @@
     "localeLeafModuleCounts": { "en-US": 31, "zh-CN": 31, "de-DE": 31, "fr-FR": 31 },
     "localeUniqueKeyCounts": { "en-US": 3295, "zh-CN": 3295, "de-DE": 3295, "fr-FR": 3295 },
     "canonicalCandidateKeyCount": 3295,
-    "activeStaticKeyCount": 2213,
+    "activeStaticKeyCount": 2212,
     "activeDynamicKeyCount": 306,
-    "reservedKeyCount": 776,
+    "reservedKeyCount": 777,
     "productionSourceFileCount": 456,
-    "literalReferenceCount": 4224,
+    "literalReferenceCount": 4223,
     "dynamicCallsiteCount": 32,
     "dynamicCallsiteSummaryCount": 32,
     "registeredDynamicCallsiteCount": 32,
@@ -91306,7 +91306,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2272,
+          "line": 2276,
           "column": 22,
           "symbol": "ConnectivityScreen",
           "defaultMessage": null,
@@ -91375,7 +91375,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2261,
+          "line": 2265,
           "column": 14,
           "symbol": "ConnectivityScreen",
           "defaultMessage": null,
@@ -91444,7 +91444,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2294,
+          "line": 2298,
           "column": 16,
           "symbol": "ConnectivityScreen",
           "defaultMessage": null,
@@ -91513,7 +91513,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2284,
+          "line": 2288,
           "column": 22,
           "symbol": "ConnectivityScreen",
           "defaultMessage": null,
@@ -91582,7 +91582,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2278,
+          "line": 2282,
           "column": 22,
           "symbol": "ConnectivityScreen",
           "defaultMessage": null,
@@ -91651,7 +91651,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2268,
+          "line": 2272,
           "column": 14,
           "symbol": "ConnectivityScreen",
           "defaultMessage": null,
@@ -98602,7 +98602,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1339,
+          "line": 1343,
           "column": 18,
           "symbol": "MapStatusScreen",
           "defaultMessage": null,
@@ -98671,7 +98671,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1285,
+          "line": 1289,
           "column": 16,
           "symbol": "MapStatusScreen",
           "defaultMessage": null,
@@ -98740,7 +98740,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1294,
+          "line": 1298,
           "column": 18,
           "symbol": "MapStatusScreen",
           "defaultMessage": null,
@@ -98809,7 +98809,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 810,
+          "line": 814,
           "column": 10,
           "symbol": "ChinaStatusMap",
           "defaultMessage": null,
@@ -98878,7 +98878,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1292,
+          "line": 1296,
           "column": 22,
           "symbol": "MapStatusScreen",
           "defaultMessage": null,
@@ -98947,7 +98947,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1307,
+          "line": 1311,
           "column": 14,
           "symbol": "MapStatusScreen",
           "defaultMessage": null,
@@ -99016,7 +99016,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1331,
+          "line": 1335,
           "column": 17,
           "symbol": "MapStatusScreen",
           "defaultMessage": null,
@@ -99101,7 +99101,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 850,
+          "line": 854,
           "column": 23,
           "symbol": "ChinaStatusMap",
           "defaultMessage": null,
@@ -99170,7 +99170,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1325,
+          "line": 1329,
           "column": 18,
           "symbol": "MapStatusScreen",
           "defaultMessage": null,
@@ -99239,7 +99239,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2115,
+          "line": 2119,
           "column": 14,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -99320,7 +99320,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2187,
+          "line": 2191,
           "column": 16,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -99389,7 +99389,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2111,
+          "line": 2115,
           "column": 14,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -99458,7 +99458,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2184,
+          "line": 2188,
           "column": 20,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -100424,7 +100424,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2105,
+          "line": 2109,
           "column": 14,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -100493,7 +100493,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2182,
+          "line": 2186,
           "column": 20,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -100562,7 +100562,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2231,
+          "line": 2235,
           "column": 12,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -100631,7 +100631,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2223,
+          "line": 2227,
           "column": 12,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -100700,7 +100700,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2239,
+          "line": 2243,
           "column": 12,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -100769,7 +100769,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2235,
+          "line": 2239,
           "column": 12,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -100838,7 +100838,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2227,
+          "line": 2231,
           "column": 12,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -100907,7 +100907,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2208,
+          "line": 2212,
           "column": 12,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -100976,7 +100976,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2204,
+          "line": 2208,
           "column": 12,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -101045,7 +101045,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2216,
+          "line": 2220,
           "column": 12,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -101114,7 +101114,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2212,
+          "line": 2216,
           "column": 12,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -101183,7 +101183,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2200,
+          "line": 2204,
           "column": 12,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -101272,7 +101272,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2170,
+          "line": 2174,
           "column": 16,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -101341,7 +101341,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2123,
+          "line": 2127,
           "column": 14,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -101410,7 +101410,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2102,
+          "line": 2106,
           "column": 14,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -101479,7 +101479,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2119,
+          "line": 2123,
           "column": 14,
           "symbol": "ConnectivityMatrix",
           "defaultMessage": null,
@@ -101824,7 +101824,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 962,
+          "line": 966,
           "column": 22,
           "symbol": "ChinaStatusMap",
           "defaultMessage": null,
@@ -101833,7 +101833,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1205,
+          "line": 1209,
           "column": 15,
           "symbol": "RegionDetail",
           "defaultMessage": null,
@@ -101902,7 +101902,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1118,
+          "line": 1122,
           "column": 20,
           "symbol": "OverviewScreen",
           "defaultMessage": null,
@@ -102040,7 +102040,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1058,
+          "line": 1062,
           "column": 20,
           "symbol": "OverviewScreen",
           "defaultMessage": null,
@@ -102049,7 +102049,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1317,
+          "line": 1321,
           "column": 14,
           "symbol": "MapStatusScreen",
           "defaultMessage": null,
@@ -102394,7 +102394,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1111,
+          "line": 1115,
           "column": 20,
           "symbol": "OverviewScreen",
           "defaultMessage": null,
@@ -102670,7 +102670,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1052,
+          "line": 1056,
           "column": 20,
           "symbol": "OverviewScreen",
           "defaultMessage": null,
@@ -102877,7 +102877,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 354,
+          "line": 358,
           "column": 14,
           "symbol": "getNarrativeMetric",
           "defaultMessage": null,
@@ -102946,7 +102946,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 347,
+          "line": 351,
           "column": 14,
           "symbol": "getNarrativeMetric",
           "defaultMessage": null,
@@ -103015,7 +103015,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 360,
+          "line": 364,
           "column": 12,
           "symbol": "getNarrativeMetric",
           "defaultMessage": null,
@@ -103372,7 +103372,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 624,
+          "line": 628,
           "column": 21,
           "symbol": "ScreenNavigator",
           "defaultMessage": null,
@@ -103441,7 +103441,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 613,
+          "line": 617,
           "column": 19,
           "symbol": "ScreenNavigator",
           "defaultMessage": null,
@@ -103510,7 +103510,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2463,
+          "line": 2467,
           "column": 14,
           "symbol": "OrganizationContributionRanking",
           "defaultMessage": null,
@@ -103579,7 +103579,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2471,
+          "line": 2475,
           "column": 14,
           "symbol": "OrganizationContributionRanking",
           "defaultMessage": null,
@@ -103648,7 +103648,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2454,
+          "line": 2458,
           "column": 14,
           "symbol": "OrganizationContributionRanking",
           "defaultMessage": null,
@@ -103717,7 +103717,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2457,
+          "line": 2461,
           "column": 14,
           "symbol": "OrganizationContributionRanking",
           "defaultMessage": null,
@@ -103786,7 +103786,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2451,
+          "line": 2455,
           "column": 14,
           "symbol": "OrganizationContributionRanking",
           "defaultMessage": null,
@@ -103855,7 +103855,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2460,
+          "line": 2464,
           "column": 14,
           "symbol": "OrganizationContributionRanking",
           "defaultMessage": null,
@@ -103924,7 +103924,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2468,
+          "line": 2472,
           "column": 14,
           "symbol": "OrganizationContributionRanking",
           "defaultMessage": null,
@@ -103993,8 +103993,8 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2598,
-          "column": 16,
+          "line": 2603,
+          "column": 18,
           "symbol": "OrganizationDailyCreationHeatmap",
           "defaultMessage": null,
           "defaultMessageExpression": null
@@ -104074,7 +104074,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2632,
+          "line": 2649,
           "column": 33,
           "symbol": "ariaLabel",
           "defaultMessage": null,
@@ -104143,8 +104143,8 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2676,
-          "column": 14,
+          "line": 2618,
+          "column": 16,
           "symbol": "OrganizationDailyCreationHeatmap",
           "defaultMessage": null,
           "defaultMessageExpression": null
@@ -104212,8 +104212,8 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2682,
-          "column": 14,
+          "line": 2624,
+          "column": 16,
           "symbol": "OrganizationDailyCreationHeatmap",
           "defaultMessage": null,
           "defaultMessageExpression": null
@@ -104281,8 +104281,8 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2606,
-          "column": 16,
+          "line": 2611,
+          "column": 18,
           "symbol": "OrganizationDailyCreationHeatmap",
           "defaultMessage": null,
           "defaultMessageExpression": null
@@ -104362,7 +104362,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2583,
+          "line": 2587,
           "column": 14,
           "symbol": "OrganizationDailyCreationHeatmap",
           "defaultMessage": null,
@@ -104431,7 +104431,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2580,
+          "line": 2584,
           "column": 14,
           "symbol": "OrganizationDailyCreationHeatmap",
           "defaultMessage": null,
@@ -104500,8 +104500,8 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2592,
-          "column": 16,
+          "line": 2597,
+          "column": 18,
           "symbol": "OrganizationDailyCreationHeatmap",
           "defaultMessage": null,
           "defaultMessageExpression": null
@@ -104628,7 +104628,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2340,
+          "line": 2344,
           "column": 19,
           "symbol": "message",
           "defaultMessage": null,
@@ -104697,7 +104697,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2777,
+          "line": 2788,
           "column": 14,
           "symbol": "OrganizationContributionScreen",
           "defaultMessage": null,
@@ -104766,7 +104766,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2815,
+          "line": 2826,
           "column": 22,
           "symbol": "OrganizationContributionScreen",
           "defaultMessage": null,
@@ -104835,7 +104835,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2791,
+          "line": 2802,
           "column": 22,
           "symbol": "OrganizationContributionScreen",
           "defaultMessage": null,
@@ -104904,7 +104904,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2807,
+          "line": 2818,
           "column": 22,
           "symbol": "OrganizationContributionScreen",
           "defaultMessage": null,
@@ -104973,7 +104973,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2799,
+          "line": 2810,
           "column": 22,
           "symbol": "OrganizationContributionScreen",
           "defaultMessage": null,
@@ -105042,7 +105042,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2360,
+          "line": 2364,
           "column": 19,
           "symbol": "message",
           "defaultMessage": null,
@@ -105170,7 +105170,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2397,
+          "line": 2401,
           "column": 11,
           "symbol": "metricLabel",
           "defaultMessage": null,
@@ -105239,7 +105239,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2396,
+          "line": 2400,
           "column": 11,
           "symbol": "metricLabel",
           "defaultMessage": null,
@@ -105308,7 +105308,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2394,
+          "line": 2398,
           "column": 9,
           "symbol": "metricLabel",
           "defaultMessage": null,
@@ -105377,7 +105377,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2446,
+          "line": 2450,
           "column": 14,
           "symbol": "OrganizationContributionRanking",
           "defaultMessage": null,
@@ -105564,7 +105564,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2781,
+          "line": 2792,
           "column": 14,
           "symbol": "OrganizationContributionScreen",
           "defaultMessage": null,
@@ -105633,7 +105633,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2655,
+          "line": 2672,
           "column": 26,
           "symbol": "OrganizationDailyCreationHeatmap",
           "defaultMessage": null,
@@ -105642,9 +105642,9 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2767,
-          "column": 19,
-          "symbol": "OrganizationContributionScreen",
+          "line": 2759,
+          "column": 11,
+          "symbol": "activeScopeLabel",
           "defaultMessage": null,
           "defaultMessageExpression": null
         }
@@ -105653,7 +105653,7 @@
     },
     {
       "id": "pages.home.nationalCarbon.organization.scope.ariaLabel",
-      "category": "active-static",
+      "category": "reserved",
       "dynamicFamilies": [],
       "moduleOwnership": {
         "en-US": ["pages_home"],
@@ -105707,17 +105707,7 @@
           }
         }
       },
-      "references": [
-        {
-          "kind": "formatMessage",
-          "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2747,
-          "column": 21,
-          "symbol": "OrganizationContributionScreen",
-          "defaultMessage": null,
-          "defaultMessageExpression": null
-        }
-      ],
+      "references": [],
       "defaultMessages": []
     },
     {
@@ -105780,7 +105770,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2649,
+          "line": 2666,
           "column": 26,
           "symbol": "OrganizationDailyCreationHeatmap",
           "defaultMessage": null,
@@ -105789,9 +105779,9 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2766,
-          "column": 19,
-          "symbol": "OrganizationContributionScreen",
+          "line": 2758,
+          "column": 11,
+          "symbol": "activeScopeLabel",
           "defaultMessage": null,
           "defaultMessageExpression": null
         }
@@ -105858,7 +105848,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2643,
+          "line": 2660,
           "column": 26,
           "symbol": "OrganizationDailyCreationHeatmap",
           "defaultMessage": null,
@@ -105867,9 +105857,9 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2764,
-          "column": 17,
-          "symbol": "OrganizationContributionScreen",
+          "line": 2756,
+          "column": 9,
+          "symbol": "activeScopeLabel",
           "defaultMessage": null,
           "defaultMessageExpression": null
         }
@@ -106054,7 +106044,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2402,
+          "line": 2406,
           "column": 14,
           "symbol": "OrganizationContributionChart",
           "defaultMessage": null,
@@ -106123,7 +106113,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1537,
+          "line": 1541,
           "column": 16,
           "symbol": "OutcomeMetricsScreen",
           "defaultMessage": null,
@@ -106192,7 +106182,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1515,
+          "line": 1519,
           "column": 18,
           "symbol": "OutcomeMetricsScreen",
           "defaultMessage": null,
@@ -106261,7 +106251,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1472,
+          "line": 1476,
           "column": 16,
           "symbol": "OutcomeMetricsScreen",
           "defaultMessage": null,
@@ -106330,7 +106320,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1523,
+          "line": 1527,
           "column": 16,
           "symbol": "OutcomeMetricsScreen",
           "defaultMessage": null,
@@ -106399,7 +106389,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1531,
+          "line": 1535,
           "column": 16,
           "symbol": "OutcomeMetricsScreen",
           "defaultMessage": null,
@@ -106468,7 +106458,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1509,
+          "line": 1513,
           "column": 16,
           "symbol": "OutcomeMetricsScreen",
           "defaultMessage": null,
@@ -106537,7 +106527,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1512,
+          "line": 1516,
           "column": 16,
           "symbol": "OutcomeMetricsScreen",
           "defaultMessage": null,
@@ -106606,7 +106596,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1506,
+          "line": 1510,
           "column": 16,
           "symbol": "OutcomeMetricsScreen",
           "defaultMessage": null,
@@ -106675,7 +106665,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1502,
+          "line": 1506,
           "column": 14,
           "symbol": "OutcomeMetricsScreen",
           "defaultMessage": null,
@@ -106764,7 +106754,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1408,
+          "line": 1412,
           "column": 21,
           "symbol": "IndustryProgressRow",
           "defaultMessage": null,
@@ -106833,7 +106823,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1488,
+          "line": 1492,
           "column": 16,
           "symbol": "OutcomeMetricsScreen",
           "defaultMessage": null,
@@ -106902,7 +106892,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1400,
+          "line": 1404,
           "column": 14,
           "symbol": "IndustryProgressRow",
           "defaultMessage": null,
@@ -106971,7 +106961,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1483,
+          "line": 1487,
           "column": 18,
           "symbol": "OutcomeMetricsScreen",
           "defaultMessage": null,
@@ -107040,7 +107030,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1485,
+          "line": 1489,
           "column": 15,
           "symbol": "OutcomeMetricsScreen",
           "defaultMessage": null,
@@ -107109,7 +107099,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1104,
+          "line": 1108,
           "column": 16,
           "symbol": "OverviewScreen",
           "defaultMessage": null,
@@ -107178,7 +107168,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1096,
+          "line": 1100,
           "column": 16,
           "symbol": "OverviewScreen",
           "defaultMessage": null,
@@ -107247,7 +107237,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1100,
+          "line": 1104,
           "column": 16,
           "symbol": "OverviewScreen",
           "defaultMessage": null,
@@ -107316,7 +107306,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1093,
+          "line": 1097,
           "column": 17,
           "symbol": "OverviewScreen",
           "defaultMessage": null,
@@ -110283,7 +110273,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1201,
+          "line": 1205,
           "column": 15,
           "symbol": "RegionDetail",
           "defaultMessage": null,
@@ -110352,7 +110342,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1197,
+          "line": 1201,
           "column": 15,
           "symbol": "RegionDetail",
           "defaultMessage": null,
@@ -110421,7 +110411,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1194,
+          "line": 1198,
           "column": 16,
           "symbol": "RegionDetail",
           "defaultMessage": null,
@@ -111741,7 +111731,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 348,
+          "line": 352,
           "column": 13,
           "symbol": "getNarrativeMetric",
           "defaultMessage": null,
@@ -111750,7 +111740,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 361,
+          "line": 365,
           "column": 11,
           "symbol": "getNarrativeMetric",
           "defaultMessage": null,
@@ -111759,7 +111749,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1113,
+          "line": 1117,
           "column": 19,
           "symbol": "OverviewScreen",
           "defaultMessage": null,
@@ -111897,7 +111887,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1060,
+          "line": 1064,
           "column": 19,
           "symbol": "OverviewScreen",
           "defaultMessage": null,
@@ -111906,7 +111896,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1322,
+          "line": 1326,
           "column": 16,
           "symbol": "MapStatusScreen",
           "defaultMessage": null,
@@ -111975,7 +111965,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 959,
+          "line": 963,
           "column": 20,
           "symbol": "ChinaStatusMap",
           "defaultMessage": null,
@@ -111984,7 +111974,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1053,
+          "line": 1057,
           "column": 19,
           "symbol": "OverviewScreen",
           "defaultMessage": null,
@@ -111993,7 +111983,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 1313,
+          "line": 1317,
           "column": 16,
           "symbol": "MapStatusScreen",
           "defaultMessage": null,
@@ -112002,7 +111992,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2274,
+          "line": 2278,
           "column": 21,
           "symbol": "ConnectivityScreen",
           "defaultMessage": null,
@@ -112011,7 +112001,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/NationalCarbonDashboard/index.tsx",
-          "line": 2280,
+          "line": 2284,
           "column": 21,
           "symbol": "ConnectivityScreen",
           "defaultMessage": null,

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,12 +3,12 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "b78ee928718894b3c2b725c00d140600be2eeeb08deb82a11a1fa93a7c06a95b",
-    "contextDigest": "0075f37ef444d1581d16d72dff96f9d363b724aece079b155456a356f0355ac4"
+    "sourceManifestDigest": "f54ab67d3ae00d351ca44b98e07012eae5776e16e9d98e518adf67fc324ec243",
+    "contextDigest": "2bcbcdee14d054dcedc4f4f9c4d56bb6b6cf791092071220a819bfe5b6eeda2e"
   },
   "catalog": {
-    "messageCount": 3256,
-    "catalogDigest": "6a1499d3ed5cdce28c0b4a0e44f3e3ed4f0ff47c1cbd90378db62a8a07d878c6",
+    "messageCount": 3295,
+    "catalogDigest": "1fcabf2dee927bac49006bd93af3a03b379c084ae57454fe61f741164033c499",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
@@ -21,7 +21,7 @@
     "acceptedDeclaredSourceEqualityDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
     "forbiddenGlossaryMatchCount": 0,
     "forbiddenGlossaryMatchDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
-    "suspiciousSourceEqualityRatio": 0.011056511056511056,
+    "suspiciousSourceEqualityRatio": 0.010925644916540212,
     "maxSuspiciousSourceEqualityRatio": 0.02
   },
   "automatedChecks": {
@@ -42,16 +42,16 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "005bd9f46043c4da07f6e19f800e227658300c5a7bf04bad58827f10c85f80d9",
-    "validationDigest": "9ba52cda8e8f5b59144fbe50e224dd174f01d6ea5766ed53cb33cedfdfce26dd",
+    "digest": "a1e2a60f3095d62761acfa2d98896f9095e3bddb41a3fd043e8f2aa364f77eac",
+    "validationDigest": "3d9a6569963cb6a8d49419a04e0518c7fad63fe1f6b4b713697709bca80e843e",
     "laneCount": 1,
-    "validatedMessageCount": 3256,
+    "validatedMessageCount": 3295,
     "validatedModuleCount": 32,
-    "highRiskMessageCount": 1483,
-    "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
+    "highRiskMessageCount": 1493,
+    "highRiskMessageDigest": "5bd9a96def8097e8d66b6e34e4797036a465eb50cb41818ea298554b8c612eea",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635",
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "e94068b83148bd82dcecd2951eda3721dc87daa54cbc03ecb0abb1c6e8752af5"
+  "qualityDigest": "e7f1d9920df6b3c7a14429cd8d4be9a5031e06a969ff9db8ec37d85e5dbff4c0"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "cc9cdad1ad0ad2149d560a591627e0c31ed015052e239f57737e4674c23ac998",
-    "validatedMessageCount": 3256,
+    "auditedInputDigest": "a4d0f503df21a95c502b60a4339c01b6b47d0f17648a055e38d741a01b69a539",
+    "validatedMessageCount": 3295,
     "validatedModules": [
       "$entry",
       "component",
@@ -39,12 +39,12 @@
       "settings",
       "validator"
     ],
-    "highRiskMessageCount": 1483,
-    "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
-    "catalogDigest": "6a1499d3ed5cdce28c0b4a0e44f3e3ed4f0ff47c1cbd90378db62a8a07d878c6",
-    "dossierDigest": "47842f3cdb6acd938d6b7a1ab4752c5c62ec98aaf68fd4f6571e7e3b41f101e9",
+    "highRiskMessageCount": 1493,
+    "highRiskMessageDigest": "5bd9a96def8097e8d66b6e34e4797036a465eb50cb41818ea298554b8c612eea",
+    "catalogDigest": "1fcabf2dee927bac49006bd93af3a03b379c084ae57454fe61f741164033c499",
+    "dossierDigest": "25febae5692b71ba65a0434115e9398fb7f63a0b42eb7c3a82f121e2cf676324",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "d83a5ca4985d045c0853d1eb33985d2bf029ca17c1c24908371d19d3511bed74",
+    "routeEvidenceDigest": "e0e74bcc62c376f54d13f1fc6471c827b9a41b727aa6e4c239a01bd9d11e7334",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -94,11 +94,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3256,
-        "messageDigest": "64f51ad4482edb68a2cb31a2139a4ed1f01eb358b91296508ff95f39dc28096e",
-        "highRiskMessageCount": 1483,
-        "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
-        "dossierDigest": "47842f3cdb6acd938d6b7a1ab4752c5c62ec98aaf68fd4f6571e7e3b41f101e9",
+        "messageCount": 3295,
+        "messageDigest": "b7bc3e8a3e81a7a210ddcef6d5259ffbe2da24906131f641f717902a65d55de4",
+        "highRiskMessageCount": 1493,
+        "highRiskMessageDigest": "5bd9a96def8097e8d66b6e34e4797036a465eb50cb41818ea298554b8c612eea",
+        "dossierDigest": "25febae5692b71ba65a0434115e9398fb7f63a0b42eb7c3a82f121e2cf676324",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "9ba52cda8e8f5b59144fbe50e224dd174f01d6ea5766ed53cb33cedfdfce26dd"
+  "validationDigest": "3d9a6569963cb6a8d49419a04e0518c7fad63fe1f6b4b713697709bca80e843e"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "b78ee928718894b3c2b725c00d140600be2eeeb08deb82a11a1fa93a7c06a95b",
-    "auditedInputDigest": "cc9cdad1ad0ad2149d560a591627e0c31ed015052e239f57737e4674c23ac998"
+    "sourceManifestDigest": "f54ab67d3ae00d351ca44b98e07012eae5776e16e9d98e518adf67fc324ec243",
+    "auditedInputDigest": "a4d0f503df21a95c502b60a4339c01b6b47d0f17648a055e38d741a01b69a539"
   },
   "inventory": {
-    "sourceMessageCount": 3256,
-    "localeMessageCount": 3256,
+    "sourceMessageCount": 3295,
+    "localeMessageCount": 3295,
     "leafModuleCount": 31,
     "dynamicFamilyCount": 15,
     "dynamicCallsiteCount": 32,
@@ -44,36 +44,36 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3256,
-    "completeCount": 3256,
+    "messageCount": 3295,
+    "completeCount": 3295,
     "blockedCount": 0,
-    "dossierDigest": "345b0601e8ae7eec40f52cda89bdbf6b1006546d02880e1c415ffceb7c0157bc",
-    "catalogDigest": "e0aa50db36b7e3807ed29e1c44f38c4e36ba05d513c7a89b7369212b16ebc44b",
+    "dossierDigest": "ae1d41f5e8d5ffee846005bfc7cbb32e3596a2ba27afce9a36be4a641fd81684",
+    "catalogDigest": "317c15687b81b84077cec4bc700d5d5305c8eea2503c4b5d819afb45cdac752b",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
     "roleCounts": {
-      "error-or-validation": 377,
-      "explanatory-copy": 121,
+      "error-or-validation": 379,
+      "explanatory-copy": 122,
       "field-guidance": 53,
-      "label-or-body-copy": 1311,
+      "label-or-body-copy": 1338,
       "navigation-or-tab": 228,
-      "reserved-catalog-copy": 288,
-      "status-or-empty-state": 114,
+      "reserved-catalog-copy": 292,
+      "status-or-empty-state": 116,
       "success-notification": 187,
-      "title-or-heading": 249,
-      "user-action": 328
+      "title-or-heading": 251,
+      "user-action": 329
     },
     "stateCounts": {
       "destructive-or-rejecting-action": 47,
-      "failure-or-invalid-input": 377,
-      "interactive-ready": 539,
-      "retained-not-currently-reachable": 396,
+      "failure-or-invalid-input": 379,
+      "interactive-ready": 540,
+      "retained-not-currently-reachable": 402,
       "successful-completion": 187,
-      "visible": 1710
+      "visible": 1740
     },
-    "riskCounts": { "high": 1483, "low": 1568, "medium": 205 },
-    "highRiskMessageCount": 1483,
-    "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf"
+    "riskCounts": { "high": 1493, "low": 1597, "medium": 205 },
+    "highRiskMessageCount": 1493,
+    "highRiskMessageDigest": "5bd9a96def8097e8d66b6e34e4797036a465eb50cb41818ea298554b8c612eea"
   },
   "typedContentDossiers": {
     "sourcePath": "src/components/ImportTidasPackage/reportContent.ts",
@@ -88,14 +88,14 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4188,
+    "literalReferenceCount": 4223,
     "dynamicCallsiteCount": 32,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "pnpm i18n:context:dossier --locale en-US --message <MESSAGE_ID>"
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
+    "digest": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -111,7 +111,7 @@
         "evidenceSchemaVersion": "tiangong.i18n-semantic-e2e-evidence.v2",
         "proofStorage": "ignored-local-or-github-actions-artifact",
         "requiredAt": "dev-release-candidate-gate",
-        "routeCoverageContractDigest": "56b08f4e25b3cb7ae275b449914a368d73d6f8b5cd0e00533fce5ac2aeed8705",
+        "routeCoverageContractDigest": "466465f8b1ab300ee23eb7208624c92564ce749aea0317c574d3a2c0de1f5d4b",
         "requiredAssertionCount": 50,
         "executionEvidence": null,
         "contractReady": true,
@@ -132,20 +132,20 @@
       "viewStateRegistry": {
         "schemaVersion": "tiangong.route-view-state-registry.v1",
         "sourcePath": "src/services/general/routeViewStateRegistry.json",
-        "sourceDigest": "e296972fc135327906352bfea38dc3ccd614bd1ab81d4053ed21f5ba65f2f170",
+        "sourceDigest": "9476fa2b88f62781a562626f39b92809be264ca1775c0bb7ac576de46295d832",
         "registryCount": 7,
         "executableVariantCount": 12,
-        "focusedVariantCount": 7
+        "focusedVariantCount": 8
       },
       "sourceFileCount": 37,
-      "sourceEvidenceDigest": "d552e299d9488180894072558ffb18b8760a53548ce04b25e582f0d0b74d225a",
+      "sourceEvidenceDigest": "5a99925398a47b16736c00c3393e9348ed650b32427d6b2ddd9ed2198839369d",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
           "route": "/",
           "viewState": "redirect-to-welcome",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "01d2189592b68f84eb5b2b9293c099fc8b175961ca037300f33079773f19a99f",
+          "sourceDigest": "46c37fb26697ce00ef06fc3025f9c575f97a0a091dec90f5dec777626b0b1c13",
           "focusedTestDigest": "2db96025ec564871cc9ebdfbd9e106b0cd6d0907f7f765574cc56a93122a4c24",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "d4754f0ac91aaabda0250ca6a0977f131654b0900d1b14b36a4c840aa42f6825",
@@ -172,7 +172,7 @@
           "route": "/welcome",
           "viewState": "overview",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "fd26650a765321bf70a703d4f841aa053a64ac5905dc8d425a034cf768c65b51",
+          "sourceDigest": "66c3c1b6d08088d3d019c30156034ffcf16338e94d39e68bc316fe426ad4359e",
           "focusedTestDigest": "5565e087364aeec68560016fed1de6dde3d6033b550a7b42578133ffdb6a94da",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "811949b6e0dccca1b6aa510e63afebb8839888cf24907b1dc2bae6a1755bf3d3",
@@ -199,7 +199,7 @@
           "route": "/welcome?view=carbon-footprint",
           "viewState": "carbon-footprint-guide",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "fd26650a765321bf70a703d4f841aa053a64ac5905dc8d425a034cf768c65b51",
+          "sourceDigest": "66c3c1b6d08088d3d019c30156034ffcf16338e94d39e68bc316fe426ad4359e",
           "focusedTestDigest": "5b5148760307f23e143c255ac0e71c63cef7b29498da1ded43e06e01659cb9c9",
           "plannedBrowserAssertionCount": 3,
           "plannedBrowserAssertionDigest": "7dce46b0e253c9000c52c96a89b772057bc78fbf5d13a1db1094e52d13b71be3",
@@ -319,13 +319,22 @@
           "route": "/dashboard/national-carbon",
           "viewState": "national-carbon-dashboard",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "bc85d65819e9ad6b0c4e544f7a05b8594a7ec715dc2f03c5635e35fd899f7aa9",
-          "focusedTestDigest": "dcdc78e899dbb0901df2ba3b74c013a4c6e0a6459de5910ebdb18f06e167a2d9",
+          "sourceDigest": "44c36ae7d1280d2fd8f9b0386f8167ef63d61a7bd7f15e597ab5eb65fbb702e6",
+          "focusedTestDigest": "c60f0433ae97c5b053a8600e61874da509a3064cc159bcf5955c6a345ccddd36",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "95b95698b9168443cacad5913312e98989fb251f09feee48fbaf5f7203c57587",
-          "derivedMessageCount": 269,
-          "derivedMessageDigest": "f8add4900da9ffe9333a7a5d7bed82008a76673a7db22cf08e295298ec4ea8e3",
-          "stateSignals": ["empty", "error", "loading", "modal", "retry", "success", "unavailable"],
+          "derivedMessageCount": 308,
+          "derivedMessageDigest": "4e864160bd7131da204bdaa6f62d80859097cbed140f499f20e231d191d7a2bd",
+          "stateSignals": [
+            "empty",
+            "error",
+            "loading",
+            "modal",
+            "ready",
+            "retry",
+            "success",
+            "unavailable"
+          ],
           "queryParameters": ["autoplay", "screen", "tid"],
           "navigationTargets": [
             "/dashboard/national-carbon",
@@ -333,7 +342,7 @@
             "/umi/plugin/openapi",
             "/user/login/password_reset"
           ],
-          "interactionKinds": [],
+          "interactionKinds": ["tooltip"],
           "acceptedTechnicalLiteralCount": 0,
           "unownedVisibleLiteralCount": 0
         },
@@ -1117,7 +1126,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "d83a5ca4985d045c0853d1eb33985d2bf029ca17c1c24908371d19d3511bed74",
+      "rowEvidenceDigest": "e0e74bcc62c376f54d13f1fc6471c827b9a41b727aa6e4c239a01bd9d11e7334",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1135,11 +1144,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "39d86ee63e4a85cb6f555c127d1903b79c661c3ed6b9fe59924e6bac7ffc6157",
-    "docs/plans/i18n/route-view-coverage.json": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
+    "docs/plans/i18n/route-view-coverage.json": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-en-US/glossary.json": "4b8443ea3f91f15383683e9ece6221e40e24ceb75442ea830964b06c12559970",
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "b69e1ffda5ca4a2b67788125ad098caa95ea053bb37314574b89f6ddf85f6ef9"
+  "contextDigest": "22cdb3b879d2df5f8ef2261bfb8da17b649beb057599a8b3f53b4e7aeb28c759"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "b78ee928718894b3c2b725c00d140600be2eeeb08deb82a11a1fa93a7c06a95b"
+    "sourceManifestDigest": "f54ab67d3ae00d351ca44b98e07012eae5776e16e9d98e518adf67fc324ec243"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "b69e1ffda5ca4a2b67788125ad098caa95ea053bb37314574b89f6ddf85f6ef9",
-    "qualityDigest": "f43d24c9188de353cf76b9b69ad08cfcf3b6d9d7e674ce86096bbfe1127a51f8",
+    "contextDigest": "22cdb3b879d2df5f8ef2261bfb8da17b649beb057599a8b3f53b4e7aeb28c759",
+    "qualityDigest": "02cd5fb7162dbe1d61e0324d942a738fef20a827cd36b6711a01d0311ed11b07",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
-    "routeViewCoverageDigest": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
+    "routeViewCoverageDigest": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "ba38bbb87f6908ad61b0c5be6f41c00ad329d90b930b35facab53d03f8f79cd9"
+  "activationDigest": "c57d70c986a4c014105c486edb03bada88f8a4ddd5686795e14f9b57e30d2a97"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,25 +3,25 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "b78ee928718894b3c2b725c00d140600be2eeeb08deb82a11a1fa93a7c06a95b",
-    "contextDigest": "b69e1ffda5ca4a2b67788125ad098caa95ea053bb37314574b89f6ddf85f6ef9"
+    "sourceManifestDigest": "f54ab67d3ae00d351ca44b98e07012eae5776e16e9d98e518adf67fc324ec243",
+    "contextDigest": "22cdb3b879d2df5f8ef2261bfb8da17b649beb057599a8b3f53b4e7aeb28c759"
   },
   "catalog": {
-    "messageCount": 3256,
-    "catalogDigest": "e0aa50db36b7e3807ed29e1c44f38c4e36ba05d513c7a89b7369212b16ebc44b",
+    "messageCount": 3295,
+    "catalogDigest": "317c15687b81b84077cec4bc700d5d5305c8eea2503c4b5d819afb45cdac752b",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
     "cjkLeakCount": 0,
-    "suspiciousSourceEqualityCount": 3178,
-    "suspiciousSourceEqualityDigest": "6d9bae9225b6cc481596d848c1abe5c3ddbd01cb2ef3d41705e57bd46742efc2",
-    "acceptedTechnicalSourceEqualityCount": 77,
-    "acceptedTechnicalSourceEqualityDigest": "2c498f32e45a368d8f4ddb6987df879250152a55da7babd4f4dbeb717b3d0583",
+    "suspiciousSourceEqualityCount": 3216,
+    "suspiciousSourceEqualityDigest": "bb238d4ab70fbb687ff8cff95005ad5f70620b4aa25ed18231aa832e6b72f242",
+    "acceptedTechnicalSourceEqualityCount": 78,
+    "acceptedTechnicalSourceEqualityDigest": "30bef409cabe4f69065b2104c6aa63b44b0f86109ef4a28135b3c975ab841906",
     "acceptedDeclaredSourceEqualityCount": 0,
     "acceptedDeclaredSourceEqualityDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
     "forbiddenGlossaryMatchCount": 0,
     "forbiddenGlossaryMatchDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
-    "suspiciousSourceEqualityRatio": 0.976044226044226,
+    "suspiciousSourceEqualityRatio": 0.9760242792109256,
     "maxSuspiciousSourceEqualityRatio": 1
   },
   "automatedChecks": {
@@ -42,16 +42,16 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "da7424538a4c1921b2e92b19478c5d14a8d33151bafbf060236f0e66f89f6580",
-    "validationDigest": "bd4843ca90c4b874590af3857e54c6b09bc4ccd0e314597bfd07dac0b47922e8",
+    "digest": "b45bd96a107c5268d6e364e600ca3b8a282a8efd85e7c48f9b68913f54cf40e4",
+    "validationDigest": "2524dc399d99eb3fd904367ab3ff52acc7d9e2d01fca65c9e8c6e4cfd01ccdf2",
     "laneCount": 1,
-    "validatedMessageCount": 3256,
+    "validatedMessageCount": 3295,
     "validatedModuleCount": 32,
-    "highRiskMessageCount": 1483,
-    "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
+    "highRiskMessageCount": 1493,
+    "highRiskMessageDigest": "5bd9a96def8097e8d66b6e34e4797036a465eb50cb41818ea298554b8c612eea",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635",
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "f43d24c9188de353cf76b9b69ad08cfcf3b6d9d7e674ce86096bbfe1127a51f8"
+  "qualityDigest": "02cd5fb7162dbe1d61e0324d942a738fef20a827cd36b6711a01d0311ed11b07"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "cc9cdad1ad0ad2149d560a591627e0c31ed015052e239f57737e4674c23ac998",
-    "validatedMessageCount": 3256,
+    "auditedInputDigest": "a4d0f503df21a95c502b60a4339c01b6b47d0f17648a055e38d741a01b69a539",
+    "validatedMessageCount": 3295,
     "validatedModules": [
       "$entry",
       "component",
@@ -39,12 +39,12 @@
       "settings",
       "validator"
     ],
-    "highRiskMessageCount": 1483,
-    "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
-    "catalogDigest": "e0aa50db36b7e3807ed29e1c44f38c4e36ba05d513c7a89b7369212b16ebc44b",
-    "dossierDigest": "345b0601e8ae7eec40f52cda89bdbf6b1006546d02880e1c415ffceb7c0157bc",
+    "highRiskMessageCount": 1493,
+    "highRiskMessageDigest": "5bd9a96def8097e8d66b6e34e4797036a465eb50cb41818ea298554b8c612eea",
+    "catalogDigest": "317c15687b81b84077cec4bc700d5d5305c8eea2503c4b5d819afb45cdac752b",
+    "dossierDigest": "ae1d41f5e8d5ffee846005bfc7cbb32e3596a2ba27afce9a36be4a641fd81684",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "d83a5ca4985d045c0853d1eb33985d2bf029ca17c1c24908371d19d3511bed74",
+    "routeEvidenceDigest": "e0e74bcc62c376f54d13f1fc6471c827b9a41b727aa6e4c239a01bd9d11e7334",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -94,11 +94,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3256,
-        "messageDigest": "64f51ad4482edb68a2cb31a2139a4ed1f01eb358b91296508ff95f39dc28096e",
-        "highRiskMessageCount": 1483,
-        "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
-        "dossierDigest": "345b0601e8ae7eec40f52cda89bdbf6b1006546d02880e1c415ffceb7c0157bc",
+        "messageCount": 3295,
+        "messageDigest": "b7bc3e8a3e81a7a210ddcef6d5259ffbe2da24906131f641f717902a65d55de4",
+        "highRiskMessageCount": 1493,
+        "highRiskMessageDigest": "5bd9a96def8097e8d66b6e34e4797036a465eb50cb41818ea298554b8c612eea",
+        "dossierDigest": "ae1d41f5e8d5ffee846005bfc7cbb32e3596a2ba27afce9a36be4a641fd81684",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "bd4843ca90c4b874590af3857e54c6b09bc4ccd0e314597bfd07dac0b47922e8"
+  "validationDigest": "2524dc399d99eb3fd904367ab3ff52acc7d9e2d01fca65c9e8c6e4cfd01ccdf2"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "b78ee928718894b3c2b725c00d140600be2eeeb08deb82a11a1fa93a7c06a95b",
-    "auditedInputDigest": "cc9cdad1ad0ad2149d560a591627e0c31ed015052e239f57737e4674c23ac998"
+    "sourceManifestDigest": "f54ab67d3ae00d351ca44b98e07012eae5776e16e9d98e518adf67fc324ec243",
+    "auditedInputDigest": "a4d0f503df21a95c502b60a4339c01b6b47d0f17648a055e38d741a01b69a539"
   },
   "inventory": {
-    "sourceMessageCount": 3256,
-    "localeMessageCount": 3256,
+    "sourceMessageCount": 3295,
+    "localeMessageCount": 3295,
     "leafModuleCount": 31,
     "dynamicFamilyCount": 15,
     "dynamicCallsiteCount": 32,
@@ -44,36 +44,36 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3256,
-    "completeCount": 3256,
+    "messageCount": 3295,
+    "completeCount": 3295,
     "blockedCount": 0,
-    "dossierDigest": "78504dea439fa416b0df31e787a54da331fb247ef8d098fed3aeae90a39a3f1e",
-    "catalogDigest": "00d4d9d84badc4791a4e9915480a0691f878a66d2422dc4d4d43c2a11ed2b835",
+    "dossierDigest": "7fac792634dbb9bffe44ff2d1f94bf0600b8e6921f078784132c90e58dc0c51b",
+    "catalogDigest": "502ad7d4a8ed9928916eacaf5d95e417d97f1f295eccc9718382f0d013743ebd",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
     "roleCounts": {
-      "error-or-validation": 377,
-      "explanatory-copy": 121,
+      "error-or-validation": 379,
+      "explanatory-copy": 122,
       "field-guidance": 53,
-      "label-or-body-copy": 1311,
+      "label-or-body-copy": 1338,
       "navigation-or-tab": 228,
-      "reserved-catalog-copy": 288,
-      "status-or-empty-state": 114,
+      "reserved-catalog-copy": 292,
+      "status-or-empty-state": 116,
       "success-notification": 187,
-      "title-or-heading": 249,
-      "user-action": 328
+      "title-or-heading": 251,
+      "user-action": 329
     },
     "stateCounts": {
       "destructive-or-rejecting-action": 47,
-      "failure-or-invalid-input": 377,
-      "interactive-ready": 539,
-      "retained-not-currently-reachable": 396,
+      "failure-or-invalid-input": 379,
+      "interactive-ready": 540,
+      "retained-not-currently-reachable": 402,
       "successful-completion": 187,
-      "visible": 1710
+      "visible": 1740
     },
-    "riskCounts": { "high": 1483, "low": 1547, "medium": 226 },
-    "highRiskMessageCount": 1483,
-    "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf"
+    "riskCounts": { "high": 1493, "low": 1576, "medium": 226 },
+    "highRiskMessageCount": 1493,
+    "highRiskMessageDigest": "5bd9a96def8097e8d66b6e34e4797036a465eb50cb41818ea298554b8c612eea"
   },
   "typedContentDossiers": {
     "sourcePath": "src/components/ImportTidasPackage/reportContent.ts",
@@ -88,14 +88,14 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4188,
+    "literalReferenceCount": 4223,
     "dynamicCallsiteCount": 32,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "pnpm i18n:context:dossier --locale fr-FR --message <MESSAGE_ID>"
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
+    "digest": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -111,7 +111,7 @@
         "evidenceSchemaVersion": "tiangong.i18n-semantic-e2e-evidence.v2",
         "proofStorage": "ignored-local-or-github-actions-artifact",
         "requiredAt": "dev-release-candidate-gate",
-        "routeCoverageContractDigest": "56b08f4e25b3cb7ae275b449914a368d73d6f8b5cd0e00533fce5ac2aeed8705",
+        "routeCoverageContractDigest": "466465f8b1ab300ee23eb7208624c92564ce749aea0317c574d3a2c0de1f5d4b",
         "requiredAssertionCount": 50,
         "executionEvidence": null,
         "contractReady": true,
@@ -132,20 +132,20 @@
       "viewStateRegistry": {
         "schemaVersion": "tiangong.route-view-state-registry.v1",
         "sourcePath": "src/services/general/routeViewStateRegistry.json",
-        "sourceDigest": "e296972fc135327906352bfea38dc3ccd614bd1ab81d4053ed21f5ba65f2f170",
+        "sourceDigest": "9476fa2b88f62781a562626f39b92809be264ca1775c0bb7ac576de46295d832",
         "registryCount": 7,
         "executableVariantCount": 12,
-        "focusedVariantCount": 7
+        "focusedVariantCount": 8
       },
       "sourceFileCount": 37,
-      "sourceEvidenceDigest": "d552e299d9488180894072558ffb18b8760a53548ce04b25e582f0d0b74d225a",
+      "sourceEvidenceDigest": "5a99925398a47b16736c00c3393e9348ed650b32427d6b2ddd9ed2198839369d",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
           "route": "/",
           "viewState": "redirect-to-welcome",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "01d2189592b68f84eb5b2b9293c099fc8b175961ca037300f33079773f19a99f",
+          "sourceDigest": "46c37fb26697ce00ef06fc3025f9c575f97a0a091dec90f5dec777626b0b1c13",
           "focusedTestDigest": "2db96025ec564871cc9ebdfbd9e106b0cd6d0907f7f765574cc56a93122a4c24",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "d4754f0ac91aaabda0250ca6a0977f131654b0900d1b14b36a4c840aa42f6825",
@@ -172,7 +172,7 @@
           "route": "/welcome",
           "viewState": "overview",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "fd26650a765321bf70a703d4f841aa053a64ac5905dc8d425a034cf768c65b51",
+          "sourceDigest": "66c3c1b6d08088d3d019c30156034ffcf16338e94d39e68bc316fe426ad4359e",
           "focusedTestDigest": "5565e087364aeec68560016fed1de6dde3d6033b550a7b42578133ffdb6a94da",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "811949b6e0dccca1b6aa510e63afebb8839888cf24907b1dc2bae6a1755bf3d3",
@@ -199,7 +199,7 @@
           "route": "/welcome?view=carbon-footprint",
           "viewState": "carbon-footprint-guide",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "fd26650a765321bf70a703d4f841aa053a64ac5905dc8d425a034cf768c65b51",
+          "sourceDigest": "66c3c1b6d08088d3d019c30156034ffcf16338e94d39e68bc316fe426ad4359e",
           "focusedTestDigest": "5b5148760307f23e143c255ac0e71c63cef7b29498da1ded43e06e01659cb9c9",
           "plannedBrowserAssertionCount": 3,
           "plannedBrowserAssertionDigest": "7dce46b0e253c9000c52c96a89b772057bc78fbf5d13a1db1094e52d13b71be3",
@@ -319,13 +319,22 @@
           "route": "/dashboard/national-carbon",
           "viewState": "national-carbon-dashboard",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "bc85d65819e9ad6b0c4e544f7a05b8594a7ec715dc2f03c5635e35fd899f7aa9",
-          "focusedTestDigest": "dcdc78e899dbb0901df2ba3b74c013a4c6e0a6459de5910ebdb18f06e167a2d9",
+          "sourceDigest": "44c36ae7d1280d2fd8f9b0386f8167ef63d61a7bd7f15e597ab5eb65fbb702e6",
+          "focusedTestDigest": "c60f0433ae97c5b053a8600e61874da509a3064cc159bcf5955c6a345ccddd36",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "95b95698b9168443cacad5913312e98989fb251f09feee48fbaf5f7203c57587",
-          "derivedMessageCount": 269,
-          "derivedMessageDigest": "f8add4900da9ffe9333a7a5d7bed82008a76673a7db22cf08e295298ec4ea8e3",
-          "stateSignals": ["empty", "error", "loading", "modal", "retry", "success", "unavailable"],
+          "derivedMessageCount": 308,
+          "derivedMessageDigest": "4e864160bd7131da204bdaa6f62d80859097cbed140f499f20e231d191d7a2bd",
+          "stateSignals": [
+            "empty",
+            "error",
+            "loading",
+            "modal",
+            "ready",
+            "retry",
+            "success",
+            "unavailable"
+          ],
           "queryParameters": ["autoplay", "screen", "tid"],
           "navigationTargets": [
             "/dashboard/national-carbon",
@@ -333,7 +342,7 @@
             "/umi/plugin/openapi",
             "/user/login/password_reset"
           ],
-          "interactionKinds": [],
+          "interactionKinds": ["tooltip"],
           "acceptedTechnicalLiteralCount": 0,
           "unownedVisibleLiteralCount": 0
         },
@@ -1117,7 +1126,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "d83a5ca4985d045c0853d1eb33985d2bf029ca17c1c24908371d19d3511bed74",
+      "rowEvidenceDigest": "e0e74bcc62c376f54d13f1fc6471c827b9a41b727aa6e4c239a01bd9d11e7334",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1135,11 +1144,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "39d86ee63e4a85cb6f555c127d1903b79c661c3ed6b9fe59924e6bac7ffc6157",
-    "docs/plans/i18n/route-view-coverage.json": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
+    "docs/plans/i18n/route-view-coverage.json": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-fr-FR/glossary.json": "057cb494f02d980106469f6a16befc102d26db5ac362b9777cd5f97c7729c91b",
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "76f45c037f0cf8e6cd11f6f96a4768cc9f4040e56aabc93c8045c7d1e637f3d5"
+  "contextDigest": "d496bd3264e8832caffa63338fa0a5495dbeed402397d0a3d0a1a661d9429858"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "b78ee928718894b3c2b725c00d140600be2eeeb08deb82a11a1fa93a7c06a95b"
+    "sourceManifestDigest": "f54ab67d3ae00d351ca44b98e07012eae5776e16e9d98e518adf67fc324ec243"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,10 +78,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "76f45c037f0cf8e6cd11f6f96a4768cc9f4040e56aabc93c8045c7d1e637f3d5",
-    "qualityDigest": "292a51009bc4d8ca874b9ba31d9dd976a1629e1fea60eb78a977d7c48ef0b5a2",
+    "contextDigest": "d496bd3264e8832caffa63338fa0a5495dbeed402397d0a3d0a1a661d9429858",
+    "qualityDigest": "9d5bef1a353cd2d90431a7bbb5d4210316d09955c62a34952a2180350b60e856",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
-    "routeViewCoverageDigest": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
+    "routeViewCoverageDigest": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "c6dffaeac5f4ef9ba92c444cb20b8fe870ae3b0c98a6f41049528065e8d9d73d"
+  "activationDigest": "ce5b2f8c8a6fa6b35343910a09768583837355e9d43436222f2d173bdde7e65a"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,25 +3,25 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "b78ee928718894b3c2b725c00d140600be2eeeb08deb82a11a1fa93a7c06a95b",
-    "contextDigest": "76f45c037f0cf8e6cd11f6f96a4768cc9f4040e56aabc93c8045c7d1e637f3d5"
+    "sourceManifestDigest": "f54ab67d3ae00d351ca44b98e07012eae5776e16e9d98e518adf67fc324ec243",
+    "contextDigest": "d496bd3264e8832caffa63338fa0a5495dbeed402397d0a3d0a1a661d9429858"
   },
   "catalog": {
-    "messageCount": 3256,
-    "catalogDigest": "00d4d9d84badc4791a4e9915480a0691f878a66d2422dc4d4d43c2a11ed2b835",
+    "messageCount": 3295,
+    "catalogDigest": "502ad7d4a8ed9928916eacaf5d95e417d97f1f295eccc9718382f0d013743ebd",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
     "cjkLeakCount": 0,
-    "suspiciousSourceEqualityCount": 0,
-    "suspiciousSourceEqualityDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
+    "suspiciousSourceEqualityCount": 1,
+    "suspiciousSourceEqualityDigest": "efbc40502bde4ae2f660ef6d9a60368e3c14ab982d1912303b55aabb82f44043",
     "acceptedTechnicalSourceEqualityCount": 28,
     "acceptedTechnicalSourceEqualityDigest": "e5cc5724e978186465e52e8ba1cbc2c0ff84eed9f318ce7a821cfefa611cb02a",
     "acceptedDeclaredSourceEqualityCount": 128,
     "acceptedDeclaredSourceEqualityDigest": "8d38edb58827afdb7cad4dd9f00498899b31fb09da1f5f0a704ae32ed5648601",
     "forbiddenGlossaryMatchCount": 0,
     "forbiddenGlossaryMatchDigest": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570",
-    "suspiciousSourceEqualityRatio": 0,
+    "suspiciousSourceEqualityRatio": 0.00030349013657056146,
     "maxSuspiciousSourceEqualityRatio": 0.02
   },
   "automatedChecks": {
@@ -42,16 +42,16 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "120d964b64c2495d04dc5cd6eb9c2e0872e76f468bb912ccff490aba53f993da",
-    "validationDigest": "e8b7db2755e9d9018b8a7de3757e609579d56f015a7b0ed40a133e4602b8baa1",
+    "digest": "a3100425fd041ab869d5afde5e8221af248bd68d6f2166c39e0164ad324d9e6b",
+    "validationDigest": "87a372ec49f5397a082d786276ef536f4e5d69b4e0aa41ff3d036f5410f9e59c",
     "laneCount": 1,
-    "validatedMessageCount": 3256,
+    "validatedMessageCount": 3295,
     "validatedModuleCount": 32,
-    "highRiskMessageCount": 1483,
-    "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
+    "highRiskMessageCount": 1493,
+    "highRiskMessageDigest": "5bd9a96def8097e8d66b6e34e4797036a465eb50cb41818ea298554b8c612eea",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635",
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "292a51009bc4d8ca874b9ba31d9dd976a1629e1fea60eb78a977d7c48ef0b5a2"
+  "qualityDigest": "9d5bef1a353cd2d90431a7bbb5d4210316d09955c62a34952a2180350b60e856"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "cc9cdad1ad0ad2149d560a591627e0c31ed015052e239f57737e4674c23ac998",
-    "validatedMessageCount": 3256,
+    "auditedInputDigest": "a4d0f503df21a95c502b60a4339c01b6b47d0f17648a055e38d741a01b69a539",
+    "validatedMessageCount": 3295,
     "validatedModules": [
       "$entry",
       "component",
@@ -39,12 +39,12 @@
       "settings",
       "validator"
     ],
-    "highRiskMessageCount": 1483,
-    "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
-    "catalogDigest": "00d4d9d84badc4791a4e9915480a0691f878a66d2422dc4d4d43c2a11ed2b835",
-    "dossierDigest": "78504dea439fa416b0df31e787a54da331fb247ef8d098fed3aeae90a39a3f1e",
+    "highRiskMessageCount": 1493,
+    "highRiskMessageDigest": "5bd9a96def8097e8d66b6e34e4797036a465eb50cb41818ea298554b8c612eea",
+    "catalogDigest": "502ad7d4a8ed9928916eacaf5d95e417d97f1f295eccc9718382f0d013743ebd",
+    "dossierDigest": "7fac792634dbb9bffe44ff2d1f94bf0600b8e6921f078784132c90e58dc0c51b",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "d83a5ca4985d045c0853d1eb33985d2bf029ca17c1c24908371d19d3511bed74",
+    "routeEvidenceDigest": "e0e74bcc62c376f54d13f1fc6471c827b9a41b727aa6e4c239a01bd9d11e7334",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -94,11 +94,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3256,
-        "messageDigest": "64f51ad4482edb68a2cb31a2139a4ed1f01eb358b91296508ff95f39dc28096e",
-        "highRiskMessageCount": 1483,
-        "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
-        "dossierDigest": "78504dea439fa416b0df31e787a54da331fb247ef8d098fed3aeae90a39a3f1e",
+        "messageCount": 3295,
+        "messageDigest": "b7bc3e8a3e81a7a210ddcef6d5259ffbe2da24906131f641f717902a65d55de4",
+        "highRiskMessageCount": 1493,
+        "highRiskMessageDigest": "5bd9a96def8097e8d66b6e34e4797036a465eb50cb41818ea298554b8c612eea",
+        "dossierDigest": "7fac792634dbb9bffe44ff2d1f94bf0600b8e6921f078784132c90e58dc0c51b",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "e8b7db2755e9d9018b8a7de3757e609579d56f015a7b0ed40a133e4602b8baa1"
+  "validationDigest": "87a372ec49f5397a082d786276ef536f4e5d69b4e0aa41ff3d036f5410f9e59c"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,12 +5,12 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "b78ee928718894b3c2b725c00d140600be2eeeb08deb82a11a1fa93a7c06a95b",
-    "auditedInputDigest": "cc9cdad1ad0ad2149d560a591627e0c31ed015052e239f57737e4674c23ac998"
+    "sourceManifestDigest": "f54ab67d3ae00d351ca44b98e07012eae5776e16e9d98e518adf67fc324ec243",
+    "auditedInputDigest": "a4d0f503df21a95c502b60a4339c01b6b47d0f17648a055e38d741a01b69a539"
   },
   "inventory": {
-    "sourceMessageCount": 3256,
-    "localeMessageCount": 3256,
+    "sourceMessageCount": 3295,
+    "localeMessageCount": 3295,
     "leafModuleCount": 31,
     "dynamicFamilyCount": 15,
     "dynamicCallsiteCount": 32,
@@ -44,36 +44,36 @@
       "preserved tokens and layout/RTL/dark risks",
       "candidate/rationale/risk/validation"
     ],
-    "messageCount": 3256,
-    "completeCount": 3256,
+    "messageCount": 3295,
+    "completeCount": 3295,
     "blockedCount": 0,
-    "dossierDigest": "09b10672f9255e2c70ec9a0535c9489c1bb595e34ad5c52e2f61102e9210b3f9",
-    "catalogDigest": "af7ec2eafb10878bd293fe7529db73ee4ba420ccd41cd3878277c7db1bba475d",
+    "dossierDigest": "8ad131fb2b4937ad71556638413843b4bfd425415302a57f6d291526c0119c02",
+    "catalogDigest": "7c496a8361d320e8aa651ae0c857d4579113d9f8912aaa32da9f52497bfec8ca",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
     "roleCounts": {
-      "error-or-validation": 377,
-      "explanatory-copy": 121,
+      "error-or-validation": 379,
+      "explanatory-copy": 122,
       "field-guidance": 53,
-      "label-or-body-copy": 1311,
+      "label-or-body-copy": 1338,
       "navigation-or-tab": 228,
-      "reserved-catalog-copy": 288,
-      "status-or-empty-state": 114,
+      "reserved-catalog-copy": 292,
+      "status-or-empty-state": 116,
       "success-notification": 187,
-      "title-or-heading": 249,
-      "user-action": 328
+      "title-or-heading": 251,
+      "user-action": 329
     },
     "stateCounts": {
       "destructive-or-rejecting-action": 47,
-      "failure-or-invalid-input": 377,
-      "interactive-ready": 539,
-      "retained-not-currently-reachable": 396,
+      "failure-or-invalid-input": 379,
+      "interactive-ready": 540,
+      "retained-not-currently-reachable": 402,
       "successful-completion": 187,
-      "visible": 1710
+      "visible": 1740
     },
-    "riskCounts": { "high": 1483, "low": 1605, "medium": 168 },
-    "highRiskMessageCount": 1483,
-    "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf"
+    "riskCounts": { "high": 1493, "low": 1634, "medium": 168 },
+    "highRiskMessageCount": 1493,
+    "highRiskMessageDigest": "5bd9a96def8097e8d66b6e34e4797036a465eb50cb41818ea298554b8c612eea"
   },
   "typedContentDossiers": {
     "sourcePath": "src/components/ImportTidasPackage/reportContent.ts",
@@ -88,14 +88,14 @@
   },
   "usageIndex": {
     "source": "docs/plans/i18n-de-DE/manifest.json messages[*].references/moduleOwnership/dynamicFamilies",
-    "literalReferenceCount": 4188,
+    "literalReferenceCount": 4223,
     "dynamicCallsiteCount": 32,
     "glossaryRuleScope": "full target catalog at the automated quality gate",
     "onDemandCommand": "pnpm i18n:context:dossier --locale zh-CN --message <MESSAGE_ID>"
   },
   "routeViewCoverage": {
     "path": "docs/plans/i18n/route-view-coverage.json",
-    "digest": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
+    "digest": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "requiredRouteViews": ["/", "/welcome", "/welcome?view=carbon-footprint"],
     "derivedEvidence": {
       "schemaVersion": "tiangong.i18n-route-view-derived-evidence.v2",
@@ -111,7 +111,7 @@
         "evidenceSchemaVersion": "tiangong.i18n-semantic-e2e-evidence.v2",
         "proofStorage": "ignored-local-or-github-actions-artifact",
         "requiredAt": "dev-release-candidate-gate",
-        "routeCoverageContractDigest": "56b08f4e25b3cb7ae275b449914a368d73d6f8b5cd0e00533fce5ac2aeed8705",
+        "routeCoverageContractDigest": "466465f8b1ab300ee23eb7208624c92564ce749aea0317c574d3a2c0de1f5d4b",
         "requiredAssertionCount": 50,
         "executionEvidence": null,
         "contractReady": true,
@@ -132,20 +132,20 @@
       "viewStateRegistry": {
         "schemaVersion": "tiangong.route-view-state-registry.v1",
         "sourcePath": "src/services/general/routeViewStateRegistry.json",
-        "sourceDigest": "e296972fc135327906352bfea38dc3ccd614bd1ab81d4053ed21f5ba65f2f170",
+        "sourceDigest": "9476fa2b88f62781a562626f39b92809be264ca1775c0bb7ac576de46295d832",
         "registryCount": 7,
         "executableVariantCount": 12,
-        "focusedVariantCount": 7
+        "focusedVariantCount": 8
       },
       "sourceFileCount": 37,
-      "sourceEvidenceDigest": "d552e299d9488180894072558ffb18b8760a53548ce04b25e582f0d0b74d225a",
+      "sourceEvidenceDigest": "5a99925398a47b16736c00c3393e9348ed650b32427d6b2ddd9ed2198839369d",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
           "route": "/",
           "viewState": "redirect-to-welcome",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "01d2189592b68f84eb5b2b9293c099fc8b175961ca037300f33079773f19a99f",
+          "sourceDigest": "46c37fb26697ce00ef06fc3025f9c575f97a0a091dec90f5dec777626b0b1c13",
           "focusedTestDigest": "2db96025ec564871cc9ebdfbd9e106b0cd6d0907f7f765574cc56a93122a4c24",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "d4754f0ac91aaabda0250ca6a0977f131654b0900d1b14b36a4c840aa42f6825",
@@ -172,7 +172,7 @@
           "route": "/welcome",
           "viewState": "overview",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "fd26650a765321bf70a703d4f841aa053a64ac5905dc8d425a034cf768c65b51",
+          "sourceDigest": "66c3c1b6d08088d3d019c30156034ffcf16338e94d39e68bc316fe426ad4359e",
           "focusedTestDigest": "5565e087364aeec68560016fed1de6dde3d6033b550a7b42578133ffdb6a94da",
           "plannedBrowserAssertionCount": 2,
           "plannedBrowserAssertionDigest": "811949b6e0dccca1b6aa510e63afebb8839888cf24907b1dc2bae6a1755bf3d3",
@@ -199,7 +199,7 @@
           "route": "/welcome?view=carbon-footprint",
           "viewState": "carbon-footprint-guide",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "fd26650a765321bf70a703d4f841aa053a64ac5905dc8d425a034cf768c65b51",
+          "sourceDigest": "66c3c1b6d08088d3d019c30156034ffcf16338e94d39e68bc316fe426ad4359e",
           "focusedTestDigest": "5b5148760307f23e143c255ac0e71c63cef7b29498da1ded43e06e01659cb9c9",
           "plannedBrowserAssertionCount": 3,
           "plannedBrowserAssertionDigest": "7dce46b0e253c9000c52c96a89b772057bc78fbf5d13a1db1094e52d13b71be3",
@@ -319,13 +319,22 @@
           "route": "/dashboard/national-carbon",
           "viewState": "national-carbon-dashboard",
           "requiredEvidenceScope": "access-boundary-observed",
-          "sourceDigest": "bc85d65819e9ad6b0c4e544f7a05b8594a7ec715dc2f03c5635e35fd899f7aa9",
-          "focusedTestDigest": "dcdc78e899dbb0901df2ba3b74c013a4c6e0a6459de5910ebdb18f06e167a2d9",
+          "sourceDigest": "44c36ae7d1280d2fd8f9b0386f8167ef63d61a7bd7f15e597ab5eb65fbb702e6",
+          "focusedTestDigest": "c60f0433ae97c5b053a8600e61874da509a3064cc159bcf5955c6a345ccddd36",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "95b95698b9168443cacad5913312e98989fb251f09feee48fbaf5f7203c57587",
-          "derivedMessageCount": 269,
-          "derivedMessageDigest": "f8add4900da9ffe9333a7a5d7bed82008a76673a7db22cf08e295298ec4ea8e3",
-          "stateSignals": ["empty", "error", "loading", "modal", "retry", "success", "unavailable"],
+          "derivedMessageCount": 308,
+          "derivedMessageDigest": "4e864160bd7131da204bdaa6f62d80859097cbed140f499f20e231d191d7a2bd",
+          "stateSignals": [
+            "empty",
+            "error",
+            "loading",
+            "modal",
+            "ready",
+            "retry",
+            "success",
+            "unavailable"
+          ],
           "queryParameters": ["autoplay", "screen", "tid"],
           "navigationTargets": [
             "/dashboard/national-carbon",
@@ -333,7 +342,7 @@
             "/umi/plugin/openapi",
             "/user/login/password_reset"
           ],
-          "interactionKinds": [],
+          "interactionKinds": ["tooltip"],
           "acceptedTechnicalLiteralCount": 0,
           "unownedVisibleLiteralCount": 0
         },
@@ -1117,7 +1126,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "d83a5ca4985d045c0853d1eb33985d2bf029ca17c1c24908371d19d3511bed74",
+      "rowEvidenceDigest": "e0e74bcc62c376f54d13f1fc6471c827b9a41b727aa6e4c239a01bd9d11e7334",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1135,11 +1144,11 @@
     "scripts/i18n/language-hardcoding-allowlist.json": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a",
     "src/components/ImportTidasPackage/reportContent.ts": "b2abf951ea5aad8bc1cb440aba7d771a5344ca1a33f36d502ff1c8c6a2961c6b",
     "docs/plans/i18n-de-DE/dynamic-families.json": "39d86ee63e4a85cb6f555c127d1903b79c661c3ed6b9fe59924e6bac7ffc6157",
-    "docs/plans/i18n/route-view-coverage.json": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
+    "docs/plans/i18n/route-view-coverage.json": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "docs/plans/i18n/fallback-contract.json": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "docs/plans/i18n-zh-CN/glossary.json": "c891add0ee4bd6d24c0213d0c839474e145d85867426df796763b8e038053d9b",
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "8567c676a788c2e018e93a7394520a8cd23d2032a0cdb94881dbacc61e2a59f8"
+  "contextDigest": "f1bf79f1d9485e04b73518f5861bb6547ea058524d60984e0dff474a66ca46f2"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "b78ee928718894b3c2b725c00d140600be2eeeb08deb82a11a1fa93a7c06a95b"
+    "sourceManifestDigest": "f54ab67d3ae00d351ca44b98e07012eae5776e16e9d98e518adf67fc324ec243"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,10 +74,10 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "8567c676a788c2e018e93a7394520a8cd23d2032a0cdb94881dbacc61e2a59f8",
-    "qualityDigest": "18d37d0d889472d108f1a2dd442b152742c9a5ad33690c98c3021735d6629ee1",
+    "contextDigest": "f1bf79f1d9485e04b73518f5861bb6547ea058524d60984e0dff474a66ca46f2",
+    "qualityDigest": "c31e23b04a73bd82ccb9934594cceb1b71f72fef8345e2779ad92425e6cee405",
     "correctionLedgerDigest": "aa1ce07437550c229c6835918fe64d8200f0c251910c4723bad48b684ac6af9b",
-    "routeViewCoverageDigest": "536ba4b35d132fa66daf8684fc28c9e20347b825b4d3f7d902e072907ffabf9e",
+    "routeViewCoverageDigest": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
     "localeFallbackRowCount": 10
   },
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "4b40dfc6a42648cebb0b960b3079da8ef6c03d39471e58b1b02944e5466f7479"
+  "activationDigest": "d639c1bf48e959b130674204d63dba64e337b27f7811b4cbb7577809317a7038"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,12 +3,12 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "b78ee928718894b3c2b725c00d140600be2eeeb08deb82a11a1fa93a7c06a95b",
-    "contextDigest": "8567c676a788c2e018e93a7394520a8cd23d2032a0cdb94881dbacc61e2a59f8"
+    "sourceManifestDigest": "f54ab67d3ae00d351ca44b98e07012eae5776e16e9d98e518adf67fc324ec243",
+    "contextDigest": "f1bf79f1d9485e04b73518f5861bb6547ea058524d60984e0dff474a66ca46f2"
   },
   "catalog": {
-    "messageCount": 3256,
-    "catalogDigest": "af7ec2eafb10878bd293fe7529db73ee4ba420ccd41cd3878277c7db1bba475d",
+    "messageCount": 3295,
+    "catalogDigest": "7c496a8361d320e8aa651ae0c857d4579113d9f8912aaa32da9f52497bfec8ca",
     "emptyTranslationCount": 0,
     "acceptedSourceEmptyCount": 1,
     "acceptedSourceEmptyDigest": "182ce2fe247d78a1af1027643331be2239d4e4815d2a32f5795a8f6954367560",
@@ -42,16 +42,16 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "bfdf6519a56245d0eeb7c6d5edab0acac2f49e7f4c9d63fb9f73b655254eae8a",
-    "validationDigest": "41f087200b457b397fd8d9a51c015fbb334a1c4d9c29d166dc3e9a3427660167",
+    "digest": "31aa2a2b8a7e476cd814d41d6eac24450819f1f1f2799b82b2b6091f99c455cf",
+    "validationDigest": "1a7353da162b97732f23f0cdf2684b31f626d85cc2284551b7fd034d1874aa10",
     "laneCount": 1,
-    "validatedMessageCount": 3256,
+    "validatedMessageCount": 3295,
     "validatedModuleCount": 32,
-    "highRiskMessageCount": 1483,
-    "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
+    "highRiskMessageCount": 1493,
+    "highRiskMessageDigest": "5bd9a96def8097e8d66b6e34e4797036a465eb50cb41818ea298554b8c612eea",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635",
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "18d37d0d889472d108f1a2dd442b152742c9a5ad33690c98c3021735d6629ee1"
+  "qualityDigest": "c31e23b04a73bd82ccb9934594cceb1b71f72fef8345e2779ad92425e6cee405"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "cc9cdad1ad0ad2149d560a591627e0c31ed015052e239f57737e4674c23ac998",
-    "validatedMessageCount": 3256,
+    "auditedInputDigest": "a4d0f503df21a95c502b60a4339c01b6b47d0f17648a055e38d741a01b69a539",
+    "validatedMessageCount": 3295,
     "validatedModules": [
       "$entry",
       "component",
@@ -39,12 +39,12 @@
       "settings",
       "validator"
     ],
-    "highRiskMessageCount": 1483,
-    "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
-    "catalogDigest": "af7ec2eafb10878bd293fe7529db73ee4ba420ccd41cd3878277c7db1bba475d",
-    "dossierDigest": "09b10672f9255e2c70ec9a0535c9489c1bb595e34ad5c52e2f61102e9210b3f9",
+    "highRiskMessageCount": 1493,
+    "highRiskMessageDigest": "5bd9a96def8097e8d66b6e34e4797036a465eb50cb41818ea298554b8c612eea",
+    "catalogDigest": "7c496a8361d320e8aa651ae0c857d4579113d9f8912aaa32da9f52497bfec8ca",
+    "dossierDigest": "8ad131fb2b4937ad71556638413843b4bfd425415302a57f6d291526c0119c02",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "d83a5ca4985d045c0853d1eb33985d2bf029ca17c1c24908371d19d3511bed74",
+    "routeEvidenceDigest": "e0e74bcc62c376f54d13f1fc6471c827b9a41b727aa6e4c239a01bd9d11e7334",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -94,11 +94,11 @@
       ],
       "executionEvidence": {
         "executor": "scripts/i18n/locale-delivery.mjs#executeStructuralValidationLane",
-        "messageCount": 3256,
-        "messageDigest": "64f51ad4482edb68a2cb31a2139a4ed1f01eb358b91296508ff95f39dc28096e",
-        "highRiskMessageCount": 1483,
-        "highRiskMessageDigest": "7bb2d08397907a8244f44566d896a8a4a8adea6e85c94bc1f6a1dd6c2c1f37cf",
-        "dossierDigest": "09b10672f9255e2c70ec9a0535c9489c1bb595e34ad5c52e2f61102e9210b3f9",
+        "messageCount": 3295,
+        "messageDigest": "b7bc3e8a3e81a7a210ddcef6d5259ffbe2da24906131f641f717902a65d55de4",
+        "highRiskMessageCount": 1493,
+        "highRiskMessageDigest": "5bd9a96def8097e8d66b6e34e4797036a465eb50cb41818ea298554b8c612eea",
+        "dossierDigest": "8ad131fb2b4937ad71556638413843b4bfd425415302a57f6d291526c0119c02",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "41f087200b457b397fd8d9a51c015fbb334a1c4d9c29d166dc3e9a3427660167"
+  "validationDigest": "1a7353da162b97732f23f0cdf2684b31f626d85cc2284551b7fd034d1874aa10"
 }

--- a/docs/plans/i18n/route-view-coverage.json
+++ b/docs/plans/i18n/route-view-coverage.json
@@ -81,6 +81,7 @@
           "map_status",
           "outcome_metrics",
           "connectivity",
+          "organization_contribution",
           "flow_topology"
         ],
         "proof": {

--- a/src/pages/NationalCarbonDashboard/index.tsx
+++ b/src/pages/NationalCarbonDashboard/index.tsx
@@ -61,6 +61,7 @@ import {
   formatDashboardDateTime,
   formatDashboardNumber as formatNumber,
   formatDashboardPercent,
+  getCanonicalRuntimeLocale,
   getDashboardRegionLabel,
   getDashboardScreenLabel,
   getDashboardStatusLabel,
@@ -2521,7 +2522,7 @@ function OrganizationDailyCreationHeatmap({
   dailyCreation: OrganizationContributionSnapshot['dailyCreation'];
 }) {
   const intl = useIntl();
-  const locale = (intl as DashboardIntl & { locale?: string }).locale ?? 'zh-CN';
+  const locale = getCanonicalRuntimeLocale();
   const getCount = useCallback(
     (day: (typeof dailyCreation.days)[number]) => {
       if (activeScope === 'process') return day.processCount;


### PR DESCRIPTION
## Summary

- replace the National Carbon Dashboard heatmap's hard-coded locale fallback with the registry-owned runtime locale
- register the `organization_contribution` screen in route/view coverage
- regenerate canonical locale audit artifacts for all four active locales

This is the scoped prerequisite for the v0.0.95 Release PR. It targets `dev` and does not merge or promote any branch.

## Validation

- `node scripts/test-runner.cjs tests/unit/pages/NationalCarbonDashboard/index.test.tsx tests/unit/pages/NationalCarbonDashboard/i18n.test.ts --runInBand --no-coverage --watchman=false` — 2 suites, 22 tests passed
- `node scripts/i18n/check-artifact-idempotence.mjs` — two generations canonical and idempotent
- `node --import tsx scripts/i18n/locale-delivery.mjs all --check` — four locales passed with no stale artifacts
- `node --import tsx scripts/reference-data/reference-resource-pipeline.mjs --production-check` — 5 resources and 4 registry languages passed
- `scripts/docpact lint --root tiangong-lca-next --worktree` — passed before commit
- `pnpm push:checked fork HEAD:refs/heads/feature/issue-992-release-preflight` — full managed gate passed, including lint, TypeScript, complete Jest coverage, and 482/482 tracked files at 100% statements/branches/functions/lines

## Environment and proof

- environment: local macOS checkout using repository-pinned Node 24.19.0 and pnpm 11.24.0
- `pnpm prepush:gate` ran through the required `push:checked` hook-owned flow
- no browser E2E was run; it is not required for this release-preflight contract repair
- no required proof lives in another repository

Refs #992

Closes linancn/tiangong-lca-next#992
