### PR TITLE
chore: prepare v0.0.97 on dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-09-02'
-lastReviewedCommit: '3b3b9e0caa0dd3784171e1176910935b9d8cb499'
+lastReviewedAt: "2026-09-02"
+lastReviewedCommit: "f9ccdce9f18212c442d42416e60e4b1cc7c4ea69"
 lastReviewedNote: 'Reviewed for Next #1008: existing data-boundary, generated Edge mirror, service and test routes cover exact-version Hybrid consumption; no ownership, routing, baseline or waiver rule was changed.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-09-02
-lastReviewedCommit: 3b3b9e0caa0dd3784171e1176910935b9d8cb499
+lastReviewedCommit: f9ccdce9f18212c442d42416e60e4b1cc7c4ea69
 lastReviewedNote: 'Reviewed for Next #1008: exact-version Hybrid consumption and its source-pinned online-backend exception remain within existing service, generated-mirror and controlled-push boundaries; no new ownership or workflow authority is introduced.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/build.yml
   - .nvmrc
 lastReviewedAt: 2026-09-02
-lastReviewedCommit: 3b3b9e0caa0dd3784171e1176910935b9d8cb499
+lastReviewedCommit: f9ccdce9f18212c442d42416e60e4b1cc7c4ea69
 lastReviewedNote: 'Reviewed for Next #1008: exact-version Hybrid consumption and its source-pinned online-backend exception remain within existing service, generated-mirror and controlled-push boundaries; no new ownership or workflow authority is introduced.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -43,7 +43,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-09-02
-lastReviewedCommit: 3b3b9e0caa0dd3784171e1176910935b9d8cb499
+lastReviewedCommit: f9ccdce9f18212c442d42416e60e4b1cc7c4ea69
 lastReviewedNote: 'Reviewed for Next #1008: focused iteration and generated-mirror checkpoints preserve the existing one-full-gate-after-final-commit policy; no hook bypass or gate change was introduced.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -44,7 +44,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-09-02
-lastReviewedCommit: 3b3b9e0caa0dd3784171e1176910935b9d8cb499
+lastReviewedCommit: f9ccdce9f18212c442d42416e60e4b1cc7c4ea69
 lastReviewedNote: 'Reviewed for Next #1008: exact-version, malformed acknowledgement, empty-result paging, display fallback and generated-mirror proof are recorded; final full qualification remains owned by the controlled push hook.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -44,7 +44,7 @@ checkPaths:
   - pnpm-workspace.yaml
   - Dockerfile.app
 lastReviewedAt: 2026-09-02
-lastReviewedCommit: 3b3b9e0caa0dd3784171e1176910935b9d8cb499
+lastReviewedCommit: f9ccdce9f18212c442d42416e60e4b1cc7c4ea69
 lastReviewedNote: 'Reviewed for Next #1008: version identity and acknowledgement cases use the maintained service-first strategy; no new testing platform or long-running observation was introduced.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -41,7 +41,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-09-02
-lastReviewedCommit: 3b3b9e0caa0dd3784171e1176910935b9d8cb499
+lastReviewedCommit: f9ccdce9f18212c442d42416e60e4b1cc7c4ea69
 lastReviewedNote: 'Reviewed for Next #1008: targeted matched-version and empty-page regressions are covered, with the final full push gate kept separate from the historical checked-in reference baseline.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-09-02
-lastReviewedCommit: 3b3b9e0caa0dd3784171e1176910935b9d8cb499
+lastReviewedCommit: f9ccdce9f18212c442d42416e60e4b1cc7c4ea69
 lastReviewedNote: 'Reviewed for Next #1008: exact id/version and acknowledged-empty fixtures reuse existing typed service mocks and controlled focused coverage patterns.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -40,7 +40,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-09-02
-lastReviewedCommit: 3b3b9e0caa0dd3784171e1176910935b9d8cb499
+lastReviewedCommit: f9ccdce9f18212c442d42416e60e4b1cc7c4ea69
 lastReviewedNote: 'Reviewed for Next #1008: malformed acknowledgements, mapping fallbacks and uncovered empty-result branches follow the existing focused-test recovery workflow.'
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.96",
+  "version": "0.0.97",
   "packageManager": "pnpm@11.24.0",
   "private": true,
   "description": "An out-of-box LCA Data solution",


### PR DESCRIPTION
<!-- tiangong-next-release-automation:v2 issue=1008 version=0.0.97 dev-base=f9ccdce9f18212c442d42416e60e4b1cc7c4ea69 main-base=fa57e46d4c407a23cb79347957ee55dfc496c51e candidate=6aa7af9fa162900e4cf3a172cc976ff8fa4cef96 -->

## Branch Contract

- base branch: `dev`
- validated environment: exact dev Release PR non-browser gate
- back-merge required after merge: No
- root workspace integration expected: after later dev-to-main promotion

## Linked Issue

Refs #1008

## Change Facts

- Prepare version `0.0.97` from exact dev base `f9ccdce9f18212c442d42416e60e4b1cc7c4ea69`.
- Change only package.json.version and keep pnpm-lock.yaml byte-for-byte unchanged.
- Keep release proof external to Git and bind it to the exact main/dev bases, candidate SHA/tree, version, workflow run, and artifact.
- Record Docpact review evidence only after the command proves the candidate has no other semantic change.
- Reviewed paths:
  - `.docpact/config.yaml`
  - `AGENTS.md`
  - `DEV.md`
  - `docs/agents/prepush-gate-policy.md`
  - `docs/agents/repo-validation.md`
  - `docs/agents/test_improvement_plan.md`
  - `docs/agents/test_todo_list.md`
  - `docs/agents/testing-patterns.md`
  - `docs/agents/testing-troubleshooting.md`

## Validation Facts

- Candidate: `6aa7af9fa162900e4cf3a172cc976ff8fa4cef96`
- Main baseline: `fa57e46d4c407a23cb79347957ee55dfc496c51e`
- Release gate: `required_by_dev_release_candidate_gate`; static preflight: `passed`
- Docpact automatic-review status: `completed`
- Docpact checked the complete main-to-candidate promotion range before the dev PR was created.
- The managed candidate push ran only structural/static checks; this PR owns one non-browser full release gate and its exact proof.
- Browser E2E is not evaluated or required by this PR. Run the manual hermetic workflow on the open business PR before release-to-dev when the change risk warrants browser evidence.

## Risks And Follow-Up

- Merge only after the exact Release Candidate release proof succeeds, then run the deterministic dev-to-main promotion command with this PR number.
