### PR TITLE
Fix review submission drawer lifecycle

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-09-01"
-lastReviewedCommit: "7a6df6d3dcb0b05f33848ef6906c5f549f5a505a"
+lastReviewedAt: "2026-09-02"
+lastReviewedCommit: "d1b17a476945c9aee00d2106ba44c0f72ce5e5a2"
 lastReviewedNote: 'Reviewed for Next Issue #991: existing OAuth, frontend-runtime, service, locale, exact Edge-mirror, and testing routes cover complete compatibility/account-bridge removal while retaining the integrated Jest/browser and organization-profile ownership.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 7a6df6d3dcb0b05f33848ef6906c5f549f5a505a
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: d1b17a476945c9aee00d2106ba44c0f72ce5e5a2
 lastReviewedNote: 'Reviewed for Next Issue #991: Account exposes only OAuth Connected Applications and Supabase-owned profile credentials; compatibility and external account-bridge code is absent while the integrated Jest/browser, organization, delivery, and modified-at-desc Process contracts remain unchanged.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -42,8 +42,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .github/workflows/build.yml
   - .nvmrc
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 7a6df6d3dcb0b05f33848ef6906c5f549f5a505a
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: d1b17a476945c9aee00d2106ba44c0f72ce5e5a2
 lastReviewedNote: 'Reviewed for Next #991 after the Jest/Umi/Electron/Playwright and organization-profile integrations: OAuth-only account and exact Edge-mirror retirement change no bootstrap commands; lint, test, build, managed-push, and deterministic release remain authoritative.'
 ---
 

--- a/docs/agents/contribution-path-analysis-design.md
+++ b/docs/agents/contribution-path-analysis-design.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-08-31
-lastReviewedCommit: 66f3ad0663b137c9d9a61ffde3abde887cd3f847
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: d1b17a476945c9aee00d2106ba44c0f72ce5e5a2
 lastReviewedNote: 'Reviewed for Next Issue #901: removing an unreachable Task Center diagnostic guard and covering retained diagnostic fallbacks does not change calculation, analysis, or contribution-path contracts.'
 ---
 

--- a/docs/agents/lca-analysis-visualization-plan.md
+++ b/docs/agents/lca-analysis-visualization-plan.md
@@ -20,8 +20,8 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-08-31
-lastReviewedCommit: 66f3ad0663b137c9d9a61ffde3abde887cd3f847
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: d1b17a476945c9aee00d2106ba44c0f72ce5e5a2
 lastReviewedNote: 'Reviewed for Next Issue #901: removing an unreachable Task Center diagnostic guard and covering retained diagnostic fallbacks does not change calculation, analysis, or contribution-path contracts.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -42,8 +42,8 @@ checkPaths:
   - scripts/typescript-native-parser.*
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 7a6df6d3dcb0b05f33848ef6906c5f549f5a505a
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: d1b17a476945c9aee00d2106ba44c0f72ce5e5a2
 lastReviewedNote: 'Reviewed for Next #991 after Issues #982/#983: source-mapped Jest 30 coverage, organization profile regressions, OAuth-only Account, and exact Edge mirror retain one full-gate owner and unchanged 100% enforcement.'
 ---
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - playwright.config.ts
   - config/docs-capture/**
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 046c505882ac28ae473a3318e2d4c94a9bf0541d
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: d1b17a476945c9aee00d2106ba44c0f72ce5e5a2
 lastReviewedNote: 'Reviewed for Next Issue #991 after the Jest/browser and organization UI integrations: Account uses OAuth grant list/revoke and Supabase credentials only, all compatibility/account-bridge callers are removed, and the stable frontend/service map remains intact.'
 related:
   - ../AGENTS.md
@@ -131,6 +131,8 @@ Process, Flow, Source, and Contact review submission use the same stable command
 `src/pages/Processes/Components/edit.tsx -> src/pages/Utils/review.tsx -> src/services/reviews/api.ts -> app_dataset_submit_review`
 
 Before calling that command, the Process editor validates the current saved record for TIDAS SDK validity, at least one exchange, and exactly one quantitative reference. Process, Flow, Source, and Contact then recursively validate their existing reference chains through the same reference-access, rule-verification, and referenced-version checks. Any blocking reference-chain issue prevents submission and is shown through the review-specific validation surface. The submit action does not calculate the full matrix, inspect Worker jobs, or require completeness or numerical-stability evidence. Database remains authoritative for authentication, workflow state, target identity, idempotency, and transactional invariants.
+
+Every dataset editor keeps its drawer mounted and visibly busy for the complete save, validation, and review-command transaction. The editor disables close actions while that transaction is pending, reloads the owning list and closes only after the review command succeeds, and remains open after validation or submission failure so the user can inspect and retry the draft.
 
 Review Admin has a separate manual quality-diagnostic path:
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -43,8 +43,8 @@ checkPaths:
   - scripts/typescript-native-parser.*
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 7a6df6d3dcb0b05f33848ef6906c5f549f5a505a
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: d1b17a476945c9aee00d2106ba44c0f72ce5e5a2
 lastReviewedNote: 'Reviewed for Next Issue #991 after Issues #982/#983: 100% source-mapped Jest proof covers organization profile behavior plus OAuth grant/account flows, asserts compatibility/account-bridge absence, and retains Supabase password/email coverage.'
 related:
   - ../AGENTS.md

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -22,8 +22,8 @@ checkPaths:
   - scripts/e2e/**
   - playwright.config.ts
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 6ff84d2eeeaf5398cf72838f8f4952a56648c35c
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: d1b17a476945c9aee00d2106ba44c0f72ce5e5a2
 lastReviewedNote: 'Reviewed for Next Issue #991 after browser-navigation and organization metadata integration: OAuth grant management is the sole integration surface, Supabase Auth is the sole password/email owner, and environment/branch/callback/database boundaries remain unchanged.'
 ---
 

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -43,8 +43,8 @@ checkPaths:
   - pnpm-lock.yaml
   - pnpm-workspace.yaml
   - Dockerfile.app
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 7a6df6d3dcb0b05f33848ef6906c5f549f5a505a
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: d1b17a476945c9aee00d2106ba44c0f72ce5e5a2
 lastReviewedNote: 'Reviewed for Next #991 after Issues #982/#983: browser, continuation, jsdom, coverage, profile-service, OAuth/account, and exact-mirror findings close through the existing strategy without a new queue or browser matrix.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -40,8 +40,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 7a6df6d3dcb0b05f33848ef6906c5f549f5a505a
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: d1b17a476945c9aee00d2106ba44c0f72ce5e5a2
 lastReviewedNote: 'Reviewed for Next #991 after Issues #982/#983: Jest/browser migration, organization profile, OAuth Account, and external bridge-removal paths are closed with no deferred testing queue.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -42,8 +42,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 7a6df6d3dcb0b05f33848ef6906c5f549f5a505a
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: d1b17a476945c9aee00d2106ba44c0f72ce5e5a2
 lastReviewedNote: 'Reviewed for Next #991 after Issues #982/#983: atomic geometry, explicit inputs, fail-closed coverage, organization profile, OAuth Account, and removed-bridge proof reuse existing service/page/integration patterns.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -39,8 +39,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 7a6df6d3dcb0b05f33848ef6906c5f549f5a505a
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: d1b17a476945c9aee00d2106ba44c0f72ce5e5a2
 lastReviewedNote: 'Reviewed for Next #991 after Issues #982/#983: service defaults, geometry, browser globals, source-mapped coverage, organization, OAuth Account, and mirror failures use existing fail-closed diagnostics.'
 ---
 

--- a/docs/agents/util_calculate.md
+++ b/docs/agents/util_calculate.md
@@ -20,8 +20,8 @@ checkPaths:
   - src/services/lca/**
   - src/components/LcaTaskCenter/**
   - src/pages/Processes/Analysis/**
-lastReviewedAt: 2026-08-31
-lastReviewedCommit: 66f3ad0663b137c9d9a61ffde3abde887cd3f847
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: d1b17a476945c9aee00d2106ba44c0f72ce5e5a2
 lastReviewedNote: 'Reviewed for Next Issue #901: removing an unreachable Task Center diagnostic guard and covering retained diagnostic fallbacks does not change calculation, analysis, or contribution-path contracts.'
 ---
 

--- a/src/components/DatasetSubmitReviewButton/index.tsx
+++ b/src/components/DatasetSubmitReviewButton/index.tsx
@@ -12,6 +12,7 @@ type Props = {
   disabled?: boolean;
   beforeSubmit: () => Promise<boolean>;
   onSuccess?: (result: unknown) => void | Promise<void>;
+  onSubmittingChange?: (submitting: boolean) => void;
 };
 
 const DatasetSubmitReviewButton: FC<Props> = ({
@@ -21,6 +22,7 @@ const DatasetSubmitReviewButton: FC<Props> = ({
   disabled = false,
   beforeSubmit,
   onSuccess,
+  onSubmittingChange,
 }) => {
   const { message } = useAntdAppApi();
   const [submitting, setSubmitting] = useState(false);
@@ -28,6 +30,7 @@ const DatasetSubmitReviewButton: FC<Props> = ({
 
   const submit = async () => {
     setSubmitting(true);
+    onSubmittingChange?.(true);
     try {
       const validationPassed = await beforeSubmit();
       if (!validationPassed) {
@@ -53,8 +56,18 @@ const DatasetSubmitReviewButton: FC<Props> = ({
         }),
       );
       await onSuccess?.(result.data);
+    } catch (error) {
+      message.error(
+        error instanceof Error && error.message
+          ? error.message
+          : intl.formatMessage({
+              id: 'pages.review.submit.error',
+              defaultMessage: 'Submit review failed.',
+            }),
+      );
     } finally {
       setSubmitting(false);
+      onSubmittingChange?.(false);
     }
   };
 

--- a/src/pages/Contacts/Components/edit.tsx
+++ b/src/pages/Contacts/Components/edit.tsx
@@ -98,6 +98,7 @@ const ContactEdit: FC<Props> = ({
   const [drawerVisible, setDrawerVisible] = useState(false);
   const formRefEdit = useRef<ProFormInstance | undefined>(undefined);
   const [spinning, setSpinning] = useState(false);
+  const [reviewSubmitting, setReviewSubmitting] = useState(false);
   const [initData, setInitData] = useState<FormContact>();
   const [fromData, setFromData] = useState<FormContact>();
   const [currentStateCode, setCurrentStateCode] = useState<number>();
@@ -724,19 +725,26 @@ const ContactEdit: FC<Props> = ({
         }
         size='90%'
         closable={false}
-        extra={<Button icon={<CloseOutlined />} style={{ border: 0 }} onClick={closeDrawer} />}
+        extra={
+          <Button
+            disabled={spinning || reviewSubmitting}
+            icon={<CloseOutlined />}
+            style={{ border: 0 }}
+            onClick={closeDrawer}
+          />
+        }
         mask={{ closable: false }}
         open={drawerVisible}
         onClose={closeDrawer}
         footer={
-          <LoadingDisabledActionGroup loading={spinning || !initData}>
+          <LoadingDisabledActionGroup loading={spinning || reviewSubmitting || !initData}>
             <Space size={'middle'} className={styles.footer_right}>
               <Button onClick={() => void handleCheckData()}>
                 <FormattedMessage id='pages.button.check' defaultMessage='Data Check' />
               </Button>
               {showSyncOpenDataButton && isReviewAdmin && (
                 <Button
-                  disabled={spinning || currentStateCode === 100}
+                  disabled={spinning || reviewSubmitting || currentStateCode === 100}
                   onClick={handleSyncToOpenData}
                 >
                   <FormattedMessage
@@ -749,8 +757,9 @@ const ContactEdit: FC<Props> = ({
                 table='contacts'
                 id={id}
                 version={version}
-                disabled={spinning || currentStateCode !== 0}
+                disabled={spinning || reviewSubmitting || currentStateCode !== 0}
                 beforeSubmit={() => handleCheckData({ actionFrom: 'review' })}
+                onSubmittingChange={setReviewSubmitting}
                 onSuccess={() => {
                   setCurrentStateCode(20);
                   actionRef?.current?.reload();
@@ -786,7 +795,7 @@ const ContactEdit: FC<Props> = ({
           </LoadingDisabledActionGroup>
         }
       >
-        <Spin spinning={spinning}>
+        <Spin spinning={spinning || reviewSubmitting}>
           <RefCheckContext.Provider value={refCheckContextValue}>
             <ProForm
               formRef={formRefEdit}

--- a/src/pages/Flowproperties/Components/edit.tsx
+++ b/src/pages/Flowproperties/Components/edit.tsx
@@ -106,6 +106,7 @@ const FlowpropertiesEdit: FC<Props> = ({
   const [initData, setInitData] = useState<FormFlowProperty & { id?: string }>();
   const [detailStateCode, setDetailStateCode] = useState<number>();
   const [spinning, setSpinning] = useState(false);
+  const [reviewSubmitting, setReviewSubmitting] = useState(false);
   const [showRules, setShowRules] = useState<boolean>(false);
   const [sdkValidationDetails, setSdkValidationDetails] = useState<ValidationIssueSdkDetail[]>([]);
   const [sdkValidationFocus, setSdkValidationFocus] = useState<ValidationIssueSdkDetail | null>(
@@ -561,12 +562,19 @@ const FlowpropertiesEdit: FC<Props> = ({
         }
         size='90%'
         closable={false}
-        extra={<Button icon={<CloseOutlined />} style={{ border: 0 }} onClick={closeDrawer} />}
+        extra={
+          <Button
+            disabled={spinning || reviewSubmitting}
+            icon={<CloseOutlined />}
+            style={{ border: 0 }}
+            onClick={closeDrawer}
+          />
+        }
         mask={{ closable: false }}
         open={drawerVisible}
         onClose={closeDrawer}
         footer={
-          <LoadingDisabledActionGroup loading={spinning || !initData}>
+          <LoadingDisabledActionGroup loading={spinning || reviewSubmitting || !initData}>
             <Space size={'middle'} className={styles.footer_right}>
               <Button onClick={() => void handleCheckData()}>
                 <FormattedMessage id='pages.button.check' defaultMessage='Data Check' />
@@ -575,8 +583,9 @@ const FlowpropertiesEdit: FC<Props> = ({
                 table='flowproperties'
                 id={id}
                 version={version}
-                disabled={spinning || detailStateCode !== 0}
+                disabled={spinning || reviewSubmitting || detailStateCode !== 0}
                 beforeSubmit={() => handleCheckData()}
+                onSubmittingChange={setReviewSubmitting}
                 onSuccess={() => {
                   setDetailStateCode(20);
                   actionRef?.current?.reload();
@@ -614,7 +623,7 @@ const FlowpropertiesEdit: FC<Props> = ({
           </LoadingDisabledActionGroup>
         }
       >
-        <Spin spinning={spinning}>
+        <Spin spinning={spinning || reviewSubmitting}>
           <RefCheckContext.Provider value={refCheckContextValue}>
             <ProForm
               formRef={formRefEdit}

--- a/src/pages/Flows/Components/edit.tsx
+++ b/src/pages/Flows/Components/edit.tsx
@@ -104,6 +104,7 @@ const FlowsEdit: FC<Props> = ({
   const aiSuggestionDataRef = useRef<Record<string, unknown> | null>(null);
   const [flowType, setFlowType] = useState<string>();
   const [spinning, setSpinning] = useState(false);
+  const [reviewSubmitting, setReviewSubmitting] = useState(false);
   const [propertyDataSource, setPropertyDataSource] = useState<FlowPropertyData[]>([]);
   const [showRules, setShowRules] = useState<boolean>(false);
   const [sdkValidationDetails, setSdkValidationDetails] = useState<ValidationIssueSdkDetail[]>([]);
@@ -661,12 +662,19 @@ const FlowsEdit: FC<Props> = ({
         title={<FormattedMessage id={'pages.button.edit'} defaultMessage={'Edit'} />}
         size='90%'
         closable={false}
-        extra={<Button icon={<CloseOutlined />} style={{ border: 0 }} onClick={closeDrawer} />}
+        extra={
+          <Button
+            disabled={spinning || reviewSubmitting}
+            icon={<CloseOutlined />}
+            style={{ border: 0 }}
+            onClick={closeDrawer}
+          />
+        }
         mask={{ closable: false }}
         open={drawerVisible}
         onClose={closeDrawer}
         footer={
-          <LoadingDisabledActionGroup loading={spinning || !initData}>
+          <LoadingDisabledActionGroup loading={spinning || reviewSubmitting || !initData}>
             <Space size={'middle'} className={styles.footer_right}>
               <AISuggestion
                 type='flow'
@@ -681,8 +689,9 @@ const FlowsEdit: FC<Props> = ({
                 table='flows'
                 id={id}
                 version={version}
-                disabled={spinning || detailStateCode !== 0}
+                disabled={spinning || reviewSubmitting || detailStateCode !== 0}
                 beforeSubmit={() => handleCheckData({ actionFrom: 'review' })}
+                onSubmittingChange={setReviewSubmitting}
                 onSuccess={() => {
                   setDetailStateCode(20);
                   actionRef?.current?.reload();
@@ -720,7 +729,7 @@ const FlowsEdit: FC<Props> = ({
           </LoadingDisabledActionGroup>
         }
       >
-        <Spin spinning={spinning}>
+        <Spin spinning={spinning || reviewSubmitting}>
           <RefCheckContext.Provider value={refCheckContextValue}>
             <ProForm
               formRef={formRefEdit}

--- a/src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx
+++ b/src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx
@@ -1702,8 +1702,10 @@ const ToolbarEdit: FC<Props> = ({
     setProblemNodes(reviewResult?.problemNodes ?? []);
 
     if (checkResult && saveResult.saveSucceeded) {
-      await editInfoRef.current?.submitReview(unReview);
-      onSubmitReviewSuccess();
+      const submitSucceeded = await editInfoRef.current?.submitReview(unReview);
+      if (submitSucceeded) {
+        onSubmitReviewSuccess();
+      }
     }
     setSpinning(false);
   };

--- a/src/pages/LifeCycleModels/Components/toolbar/eidtInfo.tsx
+++ b/src/pages/LifeCycleModels/Components/toolbar/eidtInfo.tsx
@@ -705,46 +705,47 @@ const ToolbarEditInfo = forwardRef<ToolbarEditInfoHandle, Props>(
       return { checkResult: false, unReview, problemNodes };
     };
 
-    const submitReview = async () => {
+    const submitReview = async (): Promise<boolean> => {
       setSpinning(true);
-      const currentModelDetail = modelDetailRef.current;
-      if (!currentModelDetail) {
-        message.error(
+      const fallbackErrorMessage = intl.formatMessage({
+        id: 'pages.lifecyclemodel.review.submitError',
+        defaultMessage: 'Submit review failed',
+      });
+
+      try {
+        const currentModelDetail = modelDetailRef.current;
+        if (!currentModelDetail) {
+          message.error(fallbackErrorMessage);
+          return false;
+        }
+
+        const result = await submitDatasetReview(
+          'lifecyclemodels',
+          currentModelDetail.id,
+          currentModelDetail.version,
+        );
+
+        if (result?.error) {
+          message.error(result.error.message || fallbackErrorMessage);
+          return false;
+        }
+
+        message.success(
           intl.formatMessage({
-            id: 'pages.lifecyclemodel.review.submitError',
-            defaultMessage: 'Submit review failed',
+            id: 'pages.process.review.submitSuccess',
+            defaultMessage: 'Review submitted successfully',
           }),
         );
-        setSpinning(false);
-        return;
-      }
-
-      const result = await submitDatasetReview(
-        'lifecyclemodels',
-        currentModelDetail.id,
-        currentModelDetail.version,
-      );
-
-      if (result?.error) {
+        setDrawerVisible(false);
+        return true;
+      } catch (error) {
         message.error(
-          result.error.message ||
-            intl.formatMessage({
-              id: 'pages.lifecyclemodel.review.submitError',
-              defaultMessage: 'Submit review failed',
-            }),
+          error instanceof Error && error.message ? error.message : fallbackErrorMessage,
         );
+        return false;
+      } finally {
         setSpinning(false);
-        return;
       }
-
-      message.success(
-        intl.formatMessage({
-          id: 'pages.process.review.submitSuccess',
-          defaultMessage: 'Review submitted successfully',
-        }),
-      );
-      setDrawerVisible(false);
-      setSpinning(false);
     };
 
     useImperativeHandle(ref, () => ({

--- a/src/pages/Processes/Components/edit.tsx
+++ b/src/pages/Processes/Components/edit.tsx
@@ -194,6 +194,7 @@ const ProcessEdit: FC<Props> = ({
   >(new Set());
   const [pendingTabValidationKey, setPendingTabValidationKey] = useState<TabKeysType | null>(null);
   const [spinning, setSpinning] = useState(false);
+  const [reviewSubmitting, setReviewSubmitting] = useState(false);
   const [showRules, setShowRules] = useState<boolean>(false);
   const [autoCheckTriggered, setAutoCheckTriggered] = useState(false);
   const intl = useIntl();
@@ -584,8 +585,8 @@ const ProcessEdit: FC<Props> = ({
         setSpinning(false);
         setDrawerVisible(false);
         setViewDrawerVisible(false);
+        actionRef?.current?.reload();
       }
-      actionRef?.current?.reload();
     } else {
       if (!silent) {
         if (updateResult?.error?.state_code === 100) {
@@ -950,49 +951,49 @@ const ProcessEdit: FC<Props> = ({
   };
 
   const submitReview = async () => {
+    setReviewSubmitting(true);
     setSpinning(true);
+    try {
+      const updateResult = await handleSubmit(false, { langIntent: 'validation' });
+      const validationTarget = await resolveProcessCheckTarget(updateResult);
+      const updatedProcess = toSavedProcessCheckTarget(updateResult);
 
-    const updateResult = await handleSubmit(false, { langIntent: 'validation' });
-    const validationTarget = await resolveProcessCheckTarget(updateResult);
-    const updatedProcess = toSavedProcessCheckTarget(updateResult);
-
-    if (!validationTarget) {
-      setSpinning(false);
-      return;
-    }
-    const { checkResult } = await handleCheckData('review', validationTarget);
-
-    if (checkResult && updatedProcess) {
-      setSpinning(true);
-      const submitResult = await submitDatasetReview(
-        'processes',
-        updatedProcess.id,
-        updatedProcess.version,
-      );
-      if (submitResult.error) {
-        message.error(
-          submitResult.error.message ||
-            intl.formatMessage({
-              id: 'pages.process.review.submitFailed',
-              defaultMessage: 'Review submission failed',
-            }),
-        );
-        setSpinning(false);
+      if (!validationTarget) {
         return;
       }
+      const { checkResult } = await handleCheckData('review', validationTarget);
 
-      message.success(
-        intl.formatMessage({
-          id: 'pages.process.review.submitSuccess',
-          defaultMessage: 'Review submitted successfully',
-        }),
-      );
-      actionRef?.current?.reload();
-      setDrawerVisible(false);
-      setViewDrawerVisible(false);
+      if (checkResult && updatedProcess) {
+        setSpinning(true);
+        const submitResult = await submitDatasetReview(
+          'processes',
+          updatedProcess.id,
+          updatedProcess.version,
+        );
+        if (submitResult.error) {
+          message.error(
+            submitResult.error.message ||
+              intl.formatMessage({
+                id: 'pages.process.review.submitFailed',
+                defaultMessage: 'Review submission failed',
+              }),
+          );
+          return;
+        }
+
+        message.success(
+          intl.formatMessage({
+            id: 'pages.process.review.submitSuccess',
+            defaultMessage: 'Review submitted successfully',
+          }),
+        );
+        actionRef?.current?.reload();
+        setDrawerVisible(false);
+        setViewDrawerVisible(false);
+      }
+    } finally {
       setSpinning(false);
-    } else {
-      setSpinning(false);
+      setReviewSubmitting(false);
     }
   };
 
@@ -1173,6 +1174,7 @@ const ProcessEdit: FC<Props> = ({
         closable={false}
         extra={
           <Button
+            disabled={spinning || reviewSubmitting}
             data-testid='process-edit-close'
             icon={<CloseOutlined />}
             style={{ border: 0 }}
@@ -1183,7 +1185,7 @@ const ProcessEdit: FC<Props> = ({
         open={drawerVisible}
         onClose={() => setDrawerVisible(false)}
         footer={
-          <LoadingDisabledActionGroup loading={spinning || !initData}>
+          <LoadingDisabledActionGroup loading={spinning || reviewSubmitting || !initData}>
             <Space size={'middle'} className={styles.footer_right}>
               <AISuggestion
                 type='process'
@@ -1201,7 +1203,7 @@ const ProcessEdit: FC<Props> = ({
               <>
                 {!hideReviewButton && (
                   <Button
-                    disabled={spinning}
+                    disabled={spinning || reviewSubmitting}
                     onClick={() => {
                       submitReview();
                     }}
@@ -1249,7 +1251,7 @@ const ProcessEdit: FC<Props> = ({
           data-testid='process-deep-link-state'
           hidden
         />
-        <Spin spinning={spinning}>
+        <Spin spinning={spinning || reviewSubmitting}>
           <RefCheckContext.Provider value={refCheckContextValue}>
             <ProForm
               formRef={formRefEdit}

--- a/src/pages/Sources/Components/edit.tsx
+++ b/src/pages/Sources/Components/edit.tsx
@@ -93,6 +93,7 @@ const SourceEdit: FC<Props> = ({
   const [initData, setInitData] = useState<FormSource>();
   const [detailStateCode, setDetailStateCode] = useState<number>();
   const [spinning, setSpinning] = useState(false);
+  const [reviewSubmitting, setReviewSubmitting] = useState(false);
   const [fileList0, setFileList0] = useState<UploadFile[]>([]);
   const [fileList, setFileList] = useState<UploadFile[]>([]);
   const [loadFiles, setLoadFiles] = useState<RcFile[]>([]);
@@ -590,12 +591,19 @@ const SourceEdit: FC<Props> = ({
         }
         size='90%'
         closable={false}
-        extra={<Button icon={<CloseOutlined />} style={{ border: 0 }} onClick={closeDrawer} />}
+        extra={
+          <Button
+            disabled={spinning || reviewSubmitting}
+            icon={<CloseOutlined />}
+            style={{ border: 0 }}
+            onClick={closeDrawer}
+          />
+        }
         mask={{ closable: false }}
         open={drawerVisible}
         onClose={closeDrawer}
         footer={
-          <LoadingDisabledActionGroup loading={spinning || !initData}>
+          <LoadingDisabledActionGroup loading={spinning || reviewSubmitting || !initData}>
             <Space size={'middle'} className={styles.footer_right}>
               <Button onClick={() => void handleCheckData()}>
                 <FormattedMessage id='pages.button.check' defaultMessage='Data Check' />
@@ -604,8 +612,9 @@ const SourceEdit: FC<Props> = ({
                 table='sources'
                 id={id}
                 version={version}
-                disabled={spinning || detailStateCode !== 0}
+                disabled={spinning || reviewSubmitting || detailStateCode !== 0}
                 beforeSubmit={() => handleCheckData({ actionFrom: 'review' })}
+                onSubmittingChange={setReviewSubmitting}
                 onSuccess={() => {
                   setDetailStateCode(20);
                   reload();
@@ -641,7 +650,7 @@ const SourceEdit: FC<Props> = ({
           </LoadingDisabledActionGroup>
         }
       >
-        <Spin spinning={spinning}>
+        <Spin spinning={spinning || reviewSubmitting}>
           <RefCheckContext.Provider value={refCheckContextValue}>
             <ProForm
               formRef={formRefEdit}

--- a/src/pages/Unitgroups/Components/edit.tsx
+++ b/src/pages/Unitgroups/Components/edit.tsx
@@ -92,6 +92,7 @@ const UnitGroupEdit: FC<Props> = ({
   const [detailStateCode, setDetailStateCode] = useState<number>();
   const [unitDataSource, setUnitDataSource] = useState<UnitItem[]>([]);
   const [spinning, setSpinning] = useState(false);
+  const [reviewSubmitting, setReviewSubmitting] = useState(false);
   const [showRules, setShowRules] = useState<boolean>(false);
   const [sdkValidationDetails, setSdkValidationDetails] = useState<ValidationIssueSdkDetail[]>([]);
   const [sdkValidationFocus, setSdkValidationFocus] = useState<ValidationIssueSdkDetail | null>(
@@ -609,13 +610,18 @@ const UnitGroupEdit: FC<Props> = ({
         size='90%'
         closable={false}
         extra={
-          <Button icon={<CloseOutlined />} style={{ border: 0 }} onClick={closeDrawer}></Button>
+          <Button
+            disabled={spinning || reviewSubmitting}
+            icon={<CloseOutlined />}
+            style={{ border: 0 }}
+            onClick={closeDrawer}
+          ></Button>
         }
         mask={{ closable: false }}
         open={drawerVisible}
         onClose={closeDrawer}
         footer={
-          <LoadingDisabledActionGroup loading={spinning || !initData}>
+          <LoadingDisabledActionGroup loading={spinning || reviewSubmitting || !initData}>
             <Space size={'middle'} className={styles.footer_right}>
               <Button onClick={() => void handleCheckData()}>
                 <FormattedMessage id='pages.button.check' defaultMessage='Data Check' />
@@ -624,8 +630,9 @@ const UnitGroupEdit: FC<Props> = ({
                 table='unitgroups'
                 id={id}
                 version={version}
-                disabled={spinning || detailStateCode !== 0}
+                disabled={spinning || reviewSubmitting || detailStateCode !== 0}
                 beforeSubmit={() => handleCheckData()}
+                onSubmittingChange={setReviewSubmitting}
                 onSuccess={() => {
                   setDetailStateCode(20);
                   actionRef?.current?.reload();
@@ -664,7 +671,7 @@ const UnitGroupEdit: FC<Props> = ({
           </LoadingDisabledActionGroup>
         }
       >
-        <Spin spinning={spinning}>
+        <Spin spinning={spinning || reviewSubmitting}>
           <RefCheckContext.Provider value={refCheckContextValue}>
             <ProForm
               formRef={formRefEdit}

--- a/src/services/lifeCycleModels/data.ts
+++ b/src/services/lifeCycleModels/data.ts
@@ -211,7 +211,7 @@ export type LifeCycleModelCheckDataOptions = {
 };
 
 export type LifeCycleModelToolbarEditInfoHandle<TRefData = unknown> = {
-  submitReview: (unReview: TRefData[]) => Promise<void>;
+  submitReview: (unReview: TRefData[]) => Promise<boolean>;
   handleCheckData: (
     from: LifeCycleModelCheckContext,
     nodes: LifeCycleModelGraphNode[],

--- a/tests/unit/components/DatasetSubmitReviewButton.test.tsx
+++ b/tests/unit/components/DatasetSubmitReviewButton.test.tsx
@@ -1,6 +1,6 @@
 import DatasetSubmitReviewButton from '@/components/DatasetSubmitReviewButton';
 import { submitDatasetReviewApi } from '@/services/reviews/api';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 const mockMessageError = jest.fn();
 const mockMessageSuccess = jest.fn();
@@ -26,13 +26,15 @@ jest.mock('antd', () => {
     Button: ({
       children,
       disabled,
+      loading,
       onClick,
     }: {
       children: import('react').ReactNode;
       disabled?: boolean;
+      loading?: boolean;
       onClick?: () => void;
     }) => (
-      <button type='button' disabled={disabled} onClick={onClick}>
+      <button type='button' aria-busy={loading} disabled={disabled} onClick={onClick}>
         {children}
       </button>
     ),
@@ -89,6 +91,45 @@ describe('DatasetSubmitReviewButton', () => {
     );
     expect(mockMessageSuccess).toHaveBeenCalledWith('Review submitted successfully');
     expect(onSuccess).toHaveBeenCalledWith({ review_id: 'review-id' });
+  });
+
+  it('reports submission state until the review request settles', async () => {
+    let resolveSubmit!: (value: unknown) => void;
+    const pendingSubmit = new Promise((resolve) => {
+      resolveSubmit = resolve;
+    });
+    const onSubmittingChange = jest.fn();
+    submitDatasetReviewApiMock.mockReturnValueOnce(pendingSubmit as never);
+
+    render(
+      <DatasetSubmitReviewButton
+        table='flows'
+        id='flow-id'
+        version='01.00.000'
+        beforeSubmit={jest.fn().mockResolvedValue(true)}
+        onSubmittingChange={onSubmittingChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Review' }));
+
+    await waitFor(() => expect(submitDatasetReviewApiMock).toHaveBeenCalled());
+    expect(screen.getByRole('button', { name: 'Submit Review' })).toHaveAttribute(
+      'aria-busy',
+      'true',
+    );
+    expect(onSubmittingChange).toHaveBeenLastCalledWith(true);
+
+    await act(async () => {
+      resolveSubmit({ data: { review_id: 'review-id' }, error: null });
+      await pendingSubmit;
+    });
+
+    await waitFor(() => expect(onSubmittingChange).toHaveBeenLastCalledWith(false));
+    expect(screen.getByRole('button', { name: 'Submit Review' })).toHaveAttribute(
+      'aria-busy',
+      'false',
+    );
   });
 
   it('shows backend and fallback submission errors', async () => {

--- a/tests/unit/pages/Flows/Components/edit.test.tsx
+++ b/tests/unit/pages/Flows/Components/edit.test.tsx
@@ -905,6 +905,58 @@ describe('FlowsEdit', () => {
     expect(mockSubmitDatasetReviewApi).not.toHaveBeenCalled();
   });
 
+  it('keeps the drawer busy until the review request settles', async () => {
+    let resolveSubmit!: (value: unknown) => void;
+    const pendingSubmit = new Promise((resolve) => {
+      resolveSubmit = resolve;
+    });
+    const actionRef = { current: { reload: jest.fn() } };
+    mockGetFlowDetail.mockResolvedValueOnce({
+      data: {
+        json: {
+          flowDataSet: {
+            flowInformation: {
+              dataSetInformation: {
+                name: { baseName: [{ '@xml:lang': 'en', '#text': 'Existing flow' }] },
+              },
+            },
+          },
+        },
+        stateCode: 0,
+        version: '1.0.0',
+      },
+    });
+    mockSubmitDatasetReviewApi.mockReturnValueOnce(pendingSubmit);
+
+    renderWithProviders(
+      <FlowsEdit
+        id='flow-1'
+        version='1.0.0'
+        buttonType='text'
+        lang='en'
+        actionRef={actionRef as any}
+        updateErrRef={jest.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /edit/i }));
+    await screen.findByTestId('flow-form');
+    await userEvent.click(screen.getByRole('button', { name: 'Submit Review' }));
+
+    await waitFor(() => expect(mockSubmitDatasetReviewApi).toHaveBeenCalled());
+    expect(screen.getByTestId('spinning')).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: /edit/i })).toBeInTheDocument();
+    expect(actionRef.current.reload).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveSubmit({ data: [{ review: { id: 'review-1' } }], error: null });
+      await pendingSubmit;
+    });
+
+    await waitFor(() => expect(actionRef.current.reload).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole('dialog', { name: /edit/i })).not.toBeInTheDocument();
+  });
+
   it('keeps flow data checks running when the background save fails', async () => {
     mockUpdateFlows.mockResolvedValueOnce({
       data: undefined,

--- a/tests/unit/pages/LifeCycleModels/Components/toolbar/editIndex.test.tsx
+++ b/tests/unit/pages/LifeCycleModels/Components/toolbar/editIndex.test.tsx
@@ -462,7 +462,7 @@ beforeEach(() => {
   mockUpdateEdge.mockReset();
   mockInitData.mockReset();
   mockToolbarHandleCheckData.mockReset().mockResolvedValue({ problemNodes: [] });
-  mockToolbarSubmitReview.mockReset().mockResolvedValue(undefined);
+  mockToolbarSubmitReview.mockReset().mockResolvedValue(true);
   mockToolbarUpdateReferenceDescription.mockReset().mockResolvedValue(undefined);
   mockUpdateNodeCb.mockReset().mockResolvedValue(undefined);
   mockSyncGraphData.mockReset();
@@ -1360,6 +1360,29 @@ describe('ToolbarEdit', () => {
     );
     expect(mockToolbarSubmitReview).toHaveBeenCalledWith([]);
     expect(onSubmitReviewSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the outer editor open when review submission fails', async () => {
+    mockToolbarHandleCheckData.mockResolvedValue({
+      checkResult: true,
+      unReview: [],
+      problemNodes: [],
+    });
+    mockToolbarSubmitReview.mockResolvedValueOnce(false);
+    const onSubmitReviewSuccess = jest.fn();
+
+    render(
+      <ToolbarEdit
+        {...baseProps}
+        drawerVisible={true}
+        onSubmitReviewSuccess={onSubmitReviewSuccess}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'send-icon' }));
+
+    await waitFor(() => expect(mockToolbarSubmitReview).toHaveBeenCalledWith([]));
+    expect(onSubmitReviewSuccess).not.toHaveBeenCalled();
   });
 
   it('falls back to empty review queues when validation omits them', async () => {

--- a/tests/unit/pages/LifeCycleModels/Components/toolbar/eidtInfo.test.tsx
+++ b/tests/unit/pages/LifeCycleModels/Components/toolbar/eidtInfo.test.tsx
@@ -1363,12 +1363,14 @@ describe('ToolbarEditInfo', () => {
     });
     mockAntdMessage.success.mockClear();
 
+    let submitSucceeded;
     await act(async () => {
-      await ref.current?.submitReview(checkResult.unReview);
+      submitSucceeded = await ref.current?.submitReview(checkResult.unReview);
     });
 
     expect(mockSubmitDatasetReview).toHaveBeenCalledWith('lifecyclemodels', 'model-1', '1.0');
     expect(mockAntdMessage.success).toHaveBeenCalledWith('Review submitted successfully');
+    expect(submitSucceeded).toBe(true);
   });
 
   it('stops the imperative review submission when the submit-review command fails', async () => {
@@ -1401,13 +1403,15 @@ describe('ToolbarEditInfo', () => {
     });
     mockAntdMessage.success.mockClear();
 
+    let submitSucceeded;
     await act(async () => {
-      await ref.current?.submitReview(checkResult.unReview);
+      submitSucceeded = await ref.current?.submitReview(checkResult.unReview);
     });
 
     expect(mockSubmitDatasetReview).toHaveBeenCalled();
     expect(mockAntdMessage.error).toHaveBeenCalledWith('review failed');
     expect(mockAntdMessage.success).not.toHaveBeenCalledWith('Review submitted successfully');
+    expect(submitSucceeded).toBe(false);
   });
 
   it('falls back to the default submit-review error when the command omits a message', async () => {
@@ -1454,12 +1458,14 @@ describe('ToolbarEditInfo', () => {
 
     render(<ToolbarEditInfo ref={ref} {...baseProps} />);
 
+    let submitSucceeded;
     await act(async () => {
-      await ref.current?.submitReview([]);
+      submitSucceeded = await ref.current?.submitReview([]);
     });
 
     expect(mockSubmitDatasetReview).not.toHaveBeenCalled();
     expect(mockAntdMessage.error).toHaveBeenCalledWith('Submit review failed');
+    expect(submitSucceeded).toBe(false);
   });
 
   it('surfaces process-instance validation issues separately from tab-level errors', async () => {

--- a/tests/unit/pages/Processes/Components/edit.test.tsx
+++ b/tests/unit/pages/Processes/Components/edit.test.tsx
@@ -1422,6 +1422,34 @@ describe('ProcessEdit component', () => {
     expect(mockAntdMessage.success).toHaveBeenCalledWith('Review submitted successfully');
   });
 
+  it('does not reload or close while the review request is pending', async () => {
+    let resolveSubmit!: (value: unknown) => void;
+    const pendingSubmit = new Promise((resolve) => {
+      resolveSubmit = resolve;
+    });
+    mockSubmitDatasetReview.mockReturnValueOnce(pendingSubmit);
+
+    render(<ProcessEdit {...baseProps} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    await screen.findByRole('dialog', { name: 'Edit process' });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit for Review' }));
+
+    await waitFor(() => expect(mockSubmitDatasetReview).toHaveBeenCalled());
+    expect(actionRef.current.reload).not.toHaveBeenCalled();
+    expect(screen.getByTestId('spin')).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Edit process' })).toBeInTheDocument();
+    expect(setViewDrawerVisible).not.toHaveBeenCalledWith(false);
+
+    await act(async () => {
+      resolveSubmit({ data: [{ review: { id: 'review-1' } }], error: null });
+      await pendingSubmit;
+    });
+
+    await waitFor(() => expect(actionRef.current.reload).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole('dialog', { name: 'Edit process' })).not.toBeInTheDocument();
+  });
+
   it('blocks review submission when the recursive reference chain contains a missing reference', async () => {
     const missingRef = {
       '@refObjectId': 'missing-flow',
@@ -2453,7 +2481,7 @@ describe('ProcessEdit component', () => {
       expect(mockSubmitDatasetReview).toHaveBeenCalledWith('processes', 'process-1', '1.0.0'),
     );
     expect(mockAntdMessage.success).toHaveBeenCalledWith('Review submitted successfully');
-    expect(actionRef.current.reload).toHaveBeenCalledTimes(2);
+    expect(actionRef.current.reload).toHaveBeenCalledTimes(1);
     expect(setViewDrawerVisible).toHaveBeenCalledWith(false);
   });
 });

--- a/tests/unit/services/lifeCycleModels/data.test.ts
+++ b/tests/unit/services/lifeCycleModels/data.test.ts
@@ -91,6 +91,7 @@ describe('lifeCycleModels data shapes', () => {
     const handle: LifeCycleModelToolbarEditInfoHandle<string> = {
       submitReview: async (unReview) => {
         expect(unReview).toEqual(['ref-1']);
+        return true;
       },
       handleCheckData: async () => checkResult,
       updateReferenceDescription: async (formData) => {
@@ -101,7 +102,7 @@ describe('lifeCycleModels data shapes', () => {
     expect(submodel.type).toBe('secondary');
     expect(target.targetAmount).toBe('5');
     await expect(handle.handleCheckData('review', [], [])).resolves.toEqual(checkResult);
-    await expect(handle.submitReview(['ref-1'])).resolves.toBeUndefined();
+    await expect(handle.submitReview(['ref-1'])).resolves.toBe(true);
     await expect(handle.updateReferenceDescription({ id: 'model-1' })).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Branch Contract

- base branch: `dev`
- validated environment: local Node.js `24.19.0` / pnpm `11.24.0`; no live Supabase environment
- back-merge required after merge: No
- root workspace integration expected: Yes, after this routine `dev` delivery is promoted to an eligible `main` commit

- [x] this PR targets `dev`
- [x] the work is based on `origin/dev`

## Linked Issue

Closes #1000

## Change Facts

- Keep Process review pre-save from reloading its list and unmounting the active edit drawer.
- Propagate pending review state from the shared review button to Flow, Source, Contact, Flow Property, and Unit Group drawers.
- Keep dataset drawers busy and close-disabled throughout save, validation, and review submission; reload and close only after success.
- Make Lifecycle Model review submission return an explicit success result so failed submissions do not close the outer drawer.
- Add focused pending/failure regression tests and document the stable drawer lifecycle contract.

## Validation Facts

- `pnpm test:ci tests/unit/services/lifeCycleModels/data.test.ts tests/unit/pages/LifeCycleModels/Components/edit.test.tsx tests/unit/pages/LifeCycleModels/Components/toolbar/editIndex.test.tsx tests/unit/pages/LifeCycleModels/Components/toolbar/eidtInfo.test.tsx tests/unit/components/DatasetSubmitReviewButton.test.tsx tests/unit/pages/Processes/Components/edit.test.tsx tests/unit/pages/Flows/Components/edit.test.tsx tests/unit/pages/Sources/SourceEdit.test.tsx tests/unit/pages/Contacts/ContactEdit.test.tsx tests/unit/pages/Unitgroups/Components/edit.test.tsx --runInBand --no-coverage --watchman=false` — 10 suites, 329 tests passed.
- `pnpm lint` — passed.
- `pnpm build` — passed.
- Docpact lint/config validation — passed with zero findings and zero uncovered paths.
- `pnpm push:checked fork feature/issue-1000` ran. Docpact, LCIA cache, reference-data, lint/type, coverage assertion, and push stages returned success.
- The managed push's full Jest invocation hit a local Watchman/ICU 74 dynamic-link error and produced only a one-file coverage projection despite exiting successfully. It is not claimed as complete-suite evidence; remote clean-runner CI must provide that proof.
- Browser E2E: not run; this change does not alter the localization/browser trust boundary.
- Required proof in another repository: none for repository review; later workspace integration requires an eligible promoted Next `main` commit.

## Risks And Follow-Up

- Review requests now intentionally disable drawer close actions until the command settles.
- Backend review command shape and database workflow are unchanged.
- Existing test-mock React warnings remain non-failing and are unrelated to this change.
- Root submodule integration remains pending after repository delivery and promotion.
