### PR TITLE
Remove retired macOS Intel tool age exception

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-09-05"
-lastReviewedCommit: "3af7c363c0144a5fe6f186b2e99348339eb8ac1b"
-lastReviewedNote: 'Reviewed for Next #1028: Process/Flow matched Hybrid filter and team forwarding remains within existing page, service, test, Edge, and Database ownership routes; no baseline or waiver rule changed.'
+lastReviewedAt: "2026-09-06"
+lastReviewedCommit: "1531c51676617f8a606c2fdc2897239809fc8dfb"
+lastReviewedNote: 'Reviewed for Next #1030 / workspace #980 W11: remove only the owned macOS Intel Utoo age exception. Frozen dependencies, native UI/toolchain generation, coverage and release proof contracts remain unchanged; normal delivery keeps the hook-owned full gate.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,9 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-09-05
-lastReviewedCommit: 3af7c363c0144a5fe6f186b2e99348339eb8ac1b
-lastReviewedNote: 'Reviewed for Next #1028: matched Process/Flow Hybrid requests forward canonical filters and team context without moving authorization, adaptive retrieval, or fallback ownership out of Edge and Database.'
+lastReviewedAt: 2026-09-06
+lastReviewedCommit: 1531c51676617f8a606c2fdc2897239809fc8dfb
+lastReviewedNote: 'Reviewed for Next #1030 / workspace #980 W11: remove only the owned macOS Intel Utoo age exception. Frozen dependencies, native UI/toolchain generation, coverage and release proof contracts remain unchanged; normal delivery keeps the hook-owned full gate.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV.md
+++ b/DEV.md
@@ -42,9 +42,9 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .github/workflows/build.yml
   - .nvmrc
-lastReviewedAt: 2026-09-05
-lastReviewedCommit: 3af7c363c0144a5fe6f186b2e99348339eb8ac1b
-lastReviewedNote: 'Reviewed for Next #1028: Process/Flow matched Hybrid service changes use the existing Node/pnpm bootstrap, focused serial tests, and paired Dev delivery workflow without new commands or environment switches.'
+lastReviewedAt: 2026-09-06
+lastReviewedCommit: 1531c51676617f8a606c2fdc2897239809fc8dfb
+lastReviewedNote: 'Reviewed for Next #1030 / workspace #980 W11: remove only the owned macOS Intel Utoo age exception. Frozen dependencies, native UI/toolchain generation, coverage and release proof contracts remain unchanged; normal delivery keeps the hook-owned full gate.'
 ---
 
 # Development Bootstrap

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -42,9 +42,9 @@ checkPaths:
   - scripts/typescript-native-parser.*
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-09-05
-lastReviewedCommit: 3af7c363c0144a5fe6f186b2e99348339eb8ac1b
-lastReviewedNote: 'Reviewed for Next #1028: focused Flow/Process API proof and final full-gate ownership use the existing controlled pre-push path; trigger and bypass policy remain unchanged.'
+lastReviewedAt: 2026-09-06
+lastReviewedCommit: 1531c51676617f8a606c2fdc2897239809fc8dfb
+lastReviewedNote: 'Reviewed for Next #1030 / workspace #980 W11: remove only the owned macOS Intel Utoo age exception. Frozen dependencies, native UI/toolchain generation, coverage and release proof contracts remain unchanged; normal delivery keeps the hook-owned full gate.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -43,9 +43,9 @@ checkPaths:
   - scripts/typescript-native-parser.*
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-09-05
-lastReviewedCommit: 3af7c363c0144a5fe6f186b2e99348339eb8ac1b
-lastReviewedNote: 'Reviewed for Next #1028: the proof matrix now covers Process/Flow matched filters, team context, exact identity acknowledgement, paired backend revisions, and the adaptive-route boundary; gate policy is unchanged.'
+lastReviewedAt: 2026-09-06
+lastReviewedCommit: 1531c51676617f8a606c2fdc2897239809fc8dfb
+lastReviewedNote: 'Reviewed for Next #1030 / workspace #980 W11: remove only the owned macOS Intel Utoo age exception. Frozen dependencies, native UI/toolchain generation, coverage and release proof contracts remain unchanged; normal delivery keeps the hook-owned full gate.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -43,9 +43,9 @@ checkPaths:
   - pnpm-lock.yaml
   - pnpm-workspace.yaml
   - Dockerfile.app
-lastReviewedAt: 2026-09-05
-lastReviewedCommit: 3af7c363c0144a5fe6f186b2e99348339eb8ac1b
-lastReviewedNote: 'Reviewed for Next #1028: request-shape, team resolution, fail-closed, and exact-version API cases fit the existing service-unit strategy without changing test infrastructure.'
+lastReviewedAt: 2026-09-06
+lastReviewedCommit: 1531c51676617f8a606c2fdc2897239809fc8dfb
+lastReviewedNote: 'Reviewed for Next #1030 / workspace #980 W11: remove only the owned macOS Intel Utoo age exception. Frozen dependencies, native UI/toolchain generation, coverage and release proof contracts remain unchanged; normal delivery keeps the hook-owned full gate.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -40,9 +40,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-09-05
-lastReviewedCommit: 3af7c363c0144a5fe6f186b2e99348339eb8ac1b
-lastReviewedNote: 'Reviewed for Next #1028: the changed Process/Flow service and page paths remain covered by focused suites; no coverage queue or historical reference-baseline update is required.'
+lastReviewedAt: 2026-09-06
+lastReviewedCommit: 1531c51676617f8a606c2fdc2897239809fc8dfb
+lastReviewedNote: 'Reviewed for Next #1030 / workspace #980 W11: remove only the owned macOS Intel Utoo age exception. Frozen dependencies, native UI/toolchain generation, coverage and release proof contracts remain unchanged; normal delivery keeps the hook-owned full gate.'
 ---
 
 # Testing Execution State

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -42,9 +42,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-09-05
-lastReviewedCommit: 3af7c363c0144a5fe6f186b2e99348339eb8ac1b
-lastReviewedNote: 'Reviewed for Next #1028: async team resolution, request normalization, public-team preservation, and fail-closed cases fit the existing service/API testing patterns.'
+lastReviewedAt: 2026-09-06
+lastReviewedCommit: 1531c51676617f8a606c2fdc2897239809fc8dfb
+lastReviewedNote: 'Reviewed for Next #1030 / workspace #980 W11: remove only the owned macOS Intel Utoo age exception. Frozen dependencies, native UI/toolchain generation, coverage and release proof contracts remain unchanged; normal delivery keeps the hook-owned full gate.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -39,9 +39,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-09-05
-lastReviewedCommit: 3af7c363c0144a5fe6f186b2e99348339eb8ac1b
-lastReviewedNote: 'Reviewed for Next #1028: focused serial Flow/Process Jest runs and lint passed under the documented local engine warning; troubleshooting and gate-recovery guidance remain unchanged.'
+lastReviewedAt: 2026-09-06
+lastReviewedCommit: 1531c51676617f8a606c2fdc2897239809fc8dfb
+lastReviewedNote: 'Reviewed for Next #1030 / workspace #980 W11: remove only the owned macOS Intel Utoo age exception. Frozen dependencies, native UI/toolchain generation, coverage and release proof contracts remain unchanged; normal delivery keeps the hook-owned full gate.'
 ---
 
 # Testing Troubleshooting

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,7 +52,6 @@ minimumReleaseAgeExclude:
   - '@umijs/utils@4.7.9'
   - '@umijs/zod2ts@4.7.9'
   - '@utoo/pack-darwin-arm64@1.5.13'
-  - '@utoo/pack-darwin-x64@1.5.13'
   - '@utoo/pack-linux-arm64-gnu@1.5.13'
   - '@utoo/pack-linux-arm64-musl@1.5.13'
   - '@utoo/pack-linux-x64-gnu@1.5.13'


### PR DESCRIPTION
Removes only the retired macOS Intel Utoo release-age exception from the owned pnpm policy. The other 32 entries, dependency versions, lockfile and application behavior are unchanged; nine required governance reviews are recorded.

Validation: actual pnpm configuration RED/GREEN (33 entries to 32), frozen install, production build and strict Docpact passed. The controlled push gate passed 47 receipt-contract tests and 5,995 coverage tests, with all 484 tracked source files at 100/100/100/100. The exact commit `683c64bc18319a1999a5386f8dd438fc43c4e9ca` reached canonical origin through the repository's bounded retry after a transport failure. Recovery evidence is recorded in the Issue.

This routine PR targets dev. Normal versioned release/promotion and exact root integration remain required under [workspace #980](https://github.com/tiangong-lca/workspace/issues/980).

Closes #1030
