### PR TITLE
Hydrate lightweight LifecycleModel graphs safely in edit mode

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-09-03"
-lastReviewedCommit: "eee53ce4626a3f0acb308a275a4025abb21cade8"
-lastReviewedNote: 'Reviewed for Next #1020: Account and Team information surfaces now use Ant Design theme-default typography, control sizing and spacing, while content panels size naturally; no ownership, routing, baseline or waiver rule changed.'
+lastReviewedAt: '2026-09-04'
+lastReviewedCommit: '268221f9f695944dc75d29a75c101183869001b1'
+lastReviewedNote: 'Reviewed for Next #1023: edit-mode LifecycleModel graph compatibility remains within the existing frontend, service, and test ownership rules; no routing, baseline, or waiver rule changed.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,9 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-09-03
-lastReviewedCommit: eee53ce4626a3f0acb308a275a4025abb21cade8
-lastReviewedNote: 'Reviewed for Next #1020: Account and Team theme-default UI sizing remains page-local and preserves authorization, data behavior and dev delivery boundaries.'
+lastReviewedAt: 2026-09-04
+lastReviewedCommit: 268221f9f695944dc75d29a75c101183869001b1
+lastReviewedNote: 'Reviewed for Next #1023: exact-version LifecycleModel edit hydration stays page-and-service local and preserves authorization, repository ownership, and dev delivery boundaries.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -42,9 +42,9 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .github/workflows/build.yml
   - .nvmrc
-lastReviewedAt: 2026-09-03
-lastReviewedCommit: eee53ce4626a3f0acb308a275a4025abb21cade8
-lastReviewedNote: 'Reviewed for Next #1020: Account and Team theme-default sizing uses the existing local bootstrap, focused validation and controlled dev workflow without new preview or environment switches.'
+lastReviewedAt: 2026-09-04
+lastReviewedCommit: 268221f9f695944dc75d29a75c101183869001b1
+lastReviewedNote: 'Reviewed for Next #1023: LifecycleModel edit compatibility uses the existing Node/pnpm bootstrap, serial focused tests, and controlled dev delivery workflow without new environment switches.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/contribution-path-analysis-design.md
+++ b/docs/agents/contribution-path-analysis-design.md
@@ -20,9 +20,9 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-09-02
-lastReviewedCommit: d1b17a476945c9aee00d2106ba44c0f72ce5e5a2
-lastReviewedNote: 'Reviewed for Next Issue #901: removing an unreachable Task Center diagnostic guard and covering retained diagnostic fallbacks does not change calculation, analysis, or contribution-path contracts.'
+lastReviewedAt: 2026-09-04
+lastReviewedCommit: 268221f9f695944dc75d29a75c101183869001b1
+lastReviewedNote: 'Reviewed for Next #1023: edit-mode graph hydration and persistence reconciliation do not change the proposed contribution-path analysis contract.'
 ---
 
 # Contribution Path Analysis Design

--- a/docs/agents/lca-analysis-visualization-plan.md
+++ b/docs/agents/lca-analysis-visualization-plan.md
@@ -20,9 +20,9 @@ checkPaths:
   - docs/agents/util_calculate.md
   - src/pages/Processes/Analysis/**
   - src/components/LcaTaskCenter/**
-lastReviewedAt: 2026-09-02
-lastReviewedCommit: d1b17a476945c9aee00d2106ba44c0f72ce5e5a2
-lastReviewedNote: 'Reviewed for Next Issue #901: removing an unreachable Task Center diagnostic guard and covering retained diagnostic fallbacks does not change calculation, analysis, or contribution-path contracts.'
+lastReviewedAt: 2026-09-04
+lastReviewedCommit: 268221f9f695944dc75d29a75c101183869001b1
+lastReviewedNote: 'Reviewed for Next #1023: edit-mode graph hydration and persistence reconciliation do not change the proposed LCA analysis or visualization contract.'
 ---
 
 # LCA Analysis And Visualization Plan

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -42,9 +42,9 @@ checkPaths:
   - scripts/typescript-native-parser.*
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-09-03
-lastReviewedCommit: eee53ce4626a3f0acb308a275a4025abb21cade8
-lastReviewedNote: 'Reviewed for Next #1020: generated locale artifacts were refreshed for Account callsite movement; pre-push scope, thresholds and bypass policy remain unchanged.'
+lastReviewedAt: 2026-09-04
+lastReviewedCommit: 268221f9f695944dc75d29a75c101183869001b1
+lastReviewedNote: 'Reviewed for Next #1023: focused graph compatibility tests and full-coverage proof use the existing controlled pre-push gate; trigger and bypass policy remain unchanged.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,9 +25,9 @@ checkPaths:
   - playwright.config.ts
   - config/docs-capture/**
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-09-03
-lastReviewedCommit: 0cfd00b890fb998ba7f43859bfb424617b5ecb90
-lastReviewedNote: 'Reviewed for Next #1020: page-local Account and Team sizing cleanup preserves component-service boundaries, theme ownership and existing authorization flows.'
+lastReviewedAt: 2026-09-04
+lastReviewedCommit: 268221f9f695944dc75d29a75c101183869001b1
+lastReviewedNote: 'Reviewed for Next #1023: LifecycleModel edit hydration reuses the view compatibility service and separates calculation state from persistence state without changing layer ownership.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -93,6 +93,7 @@ Rules:
 - Contact, FlowProperty, Source, and UnitGroup keyword searches use `src/services/general/hybridSearch.ts` and their four allowlisted Hybrid Edge Functions. UUID-mention and empty-keyword list paths remain on their existing RPCs. The shared service forwards the current user JWT plus query/filter/paging and optional state/team context, returns Team Data as a genuine empty result when no team is selected, and preserves transport/auth/mapping failures as `success: false` instead of presenting them as empty data
 - Process keyword searches use the indexed `search_processes` RPC and pass explicit escaped query terms without app-side field filtering. The `public_plus_owner_draft` calculation picker enables the database-owned actor-draft mode for its personal branch, requiring owner `state_code=0` rows regardless of team/review workflow metadata, then merges that result with public state-100 rows. Database migrations own the `search_text` lexical source and its PGroonga index
 - Process list rows carry nullable `model_version` alongside `model_id`. LifecycleModel actions resolve the exact owner version as `model_version ?? process.version`; null remains the legacy same-version fallback, while an explicit version must never be replaced with the latest LifecycleModel revision. LifecycleModel result submodels are queried with each submodel reference's own Process version rather than the parent Model version
+- LifecycleModel view and edit surfaces hydrate lightweight `json_tg.xflow` nodes from each referenced Process's exact ID and version through the shared compatibility normalizer. The editor calculates and validates against that hydrated graph, but save planning reconciles untouched compatibility and editor-only fields back to the stored graph representation; explicit graph edits remain persistent
 - computed message IDs must belong to an exact enumerated family that either proves a closed-world producer or implements a localized runtime fallback before an unknown value is formatted; opaque backend diagnostics are not locale keys
 - static bundles are read through consuming services, not directly by pages
 - governed classification/location bundles are generated from `reference-resource-manifest.json`, one stable base per resource, and scoped language overlays; `generatedManifest.ts`, gzip assets, cache revisions, prewarm lists, coverage, and digests are derived outputs verified by `pnpm reference-data:check`

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -43,9 +43,9 @@ checkPaths:
   - scripts/typescript-native-parser.*
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-09-03
-lastReviewedCommit: eee53ce4626a3f0acb308a275a4025abb21cade8
-lastReviewedNote: 'Reviewed for Next #1020: focused Account and Team regression tests, computed-style inspection, locale checks and production build cover the theme-default UI sizing change; controlled push-gate policy is unchanged.'
+lastReviewedAt: 2026-09-04
+lastReviewedCommit: 268221f9f695944dc75d29a75c101183869001b1
+lastReviewedNote: 'Reviewed for Next #1023: focused helper, component, compatibility, and API tests plus lint, full coverage, and production build prove edit hydration and persistence safety; validation policy is unchanged.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -22,9 +22,9 @@ checkPaths:
   - scripts/e2e/**
   - playwright.config.ts
   - tests/e2e/i18n/**
-lastReviewedAt: 2026-09-03
-lastReviewedCommit: 0cfd00b890fb998ba7f43859bfb424617b5ecb90
-lastReviewedNote: 'Reviewed for Next #1020: the temporary connected-app preview and fixtures are removed at the user request. List and disconnect always use the existing shared OAuth services, including when obsolete preview parameters remain in the URL; UI styling and authorization boundaries are unchanged.'
+lastReviewedAt: 2026-09-04
+lastReviewedCommit: 268221f9f695944dc75d29a75c101183869001b1
+lastReviewedNote: 'Reviewed for Next #1023: LifecycleModel edit hydration uses existing Process read services and the established bundle mutation path; database, Edge, authentication, and environment ownership are unchanged.'
 ---
 
 # Supabase Environment And Database Workflow

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -43,9 +43,9 @@ checkPaths:
   - pnpm-lock.yaml
   - pnpm-workspace.yaml
   - Dockerfile.app
-lastReviewedAt: 2026-09-03
-lastReviewedCommit: eee53ce4626a3f0acb308a275a4025abb21cade8
-lastReviewedNote: 'Reviewed for Next #1020: the existing focused Account and Team coverage protects the UI-only default-sizing change without new test infrastructure or strategy changes.'
+lastReviewedAt: 2026-09-04
+lastReviewedCommit: 268221f9f695944dc75d29a75c101183869001b1
+lastReviewedNote: 'Reviewed for Next #1023: focused pure-helper, component, and service tests cover graph hydration and safe persistence without changing test infrastructure or strategy.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -40,9 +40,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-09-03
-lastReviewedCommit: eee53ce4626a3f0acb308a275a4025abb21cade8
-lastReviewedNote: 'Reviewed for Next #1020: focused Account and Team suites remain green after removing custom component sizing; no coverage queue or historical baseline update is required.'
+lastReviewedAt: 2026-09-04
+lastReviewedCommit: 268221f9f695944dc75d29a75c101183869001b1
+lastReviewedNote: 'Reviewed for Next #1023: the changed graph compatibility sources retain full source-mapped coverage; no coverage queue or historical baseline update is required.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -42,9 +42,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-09-03
-lastReviewedCommit: eee53ce4626a3f0acb308a275a4025abb21cade8
-lastReviewedNote: 'Reviewed for Next #1020: the Account unit assertion now verifies the absence of a custom progress width, while existing component and integration patterns remain sufficient.'
+lastReviewedAt: 2026-09-04
+lastReviewedCommit: 268221f9f695944dc75d29a75c101183869001b1
+lastReviewedNote: 'Reviewed for Next #1023: immutable three-way graph reconciliation, edit-load behavior, and service-boundary tests fit the existing pure-helper, component, and API patterns.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -39,9 +39,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-09-03
-lastReviewedCommit: eee53ce4626a3f0acb308a275a4025abb21cade8
-lastReviewedNote: 'Reviewed for Next #1020: the obsolete 52px progress-width expectation was updated to the intended theme-default contract; troubleshooting and gate recovery guidance remain unchanged.'
+lastReviewedAt: 2026-09-04
+lastReviewedCommit: 268221f9f695944dc75d29a75c101183869001b1
+lastReviewedNote: 'Reviewed for Next #1023: targeted serial Jest runs resolved compatibility-test mocks and closed new branch coverage; troubleshooting and gate recovery guidance remain unchanged.'
 ---
 
 # Testing Troubleshooting

--- a/docs/agents/util_calculate.md
+++ b/docs/agents/util_calculate.md
@@ -20,9 +20,9 @@ checkPaths:
   - src/services/lca/**
   - src/components/LcaTaskCenter/**
   - src/pages/Processes/Analysis/**
-lastReviewedAt: 2026-09-02
-lastReviewedCommit: d1b17a476945c9aee00d2106ba44c0f72ce5e5a2
-lastReviewedNote: 'Reviewed for Next Issue #901: removing an unreachable Task Center diagnostic guard and covering retained diagnostic fallbacks does not change calculation, analysis, or contribution-path contracts.'
+lastReviewedAt: 2026-09-04
+lastReviewedCommit: 268221f9f695944dc75d29a75c101183869001b1
+lastReviewedNote: 'Reviewed for Next #1023: calculations consume the hydrated editor graph while persistence receives a separately reconciled graph; calculation and allocation algorithms are unchanged.'
 ---
 
 # Lifecycle Model Calculation Reference
@@ -111,6 +111,7 @@ lastReviewedNote: 'Reviewed for Next Issue #901: removing an unreachable Task Ce
 - primary-group reference exchange is aligned to `modelTargetAmount`
 - root `refScalingFactor` falls back to `1` when the model target amount or reference mean amount is zero or missing
 - old submodels are reused only when `nodeId`, `processId`, `allocatedExchangeFlowId`, and `allocatedExchangeDirection` all match
+- edit-mode compatibility may hydrate lightweight graph nodes and ports from exact-version Process details before calling `genLifeCycleModelProcesses`; persistence planning receives a separately reconciled graph so untouched display-only hydration is not written into `json_tg`
 - generated subproduct names emit one localized prefix and bracket wrapper for every content-language registry row whose authoring capability is enabled; a new authoring language must add its reviewed `generatedContent.subproductPrefix` in that registry instead of adding language-specific branches here
 - persistence-plan helpers that prepare ordered datasets for validation or review must stay schema-compatible with these calculation-facing structures even when they do not execute allocation logic
 

--- a/docs/plans/i18n-de-DE/context-manifest.json
+++ b/docs/plans/i18n-de-DE/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b",
-    "auditedInputDigest": "2553f5c8bfcdaac8140a474a888463f4e87aadbd989b35ff3282c27034c827e7"
+    "sourceManifestDigest": "719bc23626cd3f60498a34e204baa70143087617d15189859d4970d9532410c9",
+    "auditedInputDigest": "b343cd7235661fe597e28957ea14cd2167a3bd923568ef87a3581bfcb0ab2b8b"
   },
   "inventory": {
     "sourceMessageCount": 3322,
@@ -47,7 +47,7 @@
     "messageCount": 3322,
     "completeCount": 3322,
     "blockedCount": 0,
-    "dossierDigest": "47df64f8624aeb8b19bb0223c35c70d3cefcb13b85ac0e6bc68cff1313cb3196",
+    "dossierDigest": "3a5301bf77ec2117a1947238621c164ab72d6bf5adffe4ccbfe5f0131b9ecd82",
     "catalogDigest": "c808a402b06edfa7e58af2c3e435a2e6aeb90c161cbf26514a5847d731dfa29e",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1150,5 +1150,5 @@
     "docs/plans/i18n-de-DE/style-guide.md": "b139bb9cc48a23f9b9f69efc44611daba4684c3495aa5cf4fb0ac57e3ab3994f"
   },
   "blockedContext": [],
-  "contextDigest": "75edbf353e6c6b80a08ac507592c2534c4e8095217e0cf0a021d72ea3f59a20b"
+  "contextDigest": "3a0aad34b078015d83d7601d2d13b8aef728fc32c342c5046396872b92440833"
 }

--- a/docs/plans/i18n-de-DE/locale-activation-manifest.json
+++ b/docs/plans/i18n-de-DE/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b"
+    "sourceManifestDigest": "719bc23626cd3f60498a34e204baa70143087617d15189859d4970d9532410c9"
   },
   "registry": {
     "canonicalLocale": "de-DE",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "75edbf353e6c6b80a08ac507592c2534c4e8095217e0cf0a021d72ea3f59a20b",
-    "qualityDigest": "538209cfaa7055391051c634f4d952b0cbd4b8d77a4ca4b9a33c758dd930bba3",
+    "contextDigest": "3a0aad34b078015d83d7601d2d13b8aef728fc32c342c5046396872b92440833",
+    "qualityDigest": "ad8d0179261352ffb73deeb17a1c9aa2b981f814e68491457d9abd9d146deb32",
     "correctionLedgerDigest": "fcda3136886694c111258daee7f51b6bf0f29e3333ed7e582d7fcc349f0b4c74",
     "routeViewCoverageDigest": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "cb11b6768b5c72d6d0d246ee99bf8ca550778fb8a34dfe2475e73bd6acccd45a"
+  "activationDigest": "9f2821309967d96e7c25d7f977f784f0eb22167c0931ebe52fd8c2b7fb88adfd"
 }

--- a/docs/plans/i18n-de-DE/manifest.json
+++ b/docs/plans/i18n-de-DE/manifest.json
@@ -3,7 +3,7 @@
   "source": {
     "baseRef": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "baseCommit": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "2553f5c8bfcdaac8140a474a888463f4e87aadbd989b35ff3282c27034c827e7",
+    "auditedInputDigest": "b343cd7235661fe597e28957ea14cd2167a3bd923568ef87a3581bfcb0ab2b8b",
     "auditedInputDigestAlgorithm": "sha256(path\\0content\\0)",
     "repository": "linancn/tiangong-lca-next"
   },
@@ -45917,7 +45917,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 1904,
+          "line": 1964,
           "column": 18,
           "symbol": "ToolbarEdit",
           "defaultMessage": "Data Check",
@@ -45977,7 +45977,7 @@
             },
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 1904,
+              "line": 1964,
               "column": 18,
               "kind": "FormattedMessage"
             },
@@ -47240,7 +47240,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 971,
+          "line": 985,
           "column": 13,
           "symbol": "showMutationError",
           "defaultMessage": "Data with the same ID and version already exists.",
@@ -47300,7 +47300,7 @@
             },
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 971,
+              "line": 985,
               "column": 13,
               "kind": "formatMessage"
             },
@@ -47413,7 +47413,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 1091,
+          "line": 1121,
           "column": 15,
           "symbol": "saveData",
           "defaultMessage": "Created successfully!",
@@ -47473,7 +47473,7 @@
             },
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 1091,
+              "line": 1121,
               "column": 15,
               "kind": "formatMessage"
             },
@@ -49624,7 +49624,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 208,
+          "line": 215,
           "column": 12,
           "symbol": "edgeLabelText",
           "defaultMessage": "Input",
@@ -49633,7 +49633,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 255,
+          "line": 263,
           "column": 24,
           "symbol": "inputFlowTool",
           "defaultMessage": "Input",
@@ -49675,13 +49675,13 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 208,
+              "line": 215,
               "column": 12,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 255,
+              "line": 263,
               "column": 24,
               "kind": "formatMessage"
             },
@@ -50571,7 +50571,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 1846,
+          "line": 1906,
           "column": 13,
           "symbol": "ToolbarEdit",
           "defaultMessage": "Delete element",
@@ -50586,7 +50586,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 1846,
+              "line": 1906,
               "column": 13,
               "kind": "FormattedMessage"
             }
@@ -50796,7 +50796,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 196,
+          "line": 203,
           "column": 15,
           "symbol": "edgeLabelText",
           "defaultMessage": "Bal",
@@ -50820,7 +50820,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 196,
+              "line": 203,
               "column": 15,
               "kind": "formatMessage"
             },
@@ -50894,7 +50894,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 200,
+          "line": 207,
           "column": 14,
           "symbol": "edgeLabelText",
           "defaultMessage": "Def",
@@ -50918,7 +50918,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 200,
+              "line": 207,
               "column": 14,
               "kind": "formatMessage"
             },
@@ -50992,7 +50992,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 204,
+          "line": 211,
           "column": 14,
           "symbol": "edgeLabelText",
           "defaultMessage": "Sur",
@@ -51016,7 +51016,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 204,
+              "line": 211,
               "column": 14,
               "kind": "formatMessage"
             },
@@ -51585,7 +51585,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 357,
+          "line": 365,
           "column": 24,
           "symbol": "refTool",
           "defaultMessage": "Reference node",
@@ -51618,7 +51618,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 357,
+              "line": 365,
               "column": 24,
               "kind": "formatMessage"
             },
@@ -51841,7 +51841,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 1865,
+          "line": 1925,
           "column": 18,
           "symbol": "ToolbarEdit",
           "defaultMessage": "Save data",
@@ -51856,7 +51856,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 1865,
+              "line": 1925,
               "column": 18,
               "kind": "FormattedMessage"
             }
@@ -51924,7 +51924,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 399,
+          "line": 407,
           "column": 24,
           "symbol": "nonRefTool",
           "defaultMessage": "Set as reference",
@@ -51939,7 +51939,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 399,
+              "line": 407,
               "column": 24,
               "kind": "formatMessage"
             }
@@ -52580,7 +52580,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 212,
+          "line": 219,
           "column": 13,
           "symbol": "edgeLabelText",
           "defaultMessage": "Output",
@@ -52589,7 +52589,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 301,
+          "line": 309,
           "column": 24,
           "symbol": "outputFlowTool",
           "defaultMessage": "Output",
@@ -52631,13 +52631,13 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 212,
+              "line": 219,
               "column": 13,
               "kind": "formatMessage"
             },
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 301,
+              "line": 309,
               "column": 24,
               "kind": "formatMessage"
             },
@@ -53008,7 +53008,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 1917,
+          "line": 1977,
           "column": 20,
           "symbol": "ToolbarEdit",
           "defaultMessage": "Submit for Review",
@@ -53032,7 +53032,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 1917,
+              "line": 1977,
               "column": 20,
               "kind": "FormattedMessage"
             },
@@ -54387,7 +54387,7 @@
         {
           "kind": "FormattedMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 1832,
+          "line": 1892,
           "column": 13,
           "symbol": "ToolbarEdit",
           "defaultMessage": "Update Reference",
@@ -54492,7 +54492,7 @@
             },
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 1832,
+              "line": 1892,
               "column": 13,
               "kind": "FormattedMessage"
             },
@@ -92911,7 +92911,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 1027,
+          "line": 1047,
           "column": 15,
           "symbol": "saveData",
           "defaultMessage": "Saved successfully.",
@@ -92926,7 +92926,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 1027,
+              "line": 1047,
               "column": 15,
               "kind": "formatMessage"
             }
@@ -115664,7 +115664,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 1531,
+          "line": 1591,
           "column": 39,
           "symbol": "ToolbarEdit",
           "defaultMessage": "Automatically generated",
@@ -115679,7 +115679,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 1531,
+              "line": 1591,
               "column": 39,
               "kind": "formatMessage"
             }
@@ -132326,7 +132326,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 960,
+          "line": 974,
           "column": 13,
           "symbol": "showMutationError",
           "defaultMessage": "The model is missing reference process information. Complete or rebind the reference process, then try again.",
@@ -132341,7 +132341,7 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 960,
+              "line": 974,
               "column": 13,
               "kind": "formatMessage"
             }
@@ -132409,8 +132409,8 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 1481,
-          "column": 13,
+          "line": 1525,
+          "column": 15,
           "symbol": "ToolbarEdit",
           "defaultMessage": "Model is not public",
           "defaultMessageExpression": null
@@ -132433,8 +132433,8 @@
           "locations": [
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 1481,
-              "column": 13,
+              "line": 1525,
+              "column": 15,
               "kind": "formatMessage"
             },
             {
@@ -222874,7 +222874,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 981,
+          "line": 995,
           "column": 13,
           "symbol": "showMutationError",
           "defaultMessage": "This data is open data, save failed",
@@ -222940,7 +222940,7 @@
             },
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 981,
+              "line": 995,
               "column": 13,
               "kind": "formatMessage"
             },
@@ -232021,7 +232021,7 @@
         {
           "kind": "formatMessage",
           "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-          "line": 991,
+          "line": 1005,
           "column": 13,
           "symbol": "showMutationError",
           "defaultMessage": "Data is under review, save failed",
@@ -232087,7 +232087,7 @@
             },
             {
               "path": "src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx",
-              "line": 991,
+              "line": 1005,
               "column": 13,
               "kind": "formatMessage"
             },

--- a/docs/plans/i18n-de-DE/quality-manifest.json
+++ b/docs/plans/i18n-de-DE/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "de-DE",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b",
-    "contextDigest": "75edbf353e6c6b80a08ac507592c2534c4e8095217e0cf0a021d72ea3f59a20b"
+    "sourceManifestDigest": "719bc23626cd3f60498a34e204baa70143087617d15189859d4970d9532410c9",
+    "contextDigest": "3a0aad34b078015d83d7601d2d13b8aef728fc32c342c5046396872b92440833"
   },
   "catalog": {
     "messageCount": 3322,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-de-DE/structural-validation.json",
-    "digest": "f3ad9598b2d1f36d7ddf2dd7ab975ab0163203958c96887afeca512c80e3d8ea",
-    "validationDigest": "685cf419943848169b605af802746b3958bf0e96546d1fc88d1e2f22f2c3280d",
+    "digest": "254aa136446a7ed443e5c4b1ed6d856b30fb98bd4e86bfb277374c7c711c4b1f",
+    "validationDigest": "c7ca50c6323864dd14ac7ee7e6231daceb42733e95af569eec4d68817fc91b5c",
     "laneCount": 1,
     "validatedMessageCount": 3322,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "538209cfaa7055391051c634f4d952b0cbd4b8d77a4ca4b9a33c758dd930bba3"
+  "qualityDigest": "ad8d0179261352ffb73deeb17a1c9aa2b981f814e68491457d9abd9d146deb32"
 }

--- a/docs/plans/i18n-de-DE/structural-validation.json
+++ b/docs/plans/i18n-de-DE/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "de-DE",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "2553f5c8bfcdaac8140a474a888463f4e87aadbd989b35ff3282c27034c827e7",
+    "auditedInputDigest": "b343cd7235661fe597e28957ea14cd2167a3bd923568ef87a3581bfcb0ab2b8b",
     "validatedMessageCount": 3322,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1507,
     "highRiskMessageDigest": "37ae9bf80782335d1d0edf20bae122396e2fc524271954d6608a7f2caf3dfacd",
     "catalogDigest": "c808a402b06edfa7e58af2c3e435a2e6aeb90c161cbf26514a5847d731dfa29e",
-    "dossierDigest": "47df64f8624aeb8b19bb0223c35c70d3cefcb13b85ac0e6bc68cff1313cb3196",
+    "dossierDigest": "3a5301bf77ec2117a1947238621c164ab72d6bf5adffe4ccbfe5f0131b9ecd82",
     "typedContentDossierDigest": "33c835327898db68bb60a4db80146c0205e22332eea6dce95694220373ce89d3",
     "routeEvidenceDigest": "404c3f4ce5f4c164a8d11b6999da96087af5d6a40bdc8096b521aafa63edc2d5",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "e11cff8827c56fa95979f98e855a66017eafa6ae5821c8193f5d7334bf95a11f",
         "highRiskMessageCount": 1507,
         "highRiskMessageDigest": "37ae9bf80782335d1d0edf20bae122396e2fc524271954d6608a7f2caf3dfacd",
-        "dossierDigest": "47df64f8624aeb8b19bb0223c35c70d3cefcb13b85ac0e6bc68cff1313cb3196",
+        "dossierDigest": "3a5301bf77ec2117a1947238621c164ab72d6bf5adffe4ccbfe5f0131b9ecd82",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "685cf419943848169b605af802746b3958bf0e96546d1fc88d1e2f22f2c3280d"
+  "validationDigest": "c7ca50c6323864dd14ac7ee7e6231daceb42733e95af569eec4d68817fc91b5c"
 }

--- a/docs/plans/i18n-en-US/context-manifest.json
+++ b/docs/plans/i18n-en-US/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b",
-    "auditedInputDigest": "2553f5c8bfcdaac8140a474a888463f4e87aadbd989b35ff3282c27034c827e7"
+    "sourceManifestDigest": "719bc23626cd3f60498a34e204baa70143087617d15189859d4970d9532410c9",
+    "auditedInputDigest": "b343cd7235661fe597e28957ea14cd2167a3bd923568ef87a3581bfcb0ab2b8b"
   },
   "inventory": {
     "sourceMessageCount": 3322,
@@ -47,7 +47,7 @@
     "messageCount": 3322,
     "completeCount": 3322,
     "blockedCount": 0,
-    "dossierDigest": "81eca636199da59f9c1462fd1bc96a2455001f1ba177d8074d2a82d9a725746a",
+    "dossierDigest": "8447e37a68fd41e2feec7a113f8d9750d08d9f05d2fd4e9a4391dfaacbc1b487",
     "catalogDigest": "e712a87e78e9934accc0b9fecc82b829914a606b3f13c8c0d620d5fa4a77de13",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1150,5 +1150,5 @@
     "docs/plans/i18n-en-US/style-guide.md": "be570ee8db2b034dde7274f774730575ad9b9226af7a5ac7ab35a45d1ef2620c"
   },
   "blockedContext": [],
-  "contextDigest": "4995a4a44774c5af20162e40a6e7ded927a53758044c232354815891f525672f"
+  "contextDigest": "39483d8badf1ebc1bebd867134af2f3762e4722833a8e54347f3f1595566b6ab"
 }

--- a/docs/plans/i18n-en-US/locale-activation-manifest.json
+++ b/docs/plans/i18n-en-US/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b"
+    "sourceManifestDigest": "719bc23626cd3f60498a34e204baa70143087617d15189859d4970d9532410c9"
   },
   "registry": {
     "canonicalLocale": "en-US",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "4995a4a44774c5af20162e40a6e7ded927a53758044c232354815891f525672f",
-    "qualityDigest": "90f65c63f87e3bc807b9a2888e3bbdc1a4c2a8dcbc6ef35ecc68521953014e93",
+    "contextDigest": "39483d8badf1ebc1bebd867134af2f3762e4722833a8e54347f3f1595566b6ab",
+    "qualityDigest": "8e6cf577f80ba190cdb05934ed5b584a61fd946d745c226c1d12d2a294a54fd8",
     "correctionLedgerDigest": "fcda3136886694c111258daee7f51b6bf0f29e3333ed7e582d7fcc349f0b4c74",
     "routeViewCoverageDigest": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "3c46775c2c2a9032f4877ebd41fe89d7d57d1679ff2a76beb104f3509670c063"
+  "activationDigest": "cbc1c39a931827c9bd1a8695883f448be1cb1d4e8baf57adda941fb628b062a0"
 }

--- a/docs/plans/i18n-en-US/quality-manifest.json
+++ b/docs/plans/i18n-en-US/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "en-US",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b",
-    "contextDigest": "4995a4a44774c5af20162e40a6e7ded927a53758044c232354815891f525672f"
+    "sourceManifestDigest": "719bc23626cd3f60498a34e204baa70143087617d15189859d4970d9532410c9",
+    "contextDigest": "39483d8badf1ebc1bebd867134af2f3762e4722833a8e54347f3f1595566b6ab"
   },
   "catalog": {
     "messageCount": 3322,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-en-US/structural-validation.json",
-    "digest": "ef85d439ab2ce63c440e651576d550bb9c96fa3e4dfffa2af5f78bb4697767e7",
-    "validationDigest": "7d391e68a7a8348dd3afbb1c678b0779287842928fed8da5ebcb192fbfc13f39",
+    "digest": "b8fd7319c5f7c826092f77227cd4df11649db07549b6413452caa423646318d0",
+    "validationDigest": "15de788a2f858a4548820346ee42557eb83a69bb11228e1731c3b16d85dd6ec7",
     "laneCount": 1,
     "validatedMessageCount": 3322,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "90f65c63f87e3bc807b9a2888e3bbdc1a4c2a8dcbc6ef35ecc68521953014e93"
+  "qualityDigest": "8e6cf577f80ba190cdb05934ed5b584a61fd946d745c226c1d12d2a294a54fd8"
 }

--- a/docs/plans/i18n-en-US/structural-validation.json
+++ b/docs/plans/i18n-en-US/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "en-US",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "2553f5c8bfcdaac8140a474a888463f4e87aadbd989b35ff3282c27034c827e7",
+    "auditedInputDigest": "b343cd7235661fe597e28957ea14cd2167a3bd923568ef87a3581bfcb0ab2b8b",
     "validatedMessageCount": 3322,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1507,
     "highRiskMessageDigest": "37ae9bf80782335d1d0edf20bae122396e2fc524271954d6608a7f2caf3dfacd",
     "catalogDigest": "e712a87e78e9934accc0b9fecc82b829914a606b3f13c8c0d620d5fa4a77de13",
-    "dossierDigest": "81eca636199da59f9c1462fd1bc96a2455001f1ba177d8074d2a82d9a725746a",
+    "dossierDigest": "8447e37a68fd41e2feec7a113f8d9750d08d9f05d2fd4e9a4391dfaacbc1b487",
     "typedContentDossierDigest": "5bee69a379711b6c87e9d7d5ec71180ff52c44c9700ccb0f81f9ae1daf4a1af8",
     "routeEvidenceDigest": "404c3f4ce5f4c164a8d11b6999da96087af5d6a40bdc8096b521aafa63edc2d5",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "e11cff8827c56fa95979f98e855a66017eafa6ae5821c8193f5d7334bf95a11f",
         "highRiskMessageCount": 1507,
         "highRiskMessageDigest": "37ae9bf80782335d1d0edf20bae122396e2fc524271954d6608a7f2caf3dfacd",
-        "dossierDigest": "81eca636199da59f9c1462fd1bc96a2455001f1ba177d8074d2a82d9a725746a",
+        "dossierDigest": "8447e37a68fd41e2feec7a113f8d9750d08d9f05d2fd4e9a4391dfaacbc1b487",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "7d391e68a7a8348dd3afbb1c678b0779287842928fed8da5ebcb192fbfc13f39"
+  "validationDigest": "15de788a2f858a4548820346ee42557eb83a69bb11228e1731c3b16d85dd6ec7"
 }

--- a/docs/plans/i18n-fr-FR/context-manifest.json
+++ b/docs/plans/i18n-fr-FR/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b",
-    "auditedInputDigest": "2553f5c8bfcdaac8140a474a888463f4e87aadbd989b35ff3282c27034c827e7"
+    "sourceManifestDigest": "719bc23626cd3f60498a34e204baa70143087617d15189859d4970d9532410c9",
+    "auditedInputDigest": "b343cd7235661fe597e28957ea14cd2167a3bd923568ef87a3581bfcb0ab2b8b"
   },
   "inventory": {
     "sourceMessageCount": 3322,
@@ -47,7 +47,7 @@
     "messageCount": 3322,
     "completeCount": 3322,
     "blockedCount": 0,
-    "dossierDigest": "e21d214ab437386a1ce2dd2bfc7b00d1a7a0c9ee08a4846f197aab03b89cfe6e",
+    "dossierDigest": "70c54b1e072b4c34701a75e95dace48e6e9a26cb5b777ab093e669e6524d5f9c",
     "catalogDigest": "9a118ae3bddcdfb951bf4b15ea37c504af4c037943cfdcd0670f0efe1c0d5e09",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1150,5 +1150,5 @@
     "docs/plans/i18n-fr-FR/style-guide.md": "3b651e352a50676ed7f6609dcad88145dbd6a9ad81177ad261526b59d7bf4db4"
   },
   "blockedContext": [],
-  "contextDigest": "a02614cf19f01f33030191083228a6c96c11429e583f3337805a6a85208f0f9a"
+  "contextDigest": "b18107e2668e0dd0823a17d05e3b562bd838dcd2e3f04644f5b001a16ba2349b"
 }

--- a/docs/plans/i18n-fr-FR/locale-activation-manifest.json
+++ b/docs/plans/i18n-fr-FR/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b"
+    "sourceManifestDigest": "719bc23626cd3f60498a34e204baa70143087617d15189859d4970d9532410c9"
   },
   "registry": {
     "canonicalLocale": "fr-FR",
@@ -78,8 +78,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "a02614cf19f01f33030191083228a6c96c11429e583f3337805a6a85208f0f9a",
-    "qualityDigest": "a0b6bf52df10960dd594daf2c5eea023f8591edd65f9a4b9c95c893f1c82b674",
+    "contextDigest": "b18107e2668e0dd0823a17d05e3b562bd838dcd2e3f04644f5b001a16ba2349b",
+    "qualityDigest": "5155968222abff91822074252f35a425da6f9761ad90f8856b5890dfdc34de35",
     "correctionLedgerDigest": "fcda3136886694c111258daee7f51b6bf0f29e3333ed7e582d7fcc349f0b4c74",
     "routeViewCoverageDigest": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -125,5 +125,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "dc2b6fa1b7640f5e6ce46d50a642c36e4740be9c02946353de31e58dbc2c1fd5"
+  "activationDigest": "32845aa0823849437bc6bb9cf1e125e6ba48c4d8c5c2dfa9437d28170acfa883"
 }

--- a/docs/plans/i18n-fr-FR/quality-manifest.json
+++ b/docs/plans/i18n-fr-FR/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "fr-FR",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b",
-    "contextDigest": "a02614cf19f01f33030191083228a6c96c11429e583f3337805a6a85208f0f9a"
+    "sourceManifestDigest": "719bc23626cd3f60498a34e204baa70143087617d15189859d4970d9532410c9",
+    "contextDigest": "b18107e2668e0dd0823a17d05e3b562bd838dcd2e3f04644f5b001a16ba2349b"
   },
   "catalog": {
     "messageCount": 3322,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-fr-FR/structural-validation.json",
-    "digest": "1e3bd51c10699ed08c33cf1f1f2350ed5c3099c3fb13a3b0bac30df1acf8742e",
-    "validationDigest": "e8e733372880d67883b4ded7a8f5563ec049a300fdb95f245896db0d97385e19",
+    "digest": "6817ab27ee65bb0260929dec1836f90b3e12cd2a94d18894005500e55e0ad459",
+    "validationDigest": "a3e5e129bf874aab224b55ad700b812f21f0261ee0f7a077d6613cf07e097036",
     "laneCount": 1,
     "validatedMessageCount": 3322,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "a0b6bf52df10960dd594daf2c5eea023f8591edd65f9a4b9c95c893f1c82b674"
+  "qualityDigest": "5155968222abff91822074252f35a425da6f9761ad90f8856b5890dfdc34de35"
 }

--- a/docs/plans/i18n-fr-FR/structural-validation.json
+++ b/docs/plans/i18n-fr-FR/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "fr-FR",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "2553f5c8bfcdaac8140a474a888463f4e87aadbd989b35ff3282c27034c827e7",
+    "auditedInputDigest": "b343cd7235661fe597e28957ea14cd2167a3bd923568ef87a3581bfcb0ab2b8b",
     "validatedMessageCount": 3322,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1507,
     "highRiskMessageDigest": "37ae9bf80782335d1d0edf20bae122396e2fc524271954d6608a7f2caf3dfacd",
     "catalogDigest": "9a118ae3bddcdfb951bf4b15ea37c504af4c037943cfdcd0670f0efe1c0d5e09",
-    "dossierDigest": "e21d214ab437386a1ce2dd2bfc7b00d1a7a0c9ee08a4846f197aab03b89cfe6e",
+    "dossierDigest": "70c54b1e072b4c34701a75e95dace48e6e9a26cb5b777ab093e669e6524d5f9c",
     "typedContentDossierDigest": "b17812f17c66806d74ac991e03c9a719de58ae79adf6eed26e8b0852c98d0680",
     "routeEvidenceDigest": "404c3f4ce5f4c164a8d11b6999da96087af5d6a40bdc8096b521aafa63edc2d5",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "e11cff8827c56fa95979f98e855a66017eafa6ae5821c8193f5d7334bf95a11f",
         "highRiskMessageCount": 1507,
         "highRiskMessageDigest": "37ae9bf80782335d1d0edf20bae122396e2fc524271954d6608a7f2caf3dfacd",
-        "dossierDigest": "e21d214ab437386a1ce2dd2bfc7b00d1a7a0c9ee08a4846f197aab03b89cfe6e",
+        "dossierDigest": "70c54b1e072b4c34701a75e95dace48e6e9a26cb5b777ab093e669e6524d5f9c",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "e8e733372880d67883b4ded7a8f5563ec049a300fdb95f245896db0d97385e19"
+  "validationDigest": "a3e5e129bf874aab224b55ad700b812f21f0261ee0f7a077d6613cf07e097036"
 }

--- a/docs/plans/i18n-zh-CN/context-manifest.json
+++ b/docs/plans/i18n-zh-CN/context-manifest.json
@@ -5,8 +5,8 @@
     "repository": "linancn/tiangong-lca-next",
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
     "sourceManifestPath": "docs/plans/i18n-de-DE/manifest.json",
-    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b",
-    "auditedInputDigest": "2553f5c8bfcdaac8140a474a888463f4e87aadbd989b35ff3282c27034c827e7"
+    "sourceManifestDigest": "719bc23626cd3f60498a34e204baa70143087617d15189859d4970d9532410c9",
+    "auditedInputDigest": "b343cd7235661fe597e28957ea14cd2167a3bd923568ef87a3581bfcb0ab2b8b"
   },
   "inventory": {
     "sourceMessageCount": 3322,
@@ -47,7 +47,7 @@
     "messageCount": 3322,
     "completeCount": 3322,
     "blockedCount": 0,
-    "dossierDigest": "7e79f58ba7dee8a67efe4c0449ba2a3c2b01794ceb267272f35eca9583bb7ffa",
+    "dossierDigest": "26abd464850a345fc44d6b060eab21a0a8ffc2e79dbcfe1f5423728a3622cfb1",
     "catalogDigest": "baa30718c9ca5e7f44104cfef19da6208c86631508b1a11c9b164a72bf3108e9",
     "moduleCount": 32,
     "moduleDigest": "3b4f2df2201d552cc6e09b75bcebf64a30ac3511d401d79c50d4eb6e806195d3",
@@ -1150,5 +1150,5 @@
     "docs/plans/i18n-zh-CN/style-guide.md": "8da9e9fe011c1f93e682c7d22bfc580945de0e4cfd785115c5b5d2ed6585acfb"
   },
   "blockedContext": [],
-  "contextDigest": "e42a41738437112661b9a865e0eba94786e2ce077f2a521891b105e2a03161ad"
+  "contextDigest": "f3ae8686c9f70751a3a05c5a734867e7c7cd1dd2c823af9ad279c245362f5f6e"
 }

--- a/docs/plans/i18n-zh-CN/locale-activation-manifest.json
+++ b/docs/plans/i18n-zh-CN/locale-activation-manifest.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b"
+    "sourceManifestDigest": "719bc23626cd3f60498a34e204baa70143087617d15189859d4970d9532410c9"
   },
   "registry": {
     "canonicalLocale": "zh-CN",
@@ -74,8 +74,8 @@
     "hardcodingAllowlistDigest": "ccf0ec3cf64830f8608ac996bc503237f08628e1acd987eb786cdd24f7394a5a"
   },
   "evidence": {
-    "contextDigest": "e42a41738437112661b9a865e0eba94786e2ce077f2a521891b105e2a03161ad",
-    "qualityDigest": "36f9f0d969a1c43d05a9b23114752f1c5c6359e262651143b2dea6d4dff446cc",
+    "contextDigest": "f3ae8686c9f70751a3a05c5a734867e7c7cd1dd2c823af9ad279c245362f5f6e",
+    "qualityDigest": "6dd5805f958fb5efa04534fb54b0ca963825b5fde9c05b09390df47cf17231d6",
     "correctionLedgerDigest": "fcda3136886694c111258daee7f51b6bf0f29e3333ed7e582d7fcc349f0b4c74",
     "routeViewCoverageDigest": "5fced6d5c7a704c0b14c0b8d422a25c9e1ca9454e0524ec0d88b036c88b3de57",
     "fallbackContractDigest": "94c88648a2bc4fa2b3e3dd2b1db476db5a182e8a5dd9dce2140f6faf2cceabe5",
@@ -121,5 +121,5 @@
       "ownerIssue": "#867"
     }
   ],
-  "activationDigest": "ae620a0f31546ffa94bfd4fe3bc5cb58aa807471522d4b5828c4b37207d3886c"
+  "activationDigest": "7edd6ad61ef99880a95974e8de7e9d2dbebd878933ad87c8539cbdcefa8d1f85"
 }

--- a/docs/plans/i18n-zh-CN/quality-manifest.json
+++ b/docs/plans/i18n-zh-CN/quality-manifest.json
@@ -3,8 +3,8 @@
   "locale": "zh-CN",
   "source": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "sourceManifestDigest": "aa9224109fb4a3df1bbcc0d46be23a80167e377dfc571149b6bddfbc4fab756b",
-    "contextDigest": "e42a41738437112661b9a865e0eba94786e2ce077f2a521891b105e2a03161ad"
+    "sourceManifestDigest": "719bc23626cd3f60498a34e204baa70143087617d15189859d4970d9532410c9",
+    "contextDigest": "f3ae8686c9f70751a3a05c5a734867e7c7cd1dd2c823af9ad279c245362f5f6e"
   },
   "catalog": {
     "messageCount": 3322,
@@ -42,8 +42,8 @@
   },
   "structuralValidation": {
     "path": "docs/plans/i18n-zh-CN/structural-validation.json",
-    "digest": "cb1ef5285d2d3e5fd30a529ce9d019bb83bc5ba6a97eb63eb9f8db3799874b52",
-    "validationDigest": "20887ea2c09e59df4629ad710479d16d67449ad87785c578a8ded5213c21f1f1",
+    "digest": "1f6682a7b8917dba0333c1924f888523a9418104e8e2d7156955ea1b4b3f954d",
+    "validationDigest": "423ed3abc119b16d78d77113b88668d25fb74359fcbfb9b49fdec1b3932e7c04",
     "laneCount": 1,
     "validatedMessageCount": 3322,
     "validatedModuleCount": 32,
@@ -53,5 +53,5 @@
     "blockedItems": 0,
     "semanticReviewPerformed": false
   },
-  "qualityDigest": "36f9f0d969a1c43d05a9b23114752f1c5c6359e262651143b2dea6d4dff446cc"
+  "qualityDigest": "6dd5805f958fb5efa04534fb54b0ca963825b5fde9c05b09390df47cf17231d6"
 }

--- a/docs/plans/i18n-zh-CN/structural-validation.json
+++ b/docs/plans/i18n-zh-CN/structural-validation.json
@@ -3,7 +3,7 @@
   "locale": "zh-CN",
   "validationClosure": {
     "baselineSha": "c26f306e82ac66f50a56aafe8f89ea96c0b0c67d",
-    "auditedInputDigest": "2553f5c8bfcdaac8140a474a888463f4e87aadbd989b35ff3282c27034c827e7",
+    "auditedInputDigest": "b343cd7235661fe597e28957ea14cd2167a3bd923568ef87a3581bfcb0ab2b8b",
     "validatedMessageCount": 3322,
     "validatedModules": [
       "$entry",
@@ -42,7 +42,7 @@
     "highRiskMessageCount": 1507,
     "highRiskMessageDigest": "37ae9bf80782335d1d0edf20bae122396e2fc524271954d6608a7f2caf3dfacd",
     "catalogDigest": "baa30718c9ca5e7f44104cfef19da6208c86631508b1a11c9b164a72bf3108e9",
-    "dossierDigest": "7e79f58ba7dee8a67efe4c0449ba2a3c2b01794ceb267272f35eca9583bb7ffa",
+    "dossierDigest": "26abd464850a345fc44d6b060eab21a0a8ffc2e79dbcfe1f5423728a3622cfb1",
     "typedContentDossierDigest": "cc1ab81573e1759a7288791dd3f6cd3faee25736c2e1ccf61f2cc3378bf1971f",
     "routeEvidenceDigest": "404c3f4ce5f4c164a8d11b6999da96087af5d6a40bdc8096b521aafa63edc2d5",
     "scope": "deterministic structure only; semantic translation and rendered route review are separate production blockers owned by #635"
@@ -98,7 +98,7 @@
         "messageDigest": "e11cff8827c56fa95979f98e855a66017eafa6ae5821c8193f5d7334bf95a11f",
         "highRiskMessageCount": 1507,
         "highRiskMessageDigest": "37ae9bf80782335d1d0edf20bae122396e2fc524271954d6608a7f2caf3dfacd",
-        "dossierDigest": "7e79f58ba7dee8a67efe4c0449ba2a3c2b01794ceb267272f35eca9583bb7ffa",
+        "dossierDigest": "26abd464850a345fc44d6b060eab21a0a8ffc2e79dbcfe1f5423728a3622cfb1",
         "checks": {
           "nonEmptyTargets": true,
           "icuArgumentSignatureParity": true,
@@ -113,5 +113,5 @@
     }
   ],
   "blockedItems": [],
-  "validationDigest": "20887ea2c09e59df4629ad710479d16d67449ad87785c578a8ded5213c21f1f1"
+  "validationDigest": "423ed3abc119b16d78d77113b88668d25fb74359fcbfb9b49fdec1b3932e7c04"
 }

--- a/src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx
+++ b/src/pages/LifeCycleModels/Components/toolbar/editIndex.tsx
@@ -36,11 +36,16 @@ import {
   getLifeCycleModelPortFlowVersion,
 } from '@/services/lifeCycleModels/util';
 import {
+  getLifeCycleModelGraphProcessReferences,
+  normalizeLifeCycleModelGraphForDisplay,
+} from '@/services/lifeCycleModels/viewCompatibility';
+import {
   getProcessDetail,
   getProcessDetailByIdAndVersion,
   getProcessesByIdAndVersion,
 } from '@/services/processes/api';
 import type {
+  ProcessDetailByVersionItem,
   ProcessDetailByVersionResponse,
   ProcessDetailResponse,
 } from '@/services/processes/data';
@@ -78,9 +83,11 @@ import {
   buildProcessNodesFromDetails,
   buildSavePayload,
   buildUpdatedNodeReferencePayload,
+  type EditorGraphHydrationBaseline,
   hydrateEditorEdges,
   hydrateEditorNodes,
   normalizePastedReferenceCells,
+  reconcileHydratedEditorGraphForPersistence,
   resolveDeleteSelection,
 } from './utils/editGraph';
 import {
@@ -219,6 +226,7 @@ const ToolbarEdit: FC<Props> = ({
   const importedId = getImportedId(importData?.[0]);
 
   const editInfoRef = useRef<ToolbarEditInfoHandle>(null);
+  const editorGraphHydrationBaselineRef = useRef<EditorGraphHydrationBaseline | null>(null);
   const resizeToolRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     setThisAction(action);
@@ -897,6 +905,12 @@ const ToolbarEdit: FC<Props> = ({
         : (edges as LifeCycleModelGraphEdge[]);
 
       const newData = buildSavePayload(infoData, currentNodes, currentEdges);
+      const persistenceGraph = editorGraphHydrationBaselineRef.current
+        ? reconcileHydratedEditorGraphForPersistence(
+            newData.model ?? { nodes: [], edges: [] },
+            editorGraphHydrationBaselineRef.current,
+          )
+        : undefined;
       const fallbackValidationVersion =
         (newData?.administrativeInformation?.publicationAndOwnership?.['common:dataSetVersion'] as
           string | undefined) ??
@@ -1007,13 +1021,19 @@ const ToolbarEdit: FC<Props> = ({
           return toSaveMutationError(error);
         }
       };
-      const langOptions = options?.langIntent ? { intent: options.langIntent } : undefined;
+      const mutationOptions =
+        options?.langIntent || persistenceGraph
+          ? {
+              ...(options?.langIntent ? { intent: options.langIntent } : {}),
+              ...(persistenceGraph ? { persistenceGraph } : {}),
+            }
+          : undefined;
 
       if (thisAction === 'edit') {
         const lifecycleModelPayload = { ...newData, id: thisId, version: thisVersion };
         const result = await runMutation(() =>
-          langOptions
-            ? updateLifeCycleModel(lifecycleModelPayload, langOptions)
+          mutationOptions
+            ? updateLifeCycleModel(lifecycleModelPayload, mutationOptions)
             : updateLifeCycleModel(lifecycleModelPayload),
         );
         if (result.ok) {
@@ -1033,6 +1053,12 @@ const ToolbarEdit: FC<Props> = ({
           setThisId(savedModelId);
           setThisVersion(savedVersion);
           setJsonTg(savedLifeCycleModel?.json_tg ?? {});
+          if (persistenceGraph && editorGraphHydrationBaselineRef.current) {
+            editorGraphHydrationBaselineRef.current = {
+              storedGraph: persistenceGraph,
+              hydratedGraph: newData.model ?? { nodes: [], edges: [] },
+            };
+          }
 
           const savedEdges = (savedLifeCycleModel?.json_tg?.xflow?.edges ??
             []) as LifeCycleModelGraphEdge[];
@@ -1075,10 +1101,14 @@ const ToolbarEdit: FC<Props> = ({
           actionType === 'createVersion' ? { sourceVersion: thisVersion } : undefined;
         const result = await runMutation(() => {
           if (createVersionOptions) {
-            return createLifeCycleModel(lifecycleModelPayload, langOptions, createVersionOptions);
+            return createLifeCycleModel(
+              lifecycleModelPayload,
+              mutationOptions,
+              createVersionOptions,
+            );
           }
-          return langOptions
-            ? createLifeCycleModel(lifecycleModelPayload, langOptions)
+          return mutationOptions
+            ? createLifeCycleModel(lifecycleModelPayload, mutationOptions)
             : createLifeCycleModel(lifecycleModelPayload);
         });
         if (result.ok) {
@@ -1099,6 +1129,12 @@ const ToolbarEdit: FC<Props> = ({
           setThisVersion(savedVersion);
           setInfoData(nextPayload);
           setJsonTg(savedLifeCycleModel?.json_tg ?? {});
+          if (persistenceGraph && editorGraphHydrationBaselineRef.current) {
+            editorGraphHydrationBaselineRef.current = {
+              storedGraph: persistenceGraph,
+              hydratedGraph: newData.model ?? { nodes: [], edges: [] },
+            };
+          }
 
           const savedEdges = (savedLifeCycleModel?.json_tg?.xflow?.edges ??
             []) as LifeCycleModelGraphEdge[];
@@ -1410,24 +1446,29 @@ const ToolbarEdit: FC<Props> = ({
     [],
   );
 
-  const getProcessInstances = async (jsonTg: LifeCycleModelJsonTg) => {
-    const userId = await getUserId();
-    setUserId(userId);
-    const params: { id: string; version: string }[] = [];
-    jsonTg?.xflow?.nodes?.forEach((node) => {
-      const nodeId = node?.data?.id;
-      const nodeVersion = node?.data?.version;
-      if (nodeId && nodeVersion) {
-        params.push({
-          id: nodeId,
-          version: nodeVersion,
-        });
-      }
-    });
-    if (params.length > 0) {
-      const procresses = await getProcessesByIdAndVersion(params);
-      setProcessInstances((procresses.data ?? []) as LifeCycleModelProcessInstance[]);
-    }
+  const getEditorProcessData = async (
+    jsonTg: LifeCycleModelJsonTg,
+  ): Promise<ProcessDetailByVersionItem[]> => {
+    const params = getLifeCycleModelGraphProcessReferences(jsonTg);
+    const [nextUserId, processInstancesResult, processDetailsResult] = await Promise.all([
+      getUserId(),
+      params.length > 0
+        ? getProcessesByIdAndVersion(params).catch(() => ({ data: [] }))
+        : Promise.resolve({ data: [] }),
+      params.length > 0
+        ? getProcessDetailByIdAndVersion(params).catch(() => ({ data: [] }))
+        : Promise.resolve({ data: [] }),
+    ]);
+
+    setUserId(nextUserId);
+    setProcessInstances(
+      (Array.isArray(processInstancesResult.data)
+        ? processInstancesResult.data
+        : []) as LifeCycleModelProcessInstance[],
+    );
+    return (
+      Array.isArray(processDetailsResult.data) ? processDetailsResult.data : []
+    ) as ProcessDetailByVersionItem[];
   };
 
   useEffect(() => {
@@ -1439,12 +1480,14 @@ const ToolbarEdit: FC<Props> = ({
       setProblemNodes([]);
       setSdkProblemProcessInstanceIds([]);
       setJsonTg({});
+      editorGraphHydrationBaselineRef.current = null;
       modelData({ nodes: [], edges: [] });
       resetGraphCommandState();
       return;
     }
 
     if (importData && importData.length > 0) {
+      editorGraphHydrationBaselineRef.current = null;
       const formData = genLifeCycleModelInfoFromData(importData[0].lifeCycleModelDataSet);
       setInfoData(formData);
       const model = genLifeCycleModelData(importData[0]?.json_tg ?? {}, lang);
@@ -1475,54 +1518,71 @@ const ToolbarEdit: FC<Props> = ({
     if (id !== '') {
       setIsSave(false);
       setSpinning(true);
-      getLifeCycleModelDetail(id, version).then(async (result: LifeCycleModelDetailResponse) => {
-        if (!result.success) {
-          message.error(
-            intl.formatMessage({
-              id: 'pages.lifecyclemodel.notPublic',
-              defaultMessage: 'Model is not public',
-            }),
+      void getLifeCycleModelDetail(id, version)
+        .then(async (result: LifeCycleModelDetailResponse) => {
+          if (!result.success) {
+            message.error(
+              intl.formatMessage({
+                id: 'pages.lifecyclemodel.notPublic',
+                defaultMessage: 'Model is not public',
+              }),
+            );
+            return;
+          }
+          const fromData = genLifeCycleModelInfoFromData(
+            result.data?.json?.lifeCycleModelDataSet ?? {},
           );
-          return;
-        }
-        const fromData = genLifeCycleModelInfoFromData(
-          result.data?.json?.lifeCycleModelDataSet ?? {},
-        );
-        setJsonTg(result.data?.json_tg ?? {});
+          const storedJsonTg = result.data?.json_tg ?? {};
+          setJsonTg(storedJsonTg);
 
-        if (actionType === 'createVersion' && newVersion) {
-          fromData.administrativeInformation.publicationAndOwnership['common:dataSetVersion'] =
-            newVersion;
-        }
-        setInfoData({ ...fromData, id: thisId, version: thisVersion });
-        const model = genLifeCycleModelData(result.data?.json_tg ?? {}, lang);
-        const initNodes = hydrateEditorNodes({
-          nodes: model?.nodes ?? [],
-          refTool,
-          nonRefTool,
-          inputFlowTool,
-          outputFlowTool,
-          token,
-          lang,
-          nodeTemplateWidth,
-          nodeAttrs,
-          portsGroups: ports.groups,
-        });
-        const initEdges = hydrateEditorEdges(model?.edges ?? [], token, edgeLabelText);
-        await modelData({
-          nodes: initNodes,
-          edges: initEdges,
-        });
-
-        setNodeCount(initNodes.length);
-        resetGraphCommandState();
-        getProcessInstances(result.data?.json_tg ?? {})
-          .then(() => {})
-          .finally(() => {
-            setSpinning(false);
+          if (actionType === 'createVersion' && newVersion) {
+            fromData.administrativeInformation.publicationAndOwnership['common:dataSetVersion'] =
+              newVersion;
+          }
+          setInfoData({ ...fromData, id: thisId, version: thisVersion });
+          const processDetails = await getEditorProcessData(storedJsonTg);
+          const editorJsonTg = normalizeLifeCycleModelGraphForDisplay({
+            jsonTg: storedJsonTg,
+            lifeCycleModelDataSet: result.data?.json?.lifeCycleModelDataSet,
+            processDetails,
           });
-      });
+          const model = genLifeCycleModelData(editorJsonTg, lang);
+          const initNodes = hydrateEditorNodes({
+            nodes: model?.nodes ?? [],
+            refTool,
+            nonRefTool,
+            inputFlowTool,
+            outputFlowTool,
+            token,
+            lang,
+            nodeTemplateWidth,
+            nodeAttrs,
+            portsGroups: ports.groups,
+          });
+          const initEdges = hydrateEditorEdges(model?.edges ?? [], token, edgeLabelText);
+          editorGraphHydrationBaselineRef.current = {
+            storedGraph: {
+              nodes: storedJsonTg.xflow?.nodes ?? [],
+              edges: storedJsonTg.xflow?.edges ?? [],
+            },
+            hydratedGraph: {
+              nodes: initNodes,
+              edges: initEdges,
+            },
+          };
+          await modelData({
+            nodes: initNodes,
+            edges: initEdges,
+          });
+
+          setNodeCount(initNodes.length);
+          resetGraphCommandState();
+        })
+        .finally(() => {
+          setSpinning(false);
+        });
     } else {
+      editorGraphHydrationBaselineRef.current = null;
       const currentDateTime = formatDateTime(new Date());
       setInfoData(
         buildEmptyCreateInfoData({

--- a/src/pages/LifeCycleModels/Components/toolbar/utils/editGraph.ts
+++ b/src/pages/LifeCycleModels/Components/toolbar/utils/editGraph.ts
@@ -2,6 +2,7 @@ import { getContentGraphTextWidthDivisor } from '@/services/general/contentLangu
 import { getLangText } from '@/services/general/util';
 import type {
   LifeCycleModelEditorFormState,
+  LifeCycleModelGraphData,
   LifeCycleModelGraphEdge,
   LifeCycleModelGraphNode,
   LifeCycleModelPortItem,
@@ -41,6 +42,11 @@ type ToolbarNodeHydrationContext = ToolbarToolContext & {
 
 type GraphNodeLike = Pick<LifeCycleModelGraphNode, 'id' | 'selected'>;
 type GraphEdgeLike = Pick<LifeCycleModelGraphEdge, 'id' | 'selected' | 'source' | 'target'>;
+
+export type EditorGraphHydrationBaseline = {
+  storedGraph: LifeCycleModelGraphData;
+  hydratedGraph: LifeCycleModelGraphData;
+};
 
 const getNodeWidth = (
   node: Pick<LifeCycleModelGraphNode, 'size' | 'width'> | undefined,
@@ -547,6 +553,151 @@ export const buildSavePayload = (
       nodes,
       edges,
     },
+  };
+};
+
+const ABSENT_GRAPH_VALUE = Symbol('absent-graph-value');
+type GraphValue = unknown | typeof ABSENT_GRAPH_VALUE;
+
+const isSameGraphValue = (left: GraphValue, right: GraphValue) => {
+  if (left === ABSENT_GRAPH_VALUE || right === ABSENT_GRAPH_VALUE) {
+    return left === right;
+  }
+  return JSON.stringify(left) === JSON.stringify(right);
+};
+
+const isGraphRecord = (value: GraphValue): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const hasOwnGraphValue = (value: Record<string, unknown>, key: string) =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+/**
+ * Three-way reconciliation for editor hydration:
+ * - stored: the persisted graph before editor/display hydration
+ * - hydrated: the graph initially shown to the editor
+ * - current: the graph at save time
+ *
+ * Values that still match the hydrated baseline are restored to their stored
+ * representation. Values changed by the user remain current.
+ */
+const reconcileHydratedGraphValue = (
+  current: GraphValue,
+  stored: GraphValue,
+  hydrated: GraphValue,
+): GraphValue => {
+  if (isSameGraphValue(stored, hydrated)) {
+    return current;
+  }
+  if (isSameGraphValue(current, hydrated)) {
+    return stored;
+  }
+  if (!isGraphRecord(current) || !isGraphRecord(hydrated)) {
+    return current;
+  }
+
+  const storedRecord = isGraphRecord(stored) ? stored : {};
+  const next = { ...current };
+  const keys = new Set([
+    ...Object.keys(current),
+    ...Object.keys(storedRecord),
+    ...Object.keys(hydrated),
+  ]);
+
+  keys.forEach((key) => {
+    const nextValue = reconcileHydratedGraphValue(
+      hasOwnGraphValue(current, key) ? current[key] : ABSENT_GRAPH_VALUE,
+      hasOwnGraphValue(storedRecord, key) ? storedRecord[key] : ABSENT_GRAPH_VALUE,
+      hasOwnGraphValue(hydrated, key) ? hydrated[key] : ABSENT_GRAPH_VALUE,
+    );
+    if (nextValue === ABSENT_GRAPH_VALUE) {
+      delete next[key];
+    } else {
+      next[key] = nextValue;
+    }
+  });
+
+  return next;
+};
+
+const sanitizeStoredNode = (node: LifeCycleModelGraphNode) => {
+  const { selected, ...persistedNode } = node;
+  void selected;
+  return persistedNode;
+};
+
+const sanitizeStoredEdge = (edge: LifeCycleModelGraphEdge) => {
+  const { selected, ...persistedEdge } = edge;
+  void selected;
+  if (!edge.target) {
+    return persistedEdge;
+  }
+
+  const { x, y, ...target } = edge.target;
+  void x;
+  void y;
+  return { ...persistedEdge, target };
+};
+
+export const reconcileHydratedEditorGraphForPersistence = (
+  currentGraph: LifeCycleModelGraphData,
+  baseline: EditorGraphHydrationBaseline,
+): LifeCycleModelGraphData => {
+  const storedNodesById = new Map(
+    baseline.storedGraph.nodes
+      .filter((node) => typeof node.id === 'string')
+      .map((node) => [node.id as string, sanitizeStoredNode(node)]),
+  );
+  const hydratedNodesById = new Map(
+    baseline.hydratedGraph.nodes
+      .filter((node) => typeof node.id === 'string')
+      .map((node) => [node.id as string, node]),
+  );
+  const storedEdgesById = new Map(
+    baseline.storedGraph.edges
+      .filter((edge) => typeof edge.id === 'string')
+      .map((edge) => [edge.id as string, sanitizeStoredEdge(edge)]),
+  );
+  const hydratedEdgesById = new Map(
+    baseline.hydratedGraph.edges
+      .filter((edge) => typeof edge.id === 'string')
+      .map((edge) => [edge.id as string, edge]),
+  );
+
+  return {
+    nodes: currentGraph.nodes.map((node, index) => {
+      const storedNode =
+        typeof node.id === 'string'
+          ? storedNodesById.get(node.id)
+          : baseline.storedGraph.nodes[index]
+            ? sanitizeStoredNode(baseline.storedGraph.nodes[index])
+            : undefined;
+      const hydratedNode =
+        typeof node.id === 'string'
+          ? hydratedNodesById.get(node.id)
+          : baseline.hydratedGraph.nodes[index];
+      if (!storedNode || !hydratedNode) {
+        return node;
+      }
+      return reconcileHydratedGraphValue(node, storedNode, hydratedNode) as LifeCycleModelGraphNode;
+    }),
+    edges: currentGraph.edges.map((edge, index) => {
+      const storedEdge =
+        typeof edge.id === 'string'
+          ? storedEdgesById.get(edge.id)
+          : baseline.storedGraph.edges[index]
+            ? sanitizeStoredEdge(baseline.storedGraph.edges[index])
+            : undefined;
+      const hydratedEdge =
+        typeof edge.id === 'string'
+          ? hydratedEdgesById.get(edge.id)
+          : baseline.hydratedGraph.edges[index];
+      if (!storedEdge || !hydratedEdge) {
+        return edge;
+      }
+
+      return reconcileHydratedGraphValue(edge, storedEdge, hydratedEdge) as LifeCycleModelGraphEdge;
+    }),
   };
 };
 

--- a/src/services/lifeCycleModels/api.ts
+++ b/src/services/lifeCycleModels/api.ts
@@ -35,6 +35,7 @@ import {
 import { getProcessDetailByIdsAndVersion } from '../processes/api';
 import { genProcessName } from '../processes/util';
 import type {
+  LifeCycleModelGraphData,
   LifeCycleModelJsonTg,
   LifeCycleModelMutationResult,
   LifeCycleModelPersistencePlan,
@@ -64,6 +65,10 @@ type LifeCycleModelSearchOrderBy = {
   key: 'common:class' | 'baseName';
   lang?: SupportedContentLanguage;
   order: 'asc' | 'desc';
+};
+
+type LifeCycleModelMutationOptions = NormalizeLangPayloadForSaveOptions & {
+  persistenceGraph?: LifeCycleModelGraphData;
 };
 
 function normalizeLifeCycleModelTotalCount(row?: LifeCycleModelListRpcRow): number {
@@ -358,7 +363,7 @@ async function applyReferenceAwareRuleVerification(
 
 export async function createLifeCycleModel(
   data: any,
-  options?: NormalizeLangPayloadForSaveOptions,
+  options?: LifeCycleModelMutationOptions,
   createVersionOptions?: { sourceVersion: string },
 ): Promise<LifeCycleModelMutationResult> {
   const serializationResult = serializeLifeCycleModelForMutation(data.id, data);
@@ -391,14 +396,15 @@ export async function createLifeCycleModel(
     normalizedLifeCycleModelJsonOrdered,
     [],
   );
+  const persistenceGraph = options?.persistenceGraph ?? data?.model;
 
   const planResult = await buildSaveLifeCycleModelPersistencePlan({
     langIntent: options?.intent,
     mode: 'create',
     modelId: data.id,
     lifeCycleModelJsonOrdered: normalizedLifeCycleModelJsonOrdered,
-    nodes: data?.model?.nodes ?? [],
-    edges: data?.model?.edges ?? [],
+    nodes: persistenceGraph?.nodes ?? [],
+    edges: persistenceGraph?.edges ?? [],
     up2DownEdges,
     lifeCycleModelProcesses,
   });
@@ -425,7 +431,7 @@ export async function createLifeCycleModel(
 
 export async function updateLifeCycleModel(
   data: any,
-  options?: NormalizeLangPayloadForSaveOptions,
+  options?: LifeCycleModelMutationOptions,
 ): Promise<LifeCycleModelMutationResult> {
   const serializationResult = serializeLifeCycleModelForMutation(data.id, data);
   if (!serializationResult.success) {
@@ -489,6 +495,7 @@ export async function updateLifeCycleModel(
     data.version,
   );
   const oldProcesses = oldProcessesResult?.data ?? [];
+  const persistenceGraph = options?.persistenceGraph ?? data?.model;
 
   const planResult = await buildSaveLifeCycleModelPersistencePlan({
     langIntent: options?.intent,
@@ -496,8 +503,8 @@ export async function updateLifeCycleModel(
     modelId: data.id,
     version: data.version,
     lifeCycleModelJsonOrdered: normalizedLifeCycleModelJsonOrdered,
-    nodes: data?.model?.nodes ?? [],
-    edges: data?.model?.edges ?? [],
+    nodes: persistenceGraph?.nodes ?? [],
+    edges: persistenceGraph?.edges ?? [],
     up2DownEdges,
     lifeCycleModelProcesses,
     oldSubmodels,

--- a/tests/unit/pages/LifeCycleModels/Components/toolbar/editIndex.test.tsx
+++ b/tests/unit/pages/LifeCycleModels/Components/toolbar/editIndex.test.tsx
@@ -19,6 +19,9 @@ const mockGetProcessesByIdAndVersion = jest.fn().mockResolvedValue({ data: [] })
 const mockGetImportedId = jest.fn().mockReturnValue(undefined);
 const mockIsSupabaseDuplicateKeyError = jest.fn().mockReturnValue(false);
 const mockGetLangText = jest.fn().mockReturnValue('Flow Name');
+const mockJsonToList = jest.fn((value: any) =>
+  Array.isArray(value) ? value : value ? [value] : [],
+);
 const mockFormatDateTime = jest.fn(() => '2024-01-01 00:00');
 const mockGetUserTeamId = jest.fn().mockResolvedValue('team-1');
 const mockGetUserId = jest.fn().mockResolvedValue('user-1');
@@ -425,6 +428,7 @@ jest.mock('@/services/general/util', () => ({
   getImportedId: (...args: any[]) => mockGetImportedId(...args),
   isSupabaseDuplicateKeyError: (...args: any[]) => mockIsSupabaseDuplicateKeyError(...args),
   getLangText: (...args: any[]) => mockGetLangText(...args),
+  jsonToList: (...args: any[]) => mockJsonToList(...args),
 }));
 
 jest.mock('@/services/roles/api', () => ({
@@ -479,6 +483,9 @@ beforeEach(() => {
   mockGetImportedId.mockReset().mockReturnValue(undefined);
   mockIsSupabaseDuplicateKeyError.mockReset().mockReturnValue(false);
   mockGetLangText.mockReset().mockReturnValue('Flow Name');
+  mockJsonToList
+    .mockReset()
+    .mockImplementation((value: any) => (Array.isArray(value) ? value : value ? [value] : []));
   mockFormatDateTime.mockReset().mockReturnValue('2024-01-01 00:00');
   mockGetUserTeamId.mockReset().mockResolvedValue('team-1');
   mockGetUserId.mockReset().mockResolvedValue('user-1');
@@ -665,7 +672,12 @@ describe('ToolbarEdit', () => {
     render(<ToolbarEdit {...baseProps} drawerVisible={true} {...props} />);
 
     expect(screen.getByTestId('spin')).toBeInTheDocument();
-    await waitFor(() => expect(mockGetLifeCycleModelDetail).toHaveBeenCalledWith('model-1', '1.0'));
+    await waitFor(() =>
+      expect(mockGetLifeCycleModelDetail).toHaveBeenCalledWith(
+        props.id ?? baseProps.id,
+        props.version ?? baseProps.version,
+      ),
+    );
     await waitFor(() => expect(screen.queryByTestId('spin')).not.toBeInTheDocument());
   };
 
@@ -2206,7 +2218,12 @@ describe('ToolbarEdit', () => {
         expect.objectContaining({
           id: 'model-1',
         }),
-        undefined,
+        expect.objectContaining({
+          persistenceGraph: expect.objectContaining({
+            nodes: expect.any(Array),
+            edges: expect.any(Array),
+          }),
+        }),
         { sourceVersion: '1.0' },
       ),
     );
@@ -2682,6 +2699,162 @@ describe('ToolbarEdit', () => {
         }),
       ),
     );
+  });
+
+  it('hydrates lightweight saved graphs for editing without persisting runtime-only fields', async () => {
+    const storedJsonTg = {
+      xflow: {
+        nodes: [
+          { id: '0', data: { id: 'process-a', version: '01.00.000' } },
+          { id: '1', data: { id: 'process-b', version: '01.00.021' } },
+        ],
+        edges: [
+          {
+            id: 'edge-a',
+            source: { cell: '0' },
+            target: { cell: '1' },
+            data: {
+              connection: {
+                outputExchange: {
+                  '@flowUUID': 'flow-a',
+                  downstreamProcess: { '@flowUUID': 'flow-a' },
+                },
+              },
+            },
+          },
+        ],
+      },
+      submodels: [],
+    };
+    const storedJsonTgSnapshot = JSON.parse(JSON.stringify(storedJsonTg));
+    const lifeCycleModelDataSet = {
+      lifeCycleModelInformation: {
+        quantitativeReference: {
+          referenceToReferenceProcess: '0',
+        },
+      },
+    };
+    const processDetails = [
+      {
+        id: 'process-a',
+        version: '01.00.000',
+        json: {
+          processDataSet: {
+            processInformation: {
+              dataSetInformation: {
+                name: [{ '@xml:lang': 'en', '#text': 'Process A' }],
+              },
+            },
+            exchanges: {
+              exchange: {
+                exchangeDirection: 'OUTPUT',
+                quantitativeReference: true,
+                referenceToFlowDataSet: {
+                  '@refObjectId': 'flow-a',
+                  '@version': '01.00.000',
+                  'common:shortDescription': [{ '@xml:lang': 'en', '#text': 'Output flow A' }],
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        id: 'process-b',
+        version: '01.00.021',
+        json: {
+          processDataSet: {
+            processInformation: {
+              dataSetInformation: {
+                name: [{ '@xml:lang': 'en', '#text': 'Process B' }],
+              },
+            },
+            exchanges: {
+              exchange: {
+                exchangeDirection: 'INPUT',
+                referenceToFlowDataSet: {
+                  '@refObjectId': 'flow-a',
+                  '@version': '01.00.000',
+                  'common:shortDescription': [{ '@xml:lang': 'en', '#text': 'Input flow A' }],
+                },
+              },
+            },
+          },
+        },
+      },
+    ];
+    mockGetLifeCycleModelDetail.mockResolvedValueOnce({
+      success: true,
+      data: {
+        version: '01.00.000',
+        json: { lifeCycleModelDataSet },
+        json_tg: storedJsonTg,
+      },
+    });
+    mockGetProcessDetailByIdAndVersion.mockResolvedValueOnce({ data: processDetails });
+    mockGenLifeCycleModelData.mockImplementationOnce((jsonTg: any) => jsonTg.xflow);
+
+    await renderVisibleToolbarEdit({ version: '01.00.000' });
+
+    expect(mockGetProcessDetailByIdAndVersion).toHaveBeenCalledWith([
+      { id: 'process-a', version: '01.00.000' },
+      { id: 'process-b', version: '01.00.021' },
+    ]);
+    const initializedGraph = mockInitData.mock.calls.at(-1)?.[0];
+    expect(initializedGraph).toEqual(
+      expect.objectContaining({
+        nodes: [
+          expect.objectContaining({
+            id: '0',
+            height: 80,
+            data: expect.objectContaining({
+              label: [{ '@xml:lang': 'en', '#text': 'Process A' }],
+              quantitativeReference: '1',
+            }),
+            ports: expect.objectContaining({
+              items: [expect.objectContaining({ id: 'OUTPUT:flow-a' })],
+            }),
+            tools: expect.arrayContaining([expect.objectContaining({ id: 'ref' })]),
+          }),
+          expect.objectContaining({
+            id: '1',
+            height: 80,
+            data: expect.objectContaining({
+              label: [{ '@xml:lang': 'en', '#text': 'Process B' }],
+              quantitativeReference: '0',
+            }),
+            ports: expect.objectContaining({
+              items: [expect.objectContaining({ id: 'INPUT:flow-a' })],
+            }),
+            tools: expect.arrayContaining([expect.objectContaining({ id: 'nonRef' })]),
+          }),
+        ],
+        edges: [
+          expect.objectContaining({
+            id: 'edge-a',
+            source: { cell: '0', port: 'OUTPUT:flow-a' },
+            target: { cell: '1', port: 'INPUT:flow-a' },
+          }),
+        ],
+      }),
+    );
+    expect(storedJsonTg).toEqual(storedJsonTgSnapshot);
+
+    mockGraph.getNodes.mockReturnValue(initializedGraph.nodes);
+    mockGraph.getEdges.mockReturnValue(initializedGraph.edges);
+    await userEvent.click(screen.getByRole('button', { name: 'save-icon' }));
+
+    await waitFor(() => expect(mockUpdateLifeCycleModel).toHaveBeenCalled());
+    const [runtimePayload, mutationOptions] = mockUpdateLifeCycleModel.mock.calls.at(-1);
+    expect(runtimePayload.model.nodes[0]).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({ quantitativeReference: '1' }),
+        ports: expect.objectContaining({
+          items: [expect.objectContaining({ id: 'OUTPUT:flow-a' })],
+        }),
+      }),
+    );
+    expect(mutationOptions.persistenceGraph).toEqual(storedJsonTg.xflow);
   });
 
   it('renders process-view actions for non-owned process instances', async () => {

--- a/tests/unit/pages/LifeCycleModels/Components/toolbar/utils/editGraph.test.ts
+++ b/tests/unit/pages/LifeCycleModels/Components/toolbar/utils/editGraph.test.ts
@@ -9,6 +9,7 @@ import {
   hydrateEditorEdges,
   hydrateEditorNodes,
   normalizePastedReferenceCells,
+  reconcileHydratedEditorGraphForPersistence,
   resolveDeleteSelection,
 } from '@/pages/LifeCycleModels/Components/toolbar/utils/editGraph';
 import { SUPPORTED_CONTENT_LANGUAGES } from '@/services/general/contentLanguageRegistry';
@@ -828,6 +829,277 @@ describe('toolbar/utils/editGraph', () => {
       id: 'model-1',
       version: '1.0',
     });
+  });
+
+  it('restores untouched compatibility and editor hydration before persistence', () => {
+    const storedGraph = {
+      nodes: [
+        {
+          id: 'node-a',
+          selected: true,
+          size: { width: 350, height: 80 },
+          data: { id: 'process-a', version: '01.00.000' },
+        },
+        {
+          height: 80,
+          data: { id: 'process-b', version: '01.00.000' },
+        },
+      ],
+      edges: [
+        {
+          id: 'edge-a',
+          selected: true,
+          source: { cell: 'node-a' },
+          target: { cell: 'node-b', x: 10, y: 20 },
+          data: { connection: { outputExchange: { '@flowUUID': 'flow-a' } } },
+        },
+        {
+          data: { connection: { outputExchange: { '@flowUUID': 'flow-b' } } },
+        },
+      ],
+    } as any;
+    const hydratedGraph = {
+      nodes: [
+        {
+          id: 'node-a',
+          selected: false,
+          size: { width: 350, height: 100 },
+          attrs: { body: { stroke: '#1677ff' } },
+          tools: [{ id: 'ref' }],
+          data: {
+            id: 'process-a',
+            version: '01.00.000',
+            index: '0',
+            label: [{ '@xml:lang': 'en', '#text': 'Process A' }],
+            quantitativeReference: '1',
+          },
+          ports: {
+            groups: { groupOutput: {} },
+            items: [
+              {
+                id: 'OUTPUT:flow-a',
+                group: 'groupOutput',
+                attrs: { text: { text: 'Flow A' } },
+                data: { flowId: 'flow-a' },
+              },
+            ],
+          },
+        },
+        {
+          selected: false,
+          height: 100,
+          attrs: { body: { stroke: '#1677ff' } },
+          tools: [{ id: 'nonRef' }],
+          data: {
+            id: 'process-b',
+            version: '01.00.000',
+            index: '1',
+            label: [{ '@xml:lang': 'en', '#text': 'Process B' }],
+            quantitativeReference: '0',
+          },
+          ports: { groups: { groupInput: {} }, items: [] },
+        },
+      ],
+      edges: [
+        {
+          id: 'edge-a',
+          selected: false,
+          source: { cell: 'node-a', port: 'OUTPUT:flow-a' },
+          target: { cell: 'node-b', port: 'INPUT:flow-a' },
+          attrs: { line: { stroke: '#1677ff' } },
+          labels: ['calculated-label'],
+          data: { connection: { outputExchange: { '@flowUUID': 'flow-a' } } },
+        },
+        {
+          selected: false,
+          source: {},
+          target: {},
+          attrs: { line: { stroke: '#1677ff' } },
+          labels: ['calculated-label'],
+          data: { connection: { outputExchange: { '@flowUUID': 'flow-b' } } },
+        },
+      ],
+    } as any;
+    const currentGraph = buildSavePayload(
+      {} as any,
+      hydratedGraph.nodes,
+      hydratedGraph.edges,
+    ).model;
+    const originalStored = JSON.parse(JSON.stringify(storedGraph));
+    const originalHydrated = JSON.parse(JSON.stringify(hydratedGraph));
+    const originalCurrent = JSON.parse(JSON.stringify(currentGraph));
+
+    expect(
+      reconcileHydratedEditorGraphForPersistence(currentGraph, {
+        storedGraph,
+        hydratedGraph,
+      }),
+    ).toEqual({
+      nodes: [
+        {
+          id: 'node-a',
+          size: { width: 350, height: 80 },
+          data: { id: 'process-a', version: '01.00.000' },
+        },
+        {
+          height: 80,
+          data: { id: 'process-b', version: '01.00.000' },
+        },
+      ],
+      edges: [
+        {
+          id: 'edge-a',
+          source: { cell: 'node-a' },
+          target: { cell: 'node-b' },
+          data: { connection: { outputExchange: { '@flowUUID': 'flow-a' } } },
+        },
+        {
+          data: { connection: { outputExchange: { '@flowUUID': 'flow-b' } } },
+        },
+      ],
+    });
+    expect(storedGraph).toEqual(originalStored);
+    expect(hydratedGraph).toEqual(originalHydrated);
+    expect(currentGraph).toEqual(originalCurrent);
+  });
+
+  it('keeps intentional graph edits and graph cells added after hydration', () => {
+    const storedGraph = {
+      nodes: [
+        {
+          id: 'node-a',
+          size: { width: 350, height: 80 },
+          data: { id: 'process-a', version: '01.00.000' },
+        },
+      ],
+      edges: [
+        {
+          id: 'edge-a',
+          source: { cell: 'node-a' },
+          target: { cell: 'node-b' },
+        },
+      ],
+    } as any;
+    const hydratedGraph = {
+      nodes: [
+        {
+          id: 'node-a',
+          selected: false,
+          size: { width: 350, height: 100 },
+          attrs: { body: { stroke: '#1677ff' } },
+          tools: [{ id: 'ref' }],
+          data: {
+            id: 'process-a',
+            version: '01.00.000',
+            index: '0',
+            label: 'Hydrated name',
+            quantitativeReference: '1',
+          },
+          ports: {
+            items: [
+              {
+                id: 'OUTPUT:flow-a',
+                group: 'groupOutput',
+                data: { flowId: 'flow-a' },
+              },
+            ],
+          },
+        },
+      ],
+      edges: [
+        {
+          id: 'edge-a',
+          selected: false,
+          source: { cell: 'node-a', port: 'OUTPUT:flow-a' },
+          target: { cell: 'node-b', port: 'INPUT:flow-a' },
+          attrs: { line: { stroke: '#1677ff' } },
+          labels: ['calculated-label'],
+        },
+      ],
+    } as any;
+    const currentGraph = {
+      nodes: [
+        {
+          ...hydratedGraph.nodes[0],
+          selected: undefined,
+          x: 420,
+          size: { width: 350, height: 140 },
+          data: {
+            ...hydratedGraph.nodes[0].data,
+            index: '0',
+            label: 'Renamed process',
+            quantitativeReference: '0',
+          },
+          ports: {
+            items: [
+              ...hydratedGraph.nodes[0].ports.items,
+              {
+                id: 'INPUT:flow-b',
+                group: 'groupInput',
+                data: { flowId: 'flow-b' },
+              },
+            ],
+          },
+        },
+        {
+          id: 'node-new',
+          data: { id: 'process-new', version: '01.00.000', index: '1' },
+        },
+        {
+          data: { id: 'process-new-without-cell-id', version: '01.00.000', index: '2' },
+        },
+      ],
+      edges: [
+        {
+          ...hydratedGraph.edges[0],
+          selected: undefined,
+          source: { cell: 'node-a', port: 'OUTPUT:manual-flow' },
+        },
+        {
+          id: 'edge-new',
+          source: { cell: 'node-new' },
+          target: { cell: 'node-a' },
+        },
+        {
+          source: { cell: 'node-new' },
+          target: { cell: 'node-a' },
+        },
+      ],
+    } as any;
+
+    const result = reconcileHydratedEditorGraphForPersistence(currentGraph, {
+      storedGraph,
+      hydratedGraph,
+    });
+
+    expect(result.nodes[0]).toEqual(
+      expect.objectContaining({
+        id: 'node-a',
+        x: 420,
+        size: { width: 350, height: 140 },
+        data: expect.objectContaining({
+          label: 'Renamed process',
+          quantitativeReference: '0',
+        }),
+        ports: expect.objectContaining({
+          items: expect.arrayContaining([expect.objectContaining({ id: 'INPUT:flow-b' })]),
+        }),
+      }),
+    );
+    expect(result.nodes[0]).not.toHaveProperty('attrs');
+    expect(result.nodes[0]).not.toHaveProperty('tools');
+    expect(result.nodes[1]).toBe(currentGraph.nodes[1]);
+    expect(result.nodes[2]).toBe(currentGraph.nodes[2]);
+    expect(result.edges[0]).toEqual(
+      expect.objectContaining({
+        source: { cell: 'node-a', port: 'OUTPUT:manual-flow' },
+        target: { cell: 'node-b' },
+      }),
+    );
+    expect(result.edges[0]).not.toHaveProperty('attrs');
+    expect(result.edges[0]).not.toHaveProperty('labels');
+    expect(result.edges[1]).toBe(currentGraph.edges[1]);
+    expect(result.edges[2]).toBe(currentGraph.edges[2]);
   });
 
   it('covers fallback branches for missing optional data in helper transforms', () => {

--- a/tests/unit/services/lifeCycleModels/api.test.ts
+++ b/tests/unit/services/lifeCycleModels/api.test.ts
@@ -1178,6 +1178,66 @@ describe('createLifeCycleModel', () => {
     expect(result).toEqual(edgePayload);
   });
 
+  it('uses the hydrated graph for calculation and the reconciled graph for create persistence', async () => {
+    const rawJson = buildLifecycleModelJsonOrdered();
+    const edgePayload = buildSaveResult();
+    const runtimeGraph = {
+      nodes: [
+        {
+          id: 'node-a',
+          data: { id: sampleProcessId, version: sampleVersion, quantitativeReference: '1' },
+          ports: { items: [{ id: 'OUTPUT:flow-a' }] },
+        },
+      ],
+      edges: [
+        {
+          id: 'edge-a',
+          source: { cell: 'node-a', port: 'OUTPUT:flow-a' },
+          target: { cell: 'node-b', port: 'INPUT:flow-a' },
+        },
+      ],
+    };
+    const persistenceGraph = {
+      nodes: [{ id: 'node-a', data: { id: sampleProcessId, version: sampleVersion } }],
+      edges: [
+        {
+          id: 'edge-a',
+          source: { cell: 'node-a' },
+          target: { cell: 'node-b' },
+        },
+      ],
+    };
+    mockGenLifeCycleModelJsonOrdered.mockReturnValueOnce(rawJson);
+    mockGenLifeCycleModelProcesses.mockResolvedValueOnce({
+      lifeCycleModelProcesses: [],
+      up2DownEdges: [],
+    });
+    mockFunctionsInvoke.mockResolvedValueOnce(createMockEdgeFunctionResponse(edgePayload));
+
+    const result = await lifeCycleModelsApi.createLifeCycleModel(
+      { id: sampleModelId, model: runtimeGraph },
+      { persistenceGraph },
+    );
+
+    expect(mockGenLifeCycleModelProcesses).toHaveBeenCalledWith(
+      sampleModelId,
+      runtimeGraph.nodes,
+      rawJson,
+      [],
+    );
+    expect(mockFunctionsInvoke.mock.calls[0][1].body.parent.jsonTg.xflow).toEqual({
+      nodes: persistenceGraph.nodes,
+      edges: [
+        expect.objectContaining({
+          id: 'edge-a',
+          source: { cell: 'node-a' },
+          target: { cell: 'node-b' },
+        }),
+      ],
+    });
+    expect(result).toEqual(edgePayload);
+  });
+
   it('passes allocateVersion metadata when creating a lifecycle model version', async () => {
     const rawJson = buildLifecycleModelJsonOrdered();
     const edgePayload = buildSaveResult({
@@ -1554,6 +1614,73 @@ describe('updateLifeCycleModel', () => {
         jsonOrdered: rawJson,
       },
       processMutations: [],
+    });
+    expect(result).toEqual(edgePayload);
+  });
+
+  it('uses the hydrated graph for calculation and the reconciled graph for update persistence', async () => {
+    const rawJson = buildLifecycleModelJsonOrdered();
+    const edgePayload = buildSaveResult();
+    const runtimeGraph = {
+      nodes: [
+        {
+          id: 'node-a',
+          data: { id: sampleProcessId, version: sampleVersion, quantitativeReference: '1' },
+          ports: { items: [{ id: 'OUTPUT:flow-a' }] },
+        },
+      ],
+      edges: [
+        {
+          id: 'edge-a',
+          source: { cell: 'node-a', port: 'OUTPUT:flow-a' },
+          target: { cell: 'node-b', port: 'INPUT:flow-a' },
+        },
+      ],
+    };
+    const persistenceGraph = {
+      nodes: [{ id: 'node-a', data: { id: sampleProcessId, version: sampleVersion } }],
+      edges: [
+        {
+          id: 'edge-a',
+          source: { cell: 'node-a' },
+          target: { cell: 'node-b' },
+        },
+      ],
+    };
+    mockFrom.mockReturnValueOnce(
+      createQueryBuilder({
+        data: [{ submodels: [] }],
+        error: null,
+      }),
+    );
+    mockGenLifeCycleModelJsonOrdered.mockReturnValueOnce(rawJson);
+    mockGenLifeCycleModelProcesses.mockResolvedValueOnce({
+      lifeCycleModelProcesses: [],
+      up2DownEdges: [],
+    });
+    mockGetProcessDetailByIdsAndVersion.mockResolvedValueOnce({ data: [] });
+    mockFunctionsInvoke.mockResolvedValueOnce(createMockEdgeFunctionResponse(edgePayload));
+
+    const result = await lifeCycleModelsApi.updateLifeCycleModel(
+      { id: sampleModelId, version: sampleVersion, model: runtimeGraph },
+      { persistenceGraph },
+    );
+
+    expect(mockGenLifeCycleModelProcesses).toHaveBeenCalledWith(
+      sampleModelId,
+      runtimeGraph.nodes,
+      rawJson,
+      [],
+    );
+    expect(mockFunctionsInvoke.mock.calls[0][1].body.parent.jsonTg.xflow).toEqual({
+      nodes: persistenceGraph.nodes,
+      edges: [
+        expect.objectContaining({
+          id: 'edge-a',
+          source: { cell: 'node-a' },
+          target: { cell: 'node-b' },
+        }),
+      ],
     });
     expect(result).toEqual(edgePayload);
   });


### PR DESCRIPTION
## Summary

- Hydrate lightweight saved LifecycleModel graphs in edit mode with the same exact Process UUID/version details used by the view path.
- Keep the hydrated graph as editor/calculation state while reconciling persistence against the original stored graph, so unchanged synthesized ports, labels, and reference markers are not written back.
- Preserve intentional edits and new graph cells through the persistence reconciliation path, and cover create/update mutation behavior with focused tests.
- Refresh the canonical four-locale audit artifacts required after production source locations and the audited input digest changed.

## Design and compatibility

The editor now maintains two representations: a fully hydrated runtime graph for rendering, validation, and calculation, plus a persistence graph produced by three-way reconciliation of the stored baseline, initial hydrated graph, and current editor graph. This retains backward compatibility for lightweight historical `xflow` payloads without silently expanding them on save.

No database schema, RPC, Edge Function, or published data is changed by this PR.

## Validation

- `pnpm push:checked fork codex/issue-1023-edit-graph-hydration` completed all managed gates; its Git transport retry succeeded through the bound `pnpm push:retry` receipt.
- Docpact gate passed for 37 changed paths and 38 matched rules; coverage and freshness are both OK.
- Lint, Prettier, TypeScript, LCIA cache verification, and reference-data checks passed.
- Full Jest gate passed: 443 suites and 5,992 tests.
- Full source coverage assertion passed: 484/484 tracked source files at 100% statements, branches, functions, and lines.
- Focused LifecycleModel suites passed, including editor hydration, reconciliation, API create/update separation, view compatibility, and calculation compatibility.
- `pnpm build` passed.
- Four-locale activation checks and two-generation artifact idempotence passed.

## Risk

The main risk is accidental persistence of editor-only hydration fields. The three-way reconciliation tests prove unchanged synthesized fields restore the stored representation, while explicit user edits and newly created cells remain persisted. Exact Process identity is always fetched by UUID and version.

Closes #1023

Coordinates tiangong-lca/workspace#973
