### PR TITLE
fix(ui): align Account and Team sizing, spacing and theme styles

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-09-03"
-lastReviewedCommit: "821c671cdf41dbd54e338525fec511ad97ab317a"
-lastReviewedNote: 'Reviewed for Next #1015: scoped Account and OAuth card styling remains covered by existing frontend and OAuth routes; no ownership, routing, baseline or waiver rule changed. Reconciled with dev 821c671c: upstream #1014 process-only dashboard, v5 daily activity and architecture text are preserved; locale artifacts are regenerated for the combined source.'
+lastReviewedAt: '2026-09-03'
+lastReviewedCommit: '0cfd00b890fb998ba7f43859bfb424617b5ecb90'
+lastReviewedNote: 'Reviewed for Next #1020: Account and Team information surfaces now use Ant Design theme-default typography, control sizing and spacing, while content panels size naturally; no ownership, routing, baseline or waiver rule changed.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,8 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: 821c671cdf41dbd54e338525fec511ad97ab317a
-lastReviewedNote: 'Reviewed for Next #1015: 8px main cards and scoped page backgrounds preserve existing frontend ownership, authorization and dev delivery boundaries; temporary mock code is absent. Reconciled with dev 821c671c: upstream #1014 process-only dashboard, v5 daily activity and architecture text are preserved; locale artifacts are regenerated for the combined source.'
+lastReviewedCommit: 0cfd00b890fb998ba7f43859bfb424617b5ecb90
+lastReviewedNote: 'Reviewed for Next #1020: Account and Team theme-default UI sizing remains page-local and preserves authorization, data behavior and dev delivery boundaries.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -43,8 +43,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .nvmrc
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: 821c671cdf41dbd54e338525fec511ad97ab317a
-lastReviewedNote: 'Reviewed for Next #1015: scoped Account/OAuth styling uses the existing local bootstrap, focused validation and controlled dev push workflow without new preview or environment switches. Reconciled with dev 821c671c: upstream #1014 process-only dashboard, v5 daily activity and architecture text are preserved; locale artifacts are regenerated for the combined source.'
+lastReviewedCommit: 0cfd00b890fb998ba7f43859bfb424617b5ecb90
+lastReviewedNote: 'Reviewed for Next #1020: Account and Team theme-default sizing uses the existing local bootstrap, focused validation and controlled dev workflow without new preview or environment switches.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/data_audit_instruction.md
+++ b/docs/agents/data_audit_instruction.md
@@ -18,9 +18,9 @@ checkPaths:
   - docs/agents/data_audit_instruction.md
   - src/pages/Review/**
   - src/pages/ManageSystem/**
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 25d257d72593740432b7b051e8a52b8d476b028d
-lastReviewedNote: 'Reviewed for Next Issue #982: the team-page browser-navigation test boundary does not change submission admission, Review Admin diagnostics, or review-state transitions.'
+lastReviewedAt: 2026-09-03
+lastReviewedCommit: 0cfd00b890fb998ba7f43859bfb424617b5ecb90
+lastReviewedNote: 'Reviewed for Next #1020: Team information spacing and component-size cleanup does not change submission admission, Review Admin diagnostics or review-state transitions.'
 ---
 
 # Audit Status Reference

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -43,8 +43,8 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: 821c671cdf41dbd54e338525fec511ad97ab317a
-lastReviewedNote: 'Reviewed for Next #1015: stale locale artifacts discovered by the full gate are regenerated before the final checked push; gate scope, thresholds and bypass policy remain unchanged. Reconciled with dev 821c671c: upstream #1014 process-only dashboard, v5 daily activity and architecture text are preserved; locale artifacts are regenerated for the combined source.'
+lastReviewedCommit: 0cfd00b890fb998ba7f43859bfb424617b5ecb90
+lastReviewedNote: 'Reviewed for Next #1020: generated locale artifacts were refreshed for Account callsite movement; pre-push scope, thresholds and bypass policy remain unchanged.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - config/docs-capture/**
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: 821c671cdf41dbd54e338525fec511ad97ab317a
-lastReviewedNote: 'Reviewed for Next #1015: page-local card radii and backgrounds preserve the Account/OAuth component-service boundary, existing theme ownership and real authorization flow. Reconciled with dev 821c671c: upstream #1014 process-only dashboard, v5 daily activity and architecture text are preserved; locale artifacts are regenerated for the combined source.'
+lastReviewedCommit: 0cfd00b890fb998ba7f43859bfb424617b5ecb90
+lastReviewedNote: 'Reviewed for Next #1020: page-local Account and Team sizing cleanup preserves component-service boundaries, theme ownership and existing authorization flows.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -44,8 +44,8 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: 821c671cdf41dbd54e338525fec511ad97ab317a
-lastReviewedNote: 'Reviewed for Next #1015: existing frontend proof requirements cover the scoped card styling; focused regression and rendered-style checks supplement, not replace, the controlled push gate. Reconciled with dev 821c671c: upstream #1014 process-only dashboard, v5 daily activity and architecture text are preserved; locale artifacts are regenerated for the combined source.'
+lastReviewedCommit: 0cfd00b890fb998ba7f43859bfb424617b5ecb90
+lastReviewedNote: 'Reviewed for Next #1020: focused Account and Team regression tests, computed-style inspection, locale checks and production build cover the theme-default UI sizing change; controlled push-gate policy is unchanged.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -23,8 +23,8 @@ checkPaths:
   - playwright.config.ts
   - tests/e2e/i18n/**
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: 821c671cdf41dbd54e338525fec511ad97ab317a
-lastReviewedNote: 'Reviewed for Next #1015: card styling changes no Supabase client, environment selection, session check, authorization decision or callback behavior; temporary preview data is removed. Reconciled with dev 821c671c: upstream #1014 process-only dashboard, v5 daily activity and architecture text are preserved; locale artifacts are regenerated for the combined source.'
+lastReviewedCommit: 0cfd00b890fb998ba7f43859bfb424617b5ecb90
+lastReviewedNote: 'Reviewed for Next #1020: the temporary connected-app preview and fixtures are removed at the user request. List and disconnect always use the existing shared OAuth services, including when obsolete preview parameters remain in the URL; UI styling and authorization boundaries are unchanged.'
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/team_management.md
+++ b/docs/agents/team_management.md
@@ -19,9 +19,9 @@ checkPaths:
   - src/pages/Teams/**
   - src/pages/Review/**
   - src/pages/ManageSystem/**
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 25d257d72593740432b7b051e8a52b8d476b028d
-lastReviewedNote: 'Reviewed for Next Issue #982: explicit team-create reload testing does not change role authority, team membership, or the Review Admin-only quality diagnostic.'
+lastReviewedAt: 2026-09-03
+lastReviewedCommit: 0cfd00b890fb998ba7f43859bfb424617b5ecb90
+lastReviewedNote: 'Reviewed for Next #1020: Team information form styling now follows theme defaults without changing role authority, membership behavior or Review Admin diagnostics.'
 ---
 
 # Team Management Reference

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -44,8 +44,8 @@ checkPaths:
   - pnpm-workspace.yaml
   - Dockerfile.app
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: 821c671cdf41dbd54e338525fec511ad97ab317a
-lastReviewedNote: 'Reviewed for Next #1015: deterministic locale artifact refresh supports the existing UI regression and full-coverage strategy without new test infrastructure or business behavior. Reconciled with dev 821c671c: upstream #1014 process-only dashboard, v5 daily activity and architecture text are preserved; locale artifacts are regenerated for the combined source.'
+lastReviewedCommit: 0cfd00b890fb998ba7f43859bfb424617b5ecb90
+lastReviewedNote: 'Reviewed for Next #1020: the existing focused Account and Team coverage protects the UI-only default-sizing change without new test infrastructure or strategy changes.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -41,8 +41,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: 821c671cdf41dbd54e338525fec511ad97ab317a
-lastReviewedNote: 'Reviewed for Next #1015: locale artifact drift caused by the Account className is repaired through canonical generators; current run evidence stays in the Issue and does not rewrite the historical baseline. Reconciled with dev 821c671c: upstream #1014 process-only dashboard, v5 daily activity and architecture text are preserved; locale artifacts are regenerated for the combined source.'
+lastReviewedCommit: 0cfd00b890fb998ba7f43859bfb424617b5ecb90
+lastReviewedNote: 'Reviewed for Next #1020: focused Account and Team suites remain green after removing custom component sizing; no coverage queue or historical baseline update is required.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -43,8 +43,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: 821c671cdf41dbd54e338525fec511ad97ab317a
-lastReviewedNote: 'Reviewed for Next #1015: existing locale audit and artifact-idempotence tests cover regenerated source bindings; catalog messages, runtime fixtures and test assertions are unchanged. Reconciled with dev 821c671c: upstream #1014 process-only dashboard, v5 daily activity and architecture text are preserved; locale artifacts are regenerated for the combined source.'
+lastReviewedCommit: 0cfd00b890fb998ba7f43859bfb424617b5ecb90
+lastReviewedNote: 'Reviewed for Next #1020: the Account unit assertion now verifies the absence of a custom progress width, while existing component and integration patterns remain sufficient.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -40,8 +40,8 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: 821c671cdf41dbd54e338525fec511ad97ab317a
-lastReviewedNote: 'Reviewed for Next #1015: diagnosed stale locale digests and callsite locations are regenerated rather than weakening tests, coverage or pre-push enforcement. Reconciled with dev 821c671c: upstream #1014 process-only dashboard, v5 daily activity and architecture text are preserved; locale artifacts are regenerated for the combined source.'
+lastReviewedCommit: 0cfd00b890fb998ba7f43859bfb424617b5ecb90
+lastReviewedNote: 'Reviewed for Next #1020: the obsolete 52px progress-width expectation was updated to the intended theme-default contract; troubleshooting and gate recovery guidance remain unchanged.'
 ---
 
 # Testing Troubleshooting

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "108ab63eafb5d8b55349940d5f282e38f5eafa44468d5bf5f12c0496267adefc",
-    "auditedInputDigest": "9faebb324eab9ea2b00907d24611f94546114f71160b9d695d234c13a7e9ffe8"
+    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b",
+    "auditedInputDigest": "2553f5c8bfcdaac8140a474a888463f4e87aadbd989b35ff3282c27034c827e7"
   },
   "inventory": {
     "sourceMessageCount": 3322,
@@ -47,7 +47,7 @@
     "messageCount": 3322,
     "completeCount": 3322,
     "blockedCount": 0,
-    "dossierDigest": "d8a34669f55ac9ad703a1224733b7addfb410469608ea8443c198efc33fd53c7",
+    "dossierDigest": "47df64f8624aeb8b19bb0223c35c70d3cefcb13b85ac0e6bc68cff1313cb3196",
     "catalogDigest": "c808a402b06edfa7e58af2c3e435a2e6aeb90c161cbf26514a5847d731dfa29e",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -138,7 +138,7 @@
         "focusedVariantCount": 8
       },
       "sourceFileCount": 37,
-      "sourceEvidenceDigest": "e6d6de7e4c4a9f7c3b0c971e651ca6e1cadaab31992224d9f7835c9586811fdc",
+      "sourceEvidenceDigest": "75c5e1d12f84230dc46f1333a5179df137da88b4718bd049f970f7519d930711",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -1094,8 +1094,8 @@
           "route": "/account",
           "viewState": "account-profile",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "692a544626120fed98dc627ecc8f58f5fb01924ea0953a4e90e4b1bba741c783",
-          "focusedTestDigest": "a6833330b12f128470491dc8d400a15299e00215767f78f7a9da79ad15fc98c3",
+          "sourceDigest": "e68c593b9f379b5ee8f55fe8198b0f8c2b5269d3e4baf99df16b6070656cfba1",
+          "focusedTestDigest": "b1a7afe252a0f7d4203cae4bf000815696730272ee0cddab18b900abad3f607a",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "93ce64d1c24a3196fb75191740708109e8c0cf47d24f73a8a13db8ba3f7c08cf",
           "derivedMessageCount": 67,
@@ -1112,8 +1112,8 @@
           "route": "/team",
           "viewState": "team-membership",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "84047bd49988c1ff9e3ea98269120572d4b1c305b349d323c5838d5063428227",
-          "focusedTestDigest": "a222a805d097a243a7f21908f56156de280829bc37be1133e015348a79d74147",
+          "sourceDigest": "be8abe478dda3893cb4649cf9c019eda2e7109ae338a5df6e62761071c8c85ad",
+          "focusedTestDigest": "2b2584899c0ae9f22610f7f7efc51fea32a78cbcf814e8d3879b02e958f07bc8",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "04ae705839eb61ece4611b64026e96a021d3f6d35c0781bfcf2b3e3ea5e1f31b",
           "derivedMessageCount": 43,
@@ -1126,7 +1126,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "4294a6d5067b177730d9bf97d22afbac1698ac15affe69d348b42393e1ff1ef0",
+      "rowEvidenceDigest": "404c3f4ce5f4c164a8d11b6999da96087af5d6a40bdc8096b521aafa63edc2d5",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1150,5 +1150,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "f7e1ef9cd7e8e10bf9115a77c7b4b2696c558aef54102868217ae4c22753a808"
+  "contextDigest": "75edbf353e6c6b80a08ac507592c2534c4e8095217e0cf0a021d72ea3f59a20b"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "108ab63eafb5d8b55349940d5f282e38f5eafa44468d5bf5f12c0496267adefc"
+    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "f7e1ef9cd7e8e10bf9115a77c7b4b2696c558aef54102868217ae4c22753a808",
-    "qualityDigest": "9624bb4319c3a053057fddbd25837b3d0d9d9fafd23e7d52377c753c9d86d453",
+    "contextDigest": "75edbf353e6c6b80a08ac507592c2534c4e8095217e0cf0a021d72ea3f59a20b",
+    "qualityDigest": "538209cfaa7055391051c634f4d952b0cbd4b8d77a4ca4b9a33c758dd930bba3",
     "correctionLedgerDigest": "fcda3136886694c111258daee7f51b6bf0f29e3333ed7e582d7fcc349f0b4c74",
     "routeViewCoverageDigest": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "53baa9418e9224943d7a6178ad7eb57475b933c0b191e6804d41d77c73982f0c"
+  "activationDigest": "cb11b6768b5c72d6d0d246ee99bf8ca550778fb8a34dfe2475e73bd6acccd45a"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "9faebb324eab9ea2b00907d24611f94546114f71160b9d695d234c13a7e9ffe8",
+    "auditedInputDigest": "2553f5c8bfcdaac8140a474a888463f4e87aadbd989b35ff3282c27034c827e7",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -24624,7 +24624,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 809,
+          "line": 802,
           "column": 14,
           "symbol": "Profile",
           "defaultMessage": "Account Profile",
@@ -24645,7 +24645,7 @@
             },
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 809,
+              "line": 802,
               "column": 14,
               "kind": "FormattedMessage"
             }
@@ -24864,7 +24864,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 958,
+          "line": 970,
           "column": 15,
           "symbol": "renderTeamMembersForm",
           "defaultMessage": "My Team",
@@ -24873,7 +24873,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 1050,
+          "line": 1062,
           "column": 27,
           "symbol": "Team",
           "defaultMessage": "My Team",
@@ -24894,13 +24894,13 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 958,
+              "line": 970,
               "column": 15,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 1050,
+              "line": 1062,
               "column": 27,
               "kind": "FormattedMessage"
             }
@@ -36159,7 +36159,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 296,
+          "line": 292,
           "column": 24,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "Reset",
@@ -36168,7 +36168,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 563,
+          "line": 558,
           "column": 26,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "Reset",
@@ -36183,13 +36183,13 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 296,
+              "line": 292,
               "column": 24,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 563,
+              "line": 558,
               "column": 26,
               "kind": "formatMessage"
             }
@@ -36257,7 +36257,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 91,
+          "line": 95,
           "column": 14,
           "symbol": "renderBaseForm",
           "defaultMessage": "Basic Information",
@@ -36266,7 +36266,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 819,
+          "line": 812,
           "column": 22,
           "symbol": "Profile",
           "defaultMessage": "Basic Information",
@@ -36281,13 +36281,13 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 91,
+              "line": 95,
               "column": 14,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 819,
+              "line": 812,
               "column": 22,
               "kind": "formatMessage"
             }
@@ -36355,7 +36355,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 86,
+          "line": 90,
           "column": 9,
           "symbol": "renderBaseForm",
           "defaultMessage": "Complete your profile so teammates can recognize you more easily.",
@@ -36370,7 +36370,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 86,
+              "line": 90,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -36438,7 +36438,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 554,
+          "line": 549,
           "column": 14,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "Change Email",
@@ -36447,7 +36447,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 835,
+          "line": 828,
           "column": 22,
           "symbol": "Profile",
           "defaultMessage": "Change Email",
@@ -36462,13 +36462,13 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 554,
+              "line": 549,
               "column": 14,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 835,
+              "line": 828,
               "column": 22,
               "kind": "formatMessage"
             }
@@ -36536,7 +36536,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 287,
+          "line": 283,
           "column": 9,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "Change Password",
@@ -36545,7 +36545,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 827,
+          "line": 820,
           "column": 22,
           "symbol": "Profile",
           "defaultMessage": "Change Password",
@@ -36560,13 +36560,13 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 287,
+              "line": 283,
               "column": 9,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 827,
+              "line": 820,
               "column": 22,
               "kind": "formatMessage"
             }
@@ -36693,7 +36693,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 666,
+          "line": 660,
           "column": 21,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "Please input the new email again!",
@@ -36708,7 +36708,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 666,
+              "line": 660,
               "column": 21,
               "kind": "FormattedMessage"
             }
@@ -36776,7 +36776,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 498,
+          "line": 493,
           "column": 30,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "Confirm New Password",
@@ -36791,7 +36791,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 498,
+              "line": 493,
               "column": 30,
               "kind": "formatMessage"
             }
@@ -36859,7 +36859,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 473,
+          "line": 468,
           "column": 21,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "Please input the new password again!",
@@ -36874,7 +36874,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 473,
+              "line": 468,
               "column": 21,
               "kind": "FormattedMessage"
             }
@@ -36942,7 +36942,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 335,
+          "line": 331,
           "column": 19,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "Invalid password",
@@ -36957,7 +36957,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 335,
+              "line": 331,
               "column": 19,
               "kind": "formatMessage"
             }
@@ -37025,7 +37025,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 391,
+          "line": 387,
           "column": 30,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "Current Password",
@@ -37040,7 +37040,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 391,
+              "line": 387,
               "column": 30,
               "kind": "formatMessage"
             }
@@ -37108,7 +37108,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 381,
+          "line": 377,
           "column": 21,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "Please input the current password!",
@@ -37123,7 +37123,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 381,
+              "line": 377,
               "column": 21,
               "kind": "FormattedMessage"
             }
@@ -37274,7 +37274,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 131,
+          "line": 133,
           "column": 17,
           "symbol": "renderBaseForm",
           "defaultMessage": "Profile updated successfully.",
@@ -37289,7 +37289,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 131,
+              "line": 133,
               "column": 17,
               "kind": "formatMessage"
             }
@@ -37357,7 +37357,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 587,
+          "line": 582,
           "column": 19,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "Verification email sent successfully! Please update your email via the email link.",
@@ -37372,7 +37372,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 587,
+              "line": 582,
               "column": 19,
               "kind": "formatMessage"
             }
@@ -37440,7 +37440,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 692,
+          "line": 686,
           "column": 30,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "Enter your new email address again",
@@ -37455,7 +37455,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 692,
+              "line": 686,
               "column": 30,
               "kind": "formatMessage"
             }
@@ -37523,7 +37523,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 657,
+          "line": 651,
           "column": 17,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "Confirm New Email",
@@ -37538,7 +37538,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 657,
+              "line": 651,
               "column": 17,
               "kind": "FormattedMessage"
             }
@@ -37606,7 +37606,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 609,
+          "line": 604,
           "column": 17,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "Current Email",
@@ -37621,7 +37621,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 609,
+              "line": 604,
               "column": 17,
               "kind": "FormattedMessage"
             }
@@ -37689,7 +37689,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 702,
+          "line": 696,
           "column": 17,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "You can continue signing in with your current email until verification is complete.",
@@ -37704,7 +37704,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 702,
+              "line": 696,
               "column": 17,
               "kind": "FormattedMessage"
             }
@@ -37772,7 +37772,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 549,
+          "line": 544,
           "column": 9,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "Enter a new email address and verify it to complete the change.",
@@ -37787,7 +37787,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 549,
+              "line": 544,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -37855,7 +37855,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 712,
+          "line": 706,
           "column": 13,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "How it works",
@@ -37870,7 +37870,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 712,
+              "line": 706,
               "column": 13,
               "kind": "FormattedMessage"
             }
@@ -37938,7 +37938,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 627,
+          "line": 621,
           "column": 28,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "Enter your new email address",
@@ -37953,7 +37953,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 627,
+              "line": 621,
               "column": 28,
               "kind": "formatMessage"
             }
@@ -38021,7 +38021,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 749,
+          "line": 743,
           "column": 24,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "Complete change",
@@ -38036,7 +38036,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 749,
+              "line": 743,
               "column": 24,
               "kind": "formatMessage"
             }
@@ -38104,7 +38104,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 753,
+          "line": 747,
           "column": 26,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "Once verified, sign in with your new email",
@@ -38119,7 +38119,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 753,
+              "line": 747,
               "column": 26,
               "kind": "formatMessage"
             }
@@ -38187,7 +38187,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 729,
+          "line": 723,
           "column": 24,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "Enter new email",
@@ -38202,7 +38202,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 729,
+              "line": 723,
               "column": 24,
               "kind": "formatMessage"
             }
@@ -38270,7 +38270,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 733,
+          "line": 727,
           "column": 26,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "Make sure your email address is correct",
@@ -38285,7 +38285,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 733,
+              "line": 727,
               "column": 26,
               "kind": "formatMessage"
             }
@@ -38353,7 +38353,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 739,
+          "line": 733,
           "column": 24,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "Check verification email",
@@ -38368,7 +38368,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 739,
+              "line": 733,
               "column": 24,
               "kind": "formatMessage"
             }
@@ -38436,7 +38436,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 743,
+          "line": 737,
           "column": 26,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "Open your new inbox and follow the verification instructions",
@@ -38451,7 +38451,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 743,
+              "line": 737,
               "column": 26,
               "kind": "formatMessage"
             }
@@ -38519,7 +38519,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 567,
+          "line": 562,
           "column": 27,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "Send verification email",
@@ -38534,7 +38534,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 567,
+              "line": 562,
               "column": 27,
               "kind": "formatMessage"
             }
@@ -38602,7 +38602,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 679,
+          "line": 673,
           "column": 25,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "The two emails that you entered do not match!",
@@ -38617,7 +38617,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 679,
+              "line": 673,
               "column": 25,
               "kind": "formatMessage"
             }
@@ -38768,7 +38768,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 786,
+          "line": 779,
           "column": 13,
           "symbol": "loadCurrentUser",
           "defaultMessage": "An error occurred while loading the account profile.",
@@ -38783,7 +38783,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 786,
+              "line": 779,
               "column": 13,
               "kind": "formatMessage"
             }
@@ -38851,7 +38851,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 622,
+          "line": 617,
           "column": 22,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "New Email",
@@ -38866,7 +38866,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 622,
+              "line": 617,
               "column": 22,
               "kind": "FormattedMessage"
             }
@@ -38993,7 +38993,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 644,
+          "line": 638,
           "column": 21,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "Please input the new email!",
@@ -39008,7 +39008,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 644,
+              "line": 638,
               "column": 21,
               "kind": "FormattedMessage"
             }
@@ -39076,7 +39076,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 635,
+          "line": 629,
           "column": 21,
           "symbol": "renderChangeEmailForm",
           "defaultMessage": "The email format is incorrect!",
@@ -39091,7 +39091,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 635,
+              "line": 629,
               "column": 21,
               "kind": "FormattedMessage"
             }
@@ -39159,7 +39159,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 410,
+          "line": 405,
           "column": 28,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "New Password",
@@ -39174,7 +39174,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 410,
+              "line": 405,
               "column": 28,
               "kind": "formatMessage"
             }
@@ -39242,7 +39242,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 418,
+          "line": 413,
           "column": 21,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "Please input the new password!",
@@ -39257,7 +39257,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 418,
+              "line": 413,
               "column": 21,
               "kind": "FormattedMessage"
             }
@@ -39325,7 +39325,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 440,
+          "line": 435,
           "column": 27,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "New password should be different from the current password.",
@@ -39340,7 +39340,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 440,
+              "line": 435,
               "column": 27,
               "kind": "formatMessage"
             }
@@ -39644,7 +39644,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 428,
+          "line": 423,
           "column": 21,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "Password is invalid!",
@@ -39659,7 +39659,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 428,
+              "line": 423,
               "column": 21,
               "kind": "FormattedMessage"
             }
@@ -41527,7 +41527,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 843,
+          "line": 836,
           "column": 22,
           "symbol": "Profile",
           "defaultMessage": "Connected apps",
@@ -41542,7 +41542,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 843,
+              "line": 836,
               "column": 22,
               "kind": "formatMessage"
             }
@@ -41669,7 +41669,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 346,
+          "line": 342,
           "column": 15,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "A system error occurred while changing the password. Please try again later.",
@@ -41684,7 +41684,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 346,
+              "line": 342,
               "column": 15,
               "kind": "formatMessage"
             }
@@ -41752,7 +41752,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 320,
+          "line": 316,
           "column": 17,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "Password changed successfully!",
@@ -41767,7 +41767,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 320,
+              "line": 316,
               "column": 17,
               "kind": "formatMessage"
             }
@@ -41835,7 +41835,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 464,
+          "line": 459,
           "column": 17,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "Confirm New Password",
@@ -41850,7 +41850,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 464,
+              "line": 459,
               "column": 17,
               "kind": "FormattedMessage"
             }
@@ -41918,7 +41918,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 366,
+          "line": 362,
           "column": 17,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "Current Password",
@@ -41933,7 +41933,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 366,
+              "line": 362,
               "column": 17,
               "kind": "FormattedMessage"
             }
@@ -42001,7 +42001,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 372,
+          "line": 368,
           "column": 17,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "Please enter your current account password to verify your identity.",
@@ -42016,7 +42016,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 372,
+              "line": 368,
               "column": 17,
               "kind": "FormattedMessage"
             }
@@ -42084,7 +42084,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 281,
+          "line": 277,
           "column": 9,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "Set a secure, memorable new password for your account.",
@@ -42099,7 +42099,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 281,
+              "line": 277,
               "column": 9,
               "kind": "FormattedMessage"
             }
@@ -42167,7 +42167,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 519,
+          "line": 514,
           "column": 17,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "At least 8 characters",
@@ -42182,7 +42182,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 519,
+              "line": 514,
               "column": 17,
               "kind": "FormattedMessage"
             }
@@ -42250,7 +42250,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 526,
+          "line": 521,
           "column": 17,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "Include uppercase and lowercase letters",
@@ -42265,7 +42265,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 526,
+              "line": 521,
               "column": 17,
               "kind": "FormattedMessage"
             }
@@ -42333,7 +42333,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 533,
+          "line": 528,
           "column": 17,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "Include numbers and symbols",
@@ -42348,7 +42348,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 533,
+              "line": 528,
               "column": 17,
               "kind": "FormattedMessage"
             }
@@ -42475,7 +42475,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 510,
+          "line": 505,
           "column": 17,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "Password tips",
@@ -42490,7 +42490,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 510,
+              "line": 505,
               "column": 17,
               "kind": "FormattedMessage"
             }
@@ -42558,7 +42558,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 401,
+          "line": 397,
           "column": 17,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "New Password",
@@ -42573,7 +42573,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 401,
+              "line": 397,
               "column": 17,
               "kind": "FormattedMessage"
             }
@@ -42700,7 +42700,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 241,
+          "line": 243,
           "column": 18,
           "symbol": "getStatus",
           "defaultMessage": "Medium",
@@ -42715,7 +42715,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 241,
+              "line": 243,
               "column": 18,
               "kind": "formatMessage"
             }
@@ -42783,7 +42783,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 231,
+          "line": 233,
           "column": 18,
           "symbol": "getStatus",
           "defaultMessage": "Strong",
@@ -42798,7 +42798,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 231,
+              "line": 233,
               "column": 18,
               "kind": "formatMessage"
             }
@@ -42866,7 +42866,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 250,
+          "line": 252,
           "column": 16,
           "symbol": "getStatus",
           "defaultMessage": "Weak",
@@ -42881,7 +42881,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 250,
+              "line": 252,
               "column": 16,
               "kind": "formatMessage"
             }
@@ -42949,7 +42949,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 261,
+          "line": 263,
           "column": 11,
           "symbol": "renderPasswordStrength",
           "defaultMessage": "Password strength",
@@ -42964,7 +42964,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 261,
+              "line": 263,
               "column": 11,
               "kind": "FormattedMessage"
             }
@@ -43032,7 +43032,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 300,
+          "line": 296,
           "column": 25,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "Update password",
@@ -43047,7 +43047,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 300,
+              "line": 296,
               "column": 25,
               "kind": "formatMessage"
             }
@@ -43115,7 +43115,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 486,
+          "line": 481,
           "column": 25,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "The two passwords that you entered do not match!",
@@ -43130,7 +43130,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 486,
+              "line": 481,
               "column": 25,
               "kind": "formatMessage"
             }
@@ -43198,7 +43198,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 161,
+          "line": 163,
           "column": 20,
           "symbol": "renderBaseForm",
           "defaultMessage": "Email",
@@ -43222,7 +43222,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 161,
+              "line": 163,
               "column": 20,
               "kind": "FormattedMessage"
             },
@@ -43296,7 +43296,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 75,
+          "line": 79,
           "column": 5,
           "symbol": "profileName",
           "defaultMessage": "TianGong user",
@@ -43311,7 +43311,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 75,
+              "line": 79,
               "column": 5,
               "kind": "formatMessage"
             }
@@ -43379,7 +43379,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 174,
+          "line": 176,
           "column": 15,
           "symbol": "renderBaseForm",
           "defaultMessage": "Nickname",
@@ -43403,7 +43403,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 174,
+              "line": 176,
               "column": 15,
               "kind": "FormattedMessage"
             },
@@ -43536,7 +43536,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 178,
+          "line": 180,
           "column": 15,
           "symbol": "renderBaseForm",
           "defaultMessage": "The name you prefer to be called",
@@ -43551,7 +43551,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 178,
+              "line": 180,
               "column": 15,
               "kind": "FormattedMessage"
             }
@@ -43619,7 +43619,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 188,
+          "line": 190,
           "column": 15,
           "symbol": "renderBaseForm",
           "defaultMessage": "Organization",
@@ -43634,7 +43634,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 188,
+              "line": 190,
               "column": 15,
               "kind": "FormattedMessage"
             }
@@ -43702,7 +43702,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 204,
+          "line": 206,
           "column": 19,
           "symbol": "renderBaseForm",
           "defaultMessage": "Organization must not exceed 200 characters",
@@ -43717,7 +43717,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 204,
+              "line": 206,
               "column": 19,
               "kind": "FormattedMessage"
             }
@@ -43785,7 +43785,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 215,
+          "line": 217,
           "column": 28,
           "symbol": "renderBaseForm",
           "defaultMessage": "Enter your organization",
@@ -43800,7 +43800,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 215,
+              "line": 217,
               "column": 28,
               "kind": "formatMessage"
             }
@@ -43868,7 +43868,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 195,
+          "line": 197,
           "column": 15,
           "symbol": "renderBaseForm",
           "defaultMessage": "The organization or institution you belong to",
@@ -43883,7 +43883,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 195,
+              "line": 197,
               "column": 15,
               "kind": "FormattedMessage"
             }
@@ -43951,7 +43951,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 167,
+          "line": 169,
           "column": 20,
           "symbol": "renderBaseForm",
           "defaultMessage": "Role",
@@ -43966,7 +43966,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 167,
+              "line": 169,
               "column": 20,
               "kind": "FormattedMessage"
             }
@@ -44176,7 +44176,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 113,
+          "line": 115,
           "column": 25,
           "symbol": "renderBaseForm",
           "defaultMessage": "Save changes",
@@ -44191,7 +44191,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 113,
+              "line": 115,
               "column": 25,
               "kind": "formatMessage"
             }
@@ -44519,7 +44519,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 149,
+          "line": 151,
           "column": 15,
           "symbol": "renderBaseForm",
           "defaultMessage": "An error occurred while updating the profile.",
@@ -44534,7 +44534,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 149,
+              "line": 151,
               "column": 15,
               "kind": "formatMessage"
             }
@@ -44602,7 +44602,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Account/index.tsx",
-          "line": 328,
+          "line": 324,
           "column": 19,
           "symbol": "renderChangePasswordForm",
           "defaultMessage": "User not found",
@@ -44617,7 +44617,7 @@
           "locations": [
             {
               "path": "src/pages/Account/index.tsx",
-              "line": 328,
+              "line": 324,
               "column": 19,
               "kind": "formatMessage"
             }
@@ -247601,7 +247601,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 263,
+          "line": 275,
           "column": 11,
           "symbol": "createTeamInfo",
           "defaultMessage": "Team created successfully.",
@@ -247616,7 +247616,7 @@
           "locations": [
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 263,
+              "line": 275,
               "column": 11,
               "kind": "formatMessage"
             }
@@ -247684,7 +247684,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 232,
+          "line": 244,
           "column": 11,
           "symbol": "editTeamInfo",
           "defaultMessage": "Team updated successfully.",
@@ -247699,7 +247699,7 @@
           "locations": [
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 232,
+              "line": 244,
               "column": 11,
               "kind": "formatMessage"
             }
@@ -247767,7 +247767,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 107,
+          "line": 119,
           "column": 9,
           "symbol": "getTeamInfo",
           "defaultMessage": "Failed to get details, please refresh!",
@@ -247782,7 +247782,7 @@
           "locations": [
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 107,
+              "line": 119,
               "column": 9,
               "kind": "formatMessage"
             }
@@ -247868,7 +247868,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 666,
+          "line": 678,
           "column": 19,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": "Dark Logo",
@@ -247895,7 +247895,7 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 666,
+              "line": 678,
               "column": 19,
               "kind": "FormattedMessage"
             }
@@ -247963,7 +247963,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 672,
+          "line": 684,
           "column": 23,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": "Please upload dark logo!",
@@ -247972,7 +247972,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 682,
+          "line": 694,
           "column": 21,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": "Please upload dark logo!",
@@ -247987,13 +247987,13 @@
           "locations": [
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 672,
+              "line": 684,
               "column": 23,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 682,
+              "line": 694,
               "column": 21,
               "kind": "FormattedMessage"
             }
@@ -248070,7 +248070,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 465,
+          "line": 477,
           "column": 25,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": "Team Description",
@@ -248079,7 +248079,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 478,
+          "line": 490,
           "column": 23,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": "Team Description",
@@ -248100,13 +248100,13 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 465,
+              "line": 477,
               "column": 25,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 478,
+              "line": 490,
               "column": 23,
               "kind": "FormattedMessage"
             }
@@ -248174,7 +248174,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 487,
+          "line": 499,
           "column": 27,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": "Please input team description!",
@@ -248189,7 +248189,7 @@
           "locations": [
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 487,
+              "line": 499,
               "column": 27,
               "kind": "FormattedMessage"
             }
@@ -248275,7 +248275,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 580,
+          "line": 592,
           "column": 19,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": "Light Logo",
@@ -248302,7 +248302,7 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 580,
+              "line": 592,
               "column": 19,
               "kind": "FormattedMessage"
             }
@@ -248370,7 +248370,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 586,
+          "line": 598,
           "column": 23,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": "Please upload light logo!",
@@ -248379,7 +248379,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 596,
+          "line": 608,
           "column": 21,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": "Please upload light logo!",
@@ -248394,13 +248394,13 @@
           "locations": [
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 586,
+              "line": 598,
               "column": 23,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 596,
+              "line": 608,
               "column": 21,
               "kind": "FormattedMessage"
             }
@@ -248468,7 +248468,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 757,
+          "line": 769,
           "column": 15,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": "Transparent PNG or SVG is recommended for the best display effect.",
@@ -248483,7 +248483,7 @@
           "locations": [
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 757,
+              "line": 769,
               "column": 15,
               "kind": "FormattedMessage"
             }
@@ -248569,7 +248569,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 514,
+          "line": 526,
           "column": 21,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": "Public team information",
@@ -248596,7 +248596,7 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 514,
+              "line": 526,
               "column": 21,
               "kind": "FormattedMessage"
             }
@@ -248664,7 +248664,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 518,
+          "line": 530,
           "column": 37,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": null,
@@ -248733,7 +248733,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 422,
+          "line": 434,
           "column": 15,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": "Basic Information",
@@ -248748,7 +248748,7 @@
           "locations": [
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 422,
+              "line": 434,
               "column": 15,
               "kind": "FormattedMessage"
             }
@@ -248816,7 +248816,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 573,
+          "line": 585,
           "column": 15,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": "Team Logo",
@@ -248831,7 +248831,7 @@
           "locations": [
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 573,
+              "line": 585,
               "column": 15,
               "kind": "FormattedMessage"
             }
@@ -248899,7 +248899,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 503,
+          "line": 515,
           "column": 15,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": "Team visibility and display",
@@ -248914,7 +248914,7 @@
           "locations": [
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 503,
+              "line": 515,
               "column": 15,
               "kind": "FormattedMessage"
             }
@@ -248982,7 +248982,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 537,
+          "line": 549,
           "column": 21,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": "Apply to display on the homepage",
@@ -248997,7 +248997,7 @@
           "locations": [
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 537,
+              "line": 549,
               "column": 21,
               "kind": "FormattedMessage"
             }
@@ -249065,7 +249065,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 542,
+          "line": 554,
           "column": 30,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": null,
@@ -249143,7 +249143,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 434,
+          "line": 446,
           "column": 25,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": "Team Name",
@@ -249152,7 +249152,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 444,
+          "line": 456,
           "column": 23,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": "Team Name",
@@ -249173,13 +249173,13 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 434,
+              "line": 446,
               "column": 25,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 444,
+              "line": 456,
               "column": 23,
               "kind": "FormattedMessage"
             }
@@ -249247,7 +249247,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 450,
+          "line": 462,
           "column": 27,
           "symbol": "renderTeamInfoForm",
           "defaultMessage": "Please input team name!",
@@ -249262,7 +249262,7 @@
           "locations": [
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 450,
+              "line": 462,
               "column": 27,
               "kind": "FormattedMessage"
             }
@@ -249389,7 +249389,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 1037,
+          "line": 1049,
           "column": 14,
           "symbol": "tabs",
           "defaultMessage": "Team Information",
@@ -249404,7 +249404,7 @@
           "locations": [
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 1037,
+              "line": 1049,
               "column": 14,
               "kind": "FormattedMessage"
             }
@@ -249472,7 +249472,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 959,
+          "line": 971,
           "column": 15,
           "symbol": "renderTeamMembersForm",
           "defaultMessage": "Team Members",
@@ -249481,7 +249481,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 1044,
+          "line": 1056,
           "column": 14,
           "symbol": "Team",
           "defaultMessage": "Team Members",
@@ -249496,13 +249496,13 @@
           "locations": [
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 959,
+              "line": 971,
               "column": 15,
               "kind": "FormattedMessage"
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 1044,
+              "line": 1056,
               "column": 14,
               "kind": "FormattedMessage"
             }
@@ -249570,7 +249570,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 225,
+          "line": 237,
           "column": 11,
           "symbol": "editTeamInfo",
           "defaultMessage": "Failed to update team information.",
@@ -249579,7 +249579,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 256,
+          "line": 268,
           "column": 11,
           "symbol": "createTeamInfo",
           "defaultMessage": "Failed to update team information.",
@@ -249594,13 +249594,13 @@
           "locations": [
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 225,
+              "line": 237,
               "column": 11,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 256,
+              "line": 268,
               "column": 11,
               "kind": "formatMessage"
             }
@@ -268416,7 +268416,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 279,
+          "line": 291,
           "column": 15,
           "symbol": "uploadLogo",
           "defaultMessage": "Only image files can be uploaded!",
@@ -268437,7 +268437,7 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 279,
+              "line": 291,
               "column": 15,
               "kind": "formatMessage"
             }
@@ -268523,7 +268523,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 297,
+          "line": 309,
           "column": 17,
           "symbol": "uploadLogo",
           "defaultMessage": "Failed to upload team logo.",
@@ -268532,7 +268532,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 316,
+          "line": 328,
           "column": 15,
           "symbol": "uploadLogo",
           "defaultMessage": "Failed to upload team logo.",
@@ -268559,13 +268559,13 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 297,
+              "line": 309,
               "column": 17,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 316,
+              "line": 328,
               "column": 15,
               "kind": "formatMessage"
             }
@@ -268746,7 +268746,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 774,
+          "line": 786,
           "column": 13,
           "symbol": "updateRole",
           "defaultMessage": "Action failed!",
@@ -268755,7 +268755,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 862,
+          "line": 874,
           "column": 31,
           "symbol": "columns",
           "defaultMessage": "Action failed!",
@@ -268764,7 +268764,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 930,
+          "line": 942,
           "column": 25,
           "symbol": "columns",
           "defaultMessage": "Action failed!",
@@ -268791,19 +268791,19 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 774,
+              "line": 786,
               "column": 13,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 862,
+              "line": 874,
               "column": 31,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 930,
+              "line": 942,
               "column": 25,
               "kind": "formatMessage"
             }
@@ -268907,7 +268907,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 781,
+          "line": 793,
           "column": 13,
           "symbol": "updateRole",
           "defaultMessage": "Action success!",
@@ -268916,7 +268916,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 869,
+          "line": 881,
           "column": 31,
           "symbol": "columns",
           "defaultMessage": "Action success!",
@@ -268925,7 +268925,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 938,
+          "line": 950,
           "column": 25,
           "symbol": "columns",
           "defaultMessage": "Action success!",
@@ -268952,19 +268952,19 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 781,
+              "line": 793,
               "column": 13,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 869,
+              "line": 881,
               "column": 31,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 938,
+              "line": 950,
               "column": 25,
               "kind": "formatMessage"
             }
@@ -269050,7 +269050,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 825,
+          "line": 837,
           "column": 16,
           "symbol": "columns",
           "defaultMessage": "Actions",
@@ -269077,7 +269077,7 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 825,
+              "line": 837,
               "column": 16,
               "kind": "FormattedMessage"
             }
@@ -269154,7 +269154,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 966,
+          "line": 978,
           "column": 24,
           "symbol": "renderTeamMembersForm",
           "defaultMessage": "Add Member",
@@ -269175,7 +269175,7 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 966,
+              "line": 978,
               "column": 24,
               "kind": "FormattedMessage"
             }
@@ -269909,7 +269909,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 832,
+          "line": 844,
           "column": 19,
           "symbol": "columns",
           "defaultMessage": "Remove Member",
@@ -269930,7 +269930,7 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 832,
+              "line": 844,
               "column": 19,
               "kind": "FormattedMessage"
             }
@@ -270007,7 +270007,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 852,
+          "line": 864,
           "column": 32,
           "symbol": "columns",
           "defaultMessage": null,
@@ -270085,7 +270085,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 851,
+          "line": 863,
           "column": 30,
           "symbol": "columns",
           "defaultMessage": null,
@@ -270181,7 +270181,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 795,
+          "line": 807,
           "column": 16,
           "symbol": "columns",
           "defaultMessage": "Email",
@@ -270214,7 +270214,7 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 795,
+              "line": 807,
               "column": 16,
               "kind": "FormattedMessage"
             }
@@ -270487,7 +270487,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 800,
+          "line": 812,
           "column": 16,
           "symbol": "columns",
           "defaultMessage": "Member Name",
@@ -270508,7 +270508,7 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 800,
+              "line": 812,
               "column": 16,
               "kind": "FormattedMessage"
             }
@@ -270576,7 +270576,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 917,
+          "line": 929,
           "column": 24,
           "symbol": "columns",
           "defaultMessage": "Re-invite",
@@ -270591,7 +270591,7 @@
           "locations": [
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 917,
+              "line": 929,
               "column": 24,
               "kind": "FormattedMessage"
             }
@@ -270668,7 +270668,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 805,
+          "line": 817,
           "column": 16,
           "symbol": "columns",
           "defaultMessage": "Role",
@@ -270689,7 +270689,7 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 805,
+              "line": 817,
               "column": 16,
               "kind": "FormattedMessage"
             }
@@ -270775,7 +270775,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 811,
+          "line": 823,
           "column": 15,
           "symbol": "columns",
           "defaultMessage": "Admin",
@@ -270802,7 +270802,7 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 811,
+              "line": 823,
               "column": 15,
               "kind": "FormattedMessage"
             }
@@ -270953,7 +270953,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 813,
+          "line": 825,
           "column": 15,
           "symbol": "columns",
           "defaultMessage": "Invited",
@@ -270968,7 +270968,7 @@
           "locations": [
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 813,
+              "line": 825,
               "column": 15,
               "kind": "FormattedMessage"
             }
@@ -271045,7 +271045,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 819,
+          "line": 831,
           "column": 15,
           "symbol": "columns",
           "defaultMessage": "Member",
@@ -271066,7 +271066,7 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 819,
+              "line": 831,
               "column": 15,
               "kind": "FormattedMessage"
             }
@@ -271152,7 +271152,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 815,
+          "line": 827,
           "column": 15,
           "symbol": "columns",
           "defaultMessage": "Owner",
@@ -271179,7 +271179,7 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 815,
+              "line": 827,
               "column": 15,
               "kind": "FormattedMessage"
             }
@@ -271256,7 +271256,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 817,
+          "line": 829,
           "column": 15,
           "symbol": "columns",
           "defaultMessage": "Rejected",
@@ -271277,7 +271277,7 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 817,
+              "line": 829,
               "column": 15,
               "kind": "FormattedMessage"
             }
@@ -271354,7 +271354,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 888,
+          "line": 900,
           "column": 19,
           "symbol": "columns",
           "defaultMessage": "Set as Admin",
@@ -271375,7 +271375,7 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 888,
+              "line": 900,
               "column": 19,
               "kind": "FormattedMessage"
             }
@@ -271452,7 +271452,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/Teams/index.tsx",
-          "line": 903,
+          "line": 915,
           "column": 19,
           "symbol": "columns",
           "defaultMessage": "Set as Member",
@@ -271473,7 +271473,7 @@
             },
             {
               "path": "src/pages/Teams/index.tsx",
-              "line": 903,
+              "line": 915,
               "column": 19,
               "kind": "FormattedMessage"
             }

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "108ab63eafb5d8b55349940d5f282e38f5eafa44468d5bf5f12c0496267adefc",
-    "contextDigest": "f7e1ef9cd7e8e10bf9115a77c7b4b2696c558aef54102868217ae4c22753a808"
+    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b",
+    "contextDigest": "75edbf353e6c6b80a08ac507592c2534c4e8095217e0cf0a021d72ea3f59a20b"
   },
   "catalog": {
     "messageCount": 3322,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "eba4161a98f982b8f12896c9043b94a4356675cc0ee9cc19ddfef629dd8b1a8d",
-    "validationDigest": "e11dbfaf53cd1674bd250de932a10d5f3a3378ca1bd1721aad2e880f472efdd2",
+    "digest": "f3ad9598b2d1f36d7ddf2dd7ab975ab0163203958c96887afeca512c80e3d8ea",
+    "validationDigest": "685cf419943848169b605af802746b3958bf0e96546d1fc88d1e2f22f2c3280d",
     "laneCount": 1,
     "validatedMessageCount": 3322,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "9624bb4319c3a053057fddbd25837b3d0d9d9fafd23e7d52377c753c9d86d453"
+  "qualityDigest": "538209cfaa7055391051c634f4d952b0cbd4b8d77a4ca4b9a33c758dd930bba3"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "9faebb324eab9ea2b00907d24611f94546114f71160b9d695d234c13a7e9ffe8",
+    "auditedInputDigest": "2553f5c8bfcdaac8140a474a888463f4e87aadbd989b35ff3282c27034c827e7",
     "validatedMessageCount": 3322,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1507,
     "highRiskMessageDigest": "37ae9bf80782335d1d0edf20bae122396e2fc524271954d6608a7f2caf3dfacd",
     "catalogDigest": "c808a402b06edfa7e58af2c3e435a2e6aeb90c161cbf26514a5847d731dfa29e",
-    "dossierDigest": "d8a34669f55ac9ad703a1224733b7addfb410469608ea8443c198efc33fd53c7",
+    "dossierDigest": "47df64f8624aeb8b19bb0223c35c70d3cefcb13b85ac0e6bc68cff1313cb3196",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
-    "routeEvidenceDigest": "4294a6d5067b177730d9bf97d22afbac1698ac15affe69d348b42393e1ff1ef0",
+    "routeEvidenceDigest": "404c3f4ce5f4c164a8d11b6999da96087af5d6a40bdc8096b521aafa63edc2d5",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "e11cff8827c56fa95979f98e855a66017eafa6ae5821c8193f5d7334bf95a11f",
         "highRiskMessageCount": 1507,
         "highRiskMessageDigest": "37ae9bf80782335d1d0edf20bae122396e2fc524271954d6608a7f2caf3dfacd",
-        "dossierDigest": "d8a34669f55ac9ad703a1224733b7addfb410469608ea8443c198efc33fd53c7",
+        "dossierDigest": "47df64f8624aeb8b19bb0223c35c70d3cefcb13b85ac0e6bc68cff1313cb3196",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "e11dbfaf53cd1674bd250de932a10d5f3a3378ca1bd1721aad2e880f472efdd2"
+  "validationDigest": "685cf419943848169b605af802746b3958bf0e96546d1fc88d1e2f22f2c3280d"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "108ab63eafb5d8b55349940d5f282e38f5eafa44468d5bf5f12c0496267adefc",
-    "auditedInputDigest": "9faebb324eab9ea2b00907d24611f94546114f71160b9d695d234c13a7e9ffe8"
+    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b",
+    "auditedInputDigest": "2553f5c8bfcdaac8140a474a888463f4e87aadbd989b35ff3282c27034c827e7"
   },
   "inventory": {
     "sourceMessageCount": 3322,
@@ -47,7 +47,7 @@
     "messageCount": 3322,
     "completeCount": 3322,
     "blockedCount": 0,
-    "dossierDigest": "033d00aed8af3c67645079021e36d568fe19d3c1e314f3d2e0e3889ccb666130",
+    "dossierDigest": "81eca636199da59f9c1462fd1bc96a2455001f1ba177d8074d2a82d9a725746a",
     "catalogDigest": "e712a87e78e9934accc0b9fecc82b829914a606b3f13c8c0d620d5fa4a77de13",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -138,7 +138,7 @@
         "focusedVariantCount": 8
       },
       "sourceFileCount": 37,
-      "sourceEvidenceDigest": "e6d6de7e4c4a9f7c3b0c971e651ca6e1cadaab31992224d9f7835c9586811fdc",
+      "sourceEvidenceDigest": "75c5e1d12f84230dc46f1333a5179df137da88b4718bd049f970f7519d930711",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -1094,8 +1094,8 @@
           "route": "/account",
           "viewState": "account-profile",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "692a544626120fed98dc627ecc8f58f5fb01924ea0953a4e90e4b1bba741c783",
-          "focusedTestDigest": "a6833330b12f128470491dc8d400a15299e00215767f78f7a9da79ad15fc98c3",
+          "sourceDigest": "e68c593b9f379b5ee8f55fe8198b0f8c2b5269d3e4baf99df16b6070656cfba1",
+          "focusedTestDigest": "b1a7afe252a0f7d4203cae4bf000815696730272ee0cddab18b900abad3f607a",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "93ce64d1c24a3196fb75191740708109e8c0cf47d24f73a8a13db8ba3f7c08cf",
           "derivedMessageCount": 67,
@@ -1112,8 +1112,8 @@
           "route": "/team",
           "viewState": "team-membership",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "84047bd49988c1ff9e3ea98269120572d4b1c305b349d323c5838d5063428227",
-          "focusedTestDigest": "a222a805d097a243a7f21908f56156de280829bc37be1133e015348a79d74147",
+          "sourceDigest": "be8abe478dda3893cb4649cf9c019eda2e7109ae338a5df6e62761071c8c85ad",
+          "focusedTestDigest": "2b2584899c0ae9f22610f7f7efc51fea32a78cbcf814e8d3879b02e958f07bc8",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "04ae705839eb61ece4611b64026e96a021d3f6d35c0781bfcf2b3e3ea5e1f31b",
           "derivedMessageCount": 43,
@@ -1126,7 +1126,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "4294a6d5067b177730d9bf97d22afbac1698ac15affe69d348b42393e1ff1ef0",
+      "rowEvidenceDigest": "404c3f4ce5f4c164a8d11b6999da96087af5d6a40bdc8096b521aafa63edc2d5",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1150,5 +1150,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "52783c267c751ee855fcff53ad94ecebe56df385bee0c3c5e402f0caebd9c1b9"
+  "contextDigest": "4995a4a44774c5af20162e40a6e7ded927a53758044c232354815891f525672f"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "108ab63eafb5d8b55349940d5f282e38f5eafa44468d5bf5f12c0496267adefc"
+    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "52783c267c751ee855fcff53ad94ecebe56df385bee0c3c5e402f0caebd9c1b9",
-    "qualityDigest": "0927609b38052fdd07fc3eae8be0a6757474173a41a97683327e51916f8c5578",
+    "contextDigest": "4995a4a44774c5af20162e40a6e7ded927a53758044c232354815891f525672f",
+    "qualityDigest": "90f65c63f87e3bc807b9a2888e3bbdc1a4c2a8dcbc6ef35ecc68521953014e93",
     "correctionLedgerDigest": "fcda3136886694c111258daee7f51b6bf0f29e3333ed7e582d7fcc349f0b4c74",
     "routeViewCoverageDigest": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "bbab35649da7c4460abc3a5d90d667f2200c71ad7a6bf5da035acf42863bdc11"
+  "activationDigest": "3c46775c2c2a9032f4877ebd41fe89d7d57d1679ff2a76beb104f3509670c063"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "108ab63eafb5d8b55349940d5f282e38f5eafa44468d5bf5f12c0496267adefc",
-    "contextDigest": "52783c267c751ee855fcff53ad94ecebe56df385bee0c3c5e402f0caebd9c1b9"
+    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b",
+    "contextDigest": "4995a4a44774c5af20162e40a6e7ded927a53758044c232354815891f525672f"
   },
   "catalog": {
     "messageCount": 3322,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "3c28769e2c5894afce403bf3543348066459960992cac0fc05dcd28e2169d71c",
-    "validationDigest": "1a3249a1fd7d42efb63a7ee4feb3727eef289a175ba9283e493e4919b1a7483f",
+    "digest": "ef85d439ab2ce63c440e651576d550bb9c96fa3e4dfffa2af5f78bb4697767e7",
+    "validationDigest": "7d391e68a7a8348dd3afbb1c678b0779287842928fed8da5ebcb192fbfc13f39",
     "laneCount": 1,
     "validatedMessageCount": 3322,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "0927609b38052fdd07fc3eae8be0a6757474173a41a97683327e51916f8c5578"
+  "qualityDigest": "90f65c63f87e3bc807b9a2888e3bbdc1a4c2a8dcbc6ef35ecc68521953014e93"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "9faebb324eab9ea2b00907d24611f94546114f71160b9d695d234c13a7e9ffe8",
+    "auditedInputDigest": "2553f5c8bfcdaac8140a474a888463f4e87aadbd989b35ff3282c27034c827e7",
     "validatedMessageCount": 3322,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1507,
     "highRiskMessageDigest": "37ae9bf80782335d1d0edf20bae122396e2fc524271954d6608a7f2caf3dfacd",
     "catalogDigest": "e712a87e78e9934accc0b9fecc82b829914a606b3f13c8c0d620d5fa4a77de13",
-    "dossierDigest": "033d00aed8af3c67645079021e36d568fe19d3c1e314f3d2e0e3889ccb666130",
+    "dossierDigest": "81eca636199da59f9c1462fd1bc96a2455001f1ba177d8074d2a82d9a725746a",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
-    "routeEvidenceDigest": "4294a6d5067b177730d9bf97d22afbac1698ac15affe69d348b42393e1ff1ef0",
+    "routeEvidenceDigest": "404c3f4ce5f4c164a8d11b6999da96087af5d6a40bdc8096b521aafa63edc2d5",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "e11cff8827c56fa95979f98e855a66017eafa6ae5821c8193f5d7334bf95a11f",
         "highRiskMessageCount": 1507,
         "highRiskMessageDigest": "37ae9bf80782335d1d0edf20bae122396e2fc524271954d6608a7f2caf3dfacd",
-        "dossierDigest": "033d00aed8af3c67645079021e36d568fe19d3c1e314f3d2e0e3889ccb666130",
+        "dossierDigest": "81eca636199da59f9c1462fd1bc96a2455001f1ba177d8074d2a82d9a725746a",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "1a3249a1fd7d42efb63a7ee4feb3727eef289a175ba9283e493e4919b1a7483f"
+  "validationDigest": "7d391e68a7a8348dd3afbb1c678b0779287842928fed8da5ebcb192fbfc13f39"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "108ab63eafb5d8b55349940d5f282e38f5eafa44468d5bf5f12c0496267adefc",
-    "auditedInputDigest": "9faebb324eab9ea2b00907d24611f94546114f71160b9d695d234c13a7e9ffe8"
+    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b",
+    "auditedInputDigest": "2553f5c8bfcdaac8140a474a888463f4e87aadbd989b35ff3282c27034c827e7"
   },
   "inventory": {
     "sourceMessageCount": 3322,
@@ -47,7 +47,7 @@
     "messageCount": 3322,
     "completeCount": 3322,
     "blockedCount": 0,
-    "dossierDigest": "b8296f77e065a22f762f737eee381f3ba6c42c62bc1eb0d0ad174445eddfe94a",
+    "dossierDigest": "e21d214ab437386a1ce2dd2bfc7b00d1a7a0c9ee08a4846f197aab03b89cfe6e",
     "catalogDigest": "9a118ae3bddcdfb951bf4b15ea37c504af4c037943cfdcd0670f0efe1c0d5e09",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -138,7 +138,7 @@
         "focusedVariantCount": 8
       },
       "sourceFileCount": 37,
-      "sourceEvidenceDigest": "e6d6de7e4c4a9f7c3b0c971e651ca6e1cadaab31992224d9f7835c9586811fdc",
+      "sourceEvidenceDigest": "75c5e1d12f84230dc46f1333a5179df137da88b4718bd049f970f7519d930711",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -1094,8 +1094,8 @@
           "route": "/account",
           "viewState": "account-profile",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "692a544626120fed98dc627ecc8f58f5fb01924ea0953a4e90e4b1bba741c783",
-          "focusedTestDigest": "a6833330b12f128470491dc8d400a15299e00215767f78f7a9da79ad15fc98c3",
+          "sourceDigest": "e68c593b9f379b5ee8f55fe8198b0f8c2b5269d3e4baf99df16b6070656cfba1",
+          "focusedTestDigest": "b1a7afe252a0f7d4203cae4bf000815696730272ee0cddab18b900abad3f607a",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "93ce64d1c24a3196fb75191740708109e8c0cf47d24f73a8a13db8ba3f7c08cf",
           "derivedMessageCount": 67,
@@ -1112,8 +1112,8 @@
           "route": "/team",
           "viewState": "team-membership",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "84047bd49988c1ff9e3ea98269120572d4b1c305b349d323c5838d5063428227",
-          "focusedTestDigest": "a222a805d097a243a7f21908f56156de280829bc37be1133e015348a79d74147",
+          "sourceDigest": "be8abe478dda3893cb4649cf9c019eda2e7109ae338a5df6e62761071c8c85ad",
+          "focusedTestDigest": "2b2584899c0ae9f22610f7f7efc51fea32a78cbcf814e8d3879b02e958f07bc8",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "04ae705839eb61ece4611b64026e96a021d3f6d35c0781bfcf2b3e3ea5e1f31b",
           "derivedMessageCount": 43,
@@ -1126,7 +1126,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "4294a6d5067b177730d9bf97d22afbac1698ac15affe69d348b42393e1ff1ef0",
+      "rowEvidenceDigest": "404c3f4ce5f4c164a8d11b6999da96087af5d6a40bdc8096b521aafa63edc2d5",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1150,5 +1150,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "57a1e720d1e27b0ce99abdd6c6bcbfcabb65aa5ab41fd519b1f295d5403dc104"
+  "contextDigest": "a02614cf19f01f33030191083228a6c96c11429e583f3337805a6a85208f0f9a"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "108ab63eafb5d8b55349940d5f282e38f5eafa44468d5bf5f12c0496267adefc"
+    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "57a1e720d1e27b0ce99abdd6c6bcbfcabb65aa5ab41fd519b1f295d5403dc104",
-    "qualityDigest": "92bade85eadeba7de886ff6de4c124bc8e93d83145805281a327ffb634c8628a",
+    "contextDigest": "a02614cf19f01f33030191083228a6c96c11429e583f3337805a6a85208f0f9a",
+    "qualityDigest": "a0b6bf52df10960dd594daf2c5eea023f8591edd65f9a4b9c95c893f1c82b674",
     "correctionLedgerDigest": "fcda3136886694c111258daee7f51b6bf0f29e3333ed7e582d7fcc349f0b4c74",
     "routeViewCoverageDigest": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "93297e9a939c930583bb124f9cde85e40635aec8bee8ff5eb710ad674b5ee5a6"
+  "activationDigest": "dc2b6fa1b7640f5e6ce46d50a642c36e4740be9c02946353de31e58dbc2c1fd5"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "108ab63eafb5d8b55349940d5f282e38f5eafa44468d5bf5f12c0496267adefc",
-    "contextDigest": "57a1e720d1e27b0ce99abdd6c6bcbfcabb65aa5ab41fd519b1f295d5403dc104"
+    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b",
+    "contextDigest": "a02614cf19f01f33030191083228a6c96c11429e583f3337805a6a85208f0f9a"
   },
   "catalog": {
     "messageCount": 3322,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "56519554566194653d818acbadf79d496bdc63f2402dd7d835af437dc666bae5",
-    "validationDigest": "e740f7c23daa903780235e3649dd5512f2d6537ba96bc2adb24da9b496f55cd2",
+    "digest": "1e3bd51c10699ed08c33cf1f1f2350ed5c3099c3fb13a3b0bac30df1acf8742e",
+    "validationDigest": "e8e733372880d67883b4ded7a8f5563ec049a300fdb95f245896db0d97385e19",
     "laneCount": 1,
     "validatedMessageCount": 3322,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "92bade85eadeba7de886ff6de4c124bc8e93d83145805281a327ffb634c8628a"
+  "qualityDigest": "a0b6bf52df10960dd594daf2c5eea023f8591edd65f9a4b9c95c893f1c82b674"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "9faebb324eab9ea2b00907d24611f94546114f71160b9d695d234c13a7e9ffe8",
+    "auditedInputDigest": "2553f5c8bfcdaac8140a474a888463f4e87aadbd989b35ff3282c27034c827e7",
     "validatedMessageCount": 3322,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1507,
     "highRiskMessageDigest": "37ae9bf80782335d1d0edf20bae122396e2fc524271954d6608a7f2caf3dfacd",
     "catalogDigest": "9a118ae3bddcdfb951bf4b15ea37c504af4c037943cfdcd0670f0efe1c0d5e09",
-    "dossierDigest": "b8296f77e065a22f762f737eee381f3ba6c42c62bc1eb0d0ad174445eddfe94a",
+    "dossierDigest": "e21d214ab437386a1ce2dd2bfc7b00d1a7a0c9ee08a4846f197aab03b89cfe6e",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
-    "routeEvidenceDigest": "4294a6d5067b177730d9bf97d22afbac1698ac15affe69d348b42393e1ff1ef0",
+    "routeEvidenceDigest": "404c3f4ce5f4c164a8d11b6999da96087af5d6a40bdc8096b521aafa63edc2d5",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "e11cff8827c56fa95979f98e855a66017eafa6ae5821c8193f5d7334bf95a11f",
         "highRiskMessageCount": 1507,
         "highRiskMessageDigest": "37ae9bf80782335d1d0edf20bae122396e2fc524271954d6608a7f2caf3dfacd",
-        "dossierDigest": "b8296f77e065a22f762f737eee381f3ba6c42c62bc1eb0d0ad174445eddfe94a",
+        "dossierDigest": "e21d214ab437386a1ce2dd2bfc7b00d1a7a0c9ee08a4846f197aab03b89cfe6e",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "e740f7c23daa903780235e3649dd5512f2d6537ba96bc2adb24da9b496f55cd2"
+  "validationDigest": "e8e733372880d67883b4ded7a8f5563ec049a300fdb95f245896db0d97385e19"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "108ab63eafb5d8b55349940d5f282e38f5eafa44468d5bf5f12c0496267adefc",
-    "auditedInputDigest": "9faebb324eab9ea2b00907d24611f94546114f71160b9d695d234c13a7e9ffe8"
+    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b",
+    "auditedInputDigest": "2553f5c8bfcdaac8140a474a888463f4e87aadbd989b35ff3282c27034c827e7"
   },
   "inventory": {
     "sourceMessageCount": 3322,
@@ -47,7 +47,7 @@
     "messageCount": 3322,
     "completeCount": 3322,
     "blockedCount": 0,
-    "dossierDigest": "f731f5ed26b5e2b79bd8bb87140f0b160973e45ccfa8b812be7642f3cc557178",
+    "dossierDigest": "7e79f58ba7dee8a67efe4c0449ba2a3c2b01794ceb267272f35eca9583bb7ffa",
     "catalogDigest": "baa30718c9ca5e7f44104cfef19da6208c86631508b1a11c9b164a72bf3108e9",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -138,7 +138,7 @@
         "focusedVariantCount": 8
       },
       "sourceFileCount": 37,
-      "sourceEvidenceDigest": "e6d6de7e4c4a9f7c3b0c971e651ca6e1cadaab31992224d9f7835c9586811fdc",
+      "sourceEvidenceDigest": "75c5e1d12f84230dc46f1333a5179df137da88b4718bd049f970f7519d930711",
       "rowEvidence": [
         {
           "executableAssertionId": "rv.root.redirect-to-welcome",
@@ -1094,8 +1094,8 @@
           "route": "/account",
           "viewState": "account-profile",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "692a544626120fed98dc627ecc8f58f5fb01924ea0953a4e90e4b1bba741c783",
-          "focusedTestDigest": "a6833330b12f128470491dc8d400a15299e00215767f78f7a9da79ad15fc98c3",
+          "sourceDigest": "e68c593b9f379b5ee8f55fe8198b0f8c2b5269d3e4baf99df16b6070656cfba1",
+          "focusedTestDigest": "b1a7afe252a0f7d4203cae4bf000815696730272ee0cddab18b900abad3f607a",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "93ce64d1c24a3196fb75191740708109e8c0cf47d24f73a8a13db8ba3f7c08cf",
           "derivedMessageCount": 67,
@@ -1112,8 +1112,8 @@
           "route": "/team",
           "viewState": "team-membership",
           "requiredEvidenceScope": "internal-localization",
-          "sourceDigest": "84047bd49988c1ff9e3ea98269120572d4b1c305b349d323c5838d5063428227",
-          "focusedTestDigest": "a222a805d097a243a7f21908f56156de280829bc37be1133e015348a79d74147",
+          "sourceDigest": "be8abe478dda3893cb4649cf9c019eda2e7109ae338a5df6e62761071c8c85ad",
+          "focusedTestDigest": "2b2584899c0ae9f22610f7f7efc51fea32a78cbcf814e8d3879b02e958f07bc8",
           "plannedBrowserAssertionCount": 1,
           "plannedBrowserAssertionDigest": "04ae705839eb61ece4611b64026e96a021d3f6d35c0781bfcf2b3e3ea5e1f31b",
           "derivedMessageCount": 43,
@@ -1126,7 +1126,7 @@
           "unownedVisibleLiteralCount": 0
         }
       ],
-      "rowEvidenceDigest": "4294a6d5067b177730d9bf97d22afbac1698ac15affe69d348b42393e1ff1ef0",
+      "rowEvidenceDigest": "404c3f4ce5f4c164a8d11b6999da96087af5d6a40bdc8096b521aafa63edc2d5",
       "blockedDerivedStateCount": 0,
       "unownedVisibleLiteralCount": 0
     }
@@ -1150,5 +1150,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "a5dc8bbd96b3a4a087e21b1fd87dcaaa4ccc692f783d480c82a0c2ee14e139af"
+  "contextDigest": "e42a41738437112661b9a865e0eba94786e2ce077f2a521891b105e2a03161ad"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "108ab63eafb5d8b55349940d5f282e38f5eafa44468d5bf5f12c0496267adefc"
+    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "a5dc8bbd96b3a4a087e21b1fd87dcaaa4ccc692f783d480c82a0c2ee14e139af",
-    "qualityDigest": "8352f3621a79bb822358eda4c1ba933cc95d9880350591535e48f26b80580237",
+    "contextDigest": "e42a41738437112661b9a865e0eba94786e2ce077f2a521891b105e2a03161ad",
+    "qualityDigest": "36f9f0d969a1c43d05a9b23114752f1c5c6359e262651143b2dea6d4dff446cc",
     "correctionLedgerDigest": "fcda3136886694c111258daee7f51b6bf0f29e3333ed7e582d7fcc349f0b4c74",
     "routeViewCoverageDigest": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "2a8a64c7c41299150f72366e9f29d8fa27df281edfab363a562ae3e3b0427067"
+  "activationDigest": "ae620a0f31546ffa94bfd4fe3bc5cb58aa807471522d4b5828c4b37207d3886c"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "108ab63eafb5d8b55349940d5f282e38f5eafa44468d5bf5f12c0496267adefc",
-    "contextDigest": "a5dc8bbd96b3a4a087e21b1fd87dcaaa4ccc692f783d480c82a0c2ee14e139af"
+    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b",
+    "contextDigest": "e42a41738437112661b9a865e0eba94786e2ce077f2a521891b105e2a03161ad"
   },
   "catalog": {
     "messageCount": 3322,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "540c4448e931e11175fd4bca3861705eb965afa94c7106fdf3986d2a4071bb54",
-    "validationDigest": "872b4529a04fda29586b6d2a311868b5081196ba071ba9221b6201cfc58b07f3",
+    "digest": "cb1ef5285d2d3e5fd30a529ce9d019bb83bc5ba6a97eb63eb9f8db3799874b52",
+    "validationDigest": "20887ea2c09e59df4629ad710479d16d67449ad87785c578a8ded5213c21f1f1",
     "laneCount": 1,
     "validatedMessageCount": 3322,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "8352f3621a79bb822358eda4c1ba933cc95d9880350591535e48f26b80580237"
+  "qualityDigest": "36f9f0d969a1c43d05a9b23114752f1c5c6359e262651143b2dea6d4dff446cc"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "9faebb324eab9ea2b00907d24611f94546114f71160b9d695d234c13a7e9ffe8",
+    "auditedInputDigest": "2553f5c8bfcdaac8140a474a888463f4e87aadbd989b35ff3282c27034c827e7",
     "validatedMessageCount": 3322,
     "validatedModules": [
       "$entry",
@@ -42,9 +42,9 @@
     "highRiskMessageCount": 1507,
     "highRiskMessageDigest": "37ae9bf80782335d1d0edf20bae122396e2fc524271954d6608a7f2caf3dfacd",
     "catalogDigest": "baa30718c9ca5e7f44104cfef19da6208c86631508b1a11c9b164a72bf3108e9",
-    "dossierDigest": "f731f5ed26b5e2b79bd8bb87140f0b160973e45ccfa8b812be7642f3cc557178",
+    "dossierDigest": "7e79f58ba7dee8a67efe4c0449ba2a3c2b01794ceb267272f35eca9583bb7ffa",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
-    "routeEvidenceDigest": "4294a6d5067b177730d9bf97d22afbac1698ac15affe69d348b42393e1ff1ef0",
+    "routeEvidenceDigest": "404c3f4ce5f4c164a8d11b6999da96087af5d6a40bdc8096b521aafa63edc2d5",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
   },
   "validationLanes": [
@@ -98,7 +98,7 @@
         "messageDigest": "e11cff8827c56fa95979f98e855a66017eafa6ae5821c8193f5d7334bf95a11f",
         "highRiskMessageCount": 1507,
         "highRiskMessageDigest": "37ae9bf80782335d1d0edf20bae122396e2fc524271954d6608a7f2caf3dfacd",
-        "dossierDigest": "f731f5ed26b5e2b79bd8bb87140f0b160973e45ccfa8b812be7642f3cc557178",
+        "dossierDigest": "7e79f58ba7dee8a67efe4c0449ba2a3c2b01794ceb267272f35eca9583bb7ffa",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "872b4529a04fda29586b6d2a311868b5081196ba071ba9221b6201cfc58b07f3"
+  "validationDigest": "20887ea2c09e59df4629ad710479d16d67449ad87785c578a8ded5213c21f1f1"
 }

--- a/src/pages/Account/index.less
+++ b/src/pages/Account/index.less
@@ -1,97 +1,65 @@
 .accountPage {
-  background: #f5f5f5;
+  background: var(--ant-color-bg-layout, #f5f5f5);
 }
 
 :global(.ant-pro-layout):has(.accountPage) :global(.ant-pro-layout-bg-list) {
-  background: #f5f5f5;
+  background: var(--ant-color-bg-layout, #f5f5f5);
 }
 
 .contentCard,
 .contentPanel {
   width: min(1080px, 100%);
-  min-height: 560px;
   overflow: hidden;
   border: 1px solid var(--ant-color-border-secondary, #e9e5eb);
   border-radius: 8px;
-  box-shadow: 0 10px 30px rgb(42 23 48 / 6%);
 }
 
 .contentPanel {
-  padding: 34px 40px 38px;
+  padding: var(--ant-padding-lg, 24px);
   background: var(--ant-color-bg-container, #fff);
 }
 
-.contentCard {
-  :global(.ant-card-body) {
-    padding: 34px 40px 30px;
-  }
-}
-
 .contentHeader {
-  margin-bottom: 30px;
-  padding-bottom: 24px;
+  margin-bottom: var(--ant-margin-lg, 24px);
+  padding-bottom: var(--ant-padding, 16px);
   border-bottom: 1px solid var(--ant-color-border-secondary, #f0edf1);
 }
 
 .contentTitle {
   margin: 0 !important;
   color: var(--ant-color-text, #262329) !important;
-  font-size: 24px !important;
-  font-weight: 600 !important;
-  line-height: 1.35 !important;
 }
 
 .contentDescription,
 .emailPanel .contentDescription {
   max-width: 760px;
-  margin: 8px 0 0 !important;
+  margin: var(--ant-margin-xs, 8px) 0 0 !important;
   color: var(--ant-color-text-secondary, #8b818e) !important;
-  font-size: 14px;
-  line-height: 1.7;
 }
 
 .formSection {
-  :global(.ant-form-item) {
-    margin-bottom: 24px;
-  }
-
   :global(.ant-form-item-label > label) {
     color: var(--ant-color-text, #3d3841);
-    font-weight: 500;
   }
 
-  :global(.ant-input),
-  :global(.ant-input-affix-wrapper) {
-    min-height: 44px;
-    border-radius: 8px;
-  }
-
-  :global(.ant-input-affix-wrapper > .ant-input) {
-    min-height: auto;
-  }
-
-  :global(.ant-input-prefix) {
-    margin-inline-end: 10px;
-    color: var(--ant-color-text-secondary, #8b818e);
-  }
-
-  :global(.ant-form-item-extra) {
-    padding-top: 4px;
-    color: var(--ant-color-text-secondary, #8b818e);
+  :global(input:enabled:is(:-webkit-autofill, :autofill)) {
+    // Browser autofill owns background/color; theme the visible fill without disabling it.
+    box-shadow: 0 0 0 1000px var(--ant-color-bg-container, #fff) inset;
+    -webkit-text-fill-color: var(--ant-color-text, #262329);
+    caret-color: var(--ant-color-text, #262329);
   }
 }
 
 .profileSummary {
   display: flex;
   align-items: center;
-  gap: 18px;
-  margin-bottom: 30px;
+  gap: var(--ant-margin, 16px);
+  margin-bottom: var(--ant-margin-lg, 24px);
 }
 
 .profileAvatar {
   flex: 0 0 auto;
   color: #fff;
-  font-size: 24px;
   background: var(--ant-color-primary, #6b2a7b);
   box-shadow: 0 6px 16px rgb(107 42 123 / 18%);
 }
@@ -104,13 +72,13 @@
 .profileName {
   margin: 0 0 5px !important;
   color: var(--ant-color-text, #262329) !important;
-  font-size: 18px !important;
+  font-size: 16px !important;
 }
 
 .profileMeta {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--ant-margin-sm, 12px);
   min-width: 0;
 }
 
@@ -129,18 +97,13 @@
 .profileFormGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  column-gap: 32px;
+  column-gap: var(--ant-margin-lg, 24px);
 }
 
 .passwordForm {
-  --account-password-guide-width: 36.5%;
-  --account-password-column-gap: 40px;
-
-  padding-top: 8px;
-
-  :global(.ant-form-item) {
-    margin-bottom: 36px;
-  }
+  --account-password-column-gap: var(--ant-margin-lg, 24px);
+  // Match the email layout's 1.38:1 columns, excluding the shared column gap.
+  --account-password-guide-width: calc((100% - var(--account-password-column-gap)) / 2.38);
 }
 
 .passwordLayout {
@@ -159,9 +122,8 @@
   grid-template-columns: auto minmax(72px, 210px) auto;
   justify-content: start;
   align-items: center;
-  gap: 12px;
-  margin: -18px 0 40px;
-  font-size: 13px;
+  gap: var(--ant-margin-sm, 12px);
+  margin: 0 0 var(--ant-margin-lg, 24px);
 
   :global(.ant-progress) {
     width: 100%;
@@ -184,7 +146,7 @@
 
 .passwordGuide {
   min-width: 0;
-  padding: 12px 0 20px 44px;
+  padding-inline-start: var(--ant-padding-lg, 24px);
   color: var(--ant-color-text);
   border-inline-start: 1px solid var(--ant-color-border-secondary);
 }
@@ -192,12 +154,8 @@
 .passwordGuideHeading {
   display: flex;
   align-items: center;
-  gap: 14px;
-  margin-bottom: 28px;
-
-  .guideIcon {
-    font-size: 28px;
-  }
+  gap: var(--ant-margin-xs, 8px);
+  margin-bottom: var(--ant-margin-lg, 24px);
 
   :global(h5.ant-typography) {
     margin: 0;
@@ -213,36 +171,33 @@
 
 .guideIcon {
   color: var(--ant-color-primary, #6b2a7b);
-  font-size: 24px;
 }
 
 .guideList {
   display: grid;
-  gap: 20px;
+  gap: var(--ant-margin, 16px);
   margin: 0;
   padding: 0;
   list-style: none;
-  font-size: 16px;
 }
 
 .guideList li {
   display: flex;
   align-items: flex-start;
-  gap: 10px;
-  line-height: 1.5;
+  gap: var(--ant-margin-xs, 8px);
 }
 
 .guideList li > :first-child {
-  margin-top: 3px;
+  flex: 0 0 auto;
+  height: 1lh;
   color: var(--ant-color-primary, #6b2a7b);
-  font-size: 18px;
+  line-height: inherit;
 }
 
 .emailLayout {
   display: grid;
   grid-template-columns: minmax(0, 1.38fr) minmax(0, 1fr);
-  gap: 48px;
-  padding-top: 8px;
+  gap: var(--ant-margin-lg, 24px);
 }
 
 .emailForm,
@@ -250,117 +205,68 @@
   min-width: 0;
 }
 
-.emailForm {
-  :global(.ant-form-item) {
-    margin-bottom: 40px;
-  }
-
-  :global(.ant-form-item-label > label) {
-    font-size: 16px;
-  }
-
-  :global(.ant-input-affix-wrapper) {
-    min-height: 48px;
-  }
-
-  :global(.ant-input) {
-    font-size: 16px;
-  }
-}
-
 .emailCurrent {
-  margin: 0 0 40px;
+  margin: 0 0 var(--ant-margin-lg, 24px);
 
   dt {
     color: var(--ant-color-text-secondary);
-    font-size: 15px;
-    line-height: 1.6;
   }
 
   dd {
     display: flex;
     align-items: flex-start;
-    gap: 14px;
-    margin: 12px 0 0;
-    font-size: 16px;
-    line-height: 1.5;
+    gap: var(--ant-margin-xs, 8px);
+    margin: var(--ant-margin-xs, 8px) 0 0;
     overflow-wrap: anywhere;
   }
 
   :global(.anticon) {
     flex: 0 0 auto;
-    margin-top: 3px;
+    height: 1lh;
     color: var(--ant-color-text-secondary);
-    font-size: 18px;
+    line-height: inherit;
   }
 }
 
 .emailNote {
   display: flex;
   align-items: flex-start;
-  gap: 12px;
+  gap: var(--ant-margin-sm, 12px);
+  margin-bottom: var(--ant-margin-lg, 24px);
   color: var(--ant-color-text-secondary);
-  font-size: 15px;
-  line-height: 1.7;
 
   :global(.anticon) {
     flex: 0 0 auto;
-    margin-top: 4px;
-    font-size: 16px;
+    height: 1lh;
+    line-height: inherit;
   }
 }
 
 .emailGuide {
   min-width: 0;
-  padding: 8px 0 0 48px;
+  padding-inline-start: var(--ant-padding-lg, 24px);
   border-inline-start: 1px solid var(--ant-color-border-secondary);
 }
 
 .emailGuideTitle {
-  margin: 0 0 30px !important;
-  font-size: 20px !important;
+  margin: 0 0 var(--ant-margin-lg, 24px) !important;
   font-weight: 600 !important;
-  line-height: 1.5 !important;
-}
-
-.emailSteps .emailStep {
-  min-height: 116px;
 }
 
 .emailSteps .emailStepTitle {
   color: var(--ant-color-text);
-  font-size: 16px;
-  font-weight: 500;
+  font-size: 14px;
 }
 
 .emailSteps .emailStepContent {
-  padding-top: 10px;
+  padding-top: var(--ant-padding-xs, 8px);
   color: var(--ant-color-text-secondary);
-  font-size: 15px;
-  line-height: 1.7;
+  font-size: 12px;
 }
 
 .submitRow {
   display: flex;
   justify-content: flex-end;
-  padding-top: 12px;
-
-  :global(.ant-btn) {
-    min-width: 112px;
-    height: 42px;
-    border-radius: 8px;
-  }
-}
-
-.emailSubmitRow {
-  padding-top: 40px;
-
-  :global(.ant-btn) {
-    min-width: 120px;
-    height: 46px;
-    padding-inline: 24px;
-    font-size: 16px;
-  }
 }
 
 .oauthContent {
@@ -369,17 +275,16 @@
 
 .oauthState {
   display: block;
-  min-height: 350px;
 }
 
 .connectionCount {
   display: block;
-  margin: 2px 0 18px;
+  margin: 0 0 var(--ant-margin, 16px);
 }
 
 .connectionList {
   display: grid;
-  gap: 16px;
+  gap: var(--ant-margin, 16px);
   margin: 0;
   padding: 0;
   list-style: none;
@@ -389,10 +294,10 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto auto;
   align-items: center;
-  gap: 18px;
-  padding: 20px;
+  gap: var(--ant-margin, 16px);
+  padding: var(--ant-padding, 16px);
   border: 1px solid var(--ant-color-border-secondary, #ebe7ed);
-  border-radius: 10px;
+  border-radius: var(--ant-border-radius-lg, 8px);
   background: var(--ant-color-bg-container, #fff);
   transition:
     border-color 160ms ease,
@@ -402,51 +307,42 @@
     border-color: var(--ant-color-primary-border, #d9c7de);
     box-shadow: 0 6px 16px rgb(42 23 48 / 5%);
   }
-
-  :global(.ant-btn) {
-    min-height: 40px;
-    border-radius: 8px;
-  }
 }
 
 .connectionSummary {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: var(--ant-margin-xs, 8px);
   min-width: 0;
 }
 
 .connectionName {
   display: block;
   overflow: hidden;
-  font-size: 15px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .connectionStatus {
   margin: 0;
-  border-radius: 999px;
   justify-self: start;
 }
 
 .connectionFooterNote {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-top: 24px;
-  padding-top: 20px;
+  gap: var(--ant-margin-xs, 8px);
+  margin-top: var(--ant-margin-lg, 24px);
+  padding-top: var(--ant-padding, 16px);
   border-top: 1px solid var(--ant-color-border-secondary, #f0edf1);
 }
 
 .connectionFooterNote > :first-child {
   color: var(--ant-color-primary, #6b2a7b);
-  font-size: 18px;
 }
 
 .emptyState {
   display: flex;
-  min-height: 320px;
   flex-direction: column;
   align-items: center;
   justify-content: center;
@@ -459,26 +355,22 @@
 @media (max-width: 1399px) {
   .emailLayout {
     grid-template-columns: minmax(0, 1fr);
-    gap: 32px;
+    gap: var(--ant-margin-lg, 24px);
   }
 
   .emailGuide {
-    padding: 28px 0 0;
+    padding: var(--ant-padding-lg, 24px) 0 0;
     border-inline-start: 0;
     border-top: 1px solid var(--ant-color-border-secondary);
   }
 
-  .emailSteps .emailStep {
-    min-height: 92px;
-  }
-
   .passwordLayout {
     grid-template-columns: minmax(0, 1fr);
-    gap: 24px;
+    gap: var(--ant-margin-lg, 24px);
   }
 
   .passwordGuide {
-    padding: 24px 0 12px;
+    padding: var(--ant-padding-lg, 24px) 0 var(--ant-padding-sm, 12px);
     border-inline-start: 0;
     border-top: 1px solid var(--ant-color-border-secondary);
   }
@@ -489,45 +381,14 @@
 }
 
 @media (max-width: 767px) {
-  .emailSubmitRow :global(.ant-btn) {
-    min-width: 0;
-    padding-inline: 12px;
-    font-size: 14px;
-  }
-
-  .contentCard,
-  .contentPanel {
-    min-height: 0;
-  }
-
-  .contentPanel {
-    padding: 24px 20px 26px;
-  }
-
-  .contentCard {
-    :global(.ant-card-body) {
-      padding: 24px 20px 26px;
-    }
-  }
-
-  .contentHeader {
-    margin-bottom: 24px;
-    padding-bottom: 18px;
-  }
-
-  .contentTitle {
-    font-size: 21px !important;
-  }
-
   .profileSummary {
     align-items: flex-start;
-    margin-bottom: 26px;
   }
 
   .profileMeta {
     align-items: flex-start;
     flex-direction: column;
-    gap: 8px;
+    gap: var(--ant-margin-xs, 8px);
   }
 
   .profileFormGrid {
@@ -535,12 +396,12 @@
   }
 
   .passwordGuide {
-    margin-bottom: 8px;
+    margin-bottom: var(--ant-margin-xs, 8px);
   }
 
   .passwordStrength {
     grid-template-columns: auto minmax(40px, 1fr) auto;
-    gap: 8px;
+    gap: var(--ant-margin-xs, 8px);
   }
 
   .submitRow {
@@ -556,7 +417,7 @@
 
   .connectionItem {
     grid-template-columns: minmax(0, 1fr);
-    gap: 16px;
+    gap: var(--ant-margin, 16px);
   }
 
   .connectionItem :global(.ant-btn) {

--- a/src/pages/Account/index.tsx
+++ b/src/pages/Account/index.tsx
@@ -47,8 +47,12 @@ const AccountContentPanel: FC<{
 }> = ({ children, className, description, title }) => (
   <section className={[styles.contentPanel, className].filter(Boolean).join(' ')}>
     <header className={styles.contentHeader}>
-      <h2 className={styles.contentTitle}>{title}</h2>
-      <p className={styles.contentDescription}>{description}</p>
+      <Typography.Title className={styles.contentTitle} level={3}>
+        {title}
+      </Typography.Title>
+      <Typography.Paragraph className={styles.contentDescription} type='secondary'>
+        {description}
+      </Typography.Paragraph>
     </header>
     <div className={styles.formSection} style={ACCOUNT_FORM_CONTAINER_STYLE}>
       {children}
@@ -91,9 +95,7 @@ const Profile: FC = () => {
       title={<FormattedMessage id='pages.account.baseInfo' defaultMessage='Basic Information' />}
     >
       <div className={styles.profileSummary}>
-        <Avatar className={styles.profileAvatar} size={60}>
-          {profileInitial}
-        </Avatar>
+        <Avatar className={styles.profileAvatar}>{profileInitial}</Avatar>
         <div className={styles.profileSummaryText}>
           <Typography.Title className={styles.profileName} level={4}>
             {profileName}
@@ -263,13 +265,7 @@ const Profile: FC = () => {
             defaultMessage='Password strength'
           />
         </Typography.Text>
-        <Progress
-          percent={status.percent}
-          showInfo={false}
-          size={[52, 4]}
-          steps={3}
-          strokeColor={status.color}
-        />
+        <Progress percent={status.percent} showInfo={false} steps={3} strokeColor={status.color} />
         <Typography.Text style={{ color: status.color }}>{status.label}</Typography.Text>
       </div>
     );
@@ -404,7 +400,6 @@ const Profile: FC = () => {
                 />
               }
               fieldProps={{
-                size: 'middle',
                 prefix: <LockOutlined />,
               }}
               placeholder={intl.formatMessage({
@@ -571,7 +566,7 @@ const Profile: FC = () => {
             },
             render: (props, doms) => {
               return (
-                <div className={`${styles.submitRow} ${styles.emailSubmitRow}`}>
+                <div className={styles.submitRow}>
                   <Flex gap='middle'>{doms}</Flex>
                 </div>
               );
@@ -621,7 +616,6 @@ const Profile: FC = () => {
               name='newEmail'
               label={<FormattedMessage id='pages.account.newEmail' defaultMessage='New Email' />}
               fieldProps={{
-                size: 'middle',
                 prefix: <MailOutlined />,
               }}
               placeholder={intl.formatMessage({
@@ -708,7 +702,7 @@ const Profile: FC = () => {
           </div>
         </ProForm>
         <aside className={styles.emailGuide}>
-          <Typography.Title className={styles.emailGuideTitle} level={3}>
+          <Typography.Title className={styles.emailGuideTitle} level={5}>
             <FormattedMessage id='pages.account.email.guideTitle' defaultMessage='How it works' />
           </Typography.Title>
           <Steps
@@ -756,7 +750,6 @@ const Profile: FC = () => {
                 }),
               },
             ]}
-            size='small'
           />
         </aside>
       </div>

--- a/src/pages/Teams/index.less
+++ b/src/pages/Teams/index.less
@@ -1,12 +1,8 @@
-.team-page-tabs-body {
-  padding-left: 24px;
-}
-
 .team-page-tabs-item {
-  padding: 12px 24px 12px 0;
+  padding: var(--ant-padding-sm, 12px) var(--ant-padding-lg, 24px) var(--ant-padding-sm, 12px) 0;
 
   & + & {
-    margin-top: 16px;
+    margin-top: var(--ant-margin, 16px);
   }
 }
 
@@ -15,22 +11,18 @@
 }
 
 .team-info-card {
-  margin-bottom: 16px;
-  padding: 24px 28px;
+  margin-bottom: var(--ant-margin, 16px);
+  padding: var(--ant-padding-lg, 24px);
   background: var(--ant-color-bg-container);
   border: 1px solid var(--ant-color-border-secondary);
-  border-radius: 8px;
-  box-shadow: var(--ant-box-shadow-tertiary);
+  border-radius: var(--ant-border-radius-lg, 8px);
 }
 
-.team-info-section-title {
+.team-info-card .team-info-section-title {
   position: relative;
-  margin-bottom: 20px;
+  margin: 0 0 var(--ant-margin, 16px);
   padding-left: 14px;
   color: var(--ant-color-text);
-  font-weight: 600;
-  font-size: 16px;
-  line-height: 24px;
   overflow-wrap: anywhere;
   white-space: normal;
 
@@ -58,13 +50,9 @@
 
 .team-lang-field {
   & + & {
-    margin-top: 20px;
-    padding-top: 20px;
+    margin-top: var(--ant-margin, 16px);
+    padding-top: var(--ant-padding, 16px);
     border-top: 1px solid var(--ant-color-border-secondary);
-  }
-
-  .lang-text-item-row {
-    max-width: 620px;
   }
 
   .team-form-item {
@@ -80,18 +68,18 @@
 
 .team-switch-item {
   margin-bottom: 0;
-  padding-right: 44px;
+  padding-right: var(--ant-padding-lg, 24px);
 
   & + & {
     padding-right: 0;
-    padding-left: 44px;
+    padding-left: var(--ant-padding-lg, 24px);
     border-left: 1px solid var(--ant-color-border-secondary);
   }
 
   .team-form-item-row {
     display: grid;
     grid-template-columns: minmax(0, max-content) auto;
-    gap: 16px;
+    gap: var(--ant-margin, 16px);
     align-items: center;
   }
 
@@ -122,52 +110,39 @@
 
 .team-logo-form-item {
   margin-bottom: 0;
-  padding-right: 44px;
+  padding-right: var(--ant-padding-lg, 24px);
 
   & + & {
     padding-right: 0;
-    padding-left: 44px;
+    padding-left: var(--ant-padding-lg, 24px);
     border-left: 1px solid var(--ant-color-border-secondary);
   }
 
   .team-form-item-label {
-    padding-bottom: 8px;
+    padding-bottom: var(--ant-padding-xs, 8px);
   }
 
   .team-form-item-label > label {
     color: var(--ant-color-text);
     font-weight: 500;
   }
-
-  .team-logo-upload-root,
-  .team-logo-upload-list,
-  .team-logo-upload-item,
-  .team-logo-upload-trigger {
-    width: 168px !important;
-    height: 168px !important;
-  }
 }
 
 .team-logo-upload {
-  width: 168px;
-
   .team-logo-upload-trigger {
     background: var(--ant-color-fill-alter) !important;
     border-color: var(--ant-color-primary-border) !important;
     border-style: dashed !important;
-    border-radius: 12px !important;
   }
 
   .team-logo-upload-plus {
     color: var(--ant-color-text);
-    font-size: 30px;
   }
 
   .team-logo-upload-item {
     padding: 0 !important;
     overflow: hidden;
     border-color: var(--ant-color-border) !important;
-    border-radius: 6px !important;
 
     &::before {
       background: transparent !important;
@@ -195,8 +170,6 @@
     }
 
     .team-logo-action-icon {
-      margin: 0 12px;
-      font-size: 20px;
       filter: drop-shadow(0 1px 2px rgba(255, 255, 255, 0.6));
     }
 
@@ -229,32 +202,26 @@
 
 .team-logo-helper {
   display: inline-flex;
-  gap: 8px;
+  gap: var(--ant-margin-xs, 8px);
   align-items: center;
   width: min(100%, 680px);
-  margin-top: 18px;
-  padding: 8px 12px;
+  margin-top: var(--ant-margin, 16px);
+  padding: var(--ant-padding-xs, 8px) var(--ant-padding-sm, 12px);
   color: var(--ant-color-text-secondary);
   background: var(--ant-color-fill-alter);
   border: 1px solid var(--ant-color-border-secondary);
-  border-radius: 6px;
+  border-radius: var(--ant-border-radius, 6px);
 }
 
 .team-info-submitter {
   display: flex;
   justify-content: flex-end;
-  margin-top: 24px;
-
-  button {
-    min-width: 120px;
-  }
+  margin-top: var(--ant-margin-lg, 24px);
 }
 
 @media (max-width: 960px) {
-  .team-page-tabs {
-    .team-page-tabs-body {
-      padding-left: 0;
-    }
+  .team-lang-field .lang-text-item-row {
+    row-gap: var(--ant-margin-xs, 8px) !important;
   }
 
   .team-info-basic-grid,
@@ -265,6 +232,7 @@
 
   .team-switch-item,
   .team-switch-item + .team-switch-item,
+  .team-logo-form-item,
   .team-logo-form-item + .team-logo-form-item {
     padding-right: 0;
     padding-left: 0;
@@ -273,6 +241,6 @@
 
   .team-switch-item + .team-switch-item,
   .team-logo-form-item + .team-logo-form-item {
-    margin-top: 20px;
+    margin-top: var(--ant-margin, 16px);
   }
 }

--- a/src/pages/Teams/index.tsx
+++ b/src/pages/Teams/index.tsx
@@ -38,7 +38,19 @@ import {
   ProTable,
 } from '@ant-design/pro-components';
 import { FormattedMessage, history, useIntl, useLocation } from '@umijs/max';
-import { Button, Flex, Form, Grid, Spin, Switch, Tabs, theme, Tooltip, Upload } from 'antd';
+import {
+  Button,
+  Flex,
+  Form,
+  Grid,
+  Spin,
+  Switch,
+  Tabs,
+  theme,
+  Tooltip,
+  Typography,
+  Upload,
+} from 'antd';
 import { Children, useEffect, useRef, useState } from 'react';
 import { v4 } from 'uuid';
 import AddMemberModal from './Components/AddMemberModal';
@@ -418,12 +430,12 @@ const Team = () => {
           }}
         >
           <section className='team-info-card team-info-card-basic'>
-            <div className='team-info-section-title'>
+            <Typography.Title className='team-info-section-title' level={5}>
               <FormattedMessage
                 id='pages.team.info.section.basic'
                 defaultMessage='Basic Information'
               />
-            </div>
+            </Typography.Title>
             <div className='team-info-basic-grid'>
               <div className='team-info-basic-fields'>
                 <Form.Item
@@ -499,12 +511,12 @@ const Team = () => {
           </section>
 
           <section className='team-info-card'>
-            <div className='team-info-section-title'>
+            <Typography.Title className='team-info-section-title' level={5}>
               <FormattedMessage
                 id='pages.team.info.section.visibility'
                 defaultMessage='Team visibility and display'
               />
-            </div>
+            </Typography.Title>
             <div className='team-switch-grid'>
               <Form.Item
                 className='team-switch-item'
@@ -569,9 +581,9 @@ const Team = () => {
           </section>
 
           <section className='team-info-card team-logo-card'>
-            <div className='team-info-section-title'>
+            <Typography.Title className='team-info-section-title' level={5}>
               <FormattedMessage id='pages.team.info.section.logo' defaultMessage='Team Logo' />
-            </div>
+            </Typography.Title>
             <div className='team-logo-grid'>
               <Form.Item
                 className='team-logo-form-item'
@@ -1051,7 +1063,7 @@ const Team = () => {
       <Tabs
         activeKey={activeTabKey}
         className='team-page-tabs'
-        classNames={{ body: 'team-page-tabs-body', item: 'team-page-tabs-item' }}
+        classNames={{ item: 'team-page-tabs-item' }}
         onChange={onTabChange}
         tabPlacement={screens.lg === false ? 'top' : 'start'}
         items={tabs}

--- a/tests/integration/teams/TeamsWorkflow.integration.test.tsx
+++ b/tests/integration/teams/TeamsWorkflow.integration.test.tsx
@@ -452,6 +452,10 @@ jest.mock('antd', () => {
     Switch,
     Tabs,
     Tooltip,
+    Typography: {
+      Title: ({ children, level = 1, className }: any) =>
+        React.createElement(`h${level}`, { className }, children),
+    },
     Upload,
     message,
     theme,

--- a/tests/unit/pages/Account/ProfilePage.test.tsx
+++ b/tests/unit/pages/Account/ProfilePage.test.tsx
@@ -1022,7 +1022,7 @@ describe('Account profile page (unit)', () => {
     expect(screen.getByRole('status')).toHaveTextContent('Weak');
     expect(screen.getByRole('status')).not.toHaveTextContent('Strength:');
     expect(screen.getByRole('progressbar')).toHaveAttribute('data-steps', '3');
-    expect(screen.getByRole('progressbar')).toHaveAttribute('data-segment-width', '52');
+    expect(screen.getByRole('progressbar')).not.toHaveAttribute('data-segment-width');
 
     const newPassword = screen.getByLabelText('New Password');
     await user.type(newPassword, 'Abcdefg1!');
@@ -1038,7 +1038,7 @@ describe('Account profile page (unit)', () => {
     expect(await screen.findByRole('heading', { name: 'Alice' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Change Password' }));
-    expect(screen.getByRole('heading', { name: 'Password tips' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Password tips', level: 5 })).toBeInTheDocument();
     expect(
       screen.queryByText('Avoid using the same password on other websites.'),
     ).not.toBeInTheDocument();
@@ -1048,7 +1048,7 @@ describe('Account profile page (unit)', () => {
     expect(screen.getByRole('button', { name: 'Update password' })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Change Email' }));
     expect(screen.getByText('Enter new email')).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'How it works' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'How it works', level: 5 })).toBeInTheDocument();
     expect(screen.getByText('user@example.com')).toBeInTheDocument();
     expect(screen.queryByLabelText('Current Email')).not.toBeInTheDocument();
     expect(screen.getByTestId('email-steps')).toHaveAttribute('data-orientation', 'vertical');

--- a/tests/unit/pages/Teams/TeamPage.test.tsx
+++ b/tests/unit/pages/Teams/TeamPage.test.tsx
@@ -387,8 +387,8 @@ jest.mock('antd', () => {
   });
   Button.displayName = 'MockButton';
 
-  const Tabs = ({ items = [], activeKey, onChange, tabPlacement }: any) => (
-    <div data-testid='tabs' data-tab-position={tabPlacement}>
+  const Tabs = ({ items = [], activeKey, onChange, tabPlacement, classNames }: any) => (
+    <div data-testid='tabs' data-tab-position={tabPlacement} data-body-class={classNames?.body}>
       {items.map((item: any) => (
         <div key={item.key}>
           <button type='button' onClick={() => onChange?.(item.key)}>
@@ -445,6 +445,10 @@ jest.mock('antd', () => {
     Switch,
     Tabs,
     Tooltip,
+    Typography: {
+      Title: ({ children, level = 1, className }: any) =>
+        React.createElement(`h${level}`, { className }, children),
+    },
     Upload,
     message,
     theme,
@@ -678,6 +682,21 @@ describe('Team page validations', () => {
     renderWithProviders(<Team />);
 
     expect(screen.getByTestId('tabs')).toHaveAttribute('data-tab-position', 'top');
+  });
+
+  it('uses consistent section headings without adding another tab body inset', () => {
+    setWindowLocation('?action=create');
+
+    renderWithProviders(<Team />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Basic Information', level: 5 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Team visibility and display', level: 5 }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Team Logo', level: 5 })).toBeInTheDocument();
+    expect(screen.getByTestId('tabs')).not.toHaveAttribute('data-body-class');
   });
 
   it('prevents submission when rank requires logos but none are provided', async () => {


### PR DESCRIPTION
## Branch Contract

- Base: `dev`; head: `ForeverYoung5:feature/issue-1020`.
- Validated environment: local frontend using the existing dev configuration.
- Back-merge: not required. Main promotion and any eligible workspace integration remain separate follow-up delivery steps; neither is included in this PR.

## Linked Issue

Fixes #1020

## Change Facts

- Align Account and Team typography, control sizes, padding, gaps, borders, and responsive layouts with Ant Design defaults/theme tokens. Let Account cards and empty states grow with content rather than reserving fixed height.
- Keep the requested 16px profile name and 14px/12px email-step title/description. Match the password layout to the email form's column ratio and align icons with adjacent text.
- Make Account backgrounds and browser-autofilled inputs follow the active light/dark theme without disabling autofill.
- Use semantic Ant Design headings; remove the duplicate Team tab inset and custom upload/control sizing. Update three regression-test files for these presentation contracts.
- Refresh source-bound locale artifacts after TSX line movement and documentation review metadata. No translation-copy, dependency, backend, or database change.
- Temporary Connected Applications mock fixtures and preview branches are absent. Relative to `dev`, the OAuth list component and its existing tests are unchanged.

No changes to submission handlers, validation rules, password-strength calculation, email verification, OAuth authorization/list/revoke behavior, Team permissions/membership, uploads, or service/API calls.

## Validation Facts

- Focused Account/Team unit and integration regression: 6 suites / 80 tests passed.
- Final OAuth regression after mock cleanup: 9 tests passed (`--watchman=false`).
- `pnpm lint`, `pnpm build`, `pnpm i18n:locale:artifacts:write`, and `pnpm i18n:locale:all:check` passed.
- Staged Docpact: 37 paths, 13 reviewed governed documents, zero diagnostics; `git diff --check` passed.
- Browser/computed-style checks covered Account/Team sizing, responsive layout, icon alignment, and Account light/dark styling.
- Final hook-owned full gate on `baf55636a0f5f46fd7cc79f5faf6976112d5380c`: Docpact, LCIA/cache, reference data, lint/format/typecheck, all 47 receipt tests, all 5,987 tests in the remaining 443 suites, and the unchanged full-coverage check passed. No skipped or failed tests; 484/484 source files reached 100% statements, source-mapped branches, functions, and lines.

Local Watchman cannot launch because Homebrew ICU 74 is missing. The checked push uses a process-local PATH with pinned Node/pnpm and system binaries so Jest falls back to its native filesystem crawler. The first full-gate attempt stopped at one receipt test because its temporary HOME made Corepack download pnpm and the registry timed out; the rerun explicitly reuses the existing local Corepack cache. No repository test configuration, inventory, coverage threshold, or system installation is changed.

## Risks And Follow-Up

Presentation-only runtime scope; responsive/theme rendering is the main regression risk. Focused behavior regressions and the unchanged full coverage gate guard the existing flows. No real authorization or data mutation was performed for visual verification. PR review/CI and merge remain pending; do not treat this as main release or workspace integration completion.
